### PR TITLE
Start kubelet on boot

### DIFF
--- a/cmd/agent/internal/phases/nodestart/nspawn.go
+++ b/cmd/agent/internal/phases/nodestart/nspawn.go
@@ -29,6 +29,10 @@ func StartNSpawnMachine(log *slog.Logger, goalState *goalstates.NodeStart) phase
 func (s *startNSpawnMachine) Name() string { return "start-nspawn-machine" }
 
 func (s *startNSpawnMachine) Do(ctx context.Context) error {
+	if err := utilexec.RunCmd(ctx, s.log, utilexec.Machinectl(), "enable", s.goalState.MachineName); err != nil {
+		return fmt.Errorf("machinectl enable %s: %w", s.goalState.MachineName, err)
+	}
+
 	if err := utilexec.RunCmd(ctx, s.log, utilexec.Machinectl(), "start", s.goalState.MachineName); err != nil {
 		return fmt.Errorf("machinectl start %s: %w", s.goalState.MachineName, err)
 	}

--- a/cmd/agent/internal/phases/reset/machine.go
+++ b/cmd/agent/internal/phases/reset/machine.go
@@ -27,6 +27,10 @@ func StopMachine(log *slog.Logger, machineName string) phases.Task {
 func (t *stopMachine) Name() string { return "stop-machine" }
 
 func (t *stopMachine) Do(ctx context.Context) error {
+	if err := utilexec.RunCmd(ctx, t.log, utilexec.Machinectl(), "disable", t.machineName); err != nil {
+		t.log.Warn("failed to disable machine (may not have been enabled)", "machine", t.machineName, "error", err)
+	}
+
 	if !machineExists(ctx, t.log, t.machineName) {
 		t.log.Info("machine not running, nothing to stop", "machine", t.machineName)
 		return nil


### PR DESCRIPTION
Currently the agent runs as a one-shot process, not a daemon. It creates a systemd unit for the kubelet container and starts it without also enabling it, so kubelet never starts after reboot.