### PR TITLE
chore: pre-publication cleanup for open-source release

### DIFF
--- a/.github/workflows/agent-e2e-kind.yaml
+++ b/.github/workflows/agent-e2e-kind.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 name: Agent E2E Kind
 
 on:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 name: Deploy Docs
 
 on:

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 name: Go CI
 
 on:

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 name: Build Container Images
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 name: Release
 
 on:

--- a/.github/workflows/smoke-metalman.yaml
+++ b/.github/workflows/smoke-metalman.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 name: Smoke Metalman
 
 on:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2026 (c) Microsoft Corporation
+Copyright (c) Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ so that pods, services, and DNS work transparently across sites.
   <img src="docs/static/img/unbounded-overview.svg" alt="Unbounded Kubernetes overview: Control Plane connected to Bare Metal (PXE Boot), Public Cloud (cloud-init), and AI Infrastructure (SSH) sites via WireGuard and Direct L3 networking" width="800">
 </p>
 
-For a deeper dive, see the [Project Overview](https://legendary-sniffle-6qv7eqr.pages.github.io/concepts/overview/).
+For a deeper dive, see the [Project Overview](https://azure.github.io/unbounded-kube/concepts/overview/).
 
 ## Key Features
 
@@ -51,17 +51,17 @@ For a deeper dive, see the [Project Overview](https://legendary-sniffle-6qv7eqr.
 
 | Component | Description | Details |
 |-----------|-------------|---------|
-| **[unbounded-agent](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/agent/)** | Single binary delivered to hosts to bootstrap them as Kubernetes worker nodes using `systemd-nspawn`. | [Agent Guide](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/agent/) |
-| **[machina](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/ssh/)** | Kubernetes controller that provisions remote Linux machines over SSH. | [SSH Guide](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/ssh/), [CRD Reference](https://legendary-sniffle-6qv7eqr.pages.github.io/reference/machina-crd/) |
-| **[metalman](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/pxe/)** | Controller for PXE-booting bare-metal servers with DHCP, TFTP, HTTP, Redfish BMC, and TPM 2.0. | [PXE Guide](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/pxe/), [Bare Metal Concepts](https://legendary-sniffle-6qv7eqr.pages.github.io/concepts/bare-metal/) |
-| **[unbounded-net](https://github.com/Azure/unbounded-net)** | CNI plugin and multi-site networking system for cross-site pod connectivity. | [Networking Concepts](https://legendary-sniffle-6qv7eqr.pages.github.io/concepts/networking/) |
-| **kubectl-unbounded** | kubectl plugin for initializing sites, adding machines, and managing the cluster. | [CLI Reference](https://legendary-sniffle-6qv7eqr.pages.github.io/reference/cli/) |
+| **[unbounded-agent](https://azure.github.io/unbounded-kube/guides/agent/)** | Single binary delivered to hosts to bootstrap them as Kubernetes worker nodes using `systemd-nspawn`. | [Agent Guide](https://azure.github.io/unbounded-kube/guides/agent/) |
+| **[machina](https://azure.github.io/unbounded-kube/guides/ssh/)** | Kubernetes controller that provisions remote Linux machines over SSH. | [SSH Guide](https://azure.github.io/unbounded-kube/guides/ssh/), [CRD Reference](https://azure.github.io/unbounded-kube/reference/machina-crd/) |
+| **[metalman](https://azure.github.io/unbounded-kube/guides/pxe/)** | Controller for PXE-booting bare-metal servers with DHCP, TFTP, HTTP, Redfish BMC, and TPM 2.0. | [PXE Guide](https://azure.github.io/unbounded-kube/guides/pxe/), [Bare Metal Concepts](https://azure.github.io/unbounded-kube/concepts/bare-metal/) |
+| **[unbounded-net](https://github.com/Azure/unbounded-net)** | CNI plugin and multi-site networking system for cross-site pod connectivity. | [Networking Concepts](https://azure.github.io/unbounded-kube/concepts/networking/) |
+| **kubectl-unbounded** | kubectl plugin for initializing sites, adding machines, and managing the cluster. | [CLI Reference](https://azure.github.io/unbounded-kube/reference/cli/) |
 
 ## Quick Start
 
 Get a working multi-site cluster in under 10 minutes. This creates an AKS cluster
 and joins a remote node to it. Already have a cluster? See the
-[Bring Your Own Cluster](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/existing-cluster/) guide.
+[Bring Your Own Cluster](https://azure.github.io/unbounded-kube/guides/existing-cluster/) guide.
 
 <p align="center">
   <img src="docs/static/img/quickstart-architecture.svg" alt="Quickstart architecture: AKS cluster with gateway nodes connected to a remote site over WireGuard" width="700">
@@ -119,17 +119,17 @@ kubectl get nodes -w
 After a few minutes your remote node appears with status **Ready**.
 
 For the full walkthrough including pod networking verification, see the
-[Getting Started Guide](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/getting-started/).
+[Getting Started Guide](https://azure.github.io/unbounded-kube/guides/getting-started/).
 
 ## Documentation
 
-Full documentation is available at **[legendary-sniffle-6qv7eqr.pages.github.io](https://legendary-sniffle-6qv7eqr.pages.github.io/)**.
+Full documentation is available at **[azure.github.io/unbounded-kube](https://azure.github.io/unbounded-kube/)**.
 
 | | |
 |---|---|
-| **Concepts** | [Project Overview](https://legendary-sniffle-6qv7eqr.pages.github.io/concepts/overview/) · [Networking](https://legendary-sniffle-6qv7eqr.pages.github.io/concepts/networking/) · [Bare Metal](https://legendary-sniffle-6qv7eqr.pages.github.io/concepts/bare-metal/) |
-| **Guides** | [Getting Started](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/getting-started/) · [Existing Cluster](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/existing-cluster/) · [SSH Provisioning](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/ssh/) · [Cloud API](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/cloud-api/) · [PXE Boot](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/pxe/) · [Agent](https://legendary-sniffle-6qv7eqr.pages.github.io/guides/agent/) |
-| **Reference** | [Architecture](https://legendary-sniffle-6qv7eqr.pages.github.io/reference/architecture/) · [CLI](https://legendary-sniffle-6qv7eqr.pages.github.io/reference/cli/) · [Machine CRD](https://legendary-sniffle-6qv7eqr.pages.github.io/reference/machina-crd/) · [GPU / NVIDIA](https://legendary-sniffle-6qv7eqr.pages.github.io/reference/gpu/nvidia/) |
+| **Concepts** | [Project Overview](https://azure.github.io/unbounded-kube/concepts/overview/) · [Networking](https://azure.github.io/unbounded-kube/concepts/networking/) · [Bare Metal](https://azure.github.io/unbounded-kube/concepts/bare-metal/) |
+| **Guides** | [Getting Started](https://azure.github.io/unbounded-kube/guides/getting-started/) · [Existing Cluster](https://azure.github.io/unbounded-kube/guides/existing-cluster/) · [SSH Provisioning](https://azure.github.io/unbounded-kube/guides/ssh/) · [Cloud API](https://azure.github.io/unbounded-kube/guides/cloud-api/) · [PXE Boot](https://azure.github.io/unbounded-kube/guides/pxe/) · [Agent](https://azure.github.io/unbounded-kube/guides/agent/) |
+| **Reference** | [Architecture](https://azure.github.io/unbounded-kube/reference/architecture/) · [CLI](https://azure.github.io/unbounded-kube/reference/cli/) · [Machine CRD](https://azure.github.io/unbounded-kube/reference/machina-crd/) · [GPU / NVIDIA](https://azure.github.io/unbounded-kube/reference/gpu/nvidia/) |
 
 ## Repository Structure
 

--- a/cmd/kubectl-unbounded/app/assets/node-bootstrap/script.sh
+++ b/cmd/kubectl-unbounded/app/assets/node-bootstrap/script.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 set -eo pipefail
 
 # -----------------------------------------------------------------

--- a/demo/nebius-ssh/create.sh
+++ b/demo/nebius-ssh/create.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 #
 # Provision Nebius cloud resources for the unbounded project.
 #

--- a/hack/agent/azure-gpu-vm/gpu-vm.sh
+++ b/hack/agent/azure-gpu-vm/gpu-vm.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 #
 # gpu-vm.sh - Manage Azure GPU VMs with NVIDIA drivers.
 #

--- a/hack/agent/azure-gpu-vm/install-nvidia-drivers.sh
+++ b/hack/agent/azure-gpu-vm/install-nvidia-drivers.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 #
 # install-nvidia-drivers.sh - Install NVIDIA GPU drivers on an Azure GPU VM.
 #

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Agent E2E Kind test.
 
 Creates a QEMU VM, joins it to a Kind cluster using the production

--- a/hack/agent/qemu/vm.sh
+++ b/hack/agent/qemu/vm.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 #
 # vm.sh - Manage QEMU-based Ubuntu VMs with cloud-init support
 #

--- a/hack/agent/skills/unbounded-agent-qemu-vm-e2e/scripts/aks-config.sh
+++ b/hack/agent/skills/unbounded-agent-qemu-vm-e2e/scripts/aks-config.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # aks-config.sh — Extract unbounded-agent configuration from an AKS kubeconfig
 # and write a JSON config file matching the AgentConfig schema.
 #

--- a/hack/agent/skills/unbounded-agent-qemu-vm-e2e/scripts/analyze-bootstrap-log.py
+++ b/hack/agent/skills/unbounded-agent-qemu-vm-e2e/scripts/analyze-bootstrap-log.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """analyze-bootstrap-log.py — Parse unbounded-agent bootstrap logs and print a
 phase duration breakdown.
 

--- a/hack/cmd/forge/README.md
+++ b/hack/cmd/forge/README.md
@@ -17,7 +17,7 @@ These flags apply to all commands:
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--cloud` | `-a` | `AzurePublicCloud` | Azure cloud name |
-| `--subscription` | `-s` | `44654aed-2753-4b88-9142-af7132933b6b` | Azure subscription ID |
+| `--subscription` | `-s` | `<your-subscription-id>` | Azure subscription ID |
 | `--log-format` | | `text` | Log format (`text` or `json`) |
 
 ## Create the Cluster
@@ -75,7 +75,7 @@ bin/forge site azure add \
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--azure` | `AzurePublicCloud` | Azure cloud name |
-| `--subscription` | `44654aed-2753-4b88-9142-af7132933b6b` | Azure subscription ID |
+| `--subscription` | `<your-subscription-id>` | Azure subscription ID |
 | `--location` | `canadacentral` | Azure location |
 | `--worker-node-cidr` | `10.1.0.0/16` | CIDR range to use for worker nodes |
 | `--ssh-bastion` | `false` | Provision an SSH bastion (jump host) for the site |
@@ -100,7 +100,7 @@ bin/forge site azure add-pool \
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--azure` | `AzurePublicCloud` | Azure cloud name |
-| `--subscription` | `44654aed-2753-4b88-9142-af7132933b6b` | Azure subscription ID |
+| `--subscription` | `<your-subscription-id>` | Azure subscription ID |
 | `--location` | `canadacentral` | Azure location |
 | `--name` | | Name of the machine pool to add |
 | `--count` | `2` | Number of worker nodes to create in the pool |

--- a/hack/cmd/forge/forge/forge.go
+++ b/hack/cmd/forge/forge/forge.go
@@ -19,7 +19,7 @@ import (
 func Run() {
 	rootCfg := cmd.CommandContext{
 		CloudName:      "AzurePublicCloud",
-		SubscriptionID: "44654aed-2753-4b88-9142-af7132933b6b",
+		SubscriptionID: "",
 		LogFormat:      "text",
 		DataDir:        filepath.Join("~/.unbounded-forge"),
 	}

--- a/hack/cmd/forge/forge/site/cmd_azure.go
+++ b/hack/cmd/forge/forge/site/cmd_azure.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	azureDefaultCloud        = "AzurePublicCloud"
-	azureDefaultSubscription = "44654aed-2753-4b88-9142-af7132933b6b"
+	azureDefaultSubscription = ""
 	azureDefaultLocation     = "canadacentral"
 )
 

--- a/hack/scripts/aks-quickstart.sh
+++ b/hack/scripts/aks-quickstart.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # aks-quickstart.sh -- Create or configure an AKS cluster for unbounded-kube
 # with gateway node pools and all required networking infrastructure.
 #

--- a/hack/scripts/get-aks-cluster-cidrs.sh
+++ b/hack/scripts/get-aks-cluster-cidrs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # get-aks-cluster-cidrs.sh -- Detect CIDRs for an AKS cluster and print a
 # ready-to-paste "kubectl unbounded site init" command.
 #

--- a/hack/smoke.py
+++ b/hack/smoke.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/hack/test-goreleaser-hook.sh
+++ b/hack/test-goreleaser-hook.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # hack/test-goreleaser-hook.sh
 #
 # Tests that the goreleaser pre-hook correctly stamps the machina

--- a/images/agent-ubuntu2404-nvidia/Containerfile
+++ b/images/agent-ubuntu2404-nvidia/Containerfile
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # TODO: switch to debootstrap-based base image once we have the container registry set up
 FROM docker.io/library/ubuntu:noble@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b
 

--- a/images/agent-ubuntu2404/Containerfile
+++ b/images/agent-ubuntu2404/Containerfile
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # TODO: switch to debootstrap-based base image once we have the container registry set up
 FROM docker.io/library/ubuntu:noble@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b
 

--- a/images/host-ubuntu2404/Containerfile
+++ b/images/host-ubuntu2404/Containerfile
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # ── Build the unbounded-agent binary ────────────────────────────────
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26@sha256:ec4debba7b371fb2eaa6169a72fc61ad93b9be6a9ae9da2a010cb81a760d36e7 AS gobuilder
 

--- a/images/machina/Containerfile
+++ b/images/machina/Containerfile
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Build stage
 FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS builder
 

--- a/images/metalman/Containerfile
+++ b/images/metalman/Containerfile
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Build stage
 FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS builder
 

--- a/internal/provision/assets/unbounded-agent-install.sh
+++ b/internal/provision/assets/unbounded-agent-install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 set -eo pipefail
 
 # Required environment variable:

--- a/internal/provision/assets/unbounded-agent-uninstall.sh
+++ b/internal/provision/assets/unbounded-agent-uninstall.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 set -eo pipefail
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Prepares the repository for public release with the following changes:

- **LICENSE**: Remove year from copyright line (`Copyright (c) Microsoft Corporation.`)
- **README.md**: Replace temporary `legendary-sniffle-6qv7eqr.pages.github.io` docs URL with canonical `azure.github.io/unbounded-kube` across all 17 occurrences
- **Copyright headers**: Add `Copyright (c) Microsoft Corporation. / Licensed under the MIT License.` to 25 non-Go source files:
  - 11 shell scripts (`.sh`)
  - 3 Python files (`.py`)
  - 6 GitHub Actions workflow YAMLs
  - 5 Containerfiles
- **Subscription ID**: Remove hardcoded Azure subscription ID from `hack/cmd/forge` dev tool (code defaults + README)

## Going-Public Checklist

| Item | Status |
|------|--------|
| LICENSE present (MIT) | Pass |
| Copyright headers on all source files | Pass (this PR) |
| CONTRIBUTING.md | Present |
| CODE_OF_CONDUCT.md | Present |
| SECURITY.md | Present |
| SUPPORT.md | Present |
| NOTICE (third-party attributions) | Present |
| .github/CODEOWNERS | Present |
| No leaked secrets/credentials | Pass |
| No internal Microsoft URLs | Pass |
| No hardcoded subscription IDs | Pass (this PR) |
| No AI/ML code requiring responsible AI docs | N/A — no AI code in repo |
| PoliCheck | Requires internal tooling — run separately |

## Verification

- `make lint` — 0 issues
- `make test` — all tests pass