### PR TITLE
Fix docs site rendering after rename to Unbounded

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,4 +1,4 @@
 ---
-title: "Unbounded Kube"
-description: "Provision worker nodes via SSH or PXE and connect them to any control plane over WireGuard — no matter where they run."
+title: "Unbounded"
+description: "Provision worker nodes via SSH or PXE and connect them to any control plane over WireGuard - no matter where they run."
 ---

--- a/docs/content/guides/_index.md
+++ b/docs/content/guides/_index.md
@@ -1,4 +1,4 @@
 ---
 title: "Guides"
-description: "Tutorials and walkthroughs for Unbounded Kube."
+description: "Tutorials and walkthroughs for Unbounded."
 ---

--- a/docs/content/guides/existing-cluster.md
+++ b/docs/content/guides/existing-cluster.md
@@ -1,10 +1,10 @@
 ---
 title: "Bring Your Own Cluster"
 weight: 2
-description: "Add Unbounded Kube to an existing Kubernetes cluster and join remote nodes."
+description: "Add Unbounded to an existing Kubernetes cluster and join remote nodes."
 ---
 
-This guide adds Unbounded Kube to a Kubernetes cluster you already have running.
+This guide adds Unbounded to a Kubernetes cluster you already have running.
 You'll label gateway nodes, initialize a site, and join remote machines.
 
 > Starting from scratch? See the

--- a/docs/content/guides/getting-started.md
+++ b/docs/content/guides/getting-started.md
@@ -1,10 +1,10 @@
 ---
 title: "Getting Started"
 weight: 1
-description: "Create an AKS cluster with Unbounded Kube and join your first remote node."
+description: "Create an AKS cluster with Unbounded and join your first remote node."
 ---
 
-This guide creates an AKS cluster configured for Unbounded Kube and joins a
+This guide creates an AKS cluster configured for Unbounded and joins a
 remote node to it. You'll have a working multi-site cluster in a few minutes.
 
 ![Quickstart architecture: AKS cluster with gateway nodes connected to a remote site over WireGuard](../../img/quickstart-architecture.svg)

--- a/docs/content/guides/l3-connectivity.md
+++ b/docs/content/guides/l3-connectivity.md
@@ -10,10 +10,10 @@ private L3 connectivity between the two networks, you'll configure Unbounded
 Kube to route directly over that link -- no WireGuard overlay needed.
 
 {{< callout type="info" >}}
-This guide uses Azure VPN Gateway and a Ubiquiti router as a concrete example, but the same approach works with **any L3 interconnect** -- Azure ExpressRoute, AWS Direct Connect, GCP Cloud Interconnect, a hardware VPN appliance, or even a simple routed link between two networks. The Unbounded Kube configuration in [steps 5-9](#5-prepare-gateway-nodes) is identical regardless of how the L3 path is established.
+This guide uses Azure VPN Gateway and a Ubiquiti router as a concrete example, but the same approach works with **any L3 interconnect** -- Azure ExpressRoute, AWS Direct Connect, GCP Cloud Interconnect, a hardware VPN appliance, or even a simple routed link between two networks. The Unbounded configuration in [steps 5-9](#5-prepare-gateway-nodes) is identical regardless of how the L3 path is established.
 {{< /callout >}}
 
-> New to Unbounded Kube? Start with the
+> New to Unbounded? Start with the
 > [Getting Started]({{< relref "guides/getting-started" >}}) guide to create an
 > AKS cluster from scratch, then come back here to add L3 connectivity.
 
@@ -523,7 +523,7 @@ interfaces for the ubiquiti-site peering.
 
 ## How It Works
 
-In a standard Unbounded Kube deployment, remote nodes establish encrypted
+In a standard Unbounded deployment, remote nodes establish encrypted
 WireGuard tunnels to gateway nodes over the public internet. This is secure and
 works anywhere, but adds encapsulation overhead and requires public IPs on
 gateway nodes.
@@ -570,7 +570,7 @@ az network public-ip delete \
     --name vpn-gateway-ip
 ```
 
-To remove the Unbounded Kube site resources:
+To remove the Unbounded site resources:
 
 ```bash
 kubectl delete sitepeering aks-to-ubiquiti-peering

--- a/docs/content/reference/_index.md
+++ b/docs/content/reference/_index.md
@@ -1,4 +1,4 @@
 ---
 title: "Reference"
-description: "API and CLI reference for all Unbounded Kube components."
+description: "API and CLI reference for all Unbounded components."
 ---

--- a/docs/content/reference/architecture.md
+++ b/docs/content/reference/architecture.md
@@ -1,12 +1,12 @@
 ---
 title: "Architecture"
 weight: 1
-description: "High-level architecture of Unbounded Kube."
+description: "High-level architecture of Unbounded."
 ---
 
 ## Overview
 
-Unbounded Kube extends a standard Kubernetes cluster so that worker Nodes can
+Unbounded extends a standard Kubernetes cluster so that worker Nodes can
 run in any environment -- cloud, on-premises, or edge -- and join back to a
 central control plane. It adds:
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -7,7 +7,7 @@ description: "Complete reference for the kubectl-unbounded plugin commands."
 ## Overview
 
 `kubectl-unbounded` is a kubectl plugin that extends `kubectl` with commands for
-managing Unbounded Kube sites. Once installed, commands are available as:
+managing Unbounded sites. Once installed, commands are available as:
 
 ```bash
 kubectl unbounded <command>

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,6 +1,6 @@
-baseURL = "/"
+baseURL = "/unbounded/"
 languageCode = "en-us"
-title = "Unbounded Kube"
+title = "Unbounded"
 
 [markup]
   [markup.highlight]


### PR DESCRIPTION
## Summary

- **Fix baseURL**: The Hugo `baseURL` was `/` but the site is served at `azure.github.io/unbounded/`, causing all CSS, JS, images, and internal links to 404. Updated to `/unbounded/`.
- **Rename Unbounded Kube to Unbounded**: Updated site title, page descriptions, and guide content across 9 files to reflect the project rename. API group references (`unbounded-kube.io`, `net.unbounded-kube.io`) are intentionally unchanged as they are real Kubernetes API group names.