### PR TITLE
Make //go:embed roots satisfiable on a fresh clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,8 +89,10 @@ __pycache__/
 
 # Rendered templates
 hack/net/templates/*.json
-deploy/net/rendered/
-deploy/machina/rendered/
+# Rendered manifest output is managed by per-directory .gitignore placeholders
+# under deploy/{machina,net}/rendered/ so the //go:embed all:rendered
+# directives in deploy/{machina,net}/embed.go remain satisfiable on a fresh
+# clone.
 
 # Temporary files
 *.tmp

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ fmt: check-deps ## Format all Go source files (gofumpt + wsl_v5 whitespace)
 ifdef CI
 # In CI each job is independent; skip chained prerequisites.
 
-lint: machina-manifests net-manifests ## Run golangci-lint
+lint: ## Run golangci-lint
 	$(GOLINT) ./...
 
 test: machina-manifests net-manifests ## Run all tests with race detector
@@ -247,10 +247,10 @@ test: machina-manifests net-manifests ## Run all tests with race detector
 else
 # Locally, chain targets for convenience: test -> lint -> fmt -> check-deps.
 
-lint: fmt machina-manifests net-manifests ## Run golangci-lint (implies fmt)
+lint: fmt ## Run golangci-lint (implies fmt)
 	$(GOLINT) ./...
 
-test: lint ## Run all tests (implies lint)
+test: lint machina-manifests net-manifests ## Run all tests (implies lint)
 	$(GOTEST) ./...
 
 endif
@@ -397,7 +397,8 @@ MACHINA_MANIFEST_TEMPLATES_DIR := deploy/machina
 MACHINA_MANIFEST_RENDERED_DIR  := deploy/machina/rendered
 
 machina-manifests: ## Render machina deployment manifests into deploy/machina/rendered
-	@rm -rf $(MACHINA_MANIFEST_RENDERED_DIR)
+	@mkdir -p $(MACHINA_MANIFEST_RENDERED_DIR)
+	@find $(MACHINA_MANIFEST_RENDERED_DIR) -mindepth 1 -not -name .gitignore -delete
 	@mkdir -p $(MACHINA_MANIFEST_RENDERED_DIR)/crd
 	$(GOCMD) run ./hack/cmd/render-manifests \
 		--templates-dir $(MACHINA_MANIFEST_TEMPLATES_DIR) \
@@ -493,7 +494,8 @@ net-build-ebpf: ## Compile bpf/unbounded_encap.c to internal/net/ebpf/unbounded_
 ##@ Net Manifests
 
 net-manifests: ## Render net manifests into $(NET_MANIFEST_RENDERED_DIR)
-	@rm -rf $(NET_MANIFEST_RENDERED_DIR)
+	@mkdir -p $(NET_MANIFEST_RENDERED_DIR)
+	@find $(NET_MANIFEST_RENDERED_DIR) -mindepth 1 -not -name .gitignore -delete
 	@mkdir -p $(NET_MANIFEST_RENDERED_DIR)/crd
 	$(GOCMD) run ./hack/cmd/render-manifests \
 		--templates-dir "$(NET_MANIFEST_TEMPLATES_DIR)" \

--- a/deploy/machina/embed.go
+++ b/deploy/machina/embed.go
@@ -7,6 +7,14 @@
 // directory and the controller-gen generated CRDs under crd/; the rendered
 // tree under rendered/ is produced by `make machina-manifests` and is
 // gitignored.
+//
+// The `all:` prefix in the embed directive plus the tracked
+// rendered/.gitignore placeholder ensures the directive is satisfiable on a
+// fresh clone (before `make machina-manifests` has run), so Go tooling
+// (`go build`, `go vet`, golangci-lint, gopls, ...) can load this package
+// without requiring the rendering step to have happened first. The
+// placeholder file is harmless at runtime: consumers that materialise the
+// FS only apply *.yaml/*.yml files.
 package machina
 
 import (
@@ -14,7 +22,7 @@ import (
 	"io/fs"
 )
 
-//go:embed rendered/*.yaml rendered/crd/*.yaml
+//go:embed all:rendered
 var manifestsRaw embed.FS
 
 // Manifests exposes the rendered manifests as a filesystem rooted at the

--- a/deploy/machina/rendered/.gitignore
+++ b/deploy/machina/rendered/.gitignore
@@ -1,0 +1,5 @@
+# Keep this directory present in the repo as the embed root for
+# deploy/machina/embed.go. `make machina-manifests` writes the rendered
+# manifests (and a crd/ subdirectory) here; none of that output is tracked.
+*
+!.gitignore

--- a/deploy/net/embed.go
+++ b/deploy/net/embed.go
@@ -7,6 +7,14 @@
 // in this directory and the controller-gen generated CRDs under crd/; the
 // rendered tree under rendered/ is produced by `make net-manifests`
 // and is gitignored.
+//
+// The `all:` prefix in the embed directive plus the tracked
+// rendered/.gitignore placeholder ensures the directive is satisfiable on a
+// fresh clone (before `make net-manifests` has run), so Go tooling
+// (`go build`, `go vet`, golangci-lint, gopls, ...) can load this package
+// without requiring the rendering step to have happened first. The
+// placeholder file is harmless at runtime: consumers that materialise the
+// FS only apply *.yaml/*.yml files.
 package net
 
 import (
@@ -14,7 +22,7 @@ import (
 	"io/fs"
 )
 
-//go:embed rendered/*.yaml rendered/controller/*.yaml rendered/node/*.yaml rendered/crd/*.yaml
+//go:embed all:rendered
 var manifestsRaw embed.FS
 
 // Manifests exposes the rendered manifests as a filesystem rooted at the

--- a/deploy/net/rendered/.gitignore
+++ b/deploy/net/rendered/.gitignore
@@ -1,0 +1,6 @@
+# Keep this directory present in the repo as the embed root for
+# deploy/net/embed.go. `make net-manifests` writes the rendered manifests
+# (with controller/, node/ and crd/ subdirectories) here; none of that
+# output is tracked.
+*
+!.gitignore


### PR DESCRIPTION
deploy/{machina,net}/embed.go used `//go:embed rendered/*.yaml ...` glob patterns whose targets only exist after `make {machina,net}-manifests` has rendered them. On a fresh clone any Go tool that loads these packages (go build, go vet, golangci-lint, gopls, ...) failed at type-check time, which made even `make lint` unrunnable without first invoking the render pipeline. The `lint` target nominally listed the render targets as prerequisites, but they never fired because `lint -> fmt` ran golangci-lint first and crashed before the prereqs were processed.

Mirror the fix already used for the React frontend at internal/net/html/dist/.gitignore: track a placeholder .gitignore in each rendered/ directory and switch the embed directives to `//go:embed all:rendered`, which only requires the directory to exist. The placeholder is harmless at runtime because ApplyManifestsInDirectory only applies *.yaml/*.yml.

Also:

- Replace the `rm -rf rendered/` cleanup in the render targets with a find -delete that preserves the tracked .gitignore so re-renders don't clobber it.
- Drop the (ineffective) machina-manifests/net-manifests prereqs from the lint targets now that the embeds are self-satisfying; keep them on test where embedded content actually matters.
- Remove the now-redundant deploy/{machina,net}/rendered/ entries from the root .gitignore (the in-directory placeholders manage the rules locally) and add a pointer comment.