### PR TITLE
forge recovers a soft-deleted kv rather than failing

### DIFF
--- a/hack/cmd/forge/forge/infra/key_vault.go
+++ b/hack/cmd/forge/forge/infra/key_vault.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 
 	"github.com/Azure/unbounded-kube/hack/cmd/forge/forge/azsdk"
@@ -69,6 +70,20 @@ func (m *KeyVaultManager) CreateOrUpdate(ctx context.Context, rgName string, des
 		Properties: desired.Properties,
 	}
 
+	// Check if a soft-deleted vault with this name exists. If so, we need to
+	// recover it rather than create a new one, otherwise Azure returns a 409
+	// Conflict because it won't implicitly overwrite a soft-deleted vault.
+	deleted, err := m.GetDeleted(ctx, *desired.Name, *desired.Location)
+	if err != nil {
+		return nil, fmt.Errorf("KeyVaultManager.CreateOrUpdate: check for soft-deleted vault: %w", err)
+	}
+
+	if deleted != nil {
+		l.Info("Found soft-deleted key vault, recovering")
+
+		params.Properties.CreateMode = to.Ptr(armkeyvault.CreateModeRecover)
+	}
+
 	p, err := m.Client.BeginCreateOrUpdate(ctx, rgName, *desired.Name, params, nil)
 	if err != nil {
 		return nil, fmt.Errorf("KeyVaultManager.CreateOrUpdate: update key vault: %w", err)
@@ -89,6 +104,19 @@ func (m *KeyVaultManager) Get(ctx context.Context, rgName, name string) (*armkey
 	}
 
 	return &r.Vault, nil
+}
+
+func (m *KeyVaultManager) GetDeleted(ctx context.Context, name, location string) (*armkeyvault.DeletedVault, error) {
+	r, err := m.Client.GetDeleted(ctx, name, location, nil)
+	if err != nil {
+		if azsdk.IsNotFoundError(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("KeyVaultManager.GetDeleted: %w", err)
+	}
+
+	return &r.DeletedVault, nil
 }
 
 func (m *KeyVaultManager) Delete(ctx context.Context, rgName, name string) error {

--- a/hack/cmd/forge/forge/infra/key_vault_test.go
+++ b/hack/cmd/forge/forge/infra/key_vault_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package infra
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault/fake"
+)
+
+func newTestVaultsClient(t *testing.T, srv fake.VaultsServer) *armkeyvault.VaultsClient {
+	t.Helper()
+
+	transport := fake.NewVaultsServerTransport(&srv)
+
+	client, err := armkeyvault.NewVaultsClient("sub-id", &azfake.TokenCredential{}, &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: transport,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create vaults client: %v", err)
+	}
+
+	return client
+}
+
+func TestKeyVaultManager_CreateOrUpdate_NewVault(t *testing.T) {
+	// When no active vault and no soft-deleted vault exist, CreateOrUpdate should
+	// create a new vault without setting CreateMode.
+	var capturedParams armkeyvault.VaultCreateOrUpdateParameters
+
+	srv := fake.VaultsServer{
+		Get: func(_ context.Context, _, _ string, _ *armkeyvault.VaultsClientGetOptions) (azfake.Responder[armkeyvault.VaultsClientGetResponse], azfake.ErrorResponder) {
+			var errResp azfake.ErrorResponder
+			errResp.SetResponseError(http.StatusNotFound, "ResourceNotFound")
+
+			return azfake.Responder[armkeyvault.VaultsClientGetResponse]{}, errResp
+		},
+		GetDeleted: func(_ context.Context, _, _ string, _ *armkeyvault.VaultsClientGetDeletedOptions) (azfake.Responder[armkeyvault.VaultsClientGetDeletedResponse], azfake.ErrorResponder) {
+			var errResp azfake.ErrorResponder
+			errResp.SetResponseError(http.StatusNotFound, "DeletedVaultNotFound")
+
+			return azfake.Responder[armkeyvault.VaultsClientGetDeletedResponse]{}, errResp
+		},
+		BeginCreateOrUpdate: func(_ context.Context, _, _ string, params armkeyvault.VaultCreateOrUpdateParameters, _ *armkeyvault.VaultsClientBeginCreateOrUpdateOptions) (azfake.PollerResponder[armkeyvault.VaultsClientCreateOrUpdateResponse], azfake.ErrorResponder) {
+			capturedParams = params
+			resp := armkeyvault.VaultsClientCreateOrUpdateResponse{
+				Vault: armkeyvault.Vault{
+					Name:     to.Ptr("test-vault"),
+					Location: to.Ptr("eastus"),
+				},
+			}
+
+			var pollerResp azfake.PollerResponder[armkeyvault.VaultsClientCreateOrUpdateResponse]
+			pollerResp.SetTerminalResponse(http.StatusCreated, resp, nil)
+
+			return pollerResp, azfake.ErrorResponder{}
+		},
+	}
+
+	mgr := &KeyVaultManager{
+		Client: newTestVaultsClient(t, srv),
+		Logger: slog.Default(),
+	}
+
+	desired := armkeyvault.Vault{
+		Name:     to.Ptr("test-vault"),
+		Location: to.Ptr("eastus"),
+		Properties: &armkeyvault.VaultProperties{
+			TenantID: to.Ptr("tenant-id"),
+			SKU: &armkeyvault.SKU{
+				Family: to.Ptr(armkeyvault.SKUFamilyA),
+				Name:   to.Ptr(armkeyvault.SKUNameStandard),
+			},
+		},
+	}
+
+	result, err := mgr.CreateOrUpdate(context.Background(), "rg", desired)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate returned error: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("CreateOrUpdate returned nil vault")
+	}
+
+	if capturedParams.Properties.CreateMode != nil {
+		t.Errorf("expected CreateMode to be nil for new vault, got %v", *capturedParams.Properties.CreateMode)
+	}
+}
+
+func TestKeyVaultManager_CreateOrUpdate_RecoverSoftDeleted(t *testing.T) {
+	// When no active vault exists but a soft-deleted vault does, CreateOrUpdate
+	// should set CreateMode to "recover" before calling BeginCreateOrUpdate.
+	var capturedParams armkeyvault.VaultCreateOrUpdateParameters
+
+	srv := fake.VaultsServer{
+		Get: func(_ context.Context, _, _ string, _ *armkeyvault.VaultsClientGetOptions) (azfake.Responder[armkeyvault.VaultsClientGetResponse], azfake.ErrorResponder) {
+			var errResp azfake.ErrorResponder
+			errResp.SetResponseError(http.StatusNotFound, "ResourceNotFound")
+
+			return azfake.Responder[armkeyvault.VaultsClientGetResponse]{}, errResp
+		},
+		GetDeleted: func(_ context.Context, _, _ string, _ *armkeyvault.VaultsClientGetDeletedOptions) (azfake.Responder[armkeyvault.VaultsClientGetDeletedResponse], azfake.ErrorResponder) {
+			resp := armkeyvault.VaultsClientGetDeletedResponse{
+				DeletedVault: armkeyvault.DeletedVault{
+					Name: to.Ptr("test-vault"),
+				},
+			}
+
+			var r azfake.Responder[armkeyvault.VaultsClientGetDeletedResponse]
+			r.SetResponse(http.StatusOK, resp, nil)
+
+			return r, azfake.ErrorResponder{}
+		},
+		BeginCreateOrUpdate: func(_ context.Context, _, _ string, params armkeyvault.VaultCreateOrUpdateParameters, _ *armkeyvault.VaultsClientBeginCreateOrUpdateOptions) (azfake.PollerResponder[armkeyvault.VaultsClientCreateOrUpdateResponse], azfake.ErrorResponder) {
+			capturedParams = params
+			resp := armkeyvault.VaultsClientCreateOrUpdateResponse{
+				Vault: armkeyvault.Vault{
+					Name:     to.Ptr("test-vault"),
+					Location: to.Ptr("eastus"),
+				},
+			}
+
+			var pollerResp azfake.PollerResponder[armkeyvault.VaultsClientCreateOrUpdateResponse]
+			pollerResp.SetTerminalResponse(http.StatusOK, resp, nil)
+
+			return pollerResp, azfake.ErrorResponder{}
+		},
+	}
+
+	mgr := &KeyVaultManager{
+		Client: newTestVaultsClient(t, srv),
+		Logger: slog.Default(),
+	}
+
+	desired := armkeyvault.Vault{
+		Name:     to.Ptr("test-vault"),
+		Location: to.Ptr("eastus"),
+		Properties: &armkeyvault.VaultProperties{
+			TenantID: to.Ptr("tenant-id"),
+			SKU: &armkeyvault.SKU{
+				Family: to.Ptr(armkeyvault.SKUFamilyA),
+				Name:   to.Ptr(armkeyvault.SKUNameStandard),
+			},
+		},
+	}
+
+	result, err := mgr.CreateOrUpdate(context.Background(), "rg", desired)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate returned error: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("CreateOrUpdate returned nil vault")
+	}
+
+	if capturedParams.Properties.CreateMode == nil {
+		t.Fatal("expected CreateMode to be set, got nil")
+	}
+
+	if *capturedParams.Properties.CreateMode != armkeyvault.CreateModeRecover {
+		t.Errorf("expected CreateMode to be %q, got %q", armkeyvault.CreateModeRecover, *capturedParams.Properties.CreateMode)
+	}
+}
+
+func TestKeyVaultManager_CreateOrUpdate_ExistingVault(t *testing.T) {
+	// When the vault already exists in active state, CreateOrUpdate should
+	// return it without calling BeginCreateOrUpdate.
+	createCalled := false
+
+	srv := fake.VaultsServer{
+		Get: func(_ context.Context, _, _ string, _ *armkeyvault.VaultsClientGetOptions) (azfake.Responder[armkeyvault.VaultsClientGetResponse], azfake.ErrorResponder) {
+			resp := armkeyvault.VaultsClientGetResponse{
+				Vault: armkeyvault.Vault{
+					Name:     to.Ptr("test-vault"),
+					Location: to.Ptr("eastus"),
+				},
+			}
+
+			var r azfake.Responder[armkeyvault.VaultsClientGetResponse]
+			r.SetResponse(http.StatusOK, resp, nil)
+
+			return r, azfake.ErrorResponder{}
+		},
+		BeginCreateOrUpdate: func(_ context.Context, _, _ string, _ armkeyvault.VaultCreateOrUpdateParameters, _ *armkeyvault.VaultsClientBeginCreateOrUpdateOptions) (azfake.PollerResponder[armkeyvault.VaultsClientCreateOrUpdateResponse], azfake.ErrorResponder) {
+			createCalled = true
+			return azfake.PollerResponder[armkeyvault.VaultsClientCreateOrUpdateResponse]{}, azfake.ErrorResponder{}
+		},
+	}
+
+	mgr := &KeyVaultManager{
+		Client: newTestVaultsClient(t, srv),
+		Logger: slog.Default(),
+	}
+
+	desired := armkeyvault.Vault{
+		Name:     to.Ptr("test-vault"),
+		Location: to.Ptr("eastus"),
+		Properties: &armkeyvault.VaultProperties{
+			TenantID: to.Ptr("tenant-id"),
+			SKU: &armkeyvault.SKU{
+				Family: to.Ptr(armkeyvault.SKUFamilyA),
+				Name:   to.Ptr(armkeyvault.SKUNameStandard),
+			},
+		},
+	}
+
+	result, err := mgr.CreateOrUpdate(context.Background(), "rg", desired)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate returned error: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("CreateOrUpdate returned nil vault")
+	}
+
+	if createCalled {
+		t.Error("expected BeginCreateOrUpdate to not be called for existing vault")
+	}
+}


### PR DESCRIPTION
Fixes a bug in `forge` where if you're reusing a resource group name in the same subscription and soft-deleted key vault is turned on for your tenant the program will fail because of the key vault status. Now forge will recover the vault and use it.