### PR TITLE
[WIP] Machine CR watch-based daemon

### DIFF
--- a/.github/workflows/agent-e2e-kind.yaml
+++ b/.github/workflows/agent-e2e-kind.yaml
@@ -157,6 +157,20 @@ jobs:
       - name: Validate Machine CR (self-registered)
         run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-machine-cr-created
 
+      - name: Validate daemon watching Machine CR
+        run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-daemon
+
+      # Trigger a repave via the Machine CR and validate the daemon performs
+      # the nspawn machine update (kube1 -> kube2).
+      - name: Trigger node upgrade via Machine CR
+        run: python3 ./hack/agent/e2e-kind/e2e.py --verbose trigger-upgrade
+
+      - name: Validate node upgrade completed
+        run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-upgrade
+
+      - name: Wait for node to become Ready (post-upgrade)
+        run: python3 ./hack/agent/e2e-kind/e2e.py --verbose wait-for-node
+
       - name: Validate workload on agent node
         run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-workload
 
@@ -176,8 +190,8 @@ jobs:
       - name: Wait for node to become Ready (rejoin)
         run: python3 ./hack/agent/e2e-kind/e2e.py --verbose wait-for-node
 
-      - name: Validate Machine CR (rejoin)
-        run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-machine-cr-created
+      - name: Validate daemon watching Machine CR (rejoin)
+        run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-daemon
 
       - name: Validate workload on rejoined agent node
         run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-workload

--- a/api/machina/v1alpha3/machine_types.go
+++ b/api/machina/v1alpha3/machine_types.go
@@ -72,6 +72,13 @@ const (
 	// error result so that operators can diagnose the problem without
 	// logging into the machine.
 	MachineConditionCloudInitDone = "CloudInitDone"
+
+	// MachineConditionNodeUpdated indicates the result of a node
+	// update performed by the agent daemon. Status is True with
+	// Reason "Succeeded" after a successful update, and False with
+	// Reason "Failed" when the update fails. While the update is in
+	// progress the status is False with Reason "InProgress".
+	MachineConditionNodeUpdated = "NodeUpdated"
 )
 
 // Annotation keys.

--- a/cmd/agent/internal/cmd/daemon.go
+++ b/cmd/agent/internal/cmd/daemon.go
@@ -15,9 +15,10 @@ import (
 func newCmdDaemon(cmdCtx *CommandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "daemon",
-		Short: "Long-running daemon for node lifecycle management",
-		Long: "Long-running daemon that manages the nspawn machine lifecycle. " +
-			"Runs as a systemd unit after initial provisioning.",
+		Short: "Watch the Machine CR and reconcile the node to the desired state",
+		Long: "Long-running daemon that watches the Machine custom resource on the " +
+			"control plane and performs node updates when the desired state diverges " +
+			"from the locally applied configuration.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			defer cancel()

--- a/cmd/agent/internal/daemon/daemon.go
+++ b/cmd/agent/internal/daemon/daemon.go
@@ -9,27 +9,33 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha3 "github.com/Azure/unbounded-kube/api/machina/v1alpha3"
 	"github.com/Azure/unbounded-kube/internal/provision"
 )
 
-// kubeClientFunc constructs a controller-runtime client from a rest.Config.
-// The production implementation is client.NewWithWatch; tests can supply a fake.
+// kubeClientFunc constructs a controller-runtime WithWatch client from a
+// rest.Config. The production implementation is client.NewWithWatch;
+// tests can supply a fake.
 type kubeClientFunc func(cfg *rest.Config, opts client.Options) (client.WithWatch, error)
 
+const (
+	// watchRetryInterval is the delay between watch re-establishment attempts.
+	watchRetryInterval = 10 * time.Second
+)
+
 // Run is the main daemon entry point. It discovers the active nspawn
-// machine, builds a Kubernetes client, registers the Machine CR if needed,
-// and blocks until the context is cancelled.
-//
-// TODO: Add a trigger mechanism (e.g. file watch, signal, API) to invoke
-// updateNode when the desired config changes.
+// machine, builds a Kubernetes client from the applied config, and
+// watches the Machine CR for changes.
 func Run(ctx context.Context, log *slog.Logger) error {
 	return run(ctx, log, client.NewWithWatch)
 }
@@ -43,13 +49,14 @@ func run(ctx context.Context, log *slog.Logger, newClient kubeClientFunc) error 
 		return fmt.Errorf("find active machine: %w", err)
 	}
 
+	machineName := active.Config.MachineName
 	log.Info("daemon starting",
-		"machine_cr", active.Config.MachineName,
+		"machine_cr", machineName,
 		"nspawn_machine", active.Name,
 		"applied_version", active.Config.Cluster.Version,
 	)
 
-	// Build a controller-runtime client from the applied config.
+	// Build a controller-runtime WithWatch client from the applied config.
 	kubeClient, err := buildKubeClient(active.Config, newClient)
 	if err != nil {
 		return fmt.Errorf("build kube client: %w", err)
@@ -59,18 +66,63 @@ func run(ctx context.Context, log *slog.Logger, newClient kubeClientFunc) error 
 		"api_server", active.Config.Kubelet.ApiServer,
 	)
 
-	// Ensure a Machine CR exists before blocking. In dynamic environments
-	// (manual-bootstrap, cloud-init) a Machine CR may not have been
-	// pre-created by machina.
+	// Ensure a Machine CR exists before entering the watch loop. In
+	// dynamic environments (manual-bootstrap, cloud-init) a Machine CR
+	// may not have been pre-created by machina.
 	if err := registerMachine(ctx, log, kubeClient, active.Config); err != nil {
 		return fmt.Errorf("register machine: %w", err)
 	}
 
-	// Block until shutdown.
-	<-ctx.Done()
-	log.Info("daemon shutting down")
+	// Use client-go's rate-limiting workqueue to decouple the watch loop
+	// from reconciliation. The watch loop adds the machine name on every
+	// relevant event; the queue deduplicates and rate-limits so the
+	// worker processes at most one reconciliation at a time. This keeps
+	// the watch loop free to drain events without backpressuring the API
+	// server's HTTP/2 stream.
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "machine"},
+	)
+	defer queue.ShutDown()
 
-	return nil
+	// Worker goroutine: processes items from the queue.
+	go runWorker(ctx, log, kubeClient, queue)
+
+	// Enter the watch loop.
+	for {
+		if err := watchMachine(ctx, log, kubeClient, machineName, queue); err != nil {
+			if ctx.Err() != nil {
+				return nil // Graceful shutdown.
+			}
+
+			log.Error("watch failed, retrying", "error", err, "retry_in", watchRetryInterval)
+
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(watchRetryInterval):
+			}
+		}
+	}
+}
+
+// runWorker drains the workqueue, processing one item at a time.
+func runWorker(ctx context.Context, log *slog.Logger, c client.WithWatch, queue workqueue.TypedRateLimitingInterface[string]) {
+	for {
+		key, shutdown := queue.Get()
+		if shutdown {
+			return
+		}
+
+		if err := handleMachineEvent(ctx, log, c, key); err != nil {
+			log.Error("reconciliation failed, requeuing", "error", err)
+			queue.AddRateLimited(key)
+		} else {
+			queue.Forget(key)
+		}
+
+		queue.Done(key)
+	}
 }
 
 // buildKubeClient creates a controller-runtime WithWatch client from the
@@ -121,7 +173,6 @@ func buildKubeClient(cfg *provision.AgentConfig, newClient kubeClientFunc) (clie
 // Machine CR may not have been pre-created by machina.
 func registerMachine(ctx context.Context, log *slog.Logger, c client.Client, cfg *provision.AgentConfig) error {
 	machineName := cfg.MachineName
-
 	token := cfg.Kubelet.BootstrapToken
 	if token == "" {
 		log.Info("bootstrap token not set, skipping Machine CR registration")
@@ -134,7 +185,6 @@ func registerMachine(ctx context.Context, log *slog.Logger, c client.Client, cfg
 			slog.String("machine", machineName),
 			slog.String("machineID", string(machine.UID)),
 		)
-
 		return nil
 	} else if apimeta.IsNoMatchError(err) {
 		return fmt.Errorf("machine CRD is not installed (machina not deployed?): %w", err)
@@ -157,7 +207,6 @@ func registerMachine(ctx context.Context, log *slog.Logger, c client.Client, cfg
 		slog.String("machine", machineName),
 		slog.String("machineID", string(machine.UID)),
 	)
-
 	return nil
 }
 
@@ -182,4 +231,275 @@ func buildMachineCR(cfg *provision.AgentConfig) v1alpha3.Machine {
 			},
 		},
 	}
+}
+
+// watchMachine establishes a watch on the named Machine CR and enqueues the
+// machine name on relevant events. It returns when the watch closes or the
+// context is cancelled. The actual reconciliation happens asynchronously via
+// the workqueue, keeping this loop free to drain the watch stream.
+func watchMachine(ctx context.Context, log *slog.Logger, wc client.WithWatch, machineName string, queue workqueue.TypedRateLimitingInterface[string]) error {
+	machineList := &v1alpha3.MachineList{}
+
+	watcher, err := wc.Watch(ctx, machineList, client.MatchingFields{"metadata.name": machineName})
+	if err != nil {
+		return fmt.Errorf("start watch for Machine %q: %w", machineName, err)
+	}
+	defer watcher.Stop()
+
+	log.Info("watching Machine CR", "name", machineName)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return fmt.Errorf("watch channel closed")
+			}
+
+			if event.Type == watch.Error {
+				return fmt.Errorf("watch error event: %v", event.Object)
+			}
+
+			if event.Type != watch.Modified && event.Type != watch.Added {
+				continue
+			}
+
+			machine, ok := event.Object.(*v1alpha3.Machine)
+			if !ok {
+				log.Warn("unexpected object type in watch event")
+				continue
+			}
+
+			log.Debug("watch event",
+				"type", event.Type,
+				"generation", machine.Generation,
+				"version", machine.ResourceVersion,
+			)
+
+			// Enqueue the machine name. The workqueue deduplicates:
+			// if the name is already queued or being processed, this
+			// is a no-op.
+			queue.Add(machineName)
+		}
+	}
+}
+
+// handleMachineEvent processes a single reconciliation cycle. It reads the
+// current Machine CR from the API server, checks for drift, and performs
+// reconciliation if needed.
+func handleMachineEvent(ctx context.Context, log *slog.Logger, c client.WithWatch, machineName string) error {
+	// Read the Machine CR from the API server to get the latest state.
+	machine := &v1alpha3.Machine{}
+	if err := c.Get(ctx, client.ObjectKey{Name: machineName}, machine); err != nil {
+		return fmt.Errorf("get Machine %q: %w", machineName, err)
+	}
+
+	// Re-read the active machine state on each event, because a previous
+	// reconciliation may have changed the active nspawn machine name.
+	active, err := findActiveMachine(log)
+	if err != nil {
+		return fmt.Errorf("find active machine: %w", err)
+	}
+
+	// Build the desired config from the Machine CR overlaid on applied config.
+	desired := desiredConfigFromMachine(active.Config, machine)
+
+	// Check for operation counter drift. Counter bumps are the only
+	// trigger for reconciliation; actual config drift (version, image,
+	// etc.) is checked inside UpdateNode to decide whether the
+	// expensive rootfs reprovision is needed.
+	if !hasOperationsDrift(machine) {
+		log.Debug("no operation counter drift")
+		return nil
+	}
+
+	log.Info("operation counter drift detected",
+		"current_version", active.Config.Cluster.Version,
+		"desired_version", specVersion(machine),
+	)
+
+	// Set status to Provisioning before starting work.
+	if err := updateMachinePhase(ctx, c, machine, v1alpha3.MachinePhaseProvisioning, "agent daemon reconciling"); err != nil {
+		log.Warn("failed to update phase to Provisioning", "error", err)
+		// Continue with reconciliation even if status update fails.
+	}
+
+	// Execute the node update with the desired config.
+	if err := updateNode(ctx, log, active, desired); err != nil {
+		// Update status to Failed.
+		failMsg := fmt.Sprintf("node update failed: %v", err)
+		if updateErr := updateMachineStatus(ctx, c, machine, v1alpha3.MachinePhaseFailed, failMsg, false); updateErr != nil {
+			log.Warn("failed to update status after failure", "error", updateErr)
+		}
+
+		return fmt.Errorf("node update: %w", err)
+	}
+
+	// Acknowledge operation counters.
+	acknowledgeOperations(machine)
+
+	// Update status to Joining with success.
+	if err := updateMachineStatus(ctx, c, machine, v1alpha3.MachinePhaseJoining, "node update completed", true); err != nil {
+		log.Warn("failed to update status after success", "error", err)
+	}
+
+	log.Info("reconciliation completed",
+		"new_version", desired.Cluster.Version,
+	)
+
+	return nil
+}
+
+// desiredConfigFromMachine builds the desired AgentConfig by overlaying
+// fields from the Machine CR onto the applied config. Fields not present in
+// the CR (API server, CA cert, cluster DNS, bootstrap token, etc.) are
+// preserved from the applied config.
+func desiredConfigFromMachine(applied *provision.AgentConfig, machine *v1alpha3.Machine) *provision.AgentConfig {
+	// Deep copy the applied config as the base.
+	desired := *applied
+	desired.Cluster = applied.Cluster
+	desired.Kubelet = applied.Kubelet
+
+	// Copy labels map to avoid aliasing.
+	if applied.Kubelet.Labels != nil {
+		desired.Kubelet.Labels = make(map[string]string, len(applied.Kubelet.Labels))
+		for k, v := range applied.Kubelet.Labels {
+			desired.Kubelet.Labels[k] = v
+		}
+	}
+
+	// Copy taints slice.
+	if applied.Kubelet.RegisterWithTaints != nil {
+		desired.Kubelet.RegisterWithTaints = make([]string, len(applied.Kubelet.RegisterWithTaints))
+		copy(desired.Kubelet.RegisterWithTaints, applied.Kubelet.RegisterWithTaints)
+	}
+
+	// Preserve Attest pointer.
+	if applied.Attest != nil {
+		a := *applied.Attest
+		desired.Attest = &a
+	}
+
+	// Overlay Machine CR fields.
+	if machine.Spec.Kubernetes != nil {
+		if v := machine.Spec.Kubernetes.Version; v != "" {
+			desired.Cluster.Version = strings.TrimPrefix(v, "v")
+		}
+
+		if labels := machine.Spec.Kubernetes.NodeLabels; len(labels) > 0 {
+			desired.Kubelet.Labels = make(map[string]string, len(labels))
+			for k, v := range labels {
+				desired.Kubelet.Labels[k] = v
+			}
+		}
+
+		if taints := machine.Spec.Kubernetes.RegisterWithTaints; len(taints) > 0 {
+			desired.Kubelet.RegisterWithTaints = make([]string, len(taints))
+			copy(desired.Kubelet.RegisterWithTaints, taints)
+		}
+	}
+
+	if machine.Spec.Agent != nil && machine.Spec.Agent.Image != "" {
+		desired.OCIImage = machine.Spec.Agent.Image
+	}
+
+	return &desired
+}
+
+// hasOperationsDrift returns true if any operation counter in spec exceeds
+// the corresponding status counter.
+func hasOperationsDrift(machine *v1alpha3.Machine) bool {
+	if machine.Spec.Operations == nil {
+		return false
+	}
+
+	specOps := machine.Spec.Operations
+
+	statusOps := machine.Status.Operations
+	if statusOps == nil {
+		statusOps = &v1alpha3.OperationsStatus{}
+	}
+
+	if specOps.RepaveCounter > statusOps.RepaveCounter {
+		return true
+	}
+
+	return false
+}
+
+// specVersion extracts the kubernetes version from a Machine spec, or returns
+// empty string if not set.
+func specVersion(machine *v1alpha3.Machine) string {
+	if machine.Spec.Kubernetes != nil {
+		return machine.Spec.Kubernetes.Version
+	}
+
+	return ""
+}
+
+// acknowledgeOperations copies the spec repave counter to status, marking
+// it as acted upon. The reboot counter is not acknowledged here because
+// reboots are handled separately.
+func acknowledgeOperations(machine *v1alpha3.Machine) {
+	if machine.Spec.Operations == nil {
+		return
+	}
+
+	if machine.Status.Operations == nil {
+		machine.Status.Operations = &v1alpha3.OperationsStatus{}
+	}
+
+	machine.Status.Operations.RepaveCounter = machine.Spec.Operations.RepaveCounter
+}
+
+// updateMachinePhase sets the Machine phase, message, and a corresponding
+// NodeUpdated condition via a status update. The condition tracks the
+// in-progress state so that phase transitions are always backed by
+// observable conditions.
+func updateMachinePhase(ctx context.Context, c client.Client, machine *v1alpha3.Machine, phase v1alpha3.MachinePhase, message string) error {
+	machine.Status.Phase = phase
+	machine.Status.Message = message
+
+	apimeta.SetStatusCondition(&machine.Status.Conditions, metav1.Condition{
+		Type:               v1alpha3.MachineConditionNodeUpdated,
+		Status:             metav1.ConditionFalse,
+		Reason:             "InProgress",
+		Message:            message,
+		ObservedGeneration: machine.Generation,
+	})
+
+	return c.Status().Update(ctx, machine)
+}
+
+// updateMachineStatus sets the Machine phase, message, operation counters,
+// and the NodeUpdated condition via a status update.
+func updateMachineStatus(
+	ctx context.Context,
+	c client.Client,
+	machine *v1alpha3.Machine,
+	phase v1alpha3.MachinePhase,
+	message string,
+	success bool,
+) error {
+	machine.Status.Phase = phase
+	machine.Status.Message = message
+
+	condStatus := metav1.ConditionFalse
+	condReason := "Failed"
+
+	if success {
+		condStatus = metav1.ConditionTrue
+		condReason = "Succeeded"
+	}
+
+	apimeta.SetStatusCondition(&machine.Status.Conditions, metav1.Condition{
+		Type:               v1alpha3.MachineConditionNodeUpdated,
+		Status:             condStatus,
+		Reason:             condReason,
+		Message:            message,
+		ObservedGeneration: machine.Generation,
+	})
+
+	return c.Status().Update(ctx, machine)
 }

--- a/cmd/agent/internal/daemon/register_test.go
+++ b/cmd/agent/internal/daemon/register_test.go
@@ -26,7 +26,6 @@ func discardLogger() *slog.Logger {
 func fakeScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	utilruntime.Must(v1alpha3.AddToScheme(s))
-
 	return s
 }
 
@@ -112,7 +111,6 @@ func Test_registerMachine_NotFound_Creates(t *testing.T) {
 
 	// Verify Machine CR was created.
 	var machine v1alpha3.Machine
-
 	err = c.Get(context.Background(), client.ObjectKey{Name: "test-machine"}, &machine)
 	require.NoError(t, err)
 	assert.Equal(t, "test-machine", machine.Name)
@@ -134,7 +132,6 @@ func Test_registerMachine_Labels_Preserved(t *testing.T) {
 	require.NoError(t, err)
 
 	var machine v1alpha3.Machine
-
 	err = c.Get(context.Background(), client.ObjectKey{Name: "labeled-machine"}, &machine)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"env": "prod", "zone": "us-west"}, machine.Spec.Kubernetes.NodeLabels)

--- a/cmd/agent/internal/daemon/update.go
+++ b/cmd/agent/internal/daemon/update.go
@@ -116,13 +116,13 @@ func hasDrift(applied, desired *provision.AgentConfig) bool {
 	return false
 }
 
-// UpdateNode performs the nspawn machine update:
+// updateNode performs the nspawn machine update:
 //  1. Provision a new rootfs on the alternate machine
 //  2. Stop the old machine (graceful service shutdown + nspawn teardown)
 //  3. Start the new machine (configure, boot nspawn, start services, persist config)
 //  4. Verify kubelet health
 //  5. Remove the old machine and its applied config
-func UpdateNode(ctx context.Context, log *slog.Logger, active *ActiveMachine, newCfg *provision.AgentConfig) error {
+func updateNode(ctx context.Context, log *slog.Logger, active *ActiveMachine, newCfg *provision.AgentConfig) error {
 	// Skip the update if the desired config matches the applied config.
 	if !hasDrift(active.Config, newCfg) {
 		log.Info("no config drift detected, skipping node update")

--- a/cmd/agent/internal/goalstates/checksum.go
+++ b/cmd/agent/internal/goalstates/checksum.go
@@ -48,7 +48,6 @@ func VerifyChecksum(data []byte, checksumPath string) error {
 		// No sidecar on disk - nothing to verify.
 		return nil
 	}
-
 	if err != nil {
 		return fmt.Errorf("read checksum file %s: %w", checksumPath, err)
 	}

--- a/cmd/agent/internal/goalstates/checksum_test.go
+++ b/cmd/agent/internal/goalstates/checksum_test.go
@@ -127,7 +127,6 @@ func TestVerifyChecksum_ReadError(t *testing.T) {
 	}
 
 	data := []byte(`{"Version":"1.33.1"}`)
-
 	err := VerifyChecksum(data, checksumPath)
 	if err == nil {
 		t.Fatal("VerifyChecksum() expected error for unreadable path, got nil")

--- a/cmd/agent/internal/phases/nodestart/persist_config.go
+++ b/cmd/agent/internal/phases/nodestart/persist_config.go
@@ -46,7 +46,6 @@ func (p *persistAppliedConfig) Do(_ context.Context) error {
 	// crash between the two writes leaves a missing sidecar, which the
 	// read path treats as a warning (not an error).
 	checksumPath := goalstates.AppliedConfigChecksumPath(p.machineName)
-
 	checksum := goalstates.ComputeChecksum(data)
 	if err := utilio.WriteFile(checksumPath, []byte(checksum+"\n"), 0o600); err != nil {
 		return fmt.Errorf("write checksum to %s: %w", checksumPath, err)

--- a/cmd/kubectl-unbounded/app/machine_ops.go
+++ b/cmd/kubectl-unbounded/app/machine_ops.go
@@ -66,10 +66,6 @@ func getMachine(ctx context.Context, c client.WithWatch, name string) (*v1alpha3
 		return nil, fmt.Errorf("getting Machine: %w", err)
 	}
 
-	if machine.Spec.PXE == nil || machine.Spec.PXE.Redfish == nil {
-		return nil, fmt.Errorf("machine %s has no redfish configuration; reboots require BMC access", name)
-	}
-
 	if machine.Spec.Operations == nil {
 		machine.Spec.Operations = &v1alpha3.OperationsSpec{}
 	}

--- a/cmd/kubectl-unbounded/app/machine_reboot.go
+++ b/cmd/kubectl-unbounded/app/machine_reboot.go
@@ -39,6 +39,10 @@ func runReboot(ctx context.Context, c client.WithWatch, name string) error {
 		return err
 	}
 
+	if machine.Spec.PXE == nil || machine.Spec.PXE.Redfish == nil {
+		return fmt.Errorf("machine %s has no redfish configuration; reboots require BMC access", name)
+	}
+
 	machine.Spec.Operations.RebootCounter++
 	target := machine.Spec.Operations.RebootCounter
 

--- a/cmd/kubectl-unbounded/app/machine_repave.go
+++ b/cmd/kubectl-unbounded/app/machine_repave.go
@@ -10,10 +10,15 @@ import (
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/unbounded-kube/api/machina/v1alpha3"
 )
 
 // machineRepaveCommand returns a cobra.Command that repaves a Machine via Redfish.
 func machineRepaveCommand() *cobra.Command {
+	var kubeVersion string
+	var ociImage string
+
 	cmd := &cobra.Command{
 		Use:   "repave NAME",
 		Short: "Repave a Machine via Redfish",
@@ -26,17 +31,31 @@ func machineRepaveCommand() *cobra.Command {
 				return err
 			}
 
-			return runRepave(ctx, c, args[0])
+			return runRepave(ctx, c, args[0], kubeVersion, ociImage)
 		},
 	}
+
+	cmd.Flags().StringVar(&kubeVersion, "kube-version", "", "Kubernetes version to use for the repaved machine (e.g., \"v1.34.0\")")
+	cmd.Flags().StringVar(&ociImage, "oci-image", "", "OCI image reference for the agent (e.g., \"ghcr.io/org/repo:tag\")")
 
 	return cmd
 }
 
-func runRepave(ctx context.Context, c client.WithWatch, name string) error {
+func runRepave(ctx context.Context, c client.WithWatch, name, kubeVersion, ociImage string) error {
 	machine, err := getMachine(ctx, c, name)
 	if err != nil {
 		return err
+	}
+
+	if kubeVersion != "" {
+		machine.Spec.Kubernetes.Version = kubeVersion
+	}
+
+	if ociImage != "" {
+		if machine.Spec.Agent == nil {
+			machine.Spec.Agent = &v1alpha3.AgentSpec{}
+		}
+		machine.Spec.Agent.Image = ociImage
 	}
 
 	machine.Spec.Operations.RepaveCounter++
@@ -48,6 +67,12 @@ func runRepave(ctx context.Context, c client.WithWatch, name string) error {
 	}
 
 	printStep(fmt.Sprintf("Repaving Machine %s...", name))
+	if kubeVersion != "" {
+		printConfig("kube-version", kubeVersion)
+	}
+	if ociImage != "" {
+		printConfig("oci-image", ociImage)
+	}
 	printConfig("target", fmt.Sprintf("%d", target))
 	printConfig("repave", fmt.Sprintf("%d", machine.Spec.Operations.RepaveCounter))
 	fmt.Println()

--- a/deploy/machina/07-bootstrapper-rbac.yaml
+++ b/deploy/machina/07-bootstrapper-rbac.yaml
@@ -1,9 +1,9 @@
 ---
-# Grant bootstrap token users (system:bootstrappers group) the minimum
-# permissions required for the unbounded-agent to self-register a Machine CR
-# when one does not already exist. This is required for dynamic boot
-# environments such as manual-bootstrap and cloud-init where a Machine CR is
-# not pre-created before the agent runs.
+# Grant bootstrap token users (system:bootstrappers group) the permissions
+# required by the unbounded-agent daemon. The daemon self-registers a
+# Machine CR at startup (if one does not already exist), watches the
+# Machine CR that corresponds to its node, and updates the Machine status
+# after reconciliation.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -11,7 +11,10 @@ metadata:
 rules:
   - apiGroups: ["unbounded-kube.io"]
     resources: ["machines"]
-    verbs: ["get", "create"]
+    verbs: ["create", "get", "list", "watch"]
+  - apiGroups: ["unbounded-kube.io"]
+    resources: ["machines/status"]
+    verbs: ["get", "update", "patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/content/reference/agent/daemon.md
+++ b/docs/content/reference/agent/daemon.md
@@ -1,0 +1,188 @@
+---
+title: "Daemon"
+weight: 3
+description: "Watch-based daemon that reconciles the agent to the Machine CR goal state."
+---
+
+The unbounded-agent daemon is a long-running process on the agent host that
+watches the Machine custom resource on the control plane and reconciles the
+local node to match the desired state. It runs as a systemd service alongside
+the nspawn machine and is started automatically after the initial `start`
+phase completes.
+
+## Overview
+
+After the agent provisions a node and joins it to a cluster, the daemon
+registers a Machine CR for this node (if one does not already exist) and
+establishes a Kubernetes watch on it (matched by `MachineName` in the agent
+config). When an operation counter in the CR's spec diverges from the status,
+the daemon performs the necessary operations to bring the node into the
+desired state.
+
+![Agent daemon overview: Control Plane with Machine CR watched by the daemon on the Agent Host, which persists applied config with SHA-256 integrity sidecar](../../../img/agent-daemon-overview.svg)
+
+## Authentication
+
+The daemon authenticates to the API server using the bootstrap token from the
+applied agent config. This is a temporary arrangement - bootstrap tokens are
+short-lived and not intended for long-running daemons. A proper agent
+credential strategy (e.g. dedicated client certificates) needs to be defined
+so the daemon remains authenticated after the bootstrap token expires.
+
+The daemon builds a `rest.Config` directly from the config fields (API server
+URL, base64-encoded CA certificate, bootstrap token), avoiding any dependency
+on kubeconfig files inside the nspawn machine (which contain nspawn-internal
+paths that do not resolve on the host filesystem).
+
+The bootstrap token places the daemon in the `system:bootstrappers` group. The
+`unbounded-bootstrapper-machine` ClusterRole (deployed with machina) grants the
+daemon create, read, and update access to Machine CRs. A ClusterRoleBinding
+binds this role to the `system:bootstrappers` group.
+
+## Machine CR Registration
+
+When the daemon starts, it checks whether a Machine CR with the configured
+`MachineName` already exists. If the CR is missing (common in dynamic
+environments such as manual bootstrap or cloud-init), the daemon creates a
+minimal Machine CR from the applied config:
+
+- `metadata.name` from `MachineName`
+- `spec.kubernetes.bootstrapTokenRef` derived from the bootstrap token ID
+- `spec.kubernetes.nodeLabels` and `spec.kubernetes.registerWithTaints`
+  copied from the applied config
+
+If the CR already exists (pre-created by machina or from a previous run), it
+is left untouched. If the CRD is not installed, the daemon returns an error
+(machina must be deployed first).
+
+This self-registration happens before the watch loop begins, ensuring the
+daemon always has a Machine CR to watch.
+
+## Applied Config and Drift Detection
+
+The daemon uses an `AgentConfig` as the local goal state for the node. This
+config is persisted to disk as the applied config file
+(`/etc/unbounded/agent/<machine>-applied-config.json`) after every successful
+provisioning or update. The daemon reads it on startup to know what the node
+is currently running.
+
+### AgentConfig fields
+
+The applied config contains the full set of parameters needed to provision an
+nspawn machine:
+
+| Field | Description |
+|---|---|
+| `MachineName` | Name of this node's Machine CR |
+| `Cluster.Version` | Kubernetes version (e.g. `v1.33.1`) |
+| `Cluster.CaCertBase64` | Base64-encoded cluster CA certificate |
+| `Cluster.ClusterDNS` | ClusterIP of the kube-dns Service |
+| `Kubelet.ApiServer` | API server endpoint URL |
+| `Kubelet.BootstrapToken` | Bootstrap token for kubelet TLS bootstrapping |
+| `Kubelet.Labels` | Node labels passed to kubelet registration |
+| `Kubelet.RegisterWithTaints` | Taints applied at registration |
+| `OCIImage` | OCI image reference for the nspawn rootfs |
+
+When a Machine CR watch event arrives, the daemon builds a desired
+`AgentConfig` by overlaying CR spec fields (version, image, labels, taints)
+onto the current applied config. Fields not present in the CR (API server, CA
+cert, cluster DNS, bootstrap token) are preserved from the applied config.
+
+### Operation counter triggers
+
+Reconciliation is triggered by operation counter drift in the Machine CR, not
+by config field changes alone:
+
+| Machine CR field | Condition | Trigger |
+|---|---|---|
+| `spec.operations.repaveCounter` | `> status.operations.repaveCounter` | Repave requested |
+
+Once triggered, the update flow compares the desired config against the
+applied config to decide whether a rootfs reprovision is actually needed.
+
+After successful reconciliation, only the repave counter is acknowledged
+(copied from spec to status). The reboot counter is not acknowledged by the
+daemon.
+
+Example steps for triggering a node update:
+
+1. Update `spec.kubernetes.version` to the desired Kubernetes version.
+2. Increment `spec.operations.repaveCounter`.
+3. Wait for `status.phase` to reach `Joining` (or `Ready` once the machina
+   controller observes the Node).
+
+### Persistence and integrity
+
+The applied config is persisted to disk after every successful provisioning
+or update. A SHA-256 sidecar checksum file
+(`<machine>-applied-config.json.sha256`) is written alongside it to protect
+against bitflips.
+
+On the **write path**, `PersistAppliedConfig` writes the config JSON first,
+then computes the SHA-256 digest and writes the sidecar. A crash between the
+two writes leaves a missing sidecar, which the read path handles gracefully.
+
+On the **read path**, `findActiveMachine` verifies the sidecar checksum
+before trusting the config data:
+
+| Sidecar state | Behavior |
+|---|---|
+| Present, digest matches | Config is trusted, proceed normally |
+| Missing | Log a warning and proceed - the config may have been written by an older agent that did not produce checksums, or the agent may have crashed between the two writes |
+| Present, digest mismatch | Return `ErrChecksumMismatch` - indicates on-disk corruption; the daemon will not start |
+
+On **reset**, `RemoveAppliedConfig` removes both the config JSON and the
+`.sha256` sidecar file.
+
+## Reconciliation Flow
+
+The daemon uses a rate-limited workqueue to handle watch events. The watch
+loop enqueues events and the queue deduplicates and rate-limits so at most
+one reconciliation runs at a time.
+
+When operation counter drift is detected:
+
+1. The daemon re-reads the Machine CR from the API server (to avoid stale
+   watch events from earlier status updates) and re-discovers the active
+   nspawn machine.
+2. It sets `status.phase` to `Provisioning` and updates the Machine CR
+   status.
+3. It constructs a desired `AgentConfig` by overlaying CR spec fields
+   (version, image, labels, taints) onto the current applied config.
+4. It executes `updateNode`, which:
+   - Checks whether actual config drift exists (version, image changes)
+   - Provisions a new nspawn machine (the alternate of the current one)
+   - Gracefully stops services in the old machine
+   - Stops the old nspawn machine
+   - Starts the new machine and verifies kubelet health
+   - Removes the old machine
+   - Persists the new applied config
+5. On success, the daemon updates Machine CR status:
+   - Sets `status.phase` to `Joining` (the machina controller transitions
+     to `Ready` once the Node object appears)
+    - Copies the repave counter from spec to status (acknowledging the
+     operation)
+   - Sets a `NodeUpdated` condition to `True` / `Succeeded`
+6. On failure, the daemon sets `status.phase` to `Failed` with an error
+   message and sets `NodeUpdated` condition to `False` / `Failed`.
+
+## Systemd Unit
+
+The daemon runs as `unbounded-agent-daemon.service`. It depends on
+`network-online.target` and `machines.target` so it starts after networking
+is up and systemd-nspawn machines are available.
+
+The `start` command enables and starts this service after the initial node
+provisioning is complete and the applied config is persisted.
+
+During a `reset`, the daemon is stopped first (before any nspawn machines are
+torn down) by the `StopDaemon` task, which stops and disables the service and
+removes the unit file.
+
+## RBAC
+
+The daemon needs create, get, list, and watch access to Machine CRs, plus
+get, update, and patch access to Machine status subresources. These
+permissions are granted by the `unbounded-bootstrapper-machine` ClusterRole,
+deployed with machina, and bound to the `system:bootstrappers` group via a
+ClusterRoleBinding.

--- a/docs/static/img/agent-daemon-overview.svg
+++ b/docs/static/img/agent-daemon-overview.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 300" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <defs>
+    <marker id="arrowRight" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#4d8eff" stroke-width="1.5"/>
+    </marker>
+    <marker id="arrowLeftOut" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto-start-reverse">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#4d8eff" stroke-width="1.5"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="780" height="300" rx="12" fill="#111113"/>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- Control Plane                                      -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="30" y="20" width="310" height="280" rx="10" fill="none" stroke="#2a2a2e" stroke-width="1.5"/>
+  <text x="55" y="45" fill="#a0a0a8" font-size="11" font-weight="600">Control Plane</text>
+
+  <!-- API Server -->
+  <rect x="55" y="60" width="260" height="32" rx="6" fill="#18181b" stroke="#4d8eff" stroke-width="1" stroke-opacity="0.5"/>
+  <text x="185" y="81" text-anchor="middle" fill="#4d8eff" font-size="11" font-weight="600">API Server</text>
+
+  <!-- Machine CR box -->
+  <rect x="55" y="110" width="260" height="185" rx="8" fill="#18181b" stroke="#a78bfa" stroke-width="1.5" stroke-opacity="0.5"/>
+  <text x="80" y="135" fill="#a78bfa" font-size="12" font-weight="700">Machine CR</text>
+
+  <!-- spec fields -->
+  <text x="80" y="162" fill="#e4e4e7" font-size="11" font-weight="600">spec:</text>
+  <text x="95" y="179" fill="#a0a0a8" font-size="10" font-family="'SF Mono', 'Fira Code', monospace">kubernetes.version</text>
+  <text x="95" y="195" fill="#a0a0a8" font-size="10" font-family="'SF Mono', 'Fira Code', monospace">agent.image</text>
+  <text x="95" y="211" fill="#a0a0a8" font-size="10" font-family="'SF Mono', 'Fira Code', monospace">operations.repaveCounter: 1</text>
+
+  <!-- status fields -->
+  <text x="80" y="237" fill="#e4e4e7" font-size="11" font-weight="600">status:</text>
+  <text x="95" y="254" fill="#a0a0a8" font-size="10" font-family="'SF Mono', 'Fira Code', monospace">phase: Ready</text>
+  <text x="95" y="270" fill="#a0a0a8" font-size="10" font-family="'SF Mono', 'Fira Code', monospace">operations.repaveCounter: 1</text>
+  <text x="95" y="286" fill="#a0a0a8" font-size="10" font-family="'SF Mono', 'Fira Code', monospace">conditions: [NodeUpdated]</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- Agent Host                                         -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="440" y="20" width="310" height="280" rx="10" fill="none" stroke="#2a2a2e" stroke-width="1.5"/>
+  <text x="465" y="45" fill="#a0a0a8" font-size="11" font-weight="600">Agent Host</text>
+
+  <!-- Daemon box -->
+  <rect x="465" y="60" width="260" height="32" rx="6" fill="#18181b" stroke="#4d8eff" stroke-width="1" stroke-opacity="0.5"/>
+  <text x="595" y="81" text-anchor="middle" fill="#4d8eff" font-size="11" font-weight="600">unbounded-agent daemon</text>
+
+  <!-- Applied config box -->
+  <rect x="465" y="110" width="260" height="115" rx="8" fill="#18181b" stroke="#34d399" stroke-width="1.5" stroke-opacity="0.5"/>
+  <text x="490" y="135" fill="#34d399" font-size="11" font-weight="700">applied config</text>
+  <text x="490" y="155" fill="#a0a0a8" font-size="9" font-family="'SF Mono', 'Fira Code', monospace">/etc/unbounded/agent/</text>
+
+  <text x="490" y="178" fill="#e4e4e7" font-size="10" font-family="'SF Mono', 'Fira Code', monospace">kube1-applied-config.json</text>
+  <text x="490" y="198" fill="#e4e4e7" font-size="10" font-family="'SF Mono', 'Fira Code', monospace">kube1-applied-config.json.sha256</text>
+  <text x="490" y="215" fill="#a0a0a8" font-size="9">SHA-256 integrity sidecar</text>
+
+  <!-- nspawn machine -->
+  <rect x="465" y="240" width="260" height="20" rx="4" fill="#18181b" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+  <text x="595" y="254" text-anchor="middle" fill="#a78bfa" font-size="10" font-weight="500">nspawn machine (kube1 / kube2)</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- Arrow between control plane and agent host        -->
+  <!-- ═══════════════════════════════════════════════════ -->
+
+  <!-- Bidirectional watch / status update -->
+  <line x1="342" y1="76" x2="438" y2="76" stroke="#4d8eff" stroke-width="1.5" marker-start="url(#arrowLeftOut)" marker-end="url(#arrowRight)"/>
+  <text x="389" y="69" text-anchor="middle" fill="#4d8eff" font-size="9" font-weight="600">watch / status update</text>
+</svg>

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -28,6 +28,9 @@ Subcommands (called as individual workflow steps):
     install-machine-crd                Install Machine CRD and bootstrapper RBAC.
     delete-machine-cr                  Delete the Machine CR.
     validate-machine-cr-created        Verify agent self-registered a Machine CR.
+    validate-daemon                    Verify agent daemon is watching Machine CR and updates status.
+    trigger-upgrade                    Patch Machine CR repaveCounter to trigger a node update.
+    validate-upgrade                   Wait for node update to complete and verify status.
     reset-agent                        Run agent reset and verify cleanup.
     cleanup                            Tear down VM, networking, and Kind cluster.
 """
@@ -1130,6 +1133,389 @@ def validate_machine_cr_created() -> None:
 
 
 # ---------------------------------------------------------------------------
+# validate-daemon
+# ---------------------------------------------------------------------------
+def validate_daemon() -> None:
+    """Verify the agent daemon is running on the VM and watching the Machine CR.
+
+    Checks:
+    1. The unbounded-agent-daemon.service systemd unit is active on the VM.
+    2. The Machine CR exists in the cluster.
+    3. The daemon logs show it is watching the Machine CR.
+    """
+
+    log("Validating agent daemon...")
+
+    # 1. Check systemd unit is active on the VM.
+    log("Checking unbounded-agent-daemon.service is active...")
+    timeout_secs = 60
+    elapsed = 0
+    while elapsed < timeout_secs:
+        result = subprocess.run(
+            ["ssh", *SSH_OPTS, SSH_TARGET,
+             "sudo systemctl is-active unbounded-agent-daemon.service"],
+            capture_output=True, text=True,
+        )
+        status = result.stdout.strip()
+        if status == "active":
+            log(f"Daemon unit is active after {elapsed}s")
+            break
+        if elapsed > 0 and elapsed % 15 == 0:
+            log(f"  ({elapsed}s) Daemon status: {status}")
+        time.sleep(5)
+        elapsed += 5
+    else:
+        # Collect daemon logs for diagnostics.
+        subprocess.run(
+            ["ssh", *SSH_OPTS, SSH_TARGET,
+             "sudo journalctl -u unbounded-agent-daemon.service --no-pager -l -n 50"],
+            check=False,
+        )
+        die(f"Daemon unit not active after {timeout_secs}s (status: {status})")
+
+    # 2. Check Machine CR exists.
+    log(f"Checking Machine CR '{AGENT_MACHINE_NAME}' exists...")
+    result = subprocess.run(
+        [KUBECTL, "get", "machine", AGENT_MACHINE_NAME, "-o", "name"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        die(f"Machine CR '{AGENT_MACHINE_NAME}' not found in cluster")
+    log(f"Machine CR '{AGENT_MACHINE_NAME}' exists")
+
+    # 3. Check daemon logs for watch establishment.
+    log("Checking daemon logs for watch activity...")
+    result = subprocess.run(
+        ["ssh", *SSH_OPTS, SSH_TARGET,
+         "sudo journalctl -u unbounded-agent-daemon.service --no-pager -l -n 100"],
+        capture_output=True, text=True,
+    )
+    daemon_logs = result.stdout if result.returncode == 0 else ""
+    if VERBOSE:
+        print(daemon_logs, flush=True)
+
+    if "watching Machine CR" in daemon_logs:
+        log("Daemon is actively watching Machine CR")
+    elif "daemon starting" in daemon_logs:
+        log("Daemon has started (watch may still be establishing)")
+    else:
+        log("[WARN] Could not confirm daemon watch activity from logs")
+
+    log("============================================")
+    log("  Daemon validation PASSED")
+    log("============================================")
+
+
+# ---------------------------------------------------------------------------
+# trigger-upgrade
+# ---------------------------------------------------------------------------
+def _bump_patch_version(version: str) -> str:
+    """Bump the patch component of a semver string.
+
+    Examples:
+        "v1.33.1" -> "v1.33.2"
+        "1.33.1"  -> "1.33.2"
+    """
+    prefix = ""
+    v = version
+    if v.startswith("v"):
+        prefix = "v"
+        v = v[1:]
+
+    parts = v.split(".")
+    if len(parts) != 3:
+        die(f"Cannot parse version '{version}' as semver")
+
+    parts[2] = str(int(parts[2]) + 1)
+    return prefix + ".".join(parts)
+
+
+def trigger_upgrade() -> None:
+    """Patch the Machine CR to trigger a version upgrade via repaveCounter.
+
+    Reads the current Kubernetes version from the node, bumps the patch
+    component (e.g. v1.33.1 -> v1.33.2), and patches the Machine CR with
+    both spec.kubernetes.version and spec.operations.repaveCounter=1.
+    The daemon detects both spec drift and operations drift and triggers
+    nodeupdate.Execute().
+    """
+
+    log(f"Triggering node upgrade for Machine CR '{AGENT_MACHINE_NAME}'...")
+
+    # Get the current Kubernetes version from the node.
+    current_version = kubectl_capture([
+        "get", "node", AGENT_MACHINE_NAME,
+        "-o", "jsonpath={.status.nodeInfo.kubeletVersion}",
+    ])
+    if not current_version:
+        die("Could not determine current Kubernetes version from node")
+
+    upgrade_version = _bump_patch_version(current_version)
+    log(f"Current version: {current_version}, upgrade version: {upgrade_version}")
+
+    # Record which nspawn machine is currently active before the upgrade
+    # so validate-upgrade can confirm it switched.
+    result = subprocess.run(
+        ["ssh", *SSH_OPTS, SSH_TARGET,
+         "sudo ls /etc/unbounded/agent/"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        log(f"Applied config files before upgrade: {result.stdout.strip()}")
+
+    # Patch the Machine CR to set the new version and repaveCounter = 1.
+    # The CRD requires spec.kubernetes.bootstrapTokenRef when
+    # spec.kubernetes is present, so we include a placeholder value.
+    patch = json.dumps({
+        "spec": {
+            "kubernetes": {
+                "version": upgrade_version,
+                "bootstrapTokenRef": {
+                    "name": "not-used-by-agent-daemon",
+                },
+            },
+            "operations": {
+                "repaveCounter": 1,
+            },
+        },
+    })
+    kubectl(["patch", "machine", AGENT_MACHINE_NAME,
+             "--type=merge", "-p", patch])
+
+    log(f"Machine CR patched: spec.kubernetes.version={upgrade_version}, "
+        f"spec.operations.repaveCounter=1")
+
+    # Show the Machine CR state after patch.
+    kubectl(["get", "machine", AGENT_MACHINE_NAME, "-o", "yaml"])
+
+
+# ---------------------------------------------------------------------------
+# validate-upgrade
+# ---------------------------------------------------------------------------
+def validate_upgrade() -> None:
+    """Wait for the daemon to complete the node update and verify the result.
+
+    Checks:
+    1. The node goes through NotReady (update in progress) and comes back Ready.
+    2. Machine CR status.operations.repaveCounter == 1 (counter acknowledged).
+    3. Machine CR status.phase == "Joining".
+    4. Machine CR has NodeUpdated condition with status True.
+    5. The active nspawn machine switched (kube1 -> kube2 or vice versa).
+    6. The daemon systemd unit is still active after the update.
+    """
+
+    timeout_secs = int(os.environ.get("UPGRADE_TIMEOUT", "600"))
+
+    log("Waiting for daemon to detect drift and start node update...")
+    log(f"Timeout: {timeout_secs}s")
+
+    # Phase 1: Wait for Machine CR phase to become Provisioning or beyond.
+    # This confirms the daemon detected the drift and started reconciliation.
+    log("Phase 1: Waiting for daemon to start reconciliation...")
+    elapsed = 0
+    provisioning_seen = False
+    while elapsed < timeout_secs:
+        result = subprocess.run(
+            [KUBECTL, "get", "machine", AGENT_MACHINE_NAME,
+             "-o", "jsonpath={.status.phase}"],
+            capture_output=True, text=True,
+        )
+        phase = result.stdout.strip() if result.returncode == 0 else ""
+        if phase == "Provisioning":
+            log(f"Daemon started reconciliation (phase=Provisioning) after {elapsed}s")
+            provisioning_seen = True
+            break
+        if phase in ("Joining", "Ready"):
+            # The daemon may have already completed by the time we check.
+            log(f"Daemon already completed (phase={phase}) after {elapsed}s")
+            provisioning_seen = True
+            break
+        if phase == "Failed":
+            log("Machine CR phase is Failed - dumping daemon logs")
+            subprocess.run(
+                ["ssh", *SSH_OPTS, SSH_TARGET,
+                 "sudo journalctl -u unbounded-agent-daemon.service --no-pager -l -n 100"],
+                check=False,
+            )
+            die("Daemon reconciliation failed")
+        if elapsed > 0 and elapsed % 15 == 0:
+            log(f"  ({elapsed}s) Machine phase: {phase or '(empty)'}")
+        time.sleep(5)
+        elapsed += 5
+
+    if not provisioning_seen:
+        log("Daemon logs:")
+        subprocess.run(
+            ["ssh", *SSH_OPTS, SSH_TARGET,
+             "sudo journalctl -u unbounded-agent-daemon.service --no-pager -l -n 100"],
+            check=False,
+        )
+        die(f"Daemon did not start reconciliation within {timeout_secs}s")
+
+    # Phase 2: Wait for the node to come back Ready.
+    # During the update the old nspawn machine is stopped and the new one
+    # is started, so the node will briefly go NotReady.
+    log("Phase 2: Waiting for node to become Ready after update...")
+    node_ready_timeout = 300
+    elapsed = 0
+    while elapsed < node_ready_timeout:
+        result = subprocess.run(
+            [KUBECTL, "get", "node", AGENT_MACHINE_NAME,
+             "-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}"],
+            capture_output=True, text=True,
+        )
+        status = result.stdout.strip() if result.returncode == 0 else "unknown"
+        if status == "True":
+            log(f"Node is Ready after {elapsed}s")
+            break
+        if elapsed > 0 and elapsed % 30 == 0:
+            log(f"  ({elapsed}s) Node Ready status: {status}")
+        time.sleep(5)
+        elapsed += 5
+    else:
+        log("Node status:")
+        subprocess.run([KUBECTL, "describe", "node", AGENT_MACHINE_NAME], check=False)
+        die(f"Node did not become Ready after update within {node_ready_timeout}s")
+
+    # Phase 3: Validate Machine CR status.
+    log("Phase 3: Validating Machine CR status...")
+
+    # Wait for status to settle (the daemon updates status after the node
+    # update completes; give it a moment).
+    status_timeout = 60
+    elapsed = 0
+    status_ok = False
+    while elapsed < status_timeout:
+        machine_json = subprocess.run(
+            [KUBECTL, "get", "machine", AGENT_MACHINE_NAME, "-o", "json"],
+            capture_output=True, text=True,
+        )
+        if machine_json.returncode != 0:
+            die(f"Could not get Machine CR: {machine_json.stderr}")
+
+        machine = json.loads(machine_json.stdout)
+        status = machine.get("status", {})
+
+        # Check repaveCounter acknowledgement.
+        ops_status = status.get("operations", {})
+        repave_counter = ops_status.get("repaveCounter", 0)
+
+        # Check phase.
+        phase = status.get("phase", "")
+
+        # Check NodeUpdated condition.
+        conditions = status.get("conditions", [])
+        node_updated = None
+        for cond in conditions:
+            if cond.get("type") == "NodeUpdated":
+                node_updated = cond
+                break
+
+        if (repave_counter == 1
+                and phase in ("Joining", "Ready")
+                and node_updated is not None
+                and node_updated.get("status") == "True"
+                and node_updated.get("reason") == "Succeeded"):
+            status_ok = True
+            break
+
+        if elapsed > 0 and elapsed % 15 == 0:
+            log(f"  ({elapsed}s) phase={phase}, repaveCounter={repave_counter}, "
+                f"NodeUpdated={node_updated}")
+        time.sleep(5)
+        elapsed += 5
+
+    if not status_ok:
+        log("Machine CR status did not reach expected state:")
+        kubectl(["get", "machine", AGENT_MACHINE_NAME, "-o", "yaml"])
+        die("Machine CR status validation failed")
+
+    log(f"Machine CR status validated:")
+    log(f"  phase: {phase}")
+    log(f"  operations.repaveCounter: {repave_counter}")
+    log(f"  NodeUpdated: status={node_updated['status']}, reason={node_updated['reason']}")
+
+    # Phase 4: Verify the active nspawn machine switched.
+    log("Phase 4: Verifying nspawn machine switched...")
+    result = subprocess.run(
+        ["ssh", *SSH_OPTS, SSH_TARGET,
+         "sudo ls /etc/unbounded/agent/"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        config_files = result.stdout.strip()
+        log(f"Applied config files after upgrade: {config_files}")
+        # After upgrade, only the new machine's config should exist.
+        # e.g. kube2-applied-config.json (if it was kube1 before).
+        if "kube2-applied-config.json" in config_files:
+            log("Active machine switched to kube2 (was kube1)")
+        elif "kube1-applied-config.json" in config_files:
+            log("Active machine switched to kube1 (was kube2)")
+        else:
+            log("[WARN] Could not determine active machine from config files")
+
+    # Verify the new nspawn machine is running.
+    for nspawn_name in NSPAWN_MACHINE_NAMES:
+        result = subprocess.run(
+            ["ssh", *SSH_OPTS, SSH_TARGET,
+             f"sudo machinectl show {nspawn_name} --property=State"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and "running" in result.stdout:
+            log(f"nspawn machine '{nspawn_name}' is running (this is the new active machine)")
+
+    # Phase 5: Verify daemon is still running.
+    log("Phase 5: Verifying daemon is still active after update...")
+    result = subprocess.run(
+        ["ssh", *SSH_OPTS, SSH_TARGET,
+         "sudo systemctl is-active unbounded-agent-daemon.service"],
+        capture_output=True, text=True,
+    )
+    daemon_status = result.stdout.strip()
+    if daemon_status == "active":
+        log("Daemon is still active after upgrade")
+    else:
+        log(f"[WARN] Daemon status after upgrade: {daemon_status}")
+        subprocess.run(
+            ["ssh", *SSH_OPTS, SSH_TARGET,
+             "sudo journalctl -u unbounded-agent-daemon.service --no-pager -l -n 50"],
+            check=False,
+        )
+
+    # Phase 6: Verify applied config on disk shows the new version.
+    log("Phase 6: Verifying applied config version on disk...")
+    result = subprocess.run(
+        ["ssh", *SSH_OPTS, SSH_TARGET,
+         "sudo cat /etc/unbounded/agent/kube2-applied-config.json || " +
+         "sudo cat /etc/unbounded/agent/kube1-applied-config.json"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        applied_cfg = json.loads(result.stdout)
+        # AgentConfig uses Go-style capitalised JSON keys:
+        # {"Cluster": {"Version": "1.33.2", ...}, ...}
+        applied_version = applied_cfg.get("Cluster", {}).get("Version", "")
+        # The Machine CR spec.kubernetes.version has a "v" prefix but the
+        # applied config stores the version without it.
+        machine_version = (machine.get("spec", {})
+                           .get("kubernetes", {})
+                           .get("version", ""))
+        expected = machine_version.lstrip("v")
+        if applied_version == expected:
+            log(f"Applied config version matches: {applied_version}")
+        else:
+            die(f"Applied config version mismatch: got '{applied_version}', "
+                f"expected '{expected}'")
+    else:
+        die("Could not read applied config from VM")
+
+    log("============================================")
+    log("  Upgrade validation PASSED")
+    log("============================================")
+    kubectl(["get", "machine", AGENT_MACHINE_NAME, "-o", "yaml"])
+
+
+# ---------------------------------------------------------------------------
 # cleanup
 # ---------------------------------------------------------------------------
 def cleanup() -> None:
@@ -1199,6 +1585,9 @@ COMMANDS = {
     "install-machine-crd": install_machine_crd,
     "delete-machine-cr": delete_machine_cr,
     "validate-machine-cr-created": validate_machine_cr_created,
+    "validate-daemon": validate_daemon,
+    "trigger-upgrade": trigger_upgrade,
+    "validate-upgrade": validate_upgrade,
     "reset-agent": reset_agent,
     "cleanup": cleanup,
 }


### PR DESCRIPTION
## Summary

Implemented a Kubernetes watch-based daemon that monitors the Machine CR on the control plane and reconciles the local node to match the desired state.

### What changed

**Daemon** (`cmd/agent/internal/daemon/`)
- Watch-based loop using `client.NewWithWatch` on the Machine CR matched by `MachineName` from the applied config
- Async reconciliation via client-go workqueue (decouples watch events from reconciliation)
- Authenticates via bootstrap token from the applied config (`system:bootstrappers` group) - avoids reading kubeconfig files from inside the nspawn machine (which contain nspawn-internal paths). A TODO marks this as temporary pending a proper agent credential strategy.
- Registers a Machine CR at startup if one does not already exist (supports dynamic/manual-bootstrap environments)
- Detects operation counter drift (`spec.operations.repaveCounter > status.operations.repaveCounter`) to trigger reconciliation. Reboot counter is not handled by the daemon.
- Inside `updateNode`, checks actual config drift (version, image) before performing the expensive rootfs reprovision
- On success: sets phase to `Joining`, acknowledges repave counter (spec -> status), sets `NodeUpdated` condition to `True/Succeeded`
- On failure: sets phase to `Failed`, sets `NodeUpdated` condition to `False/Failed`
- Before reconciliation: sets phase to `Provisioning`, sets `NodeUpdated` condition to `False/InProgress`
- Re-GETs Machine CR from API server at start of each event handler to avoid stale watch events causing spurious drift
- Kube client built via parameter injection (unexported `kubeClientFunc` type) for testability

**Applied config integrity** (`cmd/agent/internal/goalstates/checksum.go`)
- SHA-256 sidecar checksum file written alongside applied config JSON
- Verified on read; missing sidecar = warning (proceed), mismatch = error

**Phase helpers** (extracted from inline code)
- `rootfs.Provision(log, gs)` - composite rootfs provisioning task
- `nodestart.StartNode(log, gs, cfg)` - composite node start task
- `nodestop.StopNode(log, machineName)` - composite node stop task
- `utilexec.MachineRun` - nspawn machine command execution

**Goal state** (`cmd/agent/internal/goalstates/`)
- `ResolveMachine()` discovers active nspawn machine and loads applied config
- `MachineGoalState` provides machine name, config, and rootfs paths
- `DaemonUnit` const consolidates the systemd unit name in one place

**RBAC** (`deploy/machina/07-bootstrapper-rbac.yaml`)
- Agent daemon RBAC consolidated into the bootstrapper ClusterRole (`unbounded-bootstrapper-machine`)
- Grants create/get/list/watch on `machines`, get/update/patch on `machines/status`
- Bound to `system:bootstrappers` group

**Systemd** (`unbounded-agent-daemon.service`)
- `After=network-online.target machines.target` ensures daemon starts after nspawn machines are available
- Enabled in the start command's serial task list after initial provisioning
- Stopped, disabled, and removed during reset (Step 1 before stopping nspawn machines)

**Config directories**
- Unified under `/etc/unbounded/kube` and `/etc/unbounded/agent` (was `/etc/unbounded-kube` and `/etc/unbounded-agent`)

**Design doc** (`docs/content/reference/agent/daemon.md`)
- Architecture SVG diagram, auth model, RBAC, systemd lifecycle, reconciliation flow

### E2E test flow (single linear sequence)

1. Start node without pre-created Machine CR
2. Wait for node Ready
3. Validate Machine CR (daemon self-registers it, polling up to 120s)
4. Validate daemon is watching
5. Trigger upgrade: patch Machine CR with new kube version + bump repaveCounter
6. Validate upgrade completed (daemon performs alternating nspawn machine update)
7. Wait for node Ready post-upgrade
8. Validate workload scheduling
9. Reset agent + delete Machine CR
10. Rejoin (run agent again on same VM, no VM recreation)
11. Wait for node Ready
12. Validate daemon watching
13. Validate workload

### Removed

- `nodestart.RegisterMachine` phase (moved to daemon)
- `deploy/agent/01-rbac.yaml` (consolidated into bootstrapper RBAC)
- Two-case e2e structure with VM recreation between cases
