### PR TITLE
node: flush stale L2-transit UDP conntrack on masquerade reconcile

### DIFF
--- a/cmd/unbounded-net-node/site_watch_reconcile.go
+++ b/cmd/unbounded-net-node/site_watch_reconcile.go
@@ -2110,6 +2110,22 @@ func syncMasqueradeRules(state *wireGuardState, nonMasqCIDRs []string) {
 	} else {
 		klog.V(4).Infof("Synced masquerade rules for default gateway (v4: %s, v6: %s)", defaultIfaceV4, defaultIfaceV6)
 	}
+
+	// Opportunistically flush stale L2-transit UDP conntrack entries. This
+	// guards against the bridge-nf-call-iptables / route-flap class of bug
+	// where a downstream host's pre-route-change L2 frames left untranslated
+	// conntrack entries on this node, causing post-route-change packets to
+	// skip MASQUERADE. See FlushStaleTransitUDPConntrack for details.
+	if defaultIfaceV4 != "" {
+		localIPs, err := unboundednetnetlink.LocalIPv4Addresses()
+		if err != nil {
+			klog.V(3).Infof("Failed to enumerate local IPs for conntrack flush: %v", err)
+		} else if n, err := unboundednetnetlink.FlushStaleTransitUDPConntrack(localIPs); err != nil {
+			klog.V(3).Infof("Failed to flush stale transit conntrack: %v", err)
+		} else if n > 0 {
+			klog.V(2).Infof("Flushed %d stale L2-transit UDP conntrack entries", n)
+		}
+	}
 }
 
 // logMeshPeerChanges logs which mesh peers were added or removed

--- a/internal/net/netlink/conntrack_flush.go
+++ b/internal/net/netlink/conntrack_flush.go
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package netlink
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+)
+
+// FlushStaleTransitUDPConntrack scans the conntrack table and removes UDP
+// entries that are pure L2 transit and have not been NAT-translated.
+// It returns the number of entries removed.
+//
+// Specifically, an entry is removed when all of the following hold:
+//   - protocol is UDP
+//   - the original and reply tuples are exact mirrors (no SNAT/DNAT applied)
+//   - neither the original source nor the original destination is one of
+//     the supplied local IPs
+//
+// This addresses a class of bugs caused by Linux bridges with
+// bridge-nf-call-iptables=1: when a downstream host's L2 frames transit a
+// bridge but are not routed by the bridge node, conntrack still tracks the
+// flow as UNREPLIED with no NAT applied. If the downstream host's default
+// route later changes to point at the bridge node, the same flow now SHOULD
+// be SNAT'd by an existing MASQUERADE rule, but conntrack reuses the stale
+// (un-NAT'd) entry and skips MASQUERADE -- packets leave with the wrong
+// source address and the upstream peer never replies.
+//
+// Periodically calling this function clears such stale entries so the next
+// packet for that flow takes a fresh path through the netfilter hooks.
+// UDP-only is intentional: TCP flows reach ESTABLISHED via SYN/SYN-ACK and
+// would be safe to leave; the staleness mostly affects connectionless UDP
+// (WireGuard handshake, GENEVE keepalive, etc).
+func FlushStaleTransitUDPConntrack(localIPs []net.IP) (uint, error) {
+	filter := newStaleTransitUDPFilter(localIPs)
+
+	// IPv4 only for now: conntrack is per-family in netlink, and the bridge
+	// transit issue is overwhelmingly an IPv4 NAT problem.
+	n, err := netlink.ConntrackDeleteFilter(netlink.ConntrackTable, syscall.AF_INET, filter)
+	if err != nil {
+		return 0, fmt.Errorf("conntrack delete: %w", err)
+	}
+
+	return n, nil
+}
+
+// staleTransitUDPFilter implements netlink.CustomConntrackFilter and matches
+// stale L2-transit UDP entries (see FlushStaleTransitUDPConntrack).
+type staleTransitUDPFilter struct {
+	localIPs map[string]struct{}
+}
+
+func newStaleTransitUDPFilter(localIPs []net.IP) *staleTransitUDPFilter {
+	set := make(map[string]struct{}, len(localIPs))
+	for _, ip := range localIPs {
+		if ip == nil {
+			continue
+		}
+
+		set[ip.String()] = struct{}{}
+	}
+
+	return &staleTransitUDPFilter{localIPs: set}
+}
+
+// MatchConntrackFlow returns true when the flow matches our predicate and
+// should be removed.
+func (f *staleTransitUDPFilter) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+	if flow == nil {
+		return false
+	}
+
+	if flow.Forward.Protocol != syscall.IPPROTO_UDP {
+		return false
+	}
+
+	// If SNAT was applied, Reverse.DstIP would be the post-NAT source IP
+	// and would not equal Forward.SrcIP. Same logic in reverse for DNAT.
+	if !flow.Forward.SrcIP.Equal(flow.Reverse.DstIP) {
+		return false
+	}
+
+	if !flow.Forward.DstIP.Equal(flow.Reverse.SrcIP) {
+		return false
+	}
+
+	if flow.Forward.SrcPort != flow.Reverse.DstPort {
+		return false
+	}
+
+	if flow.Forward.DstPort != flow.Reverse.SrcPort {
+		return false
+	}
+
+	// Skip entries originating from or destined to a local IP. Those are
+	// legitimate flows where the node itself is the source or sink, and
+	// should not be touched.
+	if _, ok := f.localIPs[flow.Forward.SrcIP.String()]; ok {
+		return false
+	}
+
+	if _, ok := f.localIPs[flow.Forward.DstIP.String()]; ok {
+		return false
+	}
+
+	return true
+}
+
+// LocalIPv4Addresses returns the IPv4 addresses currently configured on
+// non-loopback, non-link-local interfaces. It is a thin wrapper around
+// netlink.AddrList intended for use with FlushStaleTransitUDPConntrack.
+func LocalIPv4Addresses() ([]net.IP, error) {
+	addrs, err := netlink.AddrList(nil, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, fmt.Errorf("list addresses: %w", err)
+	}
+
+	out := make([]net.IP, 0, len(addrs))
+
+	for _, a := range addrs {
+		if a.IP == nil {
+			continue
+		}
+
+		if a.IP.IsLoopback() || a.IP.IsLinkLocalUnicast() {
+			continue
+		}
+
+		out = append(out, a.IP)
+	}
+
+	return out, nil
+}

--- a/internal/net/netlink/conntrack_flush_test.go
+++ b/internal/net/netlink/conntrack_flush_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package netlink
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	vishnetlink "github.com/vishvananda/netlink"
+)
+
+func makeFlow(proto uint8, fSrc, fDst, rSrc, rDst string, fSp, fDp, rSp, rDp uint16) *vishnetlink.ConntrackFlow {
+	return &vishnetlink.ConntrackFlow{
+		Forward: vishnetlink.IPTuple{
+			Protocol: proto,
+			SrcIP:    net.ParseIP(fSrc),
+			DstIP:    net.ParseIP(fDst),
+			SrcPort:  fSp,
+			DstPort:  fDp,
+		},
+		Reverse: vishnetlink.IPTuple{
+			Protocol: proto,
+			SrcIP:    net.ParseIP(rSrc),
+			DstIP:    net.ParseIP(rDst),
+			SrcPort:  rSp,
+			DstPort:  rDp,
+		},
+	}
+}
+
+func TestStaleTransitUDPFilter_MatchesUntranslatedTransit(t *testing.T) {
+	f := newStaleTransitUDPFilter([]net.IP{net.ParseIP("172.18.10.252"), net.ParseIP("10.132.164.4")})
+
+	// spark (172.18.10.7) → AKS (52.138.2.134) un-NAT'd: tuples are mirror.
+	flow := makeFlow(syscall.IPPROTO_UDP, "172.18.10.7", "52.138.2.134", "52.138.2.134", "172.18.10.7", 51821, 51820, 51820, 51821)
+	if !f.MatchConntrackFlow(flow) {
+		t.Fatal("expected mirror UDP transit flow to match (stale, un-NAT'd)")
+	}
+}
+
+func TestStaleTransitUDPFilter_SkipsNATTranslated(t *testing.T) {
+	f := newStaleTransitUDPFilter([]net.IP{net.ParseIP("10.132.164.4")})
+
+	// spark → AKS with SNAT applied: Reverse.DstIP is the post-NAT source.
+	flow := makeFlow(syscall.IPPROTO_UDP, "172.18.10.7", "52.138.2.134", "52.138.2.134", "10.132.164.4", 51821, 51820, 51820, 63470)
+	if f.MatchConntrackFlow(flow) {
+		t.Fatal("expected NAT-translated flow to be skipped")
+	}
+}
+
+func TestStaleTransitUDPFilter_SkipsTCP(t *testing.T) {
+	f := newStaleTransitUDPFilter(nil)
+
+	flow := makeFlow(syscall.IPPROTO_TCP, "172.18.10.7", "52.138.2.134", "52.138.2.134", "172.18.10.7", 5555, 80, 80, 5555)
+	if f.MatchConntrackFlow(flow) {
+		t.Fatal("expected TCP flow to be skipped")
+	}
+}
+
+func TestStaleTransitUDPFilter_SkipsLocalSource(t *testing.T) {
+	local := net.ParseIP("172.18.10.252")
+	f := newStaleTransitUDPFilter([]net.IP{local})
+
+	flow := makeFlow(syscall.IPPROTO_UDP, "172.18.10.252", "52.138.2.134", "52.138.2.134", "172.18.10.252", 9999, 51820, 51820, 9999)
+	if f.MatchConntrackFlow(flow) {
+		t.Fatal("expected flow originating from local IP to be skipped")
+	}
+}
+
+func TestStaleTransitUDPFilter_SkipsLocalDestination(t *testing.T) {
+	local := net.ParseIP("172.18.10.252")
+	f := newStaleTransitUDPFilter([]net.IP{local})
+
+	flow := makeFlow(syscall.IPPROTO_UDP, "10.0.0.1", "172.18.10.252", "172.18.10.252", "10.0.0.1", 5555, 53, 53, 5555)
+	if f.MatchConntrackFlow(flow) {
+		t.Fatal("expected flow destined to local IP to be skipped")
+	}
+}
+
+func TestStaleTransitUDPFilter_SkipsNilFlow(t *testing.T) {
+	f := newStaleTransitUDPFilter(nil)
+	if f.MatchConntrackFlow(nil) {
+		t.Fatal("expected nil flow to be skipped")
+	}
+}
+
+func TestStaleTransitUDPFilter_SkipsPortMismatch(t *testing.T) {
+	f := newStaleTransitUDPFilter(nil)
+
+	// Same IPs but ports don't mirror -> not a clean un-NAT'd entry.
+	flow := makeFlow(syscall.IPPROTO_UDP, "172.18.10.7", "52.138.2.134", "52.138.2.134", "172.18.10.7", 51821, 51820, 51820, 9999)
+	if f.MatchConntrackFlow(flow) {
+		t.Fatal("expected port-mismatched flow to be skipped")
+	}
+}


### PR DESCRIPTION
When a node has a Linux bridge interface on a downstream network and net.bridge.bridge-nf-call-iptables is enabled (required for k8s on the same node), every frame that transits the bridge invokes the netfilter hooks even when the node is not the routing target. This is normal for k8s, but creates a hazard: if a downstream host's frames are bridged out the same VLAN (not routed via this node's default-gateway iface), conntrack records the flow as UNREPLIED with no NAT applied because the MASQUERADE rule is scoped to '-o <default-iface>'.

If the downstream host's default route later changes to point at this node, the same flow now SHOULD be SNAT'd. Linux's NAT engine only computes NAT decisions on the first packet of a flow and reuses thereafter, so subsequent packets keep using the no-NAT decision from the cached entry. Packets leave with the wrong source address, the upstream peer never replies, and the affected flow stays broken until the entry ages out (effectively never for keepalived UDP).

Add FlushStaleTransitUDPConntrack which scans the conntrack table and removes UDP entries that meet all of: protocol UDP, original and reply tuples are exact mirrors (no SNAT/DNAT applied), neither tuple end is a local IP. The L2-transit-with-no-NAT case is precisely this shape. TCP is intentionally left alone (handshake state makes staleness less common, and TCP CONNRESET would be more disruptive than the self-recovery wait).

Wired into syncMasqueradeRules so any reconcile (already periodic) will opportunistically clear stale entries within seconds of a downstream route flip. No tunables, no new Site/Node configuration required.

Reproduced on a live cluster: a remote node's default route was flipped from a non-NAT'ing router to the unbounded-net gateway node, which left the gateway's apollo-side conntrack with a stale un-NAT'd WireGuard handshake entry. WG handshakes silently failed until the entry was manually flushed; with this change the next reconcile flushes it automatically.

Adds 7 unit tests for the filter predicate covering matched stale entries, NAT-translated entries, TCP, local-source/dest, nil flow, and port-mismatched mirror tuples.