### PR TITLE
fix: update URL path back to / now that unbounded-cloud.io is registered

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "/unbounded/"
+baseURL = "/"
 languageCode = "en-us"
 title = "Unbounded"
 


### PR DESCRIPTION
fix: update URL path back to / now that unbounded-cloud.io is registered