### PR TITLE
ebpf: pin cross-site supernet RoutedCidrs to a single nexthop

### DIFF
--- a/cmd/unbounded-net-node/ebpf_geneve_config.go
+++ b/cmd/unbounded-net-node/ebpf_geneve_config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -329,7 +330,10 @@ func configureEBPFTunnelPeers(
 		addPeerBPFEntries(bpfEntries, peer.PodCIDRs, underlayIP, uint32(cfg.GeneveVNI), peerIfIdx, peerFlags, peerProto, peer.Name)
 	}
 
-	for _, gwPeer := range gatewayPeers {
+	sortedGatewayPeers := append([]gatewayPeerInfo(nil), gatewayPeers...)
+	sort.Slice(sortedGatewayPeers, func(i, j int) bool { return sortedGatewayPeers[i].Name < sortedGatewayPeers[j].Name })
+
+	for _, gwPeer := range sortedGatewayPeers {
 		if len(gwPeer.InternalIPs) == 0 || len(gwPeer.PodCIDRs) == 0 {
 			continue
 		}
@@ -341,7 +345,9 @@ func configureEBPFTunnelPeers(
 
 		peerIfIdx, peerFlags, peerProto := resolveEBPFPeerTarget(gwPeer.TunnelProtocol, geneveIfIndex, ipipIfIndex, defaultIfIdx, cfg)
 		addPeerBPFEntries(bpfEntries, gwPeer.PodCIDRs, underlayIP, uint32(cfg.GeneveVNI), peerIfIdx, peerFlags, peerProto, gwPeer.Name)
-		addPeerBPFEntries(bpfEntries, gwPeer.RoutedCidrs, underlayIP, uint32(cfg.GeneveVNI), peerIfIdx, peerFlags, peerProto, gwPeer.Name)
+		// Supernet RoutedCidrs are pinned to a single nexthop (first peer wins)
+		// to avoid asymmetric ECMP across non-equivalent gateways.
+		addPeerBPFEntriesSingleNexthop(bpfEntries, gwPeer.RoutedCidrs, underlayIP, uint32(cfg.GeneveVNI), peerIfIdx, peerFlags, peerProto, gwPeer.Name)
 	}
 
 	// Store entries for deferred reconcile (after VXLAN and WG entries are added).
@@ -499,7 +505,10 @@ func configureEBPFVXLANPeers(
 		addPeerBPFEntries(bpfEntries, peer.PodCIDRs, underlayIP, vni, tunnelIfIndex, ebpfpkg.TunnelFlagSetKey, ebpfpkg.TunnelProtoVXLAN, peer.Name)
 	}
 
-	for _, gwPeer := range gatewayPeers {
+	sortedGatewayPeers := append([]gatewayPeerInfo(nil), gatewayPeers...)
+	sort.Slice(sortedGatewayPeers, func(i, j int) bool { return sortedGatewayPeers[i].Name < sortedGatewayPeers[j].Name })
+
+	for _, gwPeer := range sortedGatewayPeers {
 		if len(gwPeer.InternalIPs) == 0 || len(gwPeer.PodCIDRs) == 0 {
 			continue
 		}
@@ -510,7 +519,9 @@ func configureEBPFVXLANPeers(
 		}
 
 		addPeerBPFEntries(bpfEntries, gwPeer.PodCIDRs, underlayIP, vni, tunnelIfIndex, ebpfpkg.TunnelFlagSetKey, ebpfpkg.TunnelProtoVXLAN, gwPeer.Name)
-		addPeerBPFEntries(bpfEntries, gwPeer.RoutedCidrs, underlayIP, vni, tunnelIfIndex, ebpfpkg.TunnelFlagSetKey, ebpfpkg.TunnelProtoVXLAN, gwPeer.Name)
+		// Supernet RoutedCidrs are pinned to a single nexthop (first peer wins)
+		// to avoid asymmetric ECMP across non-equivalent gateways.
+		addPeerBPFEntriesSingleNexthop(bpfEntries, gwPeer.RoutedCidrs, underlayIP, vni, tunnelIfIndex, ebpfpkg.TunnelFlagSetKey, ebpfpkg.TunnelProtoVXLAN, gwPeer.Name)
 	}
 
 	// Store entries for deferred reconcile.
@@ -585,6 +596,43 @@ func addPeerBPFEntries(entries map[string]ebpfpkg.TunnelEndpoint, cidrs []string
 			PeerName: peerName,
 		})
 		entries[key] = ep
+	}
+}
+
+// addPeerBPFEntriesSingleNexthop is like addPeerBPFEntries but skips a CIDR if
+// it already has any nexthop programmed. Used for cross-site supernets
+// (gateway RoutedCidrs) that are typically advertised by multiple gateway
+// peers but where ECMP-fanning a TCP flow across non-equivalent gateways
+// causes asymmetric paths (the BPF flow_hash is direction-asymmetric, so a
+// SYN and its SYN-ACK can pick different gateways). Pinning the supernet
+// fallback to a single nexthop -- the first deterministically-ordered peer
+// to advertise it -- keeps a flow on one gateway end-to-end. Per-peer
+// PodCIDRs (more-specific LPM entries) continue to use multi-nexthop ECMP.
+//
+// Callers must order peers deterministically (e.g. sorted by peer name) so
+// the winning nexthop is reproducible across reconciles.
+func addPeerBPFEntriesSingleNexthop(entries map[string]ebpfpkg.TunnelEndpoint, cidrs []string, underlayIP net.IP, vni, ifindex, flags, protocol uint32, peerName string) {
+	for _, cidrStr := range cidrs {
+		_, cidr, err := net.ParseCIDR(cidrStr)
+		if err != nil {
+			continue
+		}
+
+		key := cidr.String()
+		if ep, exists := entries[key]; exists && len(ep.Nexthops) > 0 {
+			continue
+		}
+
+		entries[key] = ebpfpkg.TunnelEndpoint{
+			Nexthops: []ebpfpkg.TunnelNexthop{{
+				RemoteIP: underlayIP,
+				VNI:      vni,
+				IfIndex:  ifindex,
+				Flags:    flags | ebpfpkg.TunnelFlagHealthy,
+				Protocol: protocol,
+				PeerName: peerName,
+			}},
+		}
 	}
 }
 
@@ -736,8 +784,12 @@ func addWireGuardPeersToBPFMap(cfg *config, state *wireGuardState, wgMeshPeers [
 		addPeerBPFEntries(state.pendingBPFEntries, peer.PodCIDRs, underlayIP, 0, wgIfIndex, 0, ebpfpkg.TunnelProtoWireGuard, peer.Name)
 	}
 
-	// Add gateway WG peers.
-	for _, gwPeer := range wgGatewayPeers {
+	// Add gateway WG peers. Order by Name so RoutedCidr single-nexthop
+	// programming (first-peer-wins) is deterministic across reconciles.
+	sortedWgGatewayPeers := append([]gatewayPeerInfo(nil), wgGatewayPeers...)
+	sort.Slice(sortedWgGatewayPeers, func(i, j int) bool { return sortedWgGatewayPeers[i].Name < sortedWgGatewayPeers[j].Name })
+
+	for _, gwPeer := range sortedWgGatewayPeers {
 		if len(gwPeer.InternalIPs) == 0 {
 			continue
 		}
@@ -760,8 +812,14 @@ func addWireGuardPeersToBPFMap(cfg *config, state *wireGuardState, wgMeshPeers [
 
 		gwIfIdx := uint32(gwIface.Index)
 
-		allCIDRs := append(gwPeer.PodCIDRs, gwPeer.RoutedCidrs...)
-		addPeerBPFEntries(state.pendingBPFEntries, allCIDRs, underlayIP, 0, gwIfIdx, 0, ebpfpkg.TunnelProtoWireGuard, gwPeer.Name)
+		addPeerBPFEntries(state.pendingBPFEntries, gwPeer.PodCIDRs, underlayIP, 0, gwIfIdx, 0, ebpfpkg.TunnelProtoWireGuard, gwPeer.Name)
+		// Supernet RoutedCidrs are pinned to a single nexthop (first peer wins)
+		// to avoid asymmetric ECMP across non-equivalent gateways. WG gateway
+		// peers commonly all advertise the same cross-site supernet (e.g. an
+		// AKS pod /16) -- without this dedupe, HRW spreads SYN and SYN-ACK
+		// across different gateway nodes and stateful NAT/conntrack on the
+		// far side drops the asymmetric reply.
+		addPeerBPFEntriesSingleNexthop(state.pendingBPFEntries, gwPeer.RoutedCidrs, underlayIP, 0, gwIfIdx, 0, ebpfpkg.TunnelProtoWireGuard, gwPeer.Name)
 	}
 	state.mu.Unlock()
 

--- a/cmd/unbounded-net-node/ebpf_routedcidr_dedupe_test.go
+++ b/cmd/unbounded-net-node/ebpf_routedcidr_dedupe_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"net"
+	"testing"
+
+	ebpfpkg "github.com/Azure/unbounded/internal/net/ebpf"
+)
+
+// TestAddPeerBPFEntries_MultiNexthopForSameCIDR confirms that the
+// ECMP-eligible programming path appends nexthops for repeated CIDRs.
+func TestAddPeerBPFEntries_MultiNexthopForSameCIDR(t *testing.T) {
+	entries := make(map[string]ebpfpkg.TunnelEndpoint)
+
+	addPeerBPFEntries(entries, []string{"10.244.0.0/16"},
+		net.ParseIP("10.0.0.1"), 0, 100, 0, ebpfpkg.TunnelProtoWireGuard, "peerA")
+	addPeerBPFEntries(entries, []string{"10.244.0.0/16"},
+		net.ParseIP("10.0.0.2"), 0, 200, 0, ebpfpkg.TunnelProtoWireGuard, "peerB")
+
+	ep, ok := entries["10.244.0.0/16"]
+	if !ok {
+		t.Fatal("expected entry for 10.244.0.0/16")
+	}
+
+	if got, want := len(ep.Nexthops), 2; got != want {
+		t.Fatalf("multi-nexthop path: got %d nexthops, want %d", got, want)
+	}
+}
+
+// TestAddPeerBPFEntriesSingleNexthop_FirstWins confirms that supernet
+// RoutedCidr programming retains exactly one nexthop, set by the first
+// caller, even when subsequent peers advertise the same prefix.
+func TestAddPeerBPFEntriesSingleNexthop_FirstWins(t *testing.T) {
+	entries := make(map[string]ebpfpkg.TunnelEndpoint)
+
+	addPeerBPFEntriesSingleNexthop(entries, []string{"10.244.0.0/16"},
+		net.ParseIP("10.0.0.1"), 0, 100, 0, ebpfpkg.TunnelProtoWireGuard, "peerA")
+	addPeerBPFEntriesSingleNexthop(entries, []string{"10.244.0.0/16"},
+		net.ParseIP("10.0.0.2"), 0, 200, 0, ebpfpkg.TunnelProtoWireGuard, "peerB")
+
+	ep, ok := entries["10.244.0.0/16"]
+	if !ok {
+		t.Fatal("expected entry for 10.244.0.0/16")
+	}
+
+	if got, want := len(ep.Nexthops), 1; got != want {
+		t.Fatalf("single-nexthop path: got %d nexthops, want %d", got, want)
+	}
+
+	nh := ep.Nexthops[0]
+	if nh.PeerName != "peerA" {
+		t.Errorf("first-peer-wins: got peer %q, want %q", nh.PeerName, "peerA")
+	}
+
+	if got, want := nh.IfIndex, uint32(100); got != want {
+		t.Errorf("first-peer-wins: got ifindex %d, want %d", got, want)
+	}
+
+	if !nh.RemoteIP.Equal(net.ParseIP("10.0.0.1")) {
+		t.Errorf("first-peer-wins: got remote %s, want 10.0.0.1", nh.RemoteIP)
+	}
+}
+
+// TestAddPeerBPFEntriesSingleNexthop_DoesNotAffectExistingMultiNexthop
+// confirms that calling the single-nexthop helper for a CIDR that already
+// has multi-nexthop entries (e.g. from PodCIDR programming) leaves them
+// untouched. This guards against accidentally collapsing peer-specific
+// PodCIDR entries when a different peer's RoutedCidr happens to match.
+func TestAddPeerBPFEntriesSingleNexthop_DoesNotAffectExistingMultiNexthop(t *testing.T) {
+	entries := make(map[string]ebpfpkg.TunnelEndpoint)
+
+	addPeerBPFEntries(entries, []string{"10.244.0.0/24"},
+		net.ParseIP("10.0.0.1"), 0, 100, 0, ebpfpkg.TunnelProtoWireGuard, "peerA")
+	addPeerBPFEntries(entries, []string{"10.244.0.0/24"},
+		net.ParseIP("10.0.0.2"), 0, 200, 0, ebpfpkg.TunnelProtoWireGuard, "peerB")
+
+	addPeerBPFEntriesSingleNexthop(entries, []string{"10.244.0.0/24"},
+		net.ParseIP("10.0.0.3"), 0, 300, 0, ebpfpkg.TunnelProtoWireGuard, "peerC")
+
+	ep := entries["10.244.0.0/24"]
+	if got, want := len(ep.Nexthops), 2; got != want {
+		t.Fatalf("expected existing multi-nexthop entry to be preserved (got %d, want %d)", got, want)
+	}
+
+	for _, nh := range ep.Nexthops {
+		if nh.PeerName == "peerC" {
+			t.Errorf("single-nexthop helper unexpectedly added a nexthop for an existing entry")
+		}
+	}
+}


### PR DESCRIPTION
Gateway peers in a multi-gateway pool all advertise the same cross-site supernet (e.g. cluster pod CIDR 10.244.0.0/16). The BPF tunnel-endpoint LPM map programmed each peer as an additional nexthop for that supernet, making the supernet entry ECMP-eligible. The BPF dataplane's flow_hash is direction-asymmetric, so a SYN and its SYN-ACK can hash onto different gateway nexthops; when the SYN-ACK egresses on a gateway that did not see the SYN, that gateway has no flow state and the reply is black-holed. This appeared as a ~25-30% TCP success rate from cluster pods to remote pods that arrived via the supernet fallback route.

Per-peer PodCIDRs are unique to one gateway and remain multi-nexthop ECMP via addPeerBPFEntries; only the supernet RoutedCidrs are pinned to a single deterministic nexthop. Gateway peers are sorted by Name before iteration so the winning nexthop is reproducible across reconciles.

Adds unit tests covering: multi-nexthop append still works for repeated CIDRs (PodCIDR semantics), single-nexthop first-wins, and the single-nexthop helper does not collapse an existing multi-nexthop entry for the same CIDR.

Verified on a live cluster: spark-2c24's BPF map for 10.244.0.0/16 now shows exactly one nexthop (was two), per-peer /24 PodCIDR entries still have multiple nexthops where expected.