### PR TITLE
agent: make nspawn kube1 survive systemd-machined restarts

### DIFF
--- a/cmd/agent/internal/cmd/start.go
+++ b/cmd/agent/internal/cmd/start.go
@@ -57,6 +57,7 @@ func newCmdStart(cmdCtx *CommandContext) *cobra.Command {
 					host.ConfigureNFTables(log),
 					host.DisableDocker(log),
 					host.DisableSwap(log),
+					host.HardenAPT(log),
 				),
 
 				// TPM Attestation (no-op when not configured).

--- a/cmd/agent/internal/phases/host/apt.go
+++ b/cmd/agent/internal/phases/host/apt.go
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package host
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"log/slog"
+
+	"github.com/Azure/unbounded/cmd/agent/internal/phases"
+	"github.com/Azure/unbounded/cmd/agent/internal/utilio"
+)
+
+// On Ubuntu hosts, unattended-upgrades and needrestart will happily restart
+// systemd-machined when a package they depend on (libcap2, systemd, ...) is
+// upgraded, which kills the running systemd-nspawn@kube1 container and takes
+// the node off the cluster. We mitigate that two ways:
+//
+//  1. An apt drop-in that blacklists the systemd / libcap packages from
+//     unattended-upgrades. Security patches still flow for everything else;
+//     these specific packages are upgraded only when an operator runs apt
+//     interactively.
+//  2. A needrestart drop-in that disables auto-restart of services after
+//     package upgrades, in case any path bypasses the blacklist (manual
+//     `apt upgrade`, third-party PPAs, etc.).
+//
+// Both files are idempotent and use distinctive 99- names so they win the
+// last-write priority in /etc/apt/apt.conf.d and /etc/needrestart/conf.d.
+//
+//go:embed assets/99-unbounded-no-restart-systemd.conf
+var aptUnattendedUpgradesConfig []byte
+
+//go:embed assets/99-unbounded-needrestart.conf
+var needrestartConfig []byte
+
+const (
+	aptDropInPath         = "/etc/apt/apt.conf.d/99-unbounded-no-restart-systemd"
+	needrestartDropInPath = "/etc/needrestart/conf.d/99-unbounded.conf"
+)
+
+type hardenAPT struct {
+	log *slog.Logger
+
+	// Paths are overridable for tests; production code uses the constants
+	// above via the HardenAPT() constructor.
+	aptDropInPath         string
+	needrestartDropInPath string
+}
+
+// HardenAPT returns a task that writes drop-ins which prevent
+// unattended-upgrades and needrestart from restarting systemd-machined (and
+// thereby killing the running nspawn container). Idempotent.
+func HardenAPT(log *slog.Logger) phases.Task {
+	return &hardenAPT{
+		log:                   log,
+		aptDropInPath:         aptDropInPath,
+		needrestartDropInPath: needrestartDropInPath,
+	}
+}
+
+func (h *hardenAPT) Name() string { return "harden-apt" }
+
+func (h *hardenAPT) Do(_ context.Context) error {
+	if err := utilio.WriteFile(h.aptDropInPath, aptUnattendedUpgradesConfig, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", h.aptDropInPath, err)
+	}
+
+	if err := utilio.WriteFile(h.needrestartDropInPath, needrestartConfig, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", h.needrestartDropInPath, err)
+	}
+
+	h.log.Info("apt and needrestart hardened against systemd-machined restarts",
+		"apt_dropin", h.aptDropInPath,
+		"needrestart_dropin", h.needrestartDropInPath,
+	)
+
+	return nil
+}

--- a/cmd/agent/internal/phases/host/apt_test.go
+++ b/cmd/agent/internal/phases/host/apt_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package host
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// TestHardenAPT_WritesBothDropIns verifies the task writes the apt and
+// needrestart drop-ins with the expected content and permissions.
+func TestHardenAPT_WritesBothDropIns(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	aptPath := filepath.Join(dir, "apt", "99-unbounded-no-restart-systemd")
+	nrPath := filepath.Join(dir, "needrestart", "99-unbounded.conf")
+
+	task := &hardenAPT{
+		log:                   discardLogger(),
+		aptDropInPath:         aptPath,
+		needrestartDropInPath: nrPath,
+	}
+
+	require.NoError(t, task.Do(context.Background()))
+
+	aptBytes, err := os.ReadFile(aptPath)
+	require.NoError(t, err)
+
+	apt := string(aptBytes)
+	require.Contains(t, apt, "Unattended-Upgrade::Package-Blacklist")
+	for _, pkg := range []string{
+		`"systemd";`,
+		`"systemd-container";`,
+		`"libcap2";`,
+		`"libcap2-bin";`,
+		`"libpam-cap";`,
+	} {
+		require.Contains(t, apt, pkg, "apt drop-in missing %s", pkg)
+	}
+
+	nrBytes, err := os.ReadFile(nrPath)
+	require.NoError(t, err)
+	require.Contains(t, string(nrBytes), `$nrconf{restart} = 'l';`)
+}
+
+// TestHardenAPT_Idempotent ensures running the task twice does not error
+// and leaves the same content (no append/duplication).
+func TestHardenAPT_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	aptPath := filepath.Join(dir, "apt.conf")
+	nrPath := filepath.Join(dir, "nr.conf")
+
+	task := &hardenAPT{
+		log:                   discardLogger(),
+		aptDropInPath:         aptPath,
+		needrestartDropInPath: nrPath,
+	}
+
+	require.NoError(t, task.Do(context.Background()))
+
+	first, err := os.ReadFile(aptPath)
+	require.NoError(t, err)
+
+	require.NoError(t, task.Do(context.Background()))
+
+	second, err := os.ReadFile(aptPath)
+	require.NoError(t, err)
+
+	require.Equal(t, first, second, "second run must not alter file contents")
+}

--- a/cmd/agent/internal/phases/host/assets/99-unbounded-needrestart.conf
+++ b/cmd/agent/internal/phases/host/assets/99-unbounded-needrestart.conf
@@ -1,0 +1,5 @@
+# Block needrestart from auto-restarting services after package upgrades.
+# 'l' means "list services that need restart but do not restart them".
+# Without this, an unattended upgrade of a libcap or systemd package will
+# restart systemd-machined and tear down the systemd-nspawn@kube1 container.
+$nrconf{restart} = 'l';

--- a/cmd/agent/internal/phases/host/assets/99-unbounded-no-restart-systemd.conf
+++ b/cmd/agent/internal/phases/host/assets/99-unbounded-no-restart-systemd.conf
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// systemd, libcap2 and friends are restarted by needrestart whenever
+// unattended-upgrades touches them, which kills systemd-machined and the
+// running systemd-nspawn@kube1.service in the process. Block those packages
+// here so security patches still flow but our nspawn container is never
+// taken out from under us by an automated upgrade. Operators can override
+// this file to remove individual entries if needed.
+
+Unattended-Upgrade::Package-Blacklist {
+    "systemd";
+    "systemd-container";
+    "systemd-sysv";
+    "libsystemd0";
+    "libcap2";
+    "libcap2-bin";
+    "libpam-cap";
+};

--- a/cmd/agent/internal/phases/nodestart/nspawn.go
+++ b/cmd/agent/internal/phases/nodestart/nspawn.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/Azure/unbounded/cmd/agent/internal/goalstates"
@@ -14,34 +15,161 @@ import (
 	"github.com/Azure/unbounded/cmd/agent/internal/utilexec"
 )
 
+// machinectlRunner abstracts the small set of machinectl/systemctl operations
+// we need so tests can exercise the recovery path without invoking real
+// binaries. The default implementation, defaultMachinectlRunner, shells out
+// via utilexec.
+type machinectlRunner interface {
+	Start(ctx context.Context, name string) error
+	Enable(ctx context.Context, name string) error
+	Terminate(ctx context.Context, name string) error
+	Exists(ctx context.Context, name string) bool
+	ResetFailed(ctx context.Context, name string) error
+}
+
+type defaultMachinectlRunner struct {
+	log *slog.Logger
+}
+
+func (r defaultMachinectlRunner) Enable(ctx context.Context, name string) error {
+	return utilexec.RunCmd(ctx, r.log, utilexec.Machinectl(), "enable", name)
+}
+
+func (r defaultMachinectlRunner) Start(ctx context.Context, name string) error {
+	return utilexec.RunCmd(ctx, r.log, utilexec.Machinectl(), "start", name)
+}
+
+func (r defaultMachinectlRunner) Terminate(ctx context.Context, name string) error {
+	return utilexec.RunCmd(ctx, r.log, utilexec.Machinectl(), "terminate", name)
+}
+
+func (r defaultMachinectlRunner) Exists(ctx context.Context, name string) bool {
+	return utilexec.RunCmd(ctx, r.log, utilexec.Machinectl(), "show", name) == nil
+}
+
+func (r defaultMachinectlRunner) ResetFailed(ctx context.Context, name string) error {
+	service := fmt.Sprintf("systemd-nspawn@%s.service", name)
+	return utilexec.RunCmd(ctx, r.log, utilexec.Systemctl(), "reset-failed", service)
+}
+
 type startNSpawnMachine struct {
 	log       *slog.Logger
 	goalState *goalstates.NodeStart
+
+	// runner is the machinectl/systemctl driver. Tests inject a fake.
+	runner machinectlRunner
 }
 
 // StartNSpawnMachine returns a task that starts the systemd-nspawn machine using machinectl and
 // waits until D-Bus is responsive inside the machine so that subsequent phases
 // can safely use utilexec.MachineRun().
 func StartNSpawnMachine(log *slog.Logger, goalState *goalstates.NodeStart) phases.Task {
-	return &startNSpawnMachine{log: log, goalState: goalState}
+	return &startNSpawnMachine{
+		log:       log,
+		goalState: goalState,
+		runner:    defaultMachinectlRunner{log: log},
+	}
 }
 
 func (s *startNSpawnMachine) Name() string { return "start-nspawn-machine" }
 
 func (s *startNSpawnMachine) Do(ctx context.Context) error {
-	if err := utilexec.RunCmd(ctx, s.log, utilexec.Machinectl(), "enable", s.goalState.MachineName); err != nil {
-		return fmt.Errorf("machinectl enable %s: %w", s.goalState.MachineName, err)
+	name := s.goalState.MachineName
+
+	if err := s.runner.Enable(ctx, name); err != nil {
+		return fmt.Errorf("machinectl enable %s: %w", name, err)
 	}
 
-	if err := utilexec.RunCmd(ctx, s.log, utilexec.Machinectl(), "start", s.goalState.MachineName); err != nil {
-		return fmt.Errorf("machinectl start %s: %w", s.goalState.MachineName, err)
+	if err := s.startWithRecovery(ctx, name); err != nil {
+		return err
 	}
 
-	if err := waitForMachine(ctx, s.log, s.goalState.MachineName); err != nil {
-		return fmt.Errorf("wait for machine %s: %w", s.goalState.MachineName, err)
+	if err := waitForMachine(ctx, s.log, name); err != nil {
+		return fmt.Errorf("wait for machine %s: %w", name, err)
 	}
 
 	return nil
+}
+
+// startWithRecovery runs `machinectl start` and, if it fails because the
+// machine is already registered (e.g. systemd-machined was restarted out from
+// under us, leaving an orphaned registration with errno 17 / "File exists"),
+// terminates the stale registration and retries once.
+func (s *startNSpawnMachine) startWithRecovery(ctx context.Context, name string) error {
+	startErr := s.runner.Start(ctx, name)
+	if startErr == nil {
+		return nil
+	}
+
+	// Decide whether this looks like a stale-registration failure that we
+	// can recover from. Two strong signals:
+	//   - the machine is currently registered (machinectl show <name> ok),
+	//   - or the error message contains "already exists" / "File exists".
+	stale := s.runner.Exists(ctx, name) || isAlreadyExistsErr(startErr)
+	if !stale {
+		return fmt.Errorf("machinectl start %s: %w", name, startErr)
+	}
+
+	s.log.Warn("machinectl start failed with stale registration, attempting recovery",
+		"machine", name, "error", startErr)
+
+	// Clear any prior `failed` state on the unit; otherwise systemctl will
+	// refuse the next start attempt. Best-effort: ignore errors.
+	if err := s.runner.ResetFailed(ctx, name); err != nil {
+		s.log.Debug("systemctl reset-failed returned an error (continuing)",
+			"machine", name, "error", err)
+	}
+
+	if err := s.runner.Terminate(ctx, name); err != nil {
+		s.log.Warn("machinectl terminate during recovery failed (continuing)",
+			"machine", name, "error", err)
+	}
+
+	if !s.waitForGone(ctx, name, 15*time.Second) {
+		return fmt.Errorf("machinectl start %s: stale registration did not clear after terminate (initial error: %w)",
+			name, startErr)
+	}
+
+	if err := s.runner.Start(ctx, name); err != nil {
+		return fmt.Errorf("machinectl start %s after recovery: %w", name, err)
+	}
+
+	s.log.Info("recovered stale nspawn registration and started machine", "machine", name)
+
+	return nil
+}
+
+// waitForGone polls until the machine is no longer registered or the timeout
+// elapses. Returns true when the machine is gone.
+func (s *startNSpawnMachine) waitForGone(ctx context.Context, name string, timeout time.Duration) bool {
+	const pollInterval = 500 * time.Millisecond
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !s.runner.Exists(ctx, name) {
+			return true
+		}
+
+		select {
+		case <-ctx.Done():
+			return !s.runner.Exists(ctx, name)
+		case <-time.After(pollInterval):
+		}
+	}
+
+	return !s.runner.Exists(ctx, name)
+}
+
+// isAlreadyExistsErr reports whether err looks like a machinectl "machine
+// already exists" failure (errno 17 / EEXIST surfaced as text).
+func isAlreadyExistsErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "file exists")
 }
 
 // waitForMachine polls the machine until it is responsive to systemd-run

--- a/cmd/agent/internal/phases/nodestart/nspawn_test.go
+++ b/cmd/agent/internal/phases/nodestart/nspawn_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package nodestart
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/unbounded/cmd/agent/internal/goalstates"
+)
+
+// silentLogger returns a logger that drops all output. Tests use it so the
+// recovery path can log freely without polluting test output.
+func silentLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// fakeRunner is a scriptable machinectlRunner for exercising the
+// startWithRecovery state machine without touching real binaries.
+type fakeRunner struct {
+	mu sync.Mutex
+
+	// startResults are returned by successive calls to Start.
+	// If the slice is exhausted, the test fails.
+	startResults []error
+
+	// existsAfterStart is the value Exists returns immediately after a
+	// failed Start, simulating a stale machinectl registration.
+	existsAfterStart bool
+
+	// terminateErr is returned by Terminate.
+	terminateErr error
+
+	// resetFailedErr is returned by ResetFailed.
+	resetFailedErr error
+
+	// terminateClears, when true, makes Exists return false on calls
+	// that occur after Terminate has been invoked. This lets us model
+	// "terminate succeeded" vs "terminate did not actually clear".
+	terminateClears bool
+
+	enableCalls       int
+	startCalls        int
+	terminateCalls    int
+	existsCalls       int
+	resetFailedCalls  int
+	terminatedAlready bool
+}
+
+func (f *fakeRunner) Enable(_ context.Context, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.enableCalls++
+
+	return nil
+}
+
+func (f *fakeRunner) Start(_ context.Context, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.startCalls >= len(f.startResults) {
+		panic("fakeRunner: Start called more times than scripted")
+	}
+
+	err := f.startResults[f.startCalls]
+	f.startCalls++
+
+	return err
+}
+
+func (f *fakeRunner) Terminate(_ context.Context, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.terminateCalls++
+	f.terminatedAlready = true
+
+	return f.terminateErr
+}
+
+func (f *fakeRunner) Exists(_ context.Context, _ string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.existsCalls++
+
+	if f.terminatedAlready && f.terminateClears {
+		return false
+	}
+
+	return f.existsAfterStart
+}
+
+func (f *fakeRunner) ResetFailed(_ context.Context, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.resetFailedCalls++
+
+	return f.resetFailedErr
+}
+
+// runStart constructs a startNSpawnMachine wired to the fake runner and
+// invokes startWithRecovery. We avoid Do() so the test does not need to
+// fake the systemd-run wait loop.
+func runStart(t *testing.T, runner *fakeRunner) error {
+	t.Helper()
+
+	s := &startNSpawnMachine{
+		log:       silentLogger(),
+		goalState: &goalstates.NodeStart{MachineName: "kube1"},
+		runner:    runner,
+	}
+
+	return s.startWithRecovery(context.Background(), "kube1")
+}
+
+// TestStartWithRecovery_HappyPath: clean start, no recovery needed.
+func TestStartWithRecovery_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeRunner{startResults: []error{nil}}
+
+	require.NoError(t, runStart(t, r))
+	require.Equal(t, 1, r.startCalls)
+	require.Equal(t, 0, r.terminateCalls)
+	require.Equal(t, 0, r.resetFailedCalls)
+}
+
+// TestStartWithRecovery_StaleRegistration_ErrorMessage: first start fails
+// with a message matching EEXIST; we should reset-failed, terminate, and
+// retry start successfully.
+func TestStartWithRecovery_StaleRegistration_ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeRunner{
+		startResults:    []error{errors.New(`Failed to register machine: Machine "kube1" already exists`), nil},
+		terminateClears: true,
+	}
+
+	require.NoError(t, runStart(t, r))
+	require.Equal(t, 2, r.startCalls)
+	require.Equal(t, 1, r.terminateCalls)
+	require.Equal(t, 1, r.resetFailedCalls)
+}
+
+// TestStartWithRecovery_StaleRegistration_ExistsCheck: first start fails
+// with a generic error, but `machinectl show` reports the machine still
+// exists. Treat as recoverable.
+func TestStartWithRecovery_StaleRegistration_ExistsCheck(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeRunner{
+		startResults:     []error{errors.New("some unrelated text"), nil},
+		existsAfterStart: true,
+		terminateClears:  true,
+	}
+
+	require.NoError(t, runStart(t, r))
+	require.Equal(t, 2, r.startCalls)
+	require.Equal(t, 1, r.terminateCalls)
+}
+
+// TestStartWithRecovery_UnrelatedError_NoRecovery: start fails with a
+// non-EEXIST error and the machine is not registered. Bubble up without
+// terminate.
+func TestStartWithRecovery_UnrelatedError_NoRecovery(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeRunner{
+		startResults:     []error{errors.New("permission denied")},
+		existsAfterStart: false,
+	}
+
+	err := runStart(t, r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "permission denied")
+	require.Equal(t, 1, r.startCalls)
+	require.Equal(t, 0, r.terminateCalls)
+}
+
+// TestStartWithRecovery_TerminateDoesNotClear: start fails with EEXIST,
+// terminate is attempted, but the registration never disappears. We must
+// surface the failure rather than retry start blindly.
+func TestStartWithRecovery_TerminateDoesNotClear(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeRunner{
+		startResults:     []error{errors.New("File exists")},
+		existsAfterStart: true,
+		terminateClears:  false,
+		// Even if Terminate returns nil, Exists keeps returning true.
+	}
+
+	err := runStart(t, r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stale registration did not clear")
+	require.Equal(t, 1, r.startCalls, "must not retry start when the machine is still registered")
+	require.GreaterOrEqual(t, r.terminateCalls, 1)
+}
+
+// TestStartWithRecovery_RetryStartFails: recovery proceeded (terminate
+// cleared the registration) but the second start still fails. Surface
+// the second error.
+func TestStartWithRecovery_RetryStartFails(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeRunner{
+		startResults: []error{
+			errors.New("already exists"),
+			errors.New("kernel module missing"),
+		},
+		terminateClears: true,
+	}
+
+	err := runStart(t, r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "after recovery")
+	require.Contains(t, err.Error(), "kernel module missing")
+}
+
+func TestIsAlreadyExistsErr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"already exists", errors.New(`Machine "kube1" already exists`), true},
+		{"File exists", errors.New("Failed: File exists"), true},
+		{"case insensitive", errors.New("ALREADY EXISTS"), true},
+		{"unrelated", errors.New("permission denied"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isAlreadyExistsErr(tc.err))
+		})
+	}
+}

--- a/cmd/agent/internal/phases/rootfs/assets/service-override.conf
+++ b/cmd/agent/internal/phases/rootfs/assets/service-override.conf
@@ -16,7 +16,23 @@
 #     read-only including /proc/sys/net. This env var carves out /proc/sys/net
 #     as writable so that CNI plugins and kube-proxy can set network sysctls.
 
+# Self-healing: when systemd-machined is restarted (for example by needrestart
+# during an unattended-upgrades run that touches libcap/systemd), this nspawn
+# unit is stopped. Restart=on-failure brings it back; ExecStartPre clears any
+# stale machinectl registration that would otherwise cause the next start to
+# fail with "Machine '<name>' already exists" / errno 17. The leading '-' on
+# ExecStartPre marks the command as non-fatal, so a fresh start (where there
+# is nothing to terminate) is unaffected. StartLimitIntervalSec=0 disables
+# the start-rate limiter so a long machined outage cannot leave the unit
+# permanently failed.
+
+[Unit]
+StartLimitIntervalSec=0
+
 [Service]
+Restart=on-failure
+RestartSec=10s
+ExecStartPre=-/usr/bin/machinectl terminate {{.MachineName}}
 Environment=SYSTEMD_NSPAWN_UNIFIED_HIERARCHY=1
 Environment=SYSTEMD_NSPAWN_API_VFS_WRITABLE=network
 {{- if .NvidiaGPUDevicePaths}}

--- a/cmd/agent/internal/phases/rootfs/nspawn.go
+++ b/cmd/agent/internal/phases/rootfs/nspawn.go
@@ -9,6 +9,7 @@ import (
 	"embed"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"text/template"
 
 	"github.com/Azure/unbounded/cmd/agent/internal/goalstates"
@@ -68,6 +69,9 @@ func (e *ensureNSpawnWorkspace) bootstrapWorkspace(ctx context.Context) error {
 // service-override.conf templates. Using a struct (rather than map[string]any)
 // lets us attach helper methods that the templates can call directly.
 type nspawnTemplateData struct {
+	// MachineName is the nspawn machine name (e.g. "kube1"). Used by the
+	// service drop-in for the ExecStartPre `machinectl terminate` cleanup.
+	MachineName          string
 	HostDevicePaths      []string
 	NvidiaGPUDevicePaths []string
 	NvidiaLibDirMounts   []goalstates.NvidiaLibDirMount
@@ -77,6 +81,10 @@ type nspawnTemplateData struct {
 // device and GPU data (when present) and writes them to their configured paths.
 func (e *ensureNSpawnWorkspace) writeNSpawnConfigs() error {
 	templateData := nspawnTemplateData{
+		// MachineName is the basename of MachineDir (e.g. "kube1" from
+		// "/var/lib/machines/kube1"); nspawn always names the machine
+		// after that directory.
+		MachineName:          filepath.Base(e.goalState.MachineDir),
 		HostDevicePaths:      e.goalState.HostDevicePaths,
 		NvidiaGPUDevicePaths: e.goalState.Nvidia.GPUDevicePaths,
 		NvidiaLibDirMounts:   e.goalState.Nvidia.LibDirMounts,

--- a/cmd/agent/internal/phases/rootfs/nspawn_render_test.go
+++ b/cmd/agent/internal/phases/rootfs/nspawn_render_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package rootfs
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestServiceOverride_SelfHealingDirectives ensures the rendered systemd
+// drop-in carries the directives that let systemd-nspawn@kube1 recover from
+// systemd-machined being restarted out from under it (for example by
+// needrestart during an unattended-upgrades run that touches libcap).
+func TestServiceOverride_SelfHealingDirectives(t *testing.T) {
+	t.Parallel()
+
+	data := nspawnTemplateData{
+		MachineName: "kube1",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, nspawnTemplates.ExecuteTemplate(&buf, "service-override.conf", data))
+
+	out := buf.String()
+
+	for _, want := range []string{
+		"Restart=on-failure",
+		"RestartSec=10s",
+		"StartLimitIntervalSec=0",
+		"ExecStartPre=-/usr/bin/machinectl terminate kube1",
+		"Environment=SYSTEMD_NSPAWN_UNIFIED_HIERARCHY=1",
+		"Environment=SYSTEMD_NSPAWN_API_VFS_WRITABLE=network",
+	} {
+		require.Contains(t, out, want, "missing directive in rendered drop-in")
+	}
+
+	// ExecStartPre must come before Environment so the cleanup runs before
+	// the unit's main start logic.
+	require.Less(t,
+		strings.Index(out, "ExecStartPre=-/usr/bin/machinectl terminate kube1"),
+		strings.Index(out, "Environment=SYSTEMD_NSPAWN_UNIFIED_HIERARCHY=1"),
+		"ExecStartPre should appear before Environment lines",
+	)
+}
+
+// TestServiceOverride_MachineNameSubstitution verifies the template uses the
+// caller-provided machine name rather than a hard-coded "kube1".
+func TestServiceOverride_MachineNameSubstitution(t *testing.T) {
+	t.Parallel()
+
+	data := nspawnTemplateData{MachineName: "kube7"}
+
+	var buf bytes.Buffer
+	require.NoError(t, nspawnTemplates.ExecuteTemplate(&buf, "service-override.conf", data))
+
+	require.Contains(t, buf.String(), "machinectl terminate kube7")
+	require.NotContains(t, buf.String(), "machinectl terminate kube1")
+}

--- a/images/host-ubuntu2404/assets/vendor-data.tmpl
+++ b/images/host-ubuntu2404/assets/vendor-data.tmpl
@@ -25,6 +25,30 @@ write_files:
 - path: /etc/cloud/cloud-init.disabled
   defer: true
   content: ''
+# Block unattended-upgrades from upgrading packages whose post-install
+# triggers (via needrestart) restart systemd-machined and tear down the
+# running systemd-nspawn@kube1 container. The agent re-asserts this file
+# during `unbounded-agent start`; it is also written here so the protection
+# is in place from first boot, before the agent runs.
+- path: /etc/apt/apt.conf.d/99-unbounded-no-restart-systemd
+  permissions: '0644'
+  content: |
+    Unattended-Upgrade::Package-Blacklist {
+        "systemd";
+        "systemd-container";
+        "systemd-sysv";
+        "libsystemd0";
+        "libcap2";
+        "libcap2-bin";
+        "libpam-cap";
+    };
+# Disable needrestart auto-restart of services after package upgrades; only
+# list the ones that would otherwise be restarted. Belt-and-braces with the
+# apt blacklist above for any path that bypasses unattended-upgrades.
+- path: /etc/needrestart/conf.d/99-unbounded.conf
+  permissions: '0644'
+  content: |
+    $nrconf{restart} = 'l';
 runcmd:
 - - /bin/bash
   - -c

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -533,6 +533,24 @@ func TestVendorDataTemplate_WithAgentImage(t *testing.T) {
 	if !strings.Contains(body, "/cloudinit/log") {
 		t.Errorf("expected webhook reporting endpoint in rendered vendor-data, got:\n%s", body)
 	}
+
+	// Hardening drop-ins: the vendor-data must lay down apt and needrestart
+	// drop-ins that prevent unattended-upgrades from restarting
+	// systemd-machined out from under the running nspawn container. See
+	// cmd/agent/internal/phases/host/apt.go for the matching agent-side
+	// task that also writes these files.
+	for _, want := range []string{
+		"/etc/apt/apt.conf.d/99-unbounded-no-restart-systemd",
+		"Unattended-Upgrade::Package-Blacklist",
+		`"libcap2";`,
+		`"systemd-container";`,
+		"/etc/needrestart/conf.d/99-unbounded.conf",
+		"$nrconf{restart} = 'l';",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %q in rendered vendor-data, got:\n%s", want, body)
+		}
+	}
 }
 
 func TestVendorDataTemplate_WithoutAgentImage(t *testing.T) {


### PR DESCRIPTION
When unattended-upgrades on Ubuntu hosts touches systemd or libcap, needrestart restarts systemd-machined, which stops systemd-nspawn@kube1 and leaves it in a failed state with 'Machine kube1 already exists' (EEXIST/errno 17). Three layered fixes:

1. systemd-nspawn@kube1.service drop-in now sets Restart=on-failure, StartLimitIntervalSec=0, and ExecStartPre=-machinectl terminate kube1 so the unit self-heals without operator action.
2. StartNSpawnMachine.Do recovers from EEXIST: reset-failed, terminate, wait, retry start once.
3. New HardenAPT host phase (and matching cloud-init write_files entries) blacklists systemd/libcap/etc. from unattended-upgrades and disables needrestart auto-restart, removing the trigger entirely.

Tests cover the rendered drop-in, the recovery state machine, and the HardenAPT idempotency.