### PR TITLE
Add condition for cloudinit status

### DIFF
--- a/api/v1alpha3/machine_types.go
+++ b/api/v1alpha3/machine_types.go
@@ -62,6 +62,16 @@ const (
 	// The lastTransitionTime records when the reimage started, which is
 	// used to detect stale reimage attempts.
 	MachineConditionReimaged = "Reimaged"
+
+	// MachineConditionCloudInitDone indicates whether cloud-init has
+	// finished on the machine. Status is True with Reason "Succeeded"
+	// when cloud-init completes without errors, False with Reason
+	// "Running" while cloud-init stages are still executing, and
+	// False with Reason "Failed" when a cloud-init stage reports a
+	// failure. On failure the message includes the stage name and the
+	// error result so that operators can diagnose the problem without
+	// logging into the machine.
+	MachineConditionCloudInitDone = "CloudInitDone"
 )
 
 // Annotation keys.

--- a/hack/smoke-metalman.py
+++ b/hack/smoke-metalman.py
@@ -462,6 +462,49 @@ def assert_node_ready(name: str, timeout: int = 300) -> None:
     die(f"Timed out waiting for Node '{name}' to become Ready")
 
 
+def assert_cloud_init_done(timeout: int = 900) -> None:
+    """Assert the Machine's CloudInitDone condition reaches True/Succeeded.
+
+    Called before waiting for the Kubernetes Node to appear because
+    cloud-init must finish before the kubelet can join the cluster.
+    Fails fast if the condition transitions to Failed so that the
+    smoke test does not wait for the full node-join timeout.
+    """
+    log(f"  Waiting for Machine '{NODE_NAME}' CloudInitDone condition...")
+    for elapsed in range(timeout):
+        check_procs()
+        result = subprocess.run(
+            [KUBECTL, "get", f"machines.{API_GROUP}", NODE_NAME, "-o", "json"],
+            capture_output=True, text=True,
+        )
+        status = ""
+        reason = ""
+        message = ""
+        if result.returncode == 0:
+            try:
+                conditions = json.loads(result.stdout).get("status", {}).get("conditions", [])
+                for c in conditions:
+                    if c.get("type") == "CloudInitDone":
+                        status = c.get("status", "")
+                        reason = c.get("reason", "")
+                        message = c.get("message", "")
+                        break
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+        if status == "True":
+            if reason != "Succeeded":
+                die(f"CloudInitDone condition is True but reason is {reason!r}, expected 'Succeeded'")
+            log(f"  Machine '{NODE_NAME}' CloudInitDone condition is True/Succeeded")
+            return
+        if status == "False" and reason == "Failed":
+            die(f"Cloud-init failed: {message}")
+        if elapsed > 0 and elapsed % 30 == 0:
+            log(f"    ({elapsed}s) CloudInitDone status={status or 'not set'} reason={reason or 'not set'}")
+        time.sleep(1)
+    die(f"Timed out waiting for CloudInitDone condition on Machine '{NODE_NAME}'")
+
+
 def main() -> None:
     signal.signal(signal.SIGINT, _sigint_handler)
     atexit.register(cleanup)
@@ -714,6 +757,9 @@ def main() -> None:
     # Log free space so we can correlate disk exhaustion with VM failures.
     df = subprocess.run(["df", "-h", str(TMPDIR)], capture_output=True, text=True)
     log(f"  Host disk after image builds:\n{df.stdout.strip()}")
+
+    log("Waiting for cloud-init to complete...")
+    assert_cloud_init_done(timeout=900)
 
     log("Waiting for kubelet to join the cluster...")
     wait_k8s_node(NODE_NAME, timeout=900)

--- a/internal/metalman/cloudinit/reconciler.go
+++ b/internal/metalman/cloudinit/reconciler.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package cloudinit
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha3 "github.com/Azure/unbounded-kube/api/v1alpha3"
+)
+
+const (
+	// cloudInitTimeout is the maximum duration the CloudInitDone condition
+	// may remain in a non-terminal state (False/Running) before the
+	// controller marks it Unknown to signal that cloud-init appears stalled.
+	cloudInitTimeout = 5 * time.Minute
+)
+
+type Reconciler struct {
+	Client client.Client
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("cloudinit").
+		For(&v1alpha3.Machine{}).
+		Complete(r)
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := slog.With("controller", "cloudinit", "node", req.Name, "namespace", req.Namespace)
+
+	var machine v1alpha3.Machine
+	if err := r.Client.Get(ctx, req.NamespacedName, &machine); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	cond := meta.FindStatusCondition(machine.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+
+	// No condition yet, or status is not False (already terminal) -
+	// nothing to do.
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		return ctrl.Result{}, nil
+	}
+
+	// The condition is False. Only time out non-terminal reasons;
+	// "Failed" is already terminal.
+	if cond.Reason == "Failed" {
+		return ctrl.Result{}, nil
+	}
+
+	// Guard against zero LastTransitionTime to avoid a spurious
+	// immediate timeout.
+	if cond.LastTransitionTime.IsZero() {
+		return ctrl.Result{RequeueAfter: cloudInitTimeout}, nil
+	}
+
+	elapsed := time.Since(cond.LastTransitionTime.Time)
+	if elapsed < cloudInitTimeout {
+		return ctrl.Result{RequeueAfter: cloudInitTimeout - elapsed}, nil
+	}
+
+	log.Info("cloud-init timed out, marking condition Unknown",
+		"reason", cond.Reason, "elapsed", elapsed)
+
+	meta.SetStatusCondition(&machine.Status.Conditions, metav1.Condition{
+		Type:               v1alpha3.MachineConditionCloudInitDone,
+		Status:             metav1.ConditionUnknown,
+		Reason:             "TimedOut",
+		Message:            fmt.Sprintf("cloud-init did not complete within %s", cloudInitTimeout),
+		ObservedGeneration: machine.Generation,
+	})
+
+	return ctrl.Result{}, r.Client.Status().Update(ctx, &machine)
+}

--- a/internal/metalman/cloudinit/reconciler_test.go
+++ b/internal/metalman/cloudinit/reconciler_test.go
@@ -1,0 +1,476 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package cloudinit
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha3 "github.com/Azure/unbounded-kube/api/v1alpha3"
+)
+
+func TestMain(m *testing.M) {
+	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
+	os.Exit(m.Run())
+}
+
+func TestTimeoutRunningCondition(t *testing.T) {
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-timeout"},
+		Status: v1alpha3.MachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha3.MachineConditionCloudInitDone,
+					Status:             metav1.ConditionFalse,
+					Reason:             "Running",
+					Message:            "stage \"modules-config\" started",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+				},
+			},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-timeout"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue after timeout, got RequeueAfter=%v", result.RequeueAfter)
+	}
+
+	var updated v1alpha3.Machine
+	if err := fc.Get(ctx, req.NamespacedName, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to exist")
+	}
+
+	if cond.Status != metav1.ConditionUnknown {
+		t.Fatalf("expected condition status Unknown, got %s", cond.Status)
+	}
+
+	if cond.Reason != "TimedOut" {
+		t.Fatalf("expected reason TimedOut, got %s", cond.Reason)
+	}
+}
+
+func TestTimeoutExactBoundary(t *testing.T) {
+	// A condition at exactly the timeout boundary should be timed out
+	// (elapsed >= cloudInitTimeout triggers the timeout).
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-boundary"},
+		Status: v1alpha3.MachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha3.MachineConditionCloudInitDone,
+					Status:             metav1.ConditionFalse,
+					Reason:             "Running",
+					Message:            "stage \"modules-config\" started",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-cloudInitTimeout)),
+				},
+			},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-boundary"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue at exact boundary, got RequeueAfter=%v", result.RequeueAfter)
+	}
+
+	var updated v1alpha3.Machine
+	if err := fc.Get(ctx, req.NamespacedName, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to exist")
+	}
+
+	if cond.Status != metav1.ConditionUnknown {
+		t.Fatalf("expected condition status Unknown at boundary, got %s", cond.Status)
+	}
+}
+
+func TestNotYetTimedOut(t *testing.T) {
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-not-expired"},
+		Status: v1alpha3.MachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha3.MachineConditionCloudInitDone,
+					Status:             metav1.ConditionFalse,
+					Reason:             "Running",
+					Message:            "stage \"modules-config\" started",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Minute)),
+				},
+			},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-not-expired"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected RequeueAfter for not-yet-expired timeout")
+	}
+
+	if result.RequeueAfter > 4*time.Minute {
+		t.Fatalf("expected RequeueAfter <= 4min, got %v", result.RequeueAfter)
+	}
+
+	var updated v1alpha3.Machine
+	if err := fc.Get(ctx, req.NamespacedName, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to still exist")
+	}
+
+	if cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected condition status False (unchanged), got %s", cond.Status)
+	}
+
+	if cond.Reason != "Running" {
+		t.Fatalf("expected reason Running (unchanged), got %s", cond.Reason)
+	}
+}
+
+func TestNoCondition(t *testing.T) {
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-no-cond"},
+		Status:     v1alpha3.MachineStatus{},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-no-cond"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue when no condition, got RequeueAfter=%v", result.RequeueAfter)
+	}
+}
+
+func TestConditionAlreadyTrue(t *testing.T) {
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-true"},
+		Status: v1alpha3.MachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha3.MachineConditionCloudInitDone,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Succeeded",
+					Message:            "cloud-init completed successfully",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+				},
+			},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-true"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue for True condition, got RequeueAfter=%v", result.RequeueAfter)
+	}
+}
+
+func TestConditionAlreadyUnknown(t *testing.T) {
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-unknown"},
+		Status: v1alpha3.MachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha3.MachineConditionCloudInitDone,
+					Status:             metav1.ConditionUnknown,
+					Reason:             "TimedOut",
+					Message:            "cloud-init did not complete within 5m0s",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+				},
+			},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-unknown"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue for Unknown condition, got RequeueAfter=%v", result.RequeueAfter)
+	}
+}
+
+func TestConditionFalseWithFailedReason(t *testing.T) {
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-failed"},
+		Status: v1alpha3.MachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha3.MachineConditionCloudInitDone,
+					Status:             metav1.ConditionFalse,
+					Reason:             "Failed",
+					Message:            "stage \"modules-final\" failed",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+				},
+			},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-failed"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue for Failed condition, got RequeueAfter=%v", result.RequeueAfter)
+	}
+
+	var updated v1alpha3.Machine
+	if err := fc.Get(ctx, req.NamespacedName, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to still exist")
+	}
+
+	if cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected condition status False (unchanged), got %s", cond.Status)
+	}
+
+	if cond.Reason != "Failed" {
+		t.Fatalf("expected reason Failed (unchanged), got %s", cond.Reason)
+	}
+}
+
+func TestZeroLastTransitionTime(t *testing.T) {
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-zero-time"},
+		Status: v1alpha3.MachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   v1alpha3.MachineConditionCloudInitDone,
+					Status: metav1.ConditionFalse,
+					Reason: "Running",
+				},
+			},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-zero-time"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != cloudInitTimeout {
+		t.Fatalf("expected RequeueAfter=%v for zero LastTransitionTime, got %v",
+			cloudInitTimeout, result.RequeueAfter)
+	}
+
+	// Verify the condition was NOT modified.
+	var updated v1alpha3.Machine
+	if err := fc.Get(ctx, req.NamespacedName, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to still exist")
+	}
+
+	if cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected condition status False (unchanged), got %s", cond.Status)
+	}
+}
+
+func TestUnexpectedReasonTimesOut(t *testing.T) {
+	// Any non-Failed reason on a False condition should be subject to
+	// timeout, not just "Running".
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-unexpected"},
+		Status: v1alpha3.MachineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha3.MachineConditionCloudInitDone,
+					Status:             metav1.ConditionFalse,
+					Reason:             "SomethingElse",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+				},
+			},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(machine).
+		WithStatusSubresource(machine).
+		Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "machine-unexpected"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue after timeout, got RequeueAfter=%v", result.RequeueAfter)
+	}
+
+	var updated v1alpha3.Machine
+	if err := fc.Get(ctx, req.NamespacedName, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to exist")
+	}
+
+	if cond.Status != metav1.ConditionUnknown {
+		t.Fatalf("expected condition status Unknown, got %s", cond.Status)
+	}
+
+	if cond.Reason != "TimedOut" {
+		t.Fatalf("expected reason TimedOut, got %s", cond.Reason)
+	}
+}
+
+func TestMachineNotFound(t *testing.T) {
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := &Reconciler{Client: fc}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "nonexistent"}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue for missing machine, got RequeueAfter=%v", result.RequeueAfter)
+	}
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	if err := v1alpha3.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	return s
+}

--- a/internal/metalman/commands/serve_pxe.go
+++ b/internal/metalman/commands/serve_pxe.go
@@ -25,6 +25,7 @@ import (
 	v1alpha3 "github.com/Azure/unbounded-kube/api/v1alpha3"
 	"github.com/Azure/unbounded-kube/internal/cloudprovider"
 	"github.com/Azure/unbounded-kube/internal/metalman/attestation"
+	"github.com/Azure/unbounded-kube/internal/metalman/cloudinit"
 	"github.com/Azure/unbounded-kube/internal/metalman/dhcp"
 	"github.com/Azure/unbounded-kube/internal/metalman/indexing"
 	"github.com/Azure/unbounded-kube/internal/metalman/lifecycle"
@@ -193,6 +194,10 @@ func ServePXECmd() *cobra.Command {
 
 			if err := (&lifecycle.Reconciler{Client: mgr.GetClient()}).SetupWithManager(mgr); err != nil {
 				return fmt.Errorf("setting up Lifecycle reconciler: %w", err)
+			}
+
+			if err := (&cloudinit.Reconciler{Client: mgr.GetClient()}).SetupWithManager(mgr); err != nil {
+				return fmt.Errorf("setting up CloudInit reconciler: %w", err)
 			}
 
 			resolver := netboot.FileResolver{

--- a/internal/metalman/netboot/http.go
+++ b/internal/metalman/netboot/http.go
@@ -16,6 +16,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha3 "github.com/Azure/unbounded-kube/api/v1alpha3"
@@ -160,7 +161,97 @@ func (h *HTTPServer) handleCloudInitLog(w http.ResponseWriter, r *http.Request) 
 		log.Info("cloud-init event", "type", ev.EventType, "description", ev.Description)
 	}
 
+	h.updateCloudInitCondition(r.Context(), log, ip, &ev)
+
 	w.WriteHeader(http.StatusOK)
+}
+
+// cloudInitLastStage is the final cloud-init stage. When this stage
+// finishes successfully the CloudInitDone condition transitions to True.
+const cloudInitLastStage = "modules-final"
+
+// updateCloudInitCondition sets the CloudInitDone condition on the Machine
+// that matches the request source IP. The condition reflects the
+// cloud-init lifecycle reported through webhook events:
+func (h *HTTPServer) updateCloudInitCondition(ctx context.Context, log *slog.Logger, ip string, ev *cloudInitEvent) {
+	if h.Client == nil {
+		return
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := h.LookupNodeByIP(ctx, ip)
+		if err != nil {
+			return err
+		}
+
+		cond := buildCloudInitCondition(ev, node.Generation)
+		if cond == nil {
+			return nil
+		}
+
+		// TODO(jordan): Rename all `node` references in this file to `machine`
+		meta.SetStatusCondition(&node.Status.Conditions, *cond)
+
+		return h.Client.Status().Update(ctx, node)
+	})
+	if err != nil {
+		log.Error("cloud-init condition: updating Machine status", "ip", ip, "err", err)
+	}
+}
+
+const maxConditionMessageLen = 1024
+
+// buildCloudInitCondition returns the metav1.Condition to set for a
+// cloud-init webhook event, or nil if no update is needed.
+func buildCloudInitCondition(ev *cloudInitEvent, generation int64) *metav1.Condition {
+	switch ev.EventType {
+	case "start":
+		return &metav1.Condition{
+			Type:               v1alpha3.MachineConditionCloudInitDone,
+			Status:             metav1.ConditionFalse,
+			Reason:             "Running",
+			Message:            fmt.Sprintf("stage %q started: %s", ev.Name, ev.Description),
+			ObservedGeneration: generation,
+		}
+
+	case "finish":
+		if !strings.EqualFold(ev.Result, "SUCCESS") {
+			msg := fmt.Sprintf("stage %q failed with result %q: %s", ev.Name, ev.Result, ev.Description)
+			if len(msg) > maxConditionMessageLen {
+				msg = msg[:maxConditionMessageLen-3] + "..."
+			}
+
+			return &metav1.Condition{
+				Type:               v1alpha3.MachineConditionCloudInitDone,
+				Status:             metav1.ConditionFalse,
+				Reason:             "Failed",
+				Message:            msg,
+				ObservedGeneration: generation,
+			}
+		}
+
+		if ev.Name == cloudInitLastStage {
+			return &metav1.Condition{
+				Type:               v1alpha3.MachineConditionCloudInitDone,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Succeeded",
+				Message:            "cloud-init completed successfully",
+				ObservedGeneration: generation,
+			}
+		}
+
+		// An earlier stage succeeded - cloud-init is still running.
+		return &metav1.Condition{
+			Type:               v1alpha3.MachineConditionCloudInitDone,
+			Status:             metav1.ConditionFalse,
+			Reason:             "Running",
+			Message:            fmt.Sprintf("stage %q finished successfully, waiting for remaining stages", ev.Name),
+			ObservedGeneration: generation,
+		}
+
+	default:
+		return nil
+	}
 }
 
 func (h *HTTPServer) handleDisablePXE(w http.ResponseWriter, r *http.Request) {

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -1925,6 +1925,591 @@ func TestHandleCloudInitLog(t *testing.T) {
 	}
 }
 
+func TestBuildCloudInitCondition(t *testing.T) {
+	generation := int64(3)
+
+	tests := []struct {
+		name       string
+		event      cloudInitEvent
+		wantNil    bool
+		wantStatus metav1.ConditionStatus
+		wantReason string
+		wantSubstr string // substring expected in message
+	}{
+		{
+			name: "start event sets Running",
+			event: cloudInitEvent{
+				Name:        "init-local",
+				Description: "starting init-local",
+				EventType:   "start",
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "Running",
+			wantSubstr: `stage "init-local" started`,
+		},
+		{
+			name: "early stage finish SUCCESS sets Running",
+			event: cloudInitEvent{
+				Name:        "init-local",
+				Description: "init-local ran successfully",
+				EventType:   "finish",
+				Result:      "SUCCESS",
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "Running",
+			wantSubstr: `stage "init-local" finished successfully`,
+		},
+		{
+			name: "modules-config finish SUCCESS sets Running",
+			event: cloudInitEvent{
+				Name:        "modules-config",
+				Description: "modules-config ran successfully",
+				EventType:   "finish",
+				Result:      "SUCCESS",
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "Running",
+			wantSubstr: `stage "modules-config" finished successfully`,
+		},
+		{
+			name: "modules-final finish SUCCESS sets Succeeded",
+			event: cloudInitEvent{
+				Name:        "modules-final",
+				Description: "modules-final ran successfully and took 1.23 seconds",
+				EventType:   "finish",
+				Result:      "SUCCESS",
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: "Succeeded",
+			wantSubstr: "cloud-init completed successfully",
+		},
+		{
+			name: "finish with failure sets Failed",
+			event: cloudInitEvent{
+				Name:        "modules-config",
+				Description: "running modules-config",
+				EventType:   "finish",
+				Result:      "FAIL: command [apt-get install -y badpkg] failed with exit code 100",
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "Failed",
+			wantSubstr: `stage "modules-config" failed`,
+		},
+		{
+			name: "finish with failure includes result in message",
+			event: cloudInitEvent{
+				Name:        "modules-final",
+				Description: "running modules-final",
+				EventType:   "finish",
+				Result:      "EXCEPTION: Traceback (most recent call last): runcmd failed",
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "Failed",
+			wantSubstr: "EXCEPTION: Traceback",
+		},
+		{
+			name: "unknown event type returns nil",
+			event: cloudInitEvent{
+				Name:        "modules-config",
+				Description: "custom event",
+				EventType:   "custom",
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := buildCloudInitCondition(&tt.event, generation)
+
+			if tt.wantNil {
+				if cond != nil {
+					t.Fatalf("expected nil condition, got %+v", cond)
+				}
+
+				return
+			}
+
+			if cond == nil {
+				t.Fatal("expected non-nil condition")
+			}
+
+			if cond.Type != v1alpha3.MachineConditionCloudInitDone {
+				t.Errorf("type: got %q, want %q", cond.Type, v1alpha3.MachineConditionCloudInitDone)
+			}
+
+			if cond.Status != tt.wantStatus {
+				t.Errorf("status: got %q, want %q", cond.Status, tt.wantStatus)
+			}
+
+			if cond.Reason != tt.wantReason {
+				t.Errorf("reason: got %q, want %q", cond.Reason, tt.wantReason)
+			}
+
+			if !strings.Contains(cond.Message, tt.wantSubstr) {
+				t.Errorf("message %q should contain %q", cond.Message, tt.wantSubstr)
+			}
+
+			if cond.ObservedGeneration != generation {
+				t.Errorf("observedGeneration: got %d, want %d", cond.ObservedGeneration, generation)
+			}
+		})
+	}
+}
+
+func TestBuildCloudInitCondition_MessageTruncation(t *testing.T) {
+	// Build a result string that will exceed maxConditionMessageLen when
+	// formatted into the failure message.
+	longResult := strings.Repeat("x", maxConditionMessageLen+500)
+
+	ev := cloudInitEvent{
+		Name:        "modules-config",
+		Description: "running modules-config",
+		EventType:   "finish",
+		Result:      longResult,
+	}
+
+	cond := buildCloudInitCondition(&ev, 1)
+	if cond == nil {
+		t.Fatal("expected non-nil condition")
+	}
+
+	if len(cond.Message) > maxConditionMessageLen {
+		t.Errorf("message length %d exceeds max %d", len(cond.Message), maxConditionMessageLen)
+	}
+
+	if !strings.HasSuffix(cond.Message, "...") {
+		t.Errorf("truncated message should end with '...', got %q", cond.Message[len(cond.Message)-10:])
+	}
+
+	// Verify that the message still starts with the stage info.
+	if !strings.Contains(cond.Message, "modules-config") {
+		t.Errorf("truncated message should contain stage name, got %q", cond.Message[:100])
+	}
+}
+
+func TestCloudInitCondition_StageStartSetsRunning(t *testing.T) {
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "ci-start-node"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:      "ghcr.io/test/image:v1",
+				DHCPLeases: []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:70", IPv4: "10.0.20.10", SubnetMask: "255.255.255.0"}},
+			},
+		},
+	}
+
+	cache := NewOCICache(t.TempDir())
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(&v1alpha3.Machine{}).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+
+	srv := &HTTPServer{
+		Client:       fc,
+		FileResolver: FileResolver{Cache: cache, Reader: fc},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cloudinit/log", srv.handleCloudInitLog)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	body := `{"name":"init-local","description":"starting init-local","event_type":"start","origin":"cloudinit","timestamp":1775657336.0}`
+	req, _ := http.NewRequest("POST", ts.URL+"/cloudinit/log", strings.NewReader(body))
+	req.Header.Set("X-Forwarded-For", "10.0.20.10")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /cloudinit/log: %v", err)
+	}
+
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var updated v1alpha3.Machine
+	if err := fc.Get(t.Context(), client.ObjectKeyFromObject(node), &updated); err != nil {
+		t.Fatalf("getting updated node: %v", err)
+	}
+
+	cond := findCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to be set")
+	}
+
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("status: got %q, want %q", cond.Status, metav1.ConditionFalse)
+	}
+
+	if cond.Reason != "Running" {
+		t.Errorf("reason: got %q, want %q", cond.Reason, "Running")
+	}
+}
+
+func TestCloudInitCondition_FinalStageSuccessSetsTrue(t *testing.T) {
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "ci-done-node"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:      "ghcr.io/test/image:v1",
+				DHCPLeases: []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:71", IPv4: "10.0.20.11", SubnetMask: "255.255.255.0"}},
+			},
+		},
+	}
+
+	cache := NewOCICache(t.TempDir())
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(&v1alpha3.Machine{}).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+
+	srv := &HTTPServer{
+		Client:       fc,
+		FileResolver: FileResolver{Cache: cache, Reader: fc},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cloudinit/log", srv.handleCloudInitLog)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	body := `{"name":"modules-final","description":"modules-final ran successfully and took 1.23 seconds","event_type":"finish","origin":"cloudinit","timestamp":1775657336.0,"result":"SUCCESS"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/cloudinit/log", strings.NewReader(body))
+	req.Header.Set("X-Forwarded-For", "10.0.20.11")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /cloudinit/log: %v", err)
+	}
+
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var updated v1alpha3.Machine
+	if err := fc.Get(t.Context(), client.ObjectKeyFromObject(node), &updated); err != nil {
+		t.Fatalf("getting updated node: %v", err)
+	}
+
+	cond := findCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to be set")
+	}
+
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("status: got %q, want %q", cond.Status, metav1.ConditionTrue)
+	}
+
+	if cond.Reason != "Succeeded" {
+		t.Errorf("reason: got %q, want %q", cond.Reason, "Succeeded")
+	}
+
+	if !strings.Contains(cond.Message, "cloud-init completed successfully") {
+		t.Errorf("message %q should contain completion text", cond.Message)
+	}
+}
+
+func TestCloudInitCondition_StageFailureSetsFailedWithDetails(t *testing.T) {
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "ci-fail-node"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:      "ghcr.io/test/image:v1",
+				DHCPLeases: []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:72", IPv4: "10.0.20.12", SubnetMask: "255.255.255.0"}},
+			},
+		},
+	}
+
+	cache := NewOCICache(t.TempDir())
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(&v1alpha3.Machine{}).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+
+	srv := &HTTPServer{
+		Client:       fc,
+		FileResolver: FileResolver{Cache: cache, Reader: fc},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cloudinit/log", srv.handleCloudInitLog)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	body := `{"name":"modules-config","description":"running modules-config","event_type":"finish","origin":"cloudinit","timestamp":1775657336.0,"result":"FAIL: command [apt-get install -y badpkg] failed with exit code 100"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/cloudinit/log", strings.NewReader(body))
+	req.Header.Set("X-Forwarded-For", "10.0.20.12")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /cloudinit/log: %v", err)
+	}
+
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var updated v1alpha3.Machine
+	if err := fc.Get(t.Context(), client.ObjectKeyFromObject(node), &updated); err != nil {
+		t.Fatalf("getting updated node: %v", err)
+	}
+
+	cond := findCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	if cond == nil {
+		t.Fatal("expected CloudInitDone condition to be set")
+	}
+
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("status: got %q, want %q", cond.Status, metav1.ConditionFalse)
+	}
+
+	if cond.Reason != "Failed" {
+		t.Errorf("reason: got %q, want %q", cond.Reason, "Failed")
+	}
+
+	if !strings.Contains(cond.Message, "modules-config") {
+		t.Errorf("message %q should contain stage name", cond.Message)
+	}
+
+	if !strings.Contains(cond.Message, "FAIL: command [apt-get install -y badpkg] failed with exit code 100") {
+		t.Errorf("message %q should contain the error result", cond.Message)
+	}
+}
+
+func TestCloudInitCondition_NoClientSkipsUpdate(t *testing.T) {
+	// When Client is nil, handleCloudInitLog should still return 200
+	// but not attempt any status update.
+	srv := &HTTPServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cloudinit/log", srv.handleCloudInitLog)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	body := `{"name":"modules-final","description":"done","event_type":"finish","origin":"cloudinit","timestamp":1775657336.0,"result":"SUCCESS"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/cloudinit/log", strings.NewReader(body))
+	req.Header.Set("X-Forwarded-For", "10.0.20.99")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /cloudinit/log: %v", err)
+	}
+
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestCloudInitCondition_UnknownIPSkipsUpdate(t *testing.T) {
+	// When the IP doesn't match any Machine, updateCloudInitCondition
+	// should log a warning but the handler should still return 200.
+	cache := NewOCICache(t.TempDir())
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha3.Machine{}).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+
+	srv := &HTTPServer{
+		Client:       fc,
+		FileResolver: FileResolver{Cache: cache, Reader: fc},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cloudinit/log", srv.handleCloudInitLog)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	body := `{"name":"modules-final","description":"done","event_type":"finish","origin":"cloudinit","timestamp":1775657336.0,"result":"SUCCESS"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/cloudinit/log", strings.NewReader(body))
+	req.Header.Set("X-Forwarded-For", "10.99.99.99")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /cloudinit/log: %v", err)
+	}
+
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestCloudInitCondition_StatusUpdateError(t *testing.T) {
+	// When the status update fails, the handler should still return 200
+	// because cloud-init does not retry on error responses.
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "ci-update-err-node"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:      "ghcr.io/test/image:v1",
+				DHCPLeases: []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:75", IPv4: "10.0.20.15", SubnetMask: "255.255.255.0"}},
+			},
+		},
+	}
+
+	cache := NewOCICache(t.TempDir())
+	scheme := newScheme(t)
+
+	injectedErr := fmt.Errorf("simulated conflict")
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(&v1alpha3.Machine{}).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				return injectedErr
+			},
+		}).
+		Build()
+
+	srv := &HTTPServer{
+		Client:       fc,
+		FileResolver: FileResolver{Cache: cache, Reader: fc},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cloudinit/log", srv.handleCloudInitLog)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	body := `{"name":"modules-final","description":"done","event_type":"finish","origin":"cloudinit","timestamp":1775657336.0,"result":"SUCCESS"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/cloudinit/log", strings.NewReader(body))
+	req.Header.Set("X-Forwarded-For", "10.0.20.15")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /cloudinit/log: %v", err)
+	}
+
+	resp.Body.Close()
+
+	// Handler must still return 200 even when status update fails.
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 despite status update failure, got %d", resp.StatusCode)
+	}
+}
+
+func TestCloudInitCondition_FullLifecycle(t *testing.T) {
+	// Simulate a full cloud-init lifecycle: start -> intermediate finish -> final finish.
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "ci-lifecycle-node"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:      "ghcr.io/test/image:v1",
+				DHCPLeases: []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:73", IPv4: "10.0.20.13", SubnetMask: "255.255.255.0"}},
+			},
+		},
+	}
+
+	cache := NewOCICache(t.TempDir())
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(&v1alpha3.Machine{}).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+
+	srv := &HTTPServer{
+		Client:       fc,
+		FileResolver: FileResolver{Cache: cache, Reader: fc},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cloudinit/log", srv.handleCloudInitLog)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	postEvent := func(body string) {
+		t.Helper()
+
+		req, _ := http.NewRequest("POST", ts.URL+"/cloudinit/log", strings.NewReader(body))
+		req.Header.Set("X-Forwarded-For", "10.0.20.13")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST /cloudinit/log: %v", err)
+		}
+
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+	}
+
+	getCondition := func() *metav1.Condition {
+		t.Helper()
+
+		var updated v1alpha3.Machine
+		if err := fc.Get(t.Context(), client.ObjectKeyFromObject(node), &updated); err != nil {
+			t.Fatalf("getting updated node: %v", err)
+		}
+
+		return findCondition(updated.Status.Conditions, v1alpha3.MachineConditionCloudInitDone)
+	}
+
+	// Step 1: init-local starts
+	postEvent(`{"name":"init-local","description":"starting init-local","event_type":"start","origin":"cloudinit","timestamp":1.0}`)
+
+	cond := getCondition()
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "Running" {
+		t.Fatalf("after init-local start: expected False/Running, got %+v", cond)
+	}
+
+	// Step 2: init-local finishes successfully
+	postEvent(`{"name":"init-local","description":"init-local done","event_type":"finish","origin":"cloudinit","timestamp":2.0,"result":"SUCCESS"}`)
+
+	cond = getCondition()
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "Running" {
+		t.Fatalf("after init-local finish: expected False/Running, got %+v", cond)
+	}
+
+	// Step 3: modules-final starts
+	postEvent(`{"name":"modules-final","description":"starting modules-final","event_type":"start","origin":"cloudinit","timestamp":3.0}`)
+
+	cond = getCondition()
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "Running" {
+		t.Fatalf("after modules-final start: expected False/Running, got %+v", cond)
+	}
+
+	// Step 4: modules-final finishes successfully
+	postEvent(`{"name":"modules-final","description":"modules-final done","event_type":"finish","origin":"cloudinit","timestamp":4.0,"result":"SUCCESS"}`)
+
+	cond = getCondition()
+	if cond == nil || cond.Status != metav1.ConditionTrue || cond.Reason != "Succeeded" {
+		t.Fatalf("after modules-final finish: expected True/Succeeded, got %+v", cond)
+	}
+}
+
 func freePort(t *testing.T) int {
 	t.Helper()
 


### PR DESCRIPTION
Populates a Machine status condition with the signal provided by the existing cloudinit webhook server in metalman. Also adds a controller to handle cases where webhooks might have been dropped.

The goal is to debug cloudinit failures without needing to read the controller logs.