### PR TITLE
fix: aks-quickstart script and kubectl-unbounded build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ KUBECTL_UNBOUNDED_LDFLAGS=$(VERSION_LDFLAGS) -X github.com/Azure/unbounded-kube/
 METALMAN_TAG ?= latest
 METALMAN_IMAGE=$(CONTAINER_REGISTRY)/metalman:$(METALMAN_TAG)
 
-.PHONY: all help fmt lint test check-deps kubectl-unbounded forge inventory inventory-amd64 inventory-arm64 unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests metalman metalman-build metalman-oci metalman-oci-push gomod docs-serve
+.PHONY: all help fmt lint test check-deps kubectl-unbounded kubectl-unbounded-build forge inventory inventory-amd64 inventory-arm64 unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests metalman metalman-build metalman-oci metalman-oci-push gomod docs-serve
 
 ##@ General
 
@@ -82,8 +82,10 @@ gomod: ## Tidy go.mod and go.sum
 
 ##@ Build
 
-kubectl-unbounded: test machina-manifests ## Build the kubectl-unbounded plugin (implies test)
+kubectl-unbounded-build: machina-manifests ## Build the kubectl-unbounded binary (no lint/test)
 	$(GOBUILD) -ldflags '$(KUBECTL_UNBOUNDED_LDFLAGS)' -o $(KUBECTL_UNBOUNDED_BIN) $(KUBECTL_UNBOUNDED_CMD)/main.go
+
+kubectl-unbounded: test kubectl-unbounded-build ## Build the kubectl-unbounded plugin (implies test)
 
 forge: test ## Build the forge dev tool (implies test)
 	$(GOBUILD) -o $(FORGE_BIN) $(FORGE_CMD)/main.go

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -74,7 +74,7 @@ Initialize a new unbounded-kube site. This command:
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--cni-manifests` | `string` | unbounded-net v1.1.2 release URL | Path to a local file/directory or HTTPS URL for CNI manifests |
+| `--cni-manifests` | `string` | unbounded-net release URL | Path to a local file/directory or HTTPS URL for CNI manifests |
 | `--machina-manifests` | `string` | *(embedded manifests)* | Path to a local file/directory or HTTPS URL for machina manifests |
 | `--kubeconfig` | `string` | `$KUBECONFIG` or default | Path to kubeconfig file |
 

--- a/hack/scripts/aks-quickstart.sh
+++ b/hack/scripts/aks-quickstart.sh
@@ -462,7 +462,6 @@ do_site_init() {
     --name "$site_name" \
     --cluster-node-cidr "$cluster_node_cidr" \
     --cluster-pod-cidr "$cluster_pod_cidr" \
-    --cluster-service-cidr "$cluster_service_cidr" \
     --node-cidr "$remote_node_cidr" \
     --pod-cidr "$remote_pod_cidr"
 

--- a/internal/metalman/lifecycle/reconciler_test.go
+++ b/internal/metalman/lifecycle/reconciler_test.go
@@ -30,7 +30,7 @@ func TestRepaveTimeout(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "node-timeout", Namespace: "default"},
 		Spec: v1alpha3.MachineSpec{
 			Operations: &v1alpha3.OperationsSpec{
-				RebootCounter:  1,
+				RebootCounter: 1,
 				RepaveCounter: 1,
 			},
 		},
@@ -83,7 +83,7 @@ func TestRepaveTimeoutNotYetExpired(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "node-not-expired", Namespace: "default"},
 		Spec: v1alpha3.MachineSpec{
 			Operations: &v1alpha3.OperationsSpec{
-				RebootCounter:  1,
+				RebootCounter: 1,
 				RepaveCounter: 1,
 			},
 		},
@@ -139,13 +139,13 @@ func TestNoOpWithoutPendingRepave(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "node-noop", Namespace: "default"},
 		Spec: v1alpha3.MachineSpec{
 			Operations: &v1alpha3.OperationsSpec{
-				RebootCounter:  1,
+				RebootCounter: 1,
 				RepaveCounter: 1,
 			},
 		},
 		Status: v1alpha3.MachineStatus{
 			Operations: &v1alpha3.OperationsStatus{
-				RebootCounter:  1,
+				RebootCounter: 1,
 				RepaveCounter: 1,
 			},
 		},
@@ -176,7 +176,7 @@ func TestNoOpWhenRepaveSucceeded(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "node-succeeded", Namespace: "default"},
 		Spec: v1alpha3.MachineSpec{
 			Operations: &v1alpha3.OperationsSpec{
-				RebootCounter:  1,
+				RebootCounter: 1,
 				RepaveCounter: 1,
 			},
 		},

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -151,7 +151,7 @@ func TestRedfishRebootCycle(t *testing.T) {
 				},
 			},
 			Operations: &v1alpha3.OperationsSpec{
-				RebootCounter:  1,
+				RebootCounter: 1,
 				RepaveCounter: 1,
 			},
 		},
@@ -389,7 +389,7 @@ func TestRedfishPowerOnTimeoutRetry(t *testing.T) {
 				},
 			},
 			Operations: &v1alpha3.OperationsSpec{
-				RebootCounter:  22,
+				RebootCounter: 22,
 				RepaveCounter: 22,
 			},
 		},
@@ -706,7 +706,7 @@ func TestRedfishExactlyOnceSemantics(t *testing.T) {
 				},
 			},
 			Operations: &v1alpha3.OperationsSpec{
-				RebootCounter:  3,
+				RebootCounter: 3,
 				RepaveCounter: 1,
 			},
 		},


### PR DESCRIPTION
## Summary

Fixes several issues encountered when running `aks-quickstart.sh create` end-to-end.

## Issues Fixed

1. **`aks-quickstart.sh` passes unknown `--cluster-service-cidr` flag** -
   The script passed `--cluster-service-cidr` to `kubectl unbounded site init`,
   but the command does not accept that flag, causing `site init` to fail with
   `Error: unknown flag: --cluster-service-cidr`.

2. **No way to build `kubectl-unbounded` without lint/test** -
   Both `machina` and `metalman` have `-build` make targets that skip
   lint and test (used in Containerfiles and when the full toolchain
   is not available). `kubectl-unbounded` was missing an equivalent target,
   so any lint failure (e.g. missing OpenSSL headers for the TPM simulator)
   blocked building the binary entirely.

3. **Stale version in CLI docs** -
   `docs/content/reference/cli.md` hardcoded "unbounded-net v1.1.2 release URL"
   as the default for `--cni-manifests`, but the source code has moved to v1.2.2
   on a different host. Replaced with a version-free description to prevent
   future drift.

## Changes

- `hack/scripts/aks-quickstart.sh` - Remove `--cluster-service-cidr` from
  the `kubectl unbounded site init` invocation.
- `Makefile` - Add `kubectl-unbounded-build` target; refactor
  `kubectl-unbounded` to depend on `test` + `kubectl-unbounded-build`.
- `docs/content/reference/cli.md` - Remove hardcoded version from
  `--cni-manifests` default column.
- `internal/metalman/` - gofumpt whitespace formatting (auto-applied).