### PR TITLE
Quickstart Remote SSH Workflow

### DIFF
--- a/.github/workflows/aks-ssh-quickstart.yaml
+++ b/.github/workflows/aks-ssh-quickstart.yaml
@@ -1,0 +1,582 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: AKS SSH Quickstart
+
+"on":
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aks-ssh-quickstart-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  azure-setup:
+    runs-on: ubuntu-latest
+    environment: azure-ci
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Azure login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Show Azure context
+        run: |
+          set -euo pipefail
+          az account show --output jsonc
+
+      - name: Build unbounded-agent
+        run: |
+          set -euo pipefail
+          mkdir -p bin workflow-artifacts/agent
+          GOOS=linux GOARCH=amd64 go build -o bin/unbounded-agent ./cmd/agent
+          tar -C bin -czf workflow-artifacts/agent/unbounded-agent-linux-amd64.tar.gz unbounded-agent
+
+      - name: Generate ephemeral SSH keypair
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/aks-ssh
+          ssh-keygen -q -t ed25519 -N '' -f .tmp/aks-ssh/id_ed25519
+          chmod 600 .tmp/aks-ssh/id_ed25519
+
+      - name: Derive run-scoped names
+        run: |
+          set -euo pipefail
+          mkdir -p workflow-artifacts/metadata
+          suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          acr_name="sshquickstart${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"
+          cat > workflow-artifacts/metadata/aks-metadata.env <<EOF
+          AKS_NAME=ssh-quickstart-${suffix}
+          AKS_RG=ssh-quickstart-${suffix}
+          ACR_NAME=${acr_name}
+          ACR_LOGIN_SERVER=${acr_name}.azurecr.io
+          MACHINA_IMAGE=${acr_name}.azurecr.io/machina:${suffix}
+          UNBOUNDED_NET_CONTROLLER_IMAGE=${acr_name}.azurecr.io/unbounded-net-controller:${suffix}
+          UNBOUNDED_NET_NODE_IMAGE=${acr_name}.azurecr.io/unbounded-net-node:${suffix}
+          SITE_NAME=remote
+          REMOTE_NODE_CIDR=10.10.100.0/24
+          REMOTE_POD_CIDR=10.245.0.0/16
+          EOF
+
+      - name: Load metadata into environment
+        run: |
+          set -euo pipefail
+          cat workflow-artifacts/metadata/aks-metadata.env >> "$GITHUB_ENV"
+
+      - name: Upload metadata artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: aks-quickstart-metadata
+          path: workflow-artifacts/metadata/aks-metadata.env
+          retention-days: 1
+
+      - name: Validate remote CIDRs against AKS defaults
+        run: |
+          set -euo pipefail
+          aks_service_cidr="10.0.0.0/16"
+          aks_pod_cidr="10.244.0.0/16"
+          if [[ "$REMOTE_NODE_CIDR" == "$aks_service_cidr" || "$REMOTE_NODE_CIDR" == "$aks_pod_cidr" ]]; then
+            printf 'REMOTE_NODE_CIDR (%s) collides with AKS default CIDR (%s or %s)\n' "$REMOTE_NODE_CIDR" "$aks_service_cidr" "$aks_pod_cidr" >&2
+            exit 1
+          fi
+          if [[ "$REMOTE_POD_CIDR" == "$aks_service_cidr" || "$REMOTE_POD_CIDR" == "$aks_pod_cidr" ]]; then
+            printf 'REMOTE_POD_CIDR (%s) collides with AKS default CIDR (%s or %s)\n' "$REMOTE_POD_CIDR" "$aks_service_cidr" "$aks_pod_cidr" >&2
+            exit 1
+          fi
+
+      - name: Create Azure resource group
+        run: |
+          set -euo pipefail
+          az group create \
+            --name "$AKS_RG" \
+            --location eastus2 \
+            --output jsonc
+
+      - name: Create temporary ACR
+        run: |
+          set -euo pipefail
+          az acr create \
+            --name "$ACR_NAME" \
+            --resource-group "$AKS_RG" \
+            --location eastus2 \
+            --sku Basic \
+            --admin-enabled true \
+            --output jsonc
+
+      - name: Log in to ACR
+        run: |
+          set -euo pipefail
+          az acr login --name "$ACR_NAME"
+
+      - name: Build and push control-plane images to ACR
+        run: |
+          set -euo pipefail
+          suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          VERSION="$suffix" \
+          GIT_COMMIT="$GITHUB_SHA" \
+          CONTAINER_ENGINE=docker \
+          CONTAINER_REGISTRY="$ACR_LOGIN_SERVER" \
+          MACHINA_IMAGE="$MACHINA_IMAGE" \
+          NET_CONTROLLER_IMAGE="$UNBOUNDED_NET_CONTROLLER_IMAGE" \
+          NET_NODE_IMAGE="$UNBOUNDED_NET_NODE_IMAGE" \
+          make image-machina-local image-net-controller-local image-net-node-local
+
+          docker push "$MACHINA_IMAGE"
+          docker push "$UNBOUNDED_NET_CONTROLLER_IMAGE"
+          docker push "$UNBOUNDED_NET_NODE_IMAGE"
+
+      - name: Build kubectl-unbounded
+        run: |
+          set -euo pipefail
+          VERSION="$GITHUB_SHA" \
+          CONTAINER_REGISTRY="$ACR_LOGIN_SERVER" \
+          MACHINA_IMAGE="$MACHINA_IMAGE" \
+          NET_CONTROLLER_IMAGE="$UNBOUNDED_NET_CONTROLLER_IMAGE" \
+          NET_NODE_IMAGE="$UNBOUNDED_NET_NODE_IMAGE" \
+          make kubectl-unbounded-build
+          sudo install -m 0755 bin/kubectl-unbounded /usr/local/bin/kubectl-unbounded
+          kubectl unbounded --help >/dev/null
+
+      - name: Create AKS cluster
+        env:
+          WORKFLOW_KUBECONFIG: ${{ github.workspace }}/.tmp/aks-quickstart.kubeconfig
+          KUBECONFIG: ${{ github.workspace }}/.tmp/aks-quickstart.kubeconfig
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp
+          rm -f "$WORKFLOW_KUBECONFIG"
+          dns_service_ip="10.0.0.10"
+          az aks create \
+            --resource-group "$AKS_RG" \
+            --name "$AKS_NAME" \
+            --location eastus2 \
+            --network-plugin none \
+            --service-cidr 10.0.0.0/16 \
+            --dns-service-ip "$dns_service_ip" \
+            --node-resource-group "${AKS_NAME}-nodes" \
+            --enable-oidc-issuer \
+            --enable-managed-identity \
+            --os-sku AzureLinux \
+            --admin-username azureuser \
+            --ssh-key-value .tmp/aks-ssh/id_ed25519.pub \
+            --nodepool-name system \
+            --node-vm-size Standard_D4ds_v6 \
+            --node-count 2 \
+            --enable-node-public-ip \
+            --output none
+
+          az aks get-credentials \
+            --resource-group "$AKS_RG" \
+            --name "$AKS_NAME" \
+            --file "$WORKFLOW_KUBECONFIG" \
+            --overwrite-existing \
+            --output none
+
+      - name: Attach temporary ACR to AKS
+        run: |
+          set -euo pipefail
+          az aks update \
+            --resource-group "$AKS_RG" \
+            --name "$AKS_NAME" \
+            --attach-acr "$ACR_NAME" \
+            --output jsonc
+
+      - name: Run site init via quickstart setup
+        env:
+          WORKFLOW_KUBECONFIG: ${{ github.workspace }}/.tmp/aks-quickstart.kubeconfig
+          KUBECONFIG: ${{ github.workspace }}/.tmp/aks-quickstart.kubeconfig
+        run: |
+          set -euo pipefail
+          bash hack/scripts/aks-quickstart.sh setup \
+            --name "$AKS_NAME" \
+            --resource-group "$AKS_RG" \
+            --site-name "$SITE_NAME" \
+            --remote-node-cidr "$REMOTE_NODE_CIDR" \
+            --remote-pod-cidr "$REMOTE_POD_CIDR"
+
+      - name: Refresh workflow kubeconfig
+        env:
+          WORKFLOW_KUBECONFIG: ${{ github.workspace }}/.tmp/aks-quickstart.kubeconfig
+        run: |
+          set -euo pipefail
+          az aks get-credentials \
+            --resource-group "$AKS_RG" \
+            --name "$AKS_NAME" \
+            --file "$WORKFLOW_KUBECONFIG" \
+            --overwrite-existing \
+            --output none
+
+      - name: Create unbounded-net ACR pull secret
+        env:
+          WORKFLOW_KUBECONFIG: ${{ github.workspace }}/.tmp/aks-quickstart.kubeconfig
+          KUBECONFIG: ${{ github.workspace }}/.tmp/aks-quickstart.kubeconfig
+        run: |
+          set -euo pipefail
+          ACR_USERNAME=$(az acr credential show --name "$ACR_NAME" --query username -o tsv)
+          ACR_PASSWORD=$(az acr credential show --name "$ACR_NAME" --query 'passwords[0].value' -o tsv)
+
+          kubectl -n unbounded-net delete secret unbounded-net-acr-pull --ignore-not-found
+          kubectl -n unbounded-net create secret docker-registry unbounded-net-acr-pull \
+            --docker-server="$ACR_LOGIN_SERVER" \
+            --docker-username="$ACR_USERNAME" \
+            --docker-password="$ACR_PASSWORD"
+
+          kubectl -n unbounded-net patch serviceaccount unbounded-net-node \
+            --type merge \
+            -p '{"imagePullSecrets":[{"name":"unbounded-net-acr-pull"}]}'
+
+      - name: Stage workflow artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p workflow-artifacts/kubeconfig workflow-artifacts/ssh
+          cp .tmp/aks-quickstart.kubeconfig workflow-artifacts/kubeconfig/aks-quickstart.kubeconfig
+          cp .tmp/aks-ssh/id_ed25519 workflow-artifacts/ssh/id_ed25519
+          cp .tmp/aks-ssh/id_ed25519.pub workflow-artifacts/ssh/id_ed25519.pub
+
+      - name: Upload kubeconfig artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: aks-kubeconfig
+          path: workflow-artifacts/kubeconfig/aks-quickstart.kubeconfig
+          retention-days: 1
+
+      - name: Upload SSH material artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: aks-ssh-material
+          path: workflow-artifacts/ssh/
+          retention-days: 1
+
+      - name: Upload agent artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: aks-unbounded-agent
+          path: workflow-artifacts/agent/unbounded-agent-linux-amd64.tar.gz
+          retention-days: 1
+
+      - name: Collect Azure setup diagnostics
+        if: failure()
+        run: |
+          set -euo pipefail
+          printf 'Azure account context:\n'
+          az account show --output jsonc || true
+
+          if [[ -z "${AKS_RG:-}" ]]; then
+            printf 'AKS_RG is not set; skipping resource-group diagnostics\n'
+            exit 0
+          fi
+
+          printf 'Azure resource group state for %s:\n' "$AKS_RG"
+          az group show --name "$AKS_RG" --output jsonc || true
+
+          if [[ "$(az group exists --name "$AKS_RG")" != "true" ]]; then
+            printf 'resource group %s does not exist; skipping activity-log lookup\n' "$AKS_RG"
+            exit 0
+          fi
+
+          printf 'Recent Azure activity log entries for %s:\n' "$AKS_RG"
+          az monitor activity-log list \
+            --resource-group "$AKS_RG" \
+            --offset 2h \
+            --max-events 20 \
+            --output table || true
+
+  proxmox-bootstrap:
+    needs:
+      - azure-setup
+    runs-on:
+      - self-hosted
+      - pve
+    env:
+      PROXMOX_STORAGE: local-lvm
+      PROXMOX_CLOUDINIT_STORAGE: local-lvm
+      PROXMOX_BRIDGE: vmbr0
+      PROXMOX_GATEWAY: 10.10.100.1
+      PROXMOX_IP_PREFIX: 10.10.100
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Verify runner dependencies
+        run: |
+          set -euo pipefail
+          for tool in kubectl jq pvesh pvesm qm ip ssh scp ssh-keygen curl cksum grep; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              printf 'missing required runner dependency: %s\n' "$tool" >&2
+              exit 1
+            fi
+          done
+
+      - name: Download kubeconfig artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aks-kubeconfig
+          path: workflow-artifacts/kubeconfig
+
+      - name: Download SSH material artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aks-ssh-material
+          path: workflow-artifacts/ssh
+
+      - name: Download metadata artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aks-quickstart-metadata
+          path: workflow-artifacts/metadata
+
+      - name: Download agent artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aks-unbounded-agent
+          path: workflow-artifacts/agent
+
+      - name: Verify branch-built agent artifact
+        run: |
+          set -euo pipefail
+          test -f workflow-artifacts/agent/unbounded-agent-linux-amd64.tar.gz
+
+      - name: Restore metadata and kubeconfig environment
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp .tmp/aks-ssh
+          cp workflow-artifacts/kubeconfig/aks-quickstart.kubeconfig .tmp/aks-quickstart.kubeconfig
+          cp workflow-artifacts/ssh/id_ed25519 .tmp/aks-ssh/id_ed25519
+          cp workflow-artifacts/ssh/id_ed25519.pub .tmp/aks-ssh/id_ed25519.pub
+          chmod 600 .tmp/aks-ssh/id_ed25519
+          cat workflow-artifacts/metadata/aks-metadata.env >> "$GITHUB_ENV"
+          echo "WORKFLOW_KUBECONFIG=$PWD/.tmp/aks-quickstart.kubeconfig" >> "$GITHUB_ENV"
+          echo "KUBECONFIG=$PWD/.tmp/aks-quickstart.kubeconfig" >> "$GITHUB_ENV"
+          echo "SSH_PRIVATE_KEY=$PWD/.tmp/aks-ssh/id_ed25519" >> "$GITHUB_ENV"
+
+      - name: Build kubectl-unbounded
+        run: |
+          set -euo pipefail
+          mkdir -p bin
+          make kubectl-unbounded-build
+          install -m 0755 bin/kubectl-unbounded /usr/local/bin/kubectl-unbounded
+          kubectl unbounded --help >/dev/null
+
+      - name: Verify Proxmox workflow environment
+        run: |
+          set -euo pipefail
+          for variable in PROXMOX_STORAGE PROXMOX_CLOUDINIT_STORAGE PROXMOX_BRIDGE PROXMOX_GATEWAY PROXMOX_IP_PREFIX; do
+            if [[ -n "${!variable:-}" ]]; then
+              printf '%s is set\n' "$variable"
+            else
+              printf '%s is unset\n' "$variable" >&2
+              exit 1
+            fi
+          done
+
+      - name: Create Proxmox VMs
+        run: |
+          set -euo pipefail
+          hack/scripts/proxmox-ssh-quickstart-vms.sh create \
+            --state-file .tmp/proxmox-vms.env \
+            --ssh-public-key .tmp/aks-ssh/id_ed25519.pub \
+            --vm-prefix "$AKS_NAME"
+
+      - name: Load Proxmox VM state
+        run: |
+          set -euo pipefail
+          hack/scripts/proxmox-ssh-quickstart-vms.sh print-env \
+            --state-file .tmp/proxmox-vms.env >> "$GITHUB_ENV"
+
+      - name: Copy agent artifact to first Proxmox VM
+        run: |
+          set -euo pipefail
+          scp -o StrictHostKeyChecking=no \
+              -o BatchMode=yes \
+              -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=10 \
+              -i "$SSH_PRIVATE_KEY" \
+              workflow-artifacts/agent/unbounded-agent-linux-amd64.tar.gz \
+              "$SSH_USERNAME@$VM1_IP:/tmp/unbounded-agent-linux-amd64.tar.gz"
+          ssh -o StrictHostKeyChecking=no \
+              -o BatchMode=yes \
+              -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=10 \
+              -i "$SSH_PRIVATE_KEY" \
+              "$SSH_USERNAME@$VM1_IP" test -f /tmp/unbounded-agent-linux-amd64.tar.gz
+
+      - name: Copy agent artifact to second Proxmox VM
+        run: |
+          set -euo pipefail
+          scp -o StrictHostKeyChecking=no \
+              -o BatchMode=yes \
+              -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=10 \
+              -i "$SSH_PRIVATE_KEY" \
+              workflow-artifacts/agent/unbounded-agent-linux-amd64.tar.gz \
+              "$SSH_USERNAME@$VM2_IP:/tmp/unbounded-agent-linux-amd64.tar.gz"
+          ssh -o StrictHostKeyChecking=no \
+              -o BatchMode=yes \
+              -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=10 \
+              -i "$SSH_PRIVATE_KEY" \
+              "$SSH_USERNAME@$VM2_IP" test -f /tmp/unbounded-agent-linux-amd64.tar.gz
+
+      - name: Bootstrap first Proxmox VM
+        run: |
+          set -euo pipefail
+          agent_url="file:///tmp/unbounded-agent-linux-amd64.tar.gz"
+          kubectl unbounded machine manual-bootstrap "${SITE_NAME}-worker-1" \
+            --kubeconfig "$WORKFLOW_KUBECONFIG" \
+            --site "$SITE_NAME" \
+            --agent-url "$agent_url" \
+            | ssh -o StrictHostKeyChecking=no \
+                  -o BatchMode=yes \
+                  -o UserKnownHostsFile=/dev/null \
+                  -o ConnectTimeout=10 \
+                  -i "$SSH_PRIVATE_KEY" \
+                  "$SSH_USERNAME@$VM1_IP" sudo -n bash
+
+      - name: Bootstrap second Proxmox VM
+        run: |
+          set -euo pipefail
+          agent_url="file:///tmp/unbounded-agent-linux-amd64.tar.gz"
+          kubectl unbounded machine manual-bootstrap "${SITE_NAME}-worker-2" \
+            --kubeconfig "$WORKFLOW_KUBECONFIG" \
+            --site "$SITE_NAME" \
+            --agent-url "$agent_url" \
+            | ssh -o StrictHostKeyChecking=no \
+                  -o BatchMode=yes \
+                  -o UserKnownHostsFile=/dev/null \
+                  -o ConnectTimeout=10 \
+                  -i "$SSH_PRIVATE_KEY" \
+                  "$SSH_USERNAME@$VM2_IP" sudo -n bash
+
+      - name: Wait for both nodes to become Ready
+        run: |
+          set -euo pipefail
+          for node in "$VM1_NAME" "$VM2_NAME"; do
+            for attempt in $(seq 1 60); do
+              if KUBECONFIG="$WORKFLOW_KUBECONFIG" kubectl get node "$node" >/dev/null 2>&1; then
+                break
+              fi
+
+              if [[ "$attempt" -eq 60 ]]; then
+                printf 'node %s did not appear after %s attempts\n' "$node" "$attempt" >&2
+                exit 1
+              fi
+
+              sleep 10
+            done
+
+            KUBECONFIG="$WORKFLOW_KUBECONFIG" kubectl wait --for=condition=Ready "node/$node" --timeout=20m
+          done
+
+      - name: Cleanup Proxmox resources
+        if: always()
+        run: |
+          set -euo pipefail
+          proxmox_state_file=.tmp/proxmox-vms.env
+          cleanup_failed=0
+          mkdir -p logs
+          cp "$proxmox_state_file" logs/proxmox-vms.env 2>/dev/null || true
+
+          destroy_proxmox_vms() {
+            if [[ ! -f "$proxmox_state_file" ]]; then
+              return 0
+            fi
+
+            if ! hack/scripts/proxmox-ssh-quickstart-vms.sh destroy --state-file "$proxmox_state_file"; then
+              printf 'failed to destroy Proxmox VMs recorded in %s\n' "$proxmox_state_file" >&2
+              cleanup_failed=1
+              return 0
+            fi
+
+            rm -f "$proxmox_state_file"
+          }
+
+          destroy_proxmox_vms
+
+          if [[ "$cleanup_failed" -ne 0 ]]; then
+            exit 1
+          fi
+
+      - name: Collect cluster diagnostics
+        if: failure()
+        run: |
+          set -euo pipefail
+          mkdir -p logs
+          cp .tmp/proxmox-vms.env logs/proxmox-vms.env 2>/dev/null || true
+          KUBECONFIG="$WORKFLOW_KUBECONFIG" kubectl get nodes -o wide > logs/nodes.txt 2>&1 || true
+          KUBECONFIG="$WORKFLOW_KUBECONFIG" kubectl get machines -o wide > logs/machines.txt 2>&1 || true
+          KUBECONFIG="$WORKFLOW_KUBECONFIG" kubectl get machines -o yaml > logs/machines.yaml 2>&1 || true
+          KUBECONFIG="$WORKFLOW_KUBECONFIG" kubectl describe machines > logs/machines-describe.txt 2>&1 || true
+          KUBECONFIG="$WORKFLOW_KUBECONFIG" kubectl -n unbounded-kube logs deploy/machina-controller > logs/machina.log 2>&1 || true
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: aks-ssh-quickstart-logs
+          path: logs/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  azure-cleanup:
+    needs:
+      - azure-setup
+      - proxmox-bootstrap
+    if: always()
+    runs-on: ubuntu-latest
+    environment: azure-ci
+    timeout-minutes: 30
+    steps:
+      - name: Download metadata artifact
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aks-quickstart-metadata
+          path: workflow-artifacts/metadata
+
+      - name: Restore cleanup metadata
+        run: |
+          set -euo pipefail
+          if [[ -f workflow-artifacts/metadata/aks-metadata.env ]]; then
+            cat workflow-artifacts/metadata/aks-metadata.env >> "$GITHUB_ENV"
+          fi
+
+      - name: Azure login
+        if: ${{ env.AKS_RG != '' }}
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Delete Azure resource group
+        if: ${{ env.AKS_RG != '' }}
+        run: |
+          set -euo pipefail
+          if [[ "$(az group exists --name "$AKS_RG")" != "true" ]]; then
+            printf 'resource group %s does not exist; skipping delete\n' "$AKS_RG"
+            exit 0
+          fi
+          az group delete --yes --no-wait --name "$AKS_RG"

--- a/.github/workflows/aks-ssh-quickstart.yaml
+++ b/.github/workflows/aks-ssh-quickstart.yaml
@@ -60,7 +60,9 @@ jobs:
           set -euo pipefail
           mkdir -p workflow-artifacts/metadata
           suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          acr_name="sshquickstart${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"
+          # ACR names must be 5-50 alphanumeric chars; truncate to stay safe.
+          acr_name="sshqs${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"
+          acr_name="${acr_name:0:50}"
           cat > workflow-artifacts/metadata/aks-metadata.env <<EOF
           AKS_NAME=ssh-quickstart-${suffix}
           AKS_RG=ssh-quickstart-${suffix}
@@ -73,6 +75,9 @@ jobs:
           REMOTE_NODE_CIDR=10.10.100.0/24
           REMOTE_POD_CIDR=10.245.0.0/16
           EOF
+          # Strip leading whitespace introduced by YAML indentation so that
+          # GITHUB_ENV sees clean NAME=value lines.
+          sed -i 's/^[[:space:]]*//' workflow-artifacts/metadata/aks-metadata.env
 
       - name: Load metadata into environment
         run: |

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ AGENT_CMD=./cmd/agent
 MACHINA_BIN=bin/machina
 MACHINA_CMD=./cmd/machina
 CONTAINER_REGISTRY ?= ghcr.io/azure
-MACHINA_IMAGE=$(CONTAINER_REGISTRY)/machina:$(VERSION)
+MACHINA_IMAGE ?= $(CONTAINER_REGISTRY)/machina:$(VERSION)
 CONTAINER_ENGINE ?= podman
 
 METALMAN_BIN=bin/metalman

--- a/cmd/kubectl-unbounded/app/assets/node-bootstrap/script.sh
+++ b/cmd/kubectl-unbounded/app/assets/node-bootstrap/script.sh
@@ -28,6 +28,10 @@ AGENT_CONFIG_EOF
 # Embedded install script
 # -----------------------------------------------------------------
 
+{{- if .AgentURLLiteral }}
+export AGENT_URL={{ .AgentURLLiteral }}
+{{- end }}
+
 bash <<'INSTALL_SCRIPT_EOF'
 {{ .InstallScript }}
 INSTALL_SCRIPT_EOF

--- a/cmd/kubectl-unbounded/app/machine_manual_bootstrap.go
+++ b/cmd/kubectl-unbounded/app/machine_manual_bootstrap.go
@@ -86,6 +86,9 @@ type manualBootstrapHandler struct {
 	// variant controls the output format. Defaults to "script".
 	variant string
 
+	// agentURL optionally overrides the embedded install script download URL.
+	agentURL string
+
 	// kubeconfigPath is the path to the kubeconfig used to contact the cluster.
 	kubeconfigPath string
 
@@ -168,6 +171,10 @@ func (h *manualBootstrapHandler) validate() error {
 
 	if _, err := parseBootstrapVariant(h.variant); err != nil {
 		return err
+	}
+
+	if h.agentURL != "" && bootstrapVariant(h.variant) != variantScript {
+		return errors.New("--agent-url is only supported with --variant script")
 	}
 
 	h.kubeconfigPath = getKubeconfigPath(h.kubeconfigPath)
@@ -285,6 +292,14 @@ type manualBootstrapTemplateData struct {
 	// InstallScript is the full install script embedded verbatim inside a
 	// heredoc that is piped to bash.
 	InstallScript string
+
+	// AgentURLLiteral optionally overrides the agent download location used by
+	// the embedded install script as a shell-safe literal.
+	AgentURLLiteral string
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
 // renderScript produces a self-contained bash script that writes the agent
@@ -300,6 +315,10 @@ func (h *manualBootstrapHandler) renderScript(cfg *provision.AgentConfig) (strin
 		MachineName:     cfg.MachineName,
 		AgentConfigJSON: string(configJSON),
 		InstallScript:   provision.UnboundedAgentInstallScript(),
+	}
+
+	if h.agentURL != "" {
+		data.AgentURLLiteral = shellQuote(h.agentURL)
 	}
 
 	t, err := template.New("node-bootstrap").Parse(manualBootstrapTemplate)
@@ -357,9 +376,7 @@ func (h *manualBootstrapHandler) renderCloudInit(cfg *provision.AgentConfig) (st
 	return buf.String(), nil
 }
 
-func machineManualBootstrapCommand() *cobra.Command {
-	handler := manualBootstrapHandler{}
-
+func newMachineManualBootstrapCommand(handler *manualBootstrapHandler) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "manual-bootstrap NAME",
 		Short: "Generate a bootstrap script or cloud-init config for provisioning a machine",
@@ -396,12 +413,19 @@ Examples:
 	cmd.Flags().StringVar(&handler.ociImage, "oci-image", "", "OCI image reference for the agent rootfs")
 	cmd.Flags().StringVar(&handler.kubernetesVersion, "kubernetes-version", "", "Override the Kubernetes version (default: auto-detected from API server)")
 	cmd.Flags().StringVar(&handler.variant, "variant", "script", "Output format: script or cloud-init")
+	cmd.Flags().StringVar(&handler.agentURL, "agent-url", "", "Override URL used by the embedded agent install script")
 
 	if err := cmd.MarkFlagRequired("site"); err != nil {
 		panic(err)
 	}
 
 	return cmd
+}
+
+func machineManualBootstrapCommand() *cobra.Command {
+	handler := &manualBootstrapHandler{}
+
+	return newMachineManualBootstrapCommand(handler)
 }
 
 // resolveBootstrapToken tries to find a bootstrap token for the given site.

--- a/cmd/kubectl-unbounded/app/machine_manual_bootstrap_test.go
+++ b/cmd/kubectl-unbounded/app/machine_manual_bootstrap_test.go
@@ -105,6 +105,17 @@ func TestManualBootstrapHandler_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid: agent-url with cloud-init variant",
+			handler: manualBootstrapHandler{
+				siteName:       "dc1",
+				machineName:    "my-node",
+				kubeconfigPath: kubeconfigPath,
+				variant:        "cloud-init",
+				agentURL:       "file:///tmp/unbounded-agent-linux-amd64.tar.gz",
+			},
+			expectErr: "--agent-url is only supported with --variant script",
+		},
+		{
 			name: "valid: variant defaults to script when empty",
 			handler: manualBootstrapHandler{
 				siteName:       "dc1",
@@ -326,6 +337,91 @@ func TestManualBootstrapHandler_RenderScript(t *testing.T) {
 	require.NotContains(t, script, "unbounded-agent-uninstall.sh")
 }
 
+func TestManualBootstrapHandler_RenderScript_WithAgentURL(t *testing.T) {
+	t.Parallel()
+
+	h := &manualBootstrapHandler{
+		logger: discardLogger(),
+	}
+
+	cfg := &provision.AgentConfig{
+		MachineName: "test-node",
+		Cluster: provision.AgentClusterConfig{
+			CaCertBase64: "dGVzdA==",
+			ClusterDNS:   "10.0.0.10",
+			Version:      "v1.30.0",
+		},
+		Kubelet: provision.AgentKubeletConfig{
+			ApiServer:      "https://api-server:6443",
+			BootstrapToken: "abc123.0123456789abcdef",
+		},
+	}
+
+	h.agentURL = "file:///tmp/unbounded-agent-linux-amd64.tar.gz"
+
+	script, err := h.renderScript(cfg)
+	require.NoError(t, err)
+	agentURLExport := "export AGENT_URL='file:///tmp/unbounded-agent-linux-amd64.tar.gz'"
+	installScript := "bash <<'INSTALL_SCRIPT_EOF'"
+	require.Contains(t, script, agentURLExport)
+	require.Contains(t, script, installScript)
+	require.Less(t, strings.Index(script, agentURLExport), strings.Index(script, installScript))
+}
+
+func TestManualBootstrapHandler_RenderScript_WithUnsafeAgentURL(t *testing.T) {
+	t.Parallel()
+
+	h := &manualBootstrapHandler{
+		logger:   discardLogger(),
+		agentURL: `https://example.test/download?name="agent"&cmd=$(touch /tmp/pwned)`,
+	}
+
+	cfg := &provision.AgentConfig{
+		MachineName: "test-node",
+		Cluster: provision.AgentClusterConfig{
+			CaCertBase64: "dGVzdA==",
+			ClusterDNS:   "10.0.0.10",
+			Version:      "v1.30.0",
+		},
+		Kubelet: provision.AgentKubeletConfig{
+			ApiServer:      "https://api-server:6443",
+			BootstrapToken: "abc123.0123456789abcdef",
+		},
+	}
+
+	script, err := h.renderScript(cfg)
+	require.NoError(t, err)
+	require.Contains(t, script, `export AGENT_URL='https://example.test/download?name="agent"&cmd=$(touch /tmp/pwned)'`)
+	require.NotContains(t, script, `export AGENT_URL="https://example.test/download?name="agent"&cmd=$(touch /tmp/pwned)"`)
+	installScript := "bash <<'INSTALL_SCRIPT_EOF'"
+	require.Less(t, strings.Index(script, "export AGENT_URL='https://example.test/download?name=\"agent\"&cmd=$(touch /tmp/pwned)'"), strings.Index(script, installScript))
+}
+
+func TestManualBootstrapHandler_RenderScript_WithoutAgentURL(t *testing.T) {
+	t.Parallel()
+
+	h := &manualBootstrapHandler{
+		logger: discardLogger(),
+	}
+
+	cfg := &provision.AgentConfig{
+		MachineName: "test-node",
+		Cluster: provision.AgentClusterConfig{
+			CaCertBase64: "dGVzdA==",
+			ClusterDNS:   "10.0.0.10",
+			Version:      "v1.30.0",
+		},
+		Kubelet: provision.AgentKubeletConfig{
+			ApiServer:      "https://api-server:6443",
+			BootstrapToken: "abc123.0123456789abcdef",
+		},
+	}
+
+	script, err := h.renderScript(cfg)
+	require.NoError(t, err)
+	require.NotContains(t, script, "export AGENT_URL=")
+}
+
 func TestManualBootstrapHandler_RenderCloudInit(t *testing.T) {
 	t.Parallel()
 
@@ -414,6 +510,34 @@ func TestManualBootstrapHandler_RenderCloudInit(t *testing.T) {
 // ---------------------------------------------------------------------------
 // execute() integration test
 // ---------------------------------------------------------------------------
+
+func TestManualBootstrapHandler_Execute_WithAgentURL(t *testing.T) {
+	t.Parallel()
+
+	kubeCli := newFakeCluster(t, "dc1")
+	var buf bytes.Buffer
+	kubeconfigPath := writeTempKubeconfig(t)
+
+	h := &manualBootstrapHandler{
+		out:            &buf,
+		kubeCli:        kubeCli,
+		kubeConfig:     &rest.Config{Host: "https://my-api-server:6443"},
+		kubeconfigPath: kubeconfigPath,
+		logger:         discardLogger(),
+	}
+
+	cmd := newMachineManualBootstrapCommand(h)
+	cmd.SetArgs([]string{
+		"--site", "dc1",
+		"--kubeconfig", kubeconfigPath,
+		"--agent-url", "file:///tmp/unbounded-agent-linux-amd64.tar.gz",
+		"node-1",
+	})
+
+	err := cmd.ExecuteContext(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "export AGENT_URL='file:///tmp/unbounded-agent-linux-amd64.tar.gz'")
+}
 
 func TestManualBootstrapHandler_Execute(t *testing.T) {
 	t.Parallel()

--- a/hack/scripts/proxmox-ssh-quickstart-vms.sh
+++ b/hack/scripts/proxmox-ssh-quickstart-vms.sh
@@ -1,0 +1,888 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# These host-specific defaults are intentionally explicit so this helper does
+# not depend on hidden runner state.
+readonly REQUIRED_VALUE="__REQUIRED__"
+readonly SSH_USERNAME="ubuntu"
+readonly PROXMOX_IMAGE_FILE="${PROXMOX_IMAGE_FILE:-}"
+readonly PROXMOX_STORAGE="${PROXMOX_STORAGE:-$REQUIRED_VALUE}"
+readonly PROXMOX_CLOUDINIT_STORAGE="${PROXMOX_CLOUDINIT_STORAGE:-${PROXMOX_STORAGE}}"
+readonly PROXMOX_BRIDGE="${PROXMOX_BRIDGE:-vmbr0}"
+readonly PROXMOX_GATEWAY="${PROXMOX_GATEWAY:-$REQUIRED_VALUE}"
+readonly PROXMOX_IP_PREFIX="${PROXMOX_IP_PREFIX:-$REQUIRED_VALUE}"
+readonly PROXMOX_IP_CIDR_SUFFIX="${PROXMOX_IP_CIDR_SUFFIX:-24}"
+readonly PROXMOX_CPU_CORES="${PROXMOX_CPU_CORES:-4}"
+readonly PROXMOX_MEMORY_MB="${PROXMOX_MEMORY_MB:-8192}"
+readonly PROXMOX_DISK_GB="${PROXMOX_DISK_GB:-32}"
+readonly PROXMOX_SSH_TIMEOUT_SECONDS="${PROXMOX_SSH_TIMEOUT_SECONDS:-300}"
+readonly PROXMOX_SSH_RETRY_SECONDS="${PROXMOX_SSH_RETRY_SECONDS:-5}"
+readonly PROXMOX_IMAGE_BASE_URL="${PROXMOX_IMAGE_BASE_URL:-https://cloud-images.ubuntu.com/minimal/releases/noble/release}"
+readonly PROXMOX_IMAGE_CACHE_DIR="${PROXMOX_IMAGE_CACHE_DIR:-${HOME}/.cache/unbounded/proxmox}"
+readonly PROXMOX_IMAGE_ARCH_RAW="$(uname -m)"
+
+case "$PROXMOX_IMAGE_ARCH_RAW" in
+  x86_64)
+    readonly PROXMOX_IMAGE_ARCH="amd64"
+    ;;
+  aarch64|arm64)
+    readonly PROXMOX_IMAGE_ARCH="arm64"
+    ;;
+  *)
+    die "unsupported architecture for default Proxmox image download: ${PROXMOX_IMAGE_ARCH_RAW}"
+    ;;
+esac
+
+readonly PROXMOX_DEFAULT_IMAGE_NAME="ubuntu-24.04-minimal-cloudimg-${PROXMOX_IMAGE_ARCH}.img"
+readonly PROXMOX_DEFAULT_IMAGE_URL="${PROXMOX_IMAGE_BASE_URL}/${PROXMOX_DEFAULT_IMAGE_NAME}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  proxmox-ssh-quickstart-vms.sh create --state-file PATH --ssh-public-key PATH --vm-prefix PREFIX
+  proxmox-ssh-quickstart-vms.sh print-env --state-file PATH
+  proxmox-ssh-quickstart-vms.sh destroy --state-file PATH
+
+Required environment for create:
+  PROXMOX_STORAGE           Proxmox storage for the root disk
+  PROXMOX_GATEWAY           IPv4 gateway for the VM network
+  PROXMOX_IP_PREFIX         First three octets for deterministic VM IPs (example: 192.168.50)
+
+Optional environment for create:
+  PROXMOX_IMAGE_FILE        Local Ubuntu cloud image path to import with qm importdisk
+                             (default: cached Ubuntu 24.04 minimal cloud image)
+  PROXMOX_CLOUDINIT_STORAGE Proxmox storage for the cloud-init disk (defaults to PROXMOX_STORAGE)
+  PROXMOX_BRIDGE            Proxmox bridge for net0 (default: vmbr0)
+  PROXMOX_IP_CIDR_SUFFIX    Static IPv4 prefix length (default: 24)
+  PROXMOX_CPU_CORES         VM CPU cores (default: 4)
+  PROXMOX_MEMORY_MB         VM memory in MiB (default: 8192)
+  PROXMOX_DISK_GB           Root disk size after import (default: 32)
+  PROXMOX_SSH_TIMEOUT_SECONDS  SSH readiness timeout in seconds (default: 300)
+  PROXMOX_SSH_RETRY_SECONDS    Delay between SSH retries in seconds (default: 5)
+  PROXMOX_IMAGE_BASE_URL    Base URL for the default Ubuntu cloud image download
+  PROXMOX_IMAGE_CACHE_DIR   Cache directory for downloaded cloud images
+EOF
+  return 1
+}
+
+STATE_FILE=""
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  local name="$1"
+  command -v "$name" >/dev/null 2>&1 || die "required command not found: ${name}"
+}
+
+require_file() {
+  local path="$1"
+  local label="$2"
+  [[ -r "$path" ]] || die "${label} does not exist or is not readable: ${path}"
+}
+
+require_value() {
+  local value="$1"
+  local label="$2"
+  [[ "$value" != "$REQUIRED_VALUE" ]] || die "set ${label} before running create"
+}
+
+note() {
+  printf 'info: %s\n' "$*" >&2
+}
+
+validate_ipv4_address() {
+  local value="$1"
+  local octet=""
+
+  [[ "$value" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || return 1
+  IFS='.' read -r -a octets <<<"$value"
+  for octet in "${octets[@]}"; do
+    (( octet >= 0 && octet <= 255 )) || return 1
+  done
+}
+
+validate_ipv4_prefix() {
+  local value="$1"
+  local octet=""
+
+  [[ "$value" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){2}$ ]] || return 1
+  IFS='.' read -r -a octets <<<"$value"
+  for octet in "${octets[@]}"; do
+    (( octet >= 0 && octet <= 255 )) || return 1
+  done
+}
+
+validate_integer_range() {
+  local value="$1"
+  local label="$2"
+  local minimum="$3"
+  local maximum="$4"
+
+  [[ "$value" =~ ^[0-9]+$ ]] || die "${label} must be an integer"
+  (( value >= minimum && value <= maximum )) || die "${label} must be between ${minimum} and ${maximum}"
+}
+
+validate_positive_integer() {
+  local value="$1"
+  local label="$2"
+
+  [[ "$value" =~ ^[0-9]+$ ]] || die "${label} must be an integer"
+  (( value > 0 )) || die "${label} must be greater than zero"
+}
+
+validate_state_line() {
+  local key="$1"
+  local value="$2"
+
+  case "$key" in
+    VM1_NAME|VM2_NAME)
+      [[ "$value" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]*$ ]] || die "malformed state file ${STATE_FILE}: invalid ${key}"
+      ;;
+    VM1_IP|VM2_IP)
+      validate_ipv4_address "$value" || die "malformed state file ${STATE_FILE}: invalid ${key}"
+      ;;
+    VM1_VMID|VM2_VMID)
+      [[ "$value" =~ ^[1-9][0-9]*$ ]] || die "malformed state file ${STATE_FILE}: invalid ${key}"
+      ;;
+    SSH_USERNAME)
+      [[ "$value" =~ ^[a-z_][a-z0-9_-]*$ ]] || die "malformed state file ${STATE_FILE}: invalid ${key}"
+      ;;
+    *)
+      die "malformed state file ${STATE_FILE}: unexpected key ${key}"
+      ;;
+  esac
+}
+
+require_nonempty_state_value() {
+  local key="$1"
+  local value="$2"
+
+  [[ -n "$value" ]] || die "malformed state file ${STATE_FILE}: ${key} must not be empty"
+}
+
+load_destroy_state() {
+  local line=""
+  local key=""
+  local value=""
+  local -A seen_keys=()
+  local saw_vm1_name=0
+  local saw_vm1_vmid=0
+  local saw_vm2_name=0
+  local saw_vm2_vmid=0
+  local loaded_vm1_name=""
+  local vm1_vmid_value=""
+  local loaded_vm2_name=""
+  local vm2_vmid_value=""
+
+  require_file "$STATE_FILE" "--state-file"
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -n "$line" ]] || continue
+    [[ "$line" == *=* ]] || die "malformed state file ${STATE_FILE}: expected KEY=VALUE lines"
+    key="${line%%=*}"
+    value="${line#*=}"
+    validate_state_line "$key" "$value"
+    if [[ -n "${seen_keys[$key]+x}" ]]; then
+      die "malformed state file ${STATE_FILE}: duplicate key ${key}"
+    fi
+    seen_keys[$key]=1
+    case "$key" in
+      VM1_NAME)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm1_name=1
+        loaded_vm1_name="$value"
+        ;;
+      VM1_VMID)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm1_vmid=1
+        vm1_vmid_value="$value"
+        ;;
+      VM2_NAME)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm2_name=1
+        loaded_vm2_name="$value"
+        ;;
+      VM2_VMID)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm2_vmid=1
+        vm2_vmid_value="$value"
+        ;;
+    esac
+  done <"$STATE_FILE"
+
+  (( saw_vm1_name == 1 )) || die "malformed state file ${STATE_FILE}: missing VM1_NAME"
+  (( saw_vm1_vmid == 1 )) || die "malformed state file ${STATE_FILE}: missing VM1_VMID"
+  if (( saw_vm2_name != saw_vm2_vmid )); then
+    die "malformed state file ${STATE_FILE}: VM2_NAME and VM2_VMID must either both be present or both be absent"
+  fi
+  if (( saw_vm2_vmid == 1 )); then
+    [[ "$vm1_vmid_value" != "$vm2_vmid_value" ]] || die "malformed state file ${STATE_FILE}: VM1_VMID and VM2_VMID must not be the same"
+  fi
+
+  VM1_NAME="$loaded_vm1_name"
+  VM1_VMID="$vm1_vmid_value"
+  VM2_NAME="$loaded_vm2_name"
+  VM2_VMID="$vm2_vmid_value"
+}
+
+write_destroy_state_file() {
+  local vm1_name="$1"
+  local vm1_vmid="$2"
+  local vm2_name="$3"
+  local vm2_vmid="$4"
+  local state_dir
+  local state_base
+  local state_tmp
+
+  state_dir="$(dirname "$STATE_FILE")"
+  state_base="$(basename "$STATE_FILE")"
+  mkdir -p "$state_dir"
+  state_tmp="$(mktemp "${state_dir}/.${state_base}.tmp.XXXXXX")"
+  {
+    printf 'VM1_NAME=%s\n' "$vm1_name"
+    printf 'VM1_VMID=%s\n' "$vm1_vmid"
+    if [[ -n "$vm2_name" && -n "$vm2_vmid" ]]; then
+      printf 'VM2_NAME=%s\n' "$vm2_name"
+      printf 'VM2_VMID=%s\n' "$vm2_vmid"
+    fi
+  } >"$state_tmp"
+  mv "$state_tmp" "$STATE_FILE"
+}
+
+print_validated_state() {
+  local line=""
+  local key=""
+  local value=""
+  local output=()
+  local missing_keys=()
+  local -A seen_keys=()
+  local saw_vm1_name=0
+  local saw_vm1_vmid=0
+  local saw_vm1_ip=0
+  local saw_vm2_name=0
+  local saw_vm2_vmid=0
+  local saw_vm2_ip=0
+  local saw_ssh_username=0
+  local vm1_vmid_value=""
+  local vm2_vmid_value=""
+
+  require_file "$STATE_FILE" "--state-file"
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -n "$line" ]] || continue
+    [[ "$line" == *=* ]] || die "malformed state file ${STATE_FILE}: expected KEY=VALUE lines"
+    key="${line%%=*}"
+    value="${line#*=}"
+    validate_state_line "$key" "$value"
+    if [[ -n "${seen_keys[$key]+x}" ]]; then
+      die "malformed state file ${STATE_FILE}: duplicate key ${key}"
+    fi
+    seen_keys[$key]=1
+    case "$key" in
+      VM1_NAME)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm1_name=1
+        ;;
+      VM1_VMID)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm1_vmid=1
+        vm1_vmid_value="$value"
+        ;;
+      VM1_IP)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm1_ip=1
+        ;;
+      VM2_NAME)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm2_name=1
+        ;;
+      VM2_VMID)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm2_vmid=1
+        vm2_vmid_value="$value"
+        ;;
+      VM2_IP)
+        require_nonempty_state_value "$key" "$value"
+        saw_vm2_ip=1
+        ;;
+      SSH_USERNAME)
+        require_nonempty_state_value "$key" "$value"
+        saw_ssh_username=1
+        ;;
+    esac
+    output+=("${key}=${value}")
+  done <"$STATE_FILE"
+
+  (( saw_vm1_name == 1 )) || missing_keys+=("VM1_NAME")
+  (( saw_vm1_vmid == 1 )) || missing_keys+=("VM1_VMID")
+  (( saw_vm1_ip == 1 )) || missing_keys+=("VM1_IP")
+  (( saw_vm2_name == 1 )) || missing_keys+=("VM2_NAME")
+  (( saw_vm2_vmid == 1 )) || missing_keys+=("VM2_VMID")
+  (( saw_vm2_ip == 1 )) || missing_keys+=("VM2_IP")
+  (( saw_ssh_username == 1 )) || missing_keys+=("SSH_USERNAME")
+
+  (( ${#missing_keys[@]} == 0 )) || die "malformed state file ${STATE_FILE}: missing required keys: ${missing_keys[*]}"
+  [[ "$vm1_vmid_value" != "$vm2_vmid_value" ]] || die "malformed state file ${STATE_FILE}: VM1_VMID and VM2_VMID must not be the same"
+
+  printf '%s\n' "${output[@]}"
+}
+
+destroy_vm() {
+  local vm_label="$1"
+  local vmid="$2"
+  local expected_name="$3"
+  local vm_config=""
+  local qm_list_output=""
+
+  if ! vm_config="$(qm config "$vmid" 2>/dev/null)"; then
+    if ! qm_list_output="$(qm list 2>/dev/null)"; then
+      printf '%s\n' "qm list failed while checking ${vm_label} (${vmid}) from state file ${STATE_FILE}" >&2
+      return 1
+    fi
+    if ! grep -qE "^${vmid}[[:space:]]" <<<"$qm_list_output"; then
+      note "skipping ${vm_label}: VM ${vmid} does not exist on this Proxmox host"
+      return 0
+    fi
+    printf '%s\n' "qm config failed for ${vm_label} (${vmid}) from state file ${STATE_FILE}" >&2
+    return 1
+  fi
+
+  grep -qxF "name: ${expected_name}" <<<"$vm_config" || {
+    printf '%s\n' "recorded ${vm_label} (${vmid}) does not match expected VM name ${expected_name} in state file ${STATE_FILE}" >&2
+    return 1
+  }
+
+  if ! qm stop "$vmid" >/dev/null 2>&1; then
+    note "qm stop failed for ${vm_label} (${vmid}); continuing to destroy"
+  fi
+
+  if ! qm destroy "$vmid" --destroy-unreferenced-disks 1 >/dev/null 2>&1; then
+    printf '%s\n' "qm destroy failed for ${vm_label} (${vmid}) from state file ${STATE_FILE}" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+sanitize_vm_prefix() {
+  local value="${1,,}"
+
+  value="${value//[^a-z0-9-]/-}"
+  value="${value#-}"
+  value="${value%-}"
+  value="${value:0:54}"
+  value="${value%-}"
+  [[ -n "$value" ]] || die "--vm-prefix must include at least one letter or digit"
+  printf '%s\n' "$value"
+}
+
+derive_ip_octet() {
+  local prefix="$1"
+  local offset="$2"
+  local checksum
+
+  checksum="$(printf '%s' "$prefix" | cksum)"
+  checksum="${checksum%% *}"
+  printf '%s\n' "$((checksum % 180 + 20 + offset))"
+}
+
+ipv4_to_int() {
+  local value="$1"
+  local o1=""
+  local o2=""
+  local o3=""
+  local o4=""
+
+  IFS='.' read -r o1 o2 o3 o4 <<<"$value"
+  printf '%s\n' "$((((o1 << 24) | (o2 << 16) | (o3 << 8) | o4)))"
+}
+
+cidr_mask() {
+  local suffix="$1"
+
+  if (( suffix == 0 )); then
+    printf '0\n'
+    return 0
+  fi
+
+  printf '%s\n' "$((((0xFFFFFFFF << (32 - suffix)) & 0xFFFFFFFF)))"
+}
+
+validate_gateway_matches_vm_subnet() {
+  local gateway_ip="$1"
+  local candidate_vm_ip="$2"
+  local mask=""
+  local gateway_int=""
+  local vm_int=""
+
+  mask="$(cidr_mask "$PROXMOX_IP_CIDR_SUFFIX")"
+  gateway_int="$(ipv4_to_int "$gateway_ip")"
+  vm_int="$(ipv4_to_int "$candidate_vm_ip")"
+
+  (( (gateway_int & mask) == (vm_int & mask) )) || die "PROXMOX_GATEWAY must be within the derived VM subnet (${candidate_vm_ip}/${PROXMOX_IP_CIDR_SUFFIX})"
+  [[ "$gateway_ip" != "$candidate_vm_ip" ]] || die "PROXMOX_GATEWAY must not match the derived VM IP (${candidate_vm_ip})"
+}
+
+validate_proxmox_storage() {
+  local storage_name="$1"
+  local label="$2"
+
+  pvesm status --storage "$storage_name" >/dev/null 2>&1 || die "${label} does not exist on this Proxmox host: ${storage_name}"
+}
+
+validate_proxmox_bridge() {
+  ip link show "$PROXMOX_BRIDGE" >/dev/null 2>&1 || die "PROXMOX_BRIDGE does not exist on this Proxmox host: ${PROXMOX_BRIDGE}"
+}
+
+private_key_path_from_public_key() {
+  local public_key_path="$1"
+
+  [[ "$public_key_path" == *.pub ]] || die "--ssh-public-key must end with .pub so the matching private key can be derived for SSH readiness checks"
+  printf '%s\n' "${public_key_path%.pub}"
+}
+
+next_vmid() {
+  local value=""
+
+  if ! value="$(pvesh get /cluster/nextid)"; then
+    printf 'failed to allocate next Proxmox VMID\n' >&2
+    return 1
+  fi
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'pvesh returned an invalid Proxmox VMID: %s\n' "$value" >&2
+    return 1
+  fi
+  printf '%s\n' "$value"
+}
+
+resolve_proxmox_image_file() {
+  local image_file="$PROXMOX_IMAGE_FILE"
+
+  if [[ -n "$image_file" ]]; then
+    require_file "$image_file" "PROXMOX_IMAGE_FILE"
+    printf '%s\n' "$image_file"
+    return 0
+  fi
+
+  image_file="${PROXMOX_IMAGE_CACHE_DIR}/${PROXMOX_DEFAULT_IMAGE_NAME}"
+  mkdir -p "$PROXMOX_IMAGE_CACHE_DIR"
+
+  if [[ ! -f "$image_file" ]]; then
+    note "downloading default Ubuntu cloud image to ${image_file}"
+    curl -L -o "$image_file" "$PROXMOX_DEFAULT_IMAGE_URL"
+  else
+    note "using cached Ubuntu cloud image ${image_file}"
+  fi
+
+  require_file "$image_file" "resolved Proxmox image file"
+  printf '%s\n' "$image_file"
+}
+
+ensure_vmid_available() {
+  local vmid="$1"
+  local label="$2"
+  local qm_list_output=""
+
+  if qm config "$vmid" >/dev/null 2>&1; then
+    die "${label} ${vmid} already exists on this Proxmox host"
+  fi
+  if ! qm_list_output="$(qm list 2>/dev/null)"; then
+    die "${label} ${vmid} could not be inspected on this Proxmox host"
+  fi
+  if grep -qE "^${vmid}[[:space:]]" <<<"$qm_list_output"; then
+    die "${label} ${vmid} could not be inspected on this Proxmox host"
+  fi
+}
+
+cleanup_failed_create() {
+  local vm1_name="$1"
+  local vm1_vmid="$2"
+  local vm1_ip="$3"
+  local vm2_name="$4"
+  local vm2_vmid="$5"
+  local vm2_ip="$6"
+
+  if [[ -n "$vm1_vmid" ]]; then
+    if ! destroy_vm "VM1_VMID" "$vm1_vmid" "$vm1_name"; then
+      if [[ -n "$vm2_vmid" && "$vm2_vmid" != "$vm1_vmid" ]]; then
+        write_destroy_state_file "$vm1_name" "$vm1_vmid" "$vm2_name" "$vm2_vmid"
+      else
+        write_destroy_state_file "$vm1_name" "$vm1_vmid" "" ""
+      fi
+      die "failed to clean up partially created Proxmox VM ${vm1_name} (${vm1_vmid}); state left in ${STATE_FILE}"
+    fi
+    rm -f "$STATE_FILE"
+  fi
+}
+
+existing_state_mentions_ip() {
+  local candidate_ip="$1"
+
+  [[ -f "$STATE_FILE" ]] || return 1
+  grep -qF "$candidate_ip" "$STATE_FILE"
+}
+
+proxmox_config_mentions_ip() {
+  local candidate_ip="$1"
+  local vmid=""
+  local _rest=""
+  local qm_list_output=""
+
+  if ! qm_list_output="$(qm list)"; then
+    die "failed to list existing Proxmox VMs while checking candidate IP collisions"
+  fi
+
+  while read -r vmid _rest; do
+    [[ -n "$vmid" ]] || continue
+    [[ "$vmid" == "VMID" ]] && continue
+    if ! vm_config="$(qm config "$vmid" 2>/dev/null)"; then
+      die "failed to inspect existing Proxmox VM ${vmid} while checking candidate IP collisions"
+    fi
+    if grep -qE "^ipconfig0:.*ip=${candidate_ip}(/|,)" <<<"$vm_config"; then
+      return 0
+    fi
+  done <<<"$qm_list_output"
+
+  return 1
+}
+
+guard_candidate_ip() {
+  local candidate_ip="$1"
+  local label="$2"
+
+  if existing_state_mentions_ip "$candidate_ip"; then
+    die "${label} ${candidate_ip} already appears in the current state file ${STATE_FILE}"
+  fi
+
+  if proxmox_config_mentions_ip "$candidate_ip"; then
+    die "${label} ${candidate_ip} already appears in an existing Proxmox VM ipconfig0"
+  fi
+}
+
+validate_create_environment() {
+  require_command pvesh
+  require_command pvesm
+  require_command qm
+  require_command ip
+  require_command ssh
+  require_command curl
+  require_command cksum
+  require_command grep
+  require_file "$1" "--ssh-public-key"
+  require_value "$PROXMOX_STORAGE" "PROXMOX_STORAGE"
+  require_value "$PROXMOX_GATEWAY" "PROXMOX_GATEWAY"
+  require_value "$PROXMOX_IP_PREFIX" "PROXMOX_IP_PREFIX"
+  validate_ipv4_address "$PROXMOX_GATEWAY" || die "PROXMOX_GATEWAY must be a valid IPv4 address"
+  validate_ipv4_prefix "$PROXMOX_IP_PREFIX" || die "PROXMOX_IP_PREFIX must be three IPv4 octets such as 192.168.50"
+  validate_integer_range "$PROXMOX_IP_CIDR_SUFFIX" "PROXMOX_IP_CIDR_SUFFIX" 1 32
+  validate_positive_integer "$PROXMOX_CPU_CORES" "PROXMOX_CPU_CORES"
+  validate_positive_integer "$PROXMOX_MEMORY_MB" "PROXMOX_MEMORY_MB"
+  validate_positive_integer "$PROXMOX_DISK_GB" "PROXMOX_DISK_GB"
+  validate_positive_integer "$PROXMOX_SSH_TIMEOUT_SECONDS" "PROXMOX_SSH_TIMEOUT_SECONDS"
+  validate_positive_integer "$PROXMOX_SSH_RETRY_SECONDS" "PROXMOX_SSH_RETRY_SECONDS"
+  (( PROXMOX_SSH_TIMEOUT_SECONDS >= PROXMOX_SSH_RETRY_SECONDS )) || die "PROXMOX_SSH_TIMEOUT_SECONDS must be greater than or equal to PROXMOX_SSH_RETRY_SECONDS"
+  validate_proxmox_storage "$PROXMOX_STORAGE" "PROXMOX_STORAGE"
+  validate_proxmox_storage "$PROXMOX_CLOUDINIT_STORAGE" "PROXMOX_CLOUDINIT_STORAGE"
+  validate_proxmox_bridge
+
+  note "create expects an Ubuntu cloud image with cloud-init support and SSH user ${SSH_USERNAME}"
+}
+
+preflight_state_file_path() {
+  local state_dir
+  local state_base
+  local state_tmp
+
+  state_dir="$(dirname "$STATE_FILE")"
+  state_base="$(basename "$STATE_FILE")"
+  mkdir -p "$state_dir"
+  state_tmp="$(mktemp "${state_dir}/.${state_base}.preflight.XXXXXX")" || die "cannot create state file in ${state_dir}"
+  rm -f "$state_tmp"
+}
+
+create_vm() {
+  local vmid="$1"
+  local vm_name="$2"
+
+  qm create "$vmid" \
+    --name "$vm_name" \
+    --ostype l26 \
+    --cores "$PROXMOX_CPU_CORES" \
+    --memory "$PROXMOX_MEMORY_MB" \
+    --net0 "virtio,bridge=${PROXMOX_BRIDGE}"
+}
+
+configure_vm() {
+  local vmid="$1"
+  local vm_name="$2"
+  local vm_ip_cidr="$3"
+  local ssh_public_key="$4"
+  local image_file="$5"
+
+  qm importdisk "$vmid" "$image_file" "$PROXMOX_STORAGE" --format qcow2
+  qm set "$vmid" --scsihw virtio-scsi-single --scsi0 "${PROXMOX_STORAGE}:vm-${vmid}-disk-0"
+  qm set "$vmid" --ide2 "${PROXMOX_CLOUDINIT_STORAGE}:cloudinit"
+  qm set "$vmid" --boot order=scsi0
+  qm set "$vmid" --serial0 socket --vga serial0
+  qm set "$vmid" --agent enabled=1
+  qm set "$vmid" --ciuser "$SSH_USERNAME" --sshkeys "$ssh_public_key"
+  qm set "$vmid" --ipconfig0 "ip=${vm_ip_cidr},gw=${PROXMOX_GATEWAY}"
+  qm resize "$vmid" scsi0 "${PROXMOX_DISK_GB}G"
+  qm start "$vmid"
+}
+
+wait_for_ssh() {
+  local vm_name="$1"
+  local vm_ip="$2"
+  local ssh_private_key="$3"
+  local ssh_deadline
+
+  ssh_deadline="$((SECONDS + PROXMOX_SSH_TIMEOUT_SECONDS))"
+  while (( SECONDS < ssh_deadline )); do
+    if ssh -o BatchMode=yes \
+      -o StrictHostKeyChecking=no \
+      -o UserKnownHostsFile=/dev/null \
+      -o ConnectTimeout=5 \
+      -i "$ssh_private_key" \
+      "${SSH_USERNAME}@${vm_ip}" true >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$PROXMOX_SSH_RETRY_SECONDS"
+  done
+
+  die "timed out waiting for SSH on ${vm_name} (${vm_ip})"
+}
+
+wait_for_guest_readiness() {
+  local vm_name="$1"
+  local vm_ip="$2"
+  local ssh_private_key="$3"
+  local ssh_deadline
+
+  ssh_deadline="$((SECONDS + PROXMOX_SSH_TIMEOUT_SECONDS))"
+  while (( SECONDS < ssh_deadline )); do
+    if ssh -o BatchMode=yes \
+      -o StrictHostKeyChecking=no \
+      -o UserKnownHostsFile=/dev/null \
+      -o ConnectTimeout=5 \
+      -i "$ssh_private_key" \
+      "${SSH_USERNAME}@${vm_ip}" \
+      'cloud-init status --wait >/dev/null 2>&1 || ! pgrep -x apt-get >/dev/null 2>&1' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$PROXMOX_SSH_RETRY_SECONDS"
+  done
+
+  die "timed out waiting for guest readiness on ${vm_name} (${vm_ip})"
+}
+
+write_state_file() {
+  local vm1_name="$1"
+  local vm1_vmid="$2"
+  local vm1_ip="$3"
+  local vm2_name="$4"
+  local vm2_vmid="$5"
+  local vm2_ip="$6"
+  local state_dir
+  local state_base
+  local state_tmp
+
+  state_dir="$(dirname "$STATE_FILE")"
+  state_base="$(basename "$STATE_FILE")"
+  mkdir -p "$state_dir"
+  state_tmp="$(mktemp "${state_dir}/.${state_base}.tmp.XXXXXX")"
+  {
+    printf 'VM1_NAME=%s\n' "$vm1_name"
+    printf 'VM1_VMID=%s\n' "$vm1_vmid"
+    printf 'VM1_IP=%s\n' "$vm1_ip"
+    printf 'VM2_NAME=%s\n' "$vm2_name"
+    printf 'VM2_VMID=%s\n' "$vm2_vmid"
+    printf 'VM2_IP=%s\n' "$vm2_ip"
+    printf 'SSH_USERNAME=%s\n' "$SSH_USERNAME"
+  } >"$state_tmp"
+  mv "$state_tmp" "$STATE_FILE"
+}
+
+cmd_create() {
+  local ssh_public_key=""
+  local ssh_private_key=""
+  local raw_vm_prefix=""
+  local vm_prefix=""
+  local vm1_name=""
+  local vm2_name=""
+  local vm1_vmid=""
+  local vm2_vmid=""
+  local vm1_octet=""
+  local vm2_octet=""
+  local vm1_ip=""
+  local vm2_ip=""
+  local vm1_ip_cidr=""
+  local vm2_ip_cidr=""
+  local proxmox_image_file=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --state-file)
+        [[ $# -ge 2 ]] || die "missing value for --state-file"
+        STATE_FILE="$2"
+        shift 2
+        ;;
+      --ssh-public-key)
+        [[ $# -ge 2 ]] || die "missing value for --ssh-public-key"
+        ssh_public_key="$2"
+        shift 2
+        ;;
+      --vm-prefix)
+        [[ $# -ge 2 ]] || die "missing value for --vm-prefix"
+        raw_vm_prefix="$2"
+        shift 2
+        ;;
+      *)
+        die "unknown create argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$STATE_FILE" ]] || die "--state-file is required"
+  [[ -n "$ssh_public_key" ]] || die "--ssh-public-key is required"
+  [[ -n "$raw_vm_prefix" ]] || die "--vm-prefix is required"
+  [[ ! -e "$STATE_FILE" ]] || die "--state-file already exists: ${STATE_FILE}"
+  preflight_state_file_path
+
+  validate_create_environment "$ssh_public_key"
+  proxmox_image_file="$(resolve_proxmox_image_file)"
+
+  ssh_private_key="$(private_key_path_from_public_key "$ssh_public_key")"
+  require_file "$ssh_private_key" "matching private key"
+
+  vm_prefix="$(sanitize_vm_prefix "$raw_vm_prefix")"
+  vm1_name="${vm_prefix}-worker-1"
+  vm2_name="${vm_prefix}-worker-2"
+
+  vm1_octet="$(derive_ip_octet "$vm_prefix" 0)"
+  vm2_octet="$(derive_ip_octet "$vm_prefix" 1)"
+  vm1_ip="${PROXMOX_IP_PREFIX}.${vm1_octet}"
+  vm2_ip="${PROXMOX_IP_PREFIX}.${vm2_octet}"
+  vm1_ip_cidr="${vm1_ip}/${PROXMOX_IP_CIDR_SUFFIX}"
+  vm2_ip_cidr="${vm2_ip}/${PROXMOX_IP_CIDR_SUFFIX}"
+
+  [[ "$vm1_ip" != "$vm2_ip" ]] || die "derived duplicate candidate IPs for ${vm_prefix}: ${vm1_ip}"
+  validate_gateway_matches_vm_subnet "$PROXMOX_GATEWAY" "$vm1_ip"
+  validate_gateway_matches_vm_subnet "$PROXMOX_GATEWAY" "$vm2_ip"
+  guard_candidate_ip "$vm1_ip" "VM1_IP"
+  guard_candidate_ip "$vm2_ip" "VM2_IP"
+
+  if ! vm1_vmid="$(next_vmid)"; then
+    die "failed to allocate the first Proxmox VMID"
+  fi
+  ensure_vmid_available "$vm1_vmid" "VM1_VMID"
+  if ! create_vm "$vm1_vmid" "$vm1_name"; then
+    cleanup_failed_create "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "" "$vm2_ip"
+    die "failed to create Proxmox VM ${vm1_name} (${vm1_vmid})"
+  fi
+  if ! vm2_vmid="$(next_vmid)"; then
+    cleanup_failed_create "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "" "$vm2_ip"
+    die "failed to allocate a second Proxmox VMID after creating ${vm1_name} (${vm1_vmid})"
+  fi
+  if [[ "$vm1_vmid" == "$vm2_vmid" ]]; then
+    cleanup_failed_create "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "$vm2_vmid" "$vm2_ip"
+    die "pvesh returned duplicate VMIDs for ${vm_prefix}: ${vm1_vmid}"
+  fi
+  if qm config "$vm2_vmid" >/dev/null 2>&1; then
+    cleanup_failed_create "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "$vm2_vmid" "$vm2_ip"
+    die "VM2_VMID ${vm2_vmid} already exists on this Proxmox host"
+  fi
+  if ! qm_list_output="$(qm list 2>/dev/null)"; then
+    cleanup_failed_create "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "$vm2_vmid" "$vm2_ip"
+    die "VM2_VMID ${vm2_vmid} could not be inspected on this Proxmox host"
+  fi
+  if grep -qE "^${vm2_vmid}[[:space:]]" <<<"$qm_list_output"; then
+    cleanup_failed_create "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "$vm2_vmid" "$vm2_ip"
+    die "VM2_VMID ${vm2_vmid} could not be inspected on this Proxmox host"
+  fi
+  if ! write_state_file "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "$vm2_vmid" "$vm2_ip"; then
+    cleanup_failed_create "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "$vm2_vmid" "$vm2_ip"
+    die "failed to persist Proxmox VM state after allocating ${vm1_vmid} and ${vm2_vmid}"
+  fi
+
+  configure_vm "$vm1_vmid" "$vm1_name" "$vm1_ip_cidr" "$ssh_public_key" "$proxmox_image_file" || die "failed to configure Proxmox VM ${vm1_name} (${vm1_vmid})"
+  create_vm "$vm2_vmid" "$vm2_name" || die "failed to create Proxmox VM ${vm2_name} (${vm2_vmid})"
+  configure_vm "$vm2_vmid" "$vm2_name" "$vm2_ip_cidr" "$ssh_public_key" "$proxmox_image_file" || die "failed to configure Proxmox VM ${vm2_name} (${vm2_vmid})"
+
+  wait_for_ssh "$vm1_name" "$vm1_ip" "$ssh_private_key" || die "failed waiting for SSH on ${vm1_name} (${vm1_ip})"
+  wait_for_ssh "$vm2_name" "$vm2_ip" "$ssh_private_key" || die "failed waiting for SSH on ${vm2_name} (${vm2_ip})"
+  wait_for_guest_readiness "$vm1_name" "$vm1_ip" "$ssh_private_key" || die "failed waiting for guest readiness on ${vm1_name} (${vm1_ip})"
+  wait_for_guest_readiness "$vm2_name" "$vm2_ip" "$ssh_private_key" || die "failed waiting for guest readiness on ${vm2_name} (${vm2_ip})"
+  write_state_file "$vm1_name" "$vm1_vmid" "$vm1_ip" "$vm2_name" "$vm2_vmid" "$vm2_ip"
+}
+
+cmd_destroy() {
+  local failures=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --state-file)
+        [[ $# -ge 2 ]] || die "missing value for --state-file"
+        STATE_FILE="$2"
+        shift 2
+        ;;
+      *)
+        die "unknown destroy argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$STATE_FILE" ]] || die "--state-file is required"
+  require_command qm
+  load_destroy_state
+
+  if ! destroy_vm "VM1_VMID" "$VM1_VMID" "$VM1_NAME"; then
+    failures+=("VM1_VMID=${VM1_VMID}")
+  fi
+
+  if [[ -n "${VM2_VMID:-}" && -n "${VM2_NAME:-}" ]] && ! destroy_vm "VM2_VMID" "$VM2_VMID" "$VM2_NAME"; then
+    failures+=("VM2_VMID=${VM2_VMID}")
+  fi
+
+  if (( ${#failures[@]} > 0 )); then
+    die "destroy encountered teardown failures for: ${failures[*]}"
+  fi
+
+  rm -f "$STATE_FILE"
+}
+
+cmd_print_env() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --state-file)
+        [[ $# -ge 2 ]] || die "missing value for --state-file"
+        STATE_FILE="$2"
+        shift 2
+        ;;
+      *)
+        die "unknown print-env argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$STATE_FILE" ]] || die "--state-file is required"
+  print_validated_state
+}
+
+main() {
+  local cmd="${1:-}"
+  [[ -n "$cmd" ]] || return 1
+  shift || true
+  case "$cmd" in
+    create) cmd_create "$@" ;;
+    print-env) cmd_print_env "$@" ;;
+    destroy) cmd_destroy "$@" ;;
+    -h|--help|help) usage ;;
+    *) usage ;;
+  esac
+}
+
+main "$@" || usage

--- a/hack/scripts/proxmox-ssh-quickstart-vms.sh
+++ b/hack/scripts/proxmox-ssh-quickstart-vms.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# proxmox-ssh-quickstart-vms.sh - Create, query, and destroy Proxmox VMs for
+# the AKS SSH quickstart CI workflow. It provisions Ubuntu cloud-init VMs on a
+# self-hosted Proxmox runner so the aks-ssh-quickstart workflow can bootstrap
+# them as remote Kubernetes nodes and verify they join the cluster.
+
 # These host-specific defaults are intentionally explicit so this helper does
 # not depend on hidden runner state.
 readonly REQUIRED_VALUE="__REQUIRED__"

--- a/internal/provision/script_test.go
+++ b/internal/provision/script_test.go
@@ -17,6 +17,10 @@ func TestUnboundedAgentInstallScript(t *testing.T) {
 	require.NotEmpty(t, script)
 	require.Contains(t, script, "#!/bin/bash")
 	require.Contains(t, script, "unbounded-agent")
+	require.Contains(t, script, `if [ -z "${AGENT_URL}" ]; then
+    AGENT_URL="https://github.com/Azure/unbounded-kube/releases/download/${AGENT_VERSION}/unbounded-agent-linux-${arch}.tar.gz"
+fi`)
+	require.Contains(t, script, `curl -fsSL "${AGENT_URL}" | tar -xz -C /usr/local/bin unbounded-agent`)
 }
 
 func TestUnboundedAgentUninstallScript(t *testing.T) {


### PR DESCRIPTION

This pull request adds support for overriding the agent install script download URL via a new `--agent-url` flag in the `manual-bootstrap` command. This enables users to specify a custom URL for the agent binary when generating bootstrap scripts, improving flexibility for air-gapped or custom deployments. The change is carefully scoped to only apply to the `script` variant, and includes robust shell-quoting for safety. Comprehensive tests are added to verify correct behavior and security.

**Manual bootstrap enhancements:**

* Added a new `--agent-url` flag to the `manual-bootstrap` command, allowing users to override the agent download URL in the generated install script. The flag is only supported for the `script` variant, with validation to prevent misuse. (`cmd/kubectl-unbounded/app/machine_manual_bootstrap.go` [[1]](diffhunk://#diff-71684b69dbe71342af1c6afc783ab88049624ffacd43a541cce841e33f48f183R89-R91) [[2]](diffhunk://#diff-71684b69dbe71342af1c6afc783ab88049624ffacd43a541cce841e33f48f183R176-R179) [[3]](diffhunk://#diff-71684b69dbe71342af1c6afc783ab88049624ffacd43a541cce841e33f48f183R416) [[4]](diffhunk://#diff-71684b69dbe71342af1c6afc783ab88049624ffacd43a541cce841e33f48f183R425-R430)
* Modified the script rendering logic to inject the custom agent URL as an exported environment variable (`AGENT_URL`) in a shell-safe manner when the flag is set. (`cmd/kubectl-unbounded/app/machine_manual_bootstrap.go` [[1]](diffhunk://#diff-e4ba2af5b6b7fb40afbcf5c216616989e72c2861425177736c1bb6e06dc04e0fR31-R34) [[2]](diffhunk://#diff-71684b69dbe71342af1c6afc783ab88049624ffacd43a541cce841e33f48f183R295-R302) [[3]](diffhunk://#diff-71684b69dbe71342af1c6afc783ab88049624ffacd43a541cce841e33f48f183R320-R323)

**Testing improvements:**

* Added unit and integration tests to verify that the `--agent-url` flag works as intended, including proper shell quoting and variant validation. Tests ensure the agent URL is correctly injected or omitted, and that unsafe values are handled securely. (`cmd/kubectl-unbounded/app/machine_manual_bootstrap_test.go` [[1]](diffhunk://#diff-fe00739099cf333576242b7f3155981bf818037b1fa98804d741edadc9483795R107-R117) [[2]](diffhunk://#diff-fe00739099cf333576242b7f3155981bf818037b1fa98804d741edadc9483795R340-R424) [[3]](diffhunk://#diff-fe00739099cf333576242b7f3155981bf818037b1fa98804d741edadc9483795R514-R541)

**Install script validation:**

* Updated tests to ensure the agent install script supports the new `AGENT_URL` environment variable and uses it as the download source if set. (`internal/provision/script_test.go` [internal/provision/script_test.goR20-R23](diffhunk://#diff-b94b8fdc55a77ce8919f2e683d57bbd907438a431518fad5403c7613d3a3344cR20-R23))

**Build configuration:**

* Minor Makefile change to allow overriding the `MACHINA_IMAGE` variable externally. (`Makefile` [MakefileL21-R21](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L21-R21))