### PR TITLE
fix: use root-relative baseURL and update repo links in docs

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://project-unbounded.github.io/unbounded-kube/"
+baseURL = "/"
 languageCode = "en-us"
 title = "Unbounded Kube"
 
@@ -16,7 +16,7 @@ title = "Unbounded Kube"
 
 [params]
   description = "Run nodes across multiple cloud providers and bare-metal infrastructure to form a unified Kubernetes cluster, no matter where your infrastructure lives."
-  repo = "https://github.com/project-unbounded/unbounded-kube"
+  repo = "https://github.com/Azure/unbounded-kube"
 
 [menu]
   [[menu.main]]
@@ -33,5 +33,5 @@ title = "Unbounded Kube"
     weight = 3
   [[menu.main]]
     name = "GitHub"
-    url = "https://github.com/project-unbounded/unbounded-kube"
+    url = "https://github.com/Azure/unbounded-kube"
     weight = 4


### PR DESCRIPTION
## Summary

- Set Hugo `baseURL` to `"/"` so all asset paths (CSS, images, JS, navigation links) are root-relative, fixing broken styling on the deployed GitHub Pages site at `legendary-sniffle-6qv7eqr.pages.github.io`
- Update `repo` param and GitHub menu link from `project-unbounded/unbounded-kube` to `Azure/unbounded-kube`

## Problem

The `baseURL` was set to `https://project-unbounded.github.io/unbounded-kube/`, causing Hugo's `relURL` function to generate paths prefixed with `/unbounded-kube/` (e.g., `/unbounded-kube/css/style.css`). Since the site is actually deployed at the root of `legendary-sniffle-6qv7eqr.pages.github.io`, all 29 asset references across templates were returning 404s — breaking CSS, images, favicon, navigation, and search.

## Fix

Setting `baseURL = "/"` makes `relURL` produce clean root-relative paths like `/css/style.css`, which resolve correctly on any domain where the site is served from root. This removes the dependency on any specific domain or subpath.