### PR TITLE
Add buffer pool for unbounded-storage

### DIFF
--- a/cmd/unbounded-storage/Cargo.lock
+++ b/cmd/unbounded-storage/Cargo.lock
@@ -3,5 +3,14 @@
 version = 4
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "unbounded-storage"
 version = "0.1.0"
+dependencies = [
+ "libc",
+]

--- a/cmd/unbounded-storage/Cargo.toml
+++ b/cmd/unbounded-storage/Cargo.toml
@@ -8,4 +8,11 @@ publish = false
 name = "unbounded-storage"
 path = "src/main.rs"
 
+[lib]
+name = "unbounded_storage"
+path = "src/lib.rs"
+
 [dependencies]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"

--- a/cmd/unbounded-storage/src/bufferpool/free_list.rs
+++ b/cmd/unbounded-storage/src/bufferpool/free_list.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Single-shard free page allocator. Parks awaiting wakers when the
+//! backing is exhausted and wakes the oldest one on each
+//! [`FreeList::release`]. The pool runs single-threaded inside its
+//! NUMA shard so the underlying [`RefCell`] is sufficient; no atomics
+//! are required.
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+
+pub(super) struct FreeList {
+    inner: RefCell<Inner>,
+}
+
+struct Inner {
+    free: Vec<u32>,
+    waiters: VecDeque<Waker>,
+}
+
+impl FreeList {
+    pub fn new(page_count: u32) -> Self {
+        let mut free = Vec::with_capacity(page_count as usize);
+        // Reverse so popping gives ascending page indices, which
+        // makes test assertions deterministic.
+        for i in (0..page_count).rev() {
+            free.push(i);
+        }
+        Self {
+            inner: RefCell::new(Inner {
+                free,
+                waiters: VecDeque::new(),
+            }),
+        }
+    }
+
+    /// Try to grab a free page without parking.
+    #[allow(dead_code)]
+    pub fn try_alloc(&self) -> Option<u32> {
+        self.inner.borrow_mut().free.pop()
+    }
+
+    /// Park until a free page is available, then return it.
+    pub fn alloc(&self) -> AllocFuture<'_> {
+        AllocFuture { list: self }
+    }
+
+    /// Return `page_idx` to the pool and wake the oldest waiter.
+    pub fn release(&self, page_idx: u32) {
+        let waker = {
+            let mut g = self.inner.borrow_mut();
+            g.free.push(page_idx);
+            g.waiters.pop_front()
+        };
+        if let Some(w) = waker {
+            w.wake();
+        }
+    }
+
+    #[cfg(test)]
+    pub fn available(&self) -> usize {
+        self.inner.borrow().free.len()
+    }
+}
+
+pub(super) struct AllocFuture<'a> {
+    list: &'a FreeList,
+}
+
+impl<'a> Future for AllocFuture<'a> {
+    type Output = u32;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<u32> {
+        let mut g = self.list.inner.borrow_mut();
+        if let Some(p) = g.free.pop() {
+            Poll::Ready(p)
+        } else {
+            g.waiters.push_back(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}

--- a/cmd/unbounded-storage/src/bufferpool/inflight.rs
+++ b/cmd/unbounded-storage/src/bufferpool/inflight.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Per-stripe single-flight bookkeeping.
+//!
+//! One [`StripeFetch`] lives in the pool's inflight map per active
+//! [`StripeKey`]. Each [`PageSlot`] within it tracks the lifecycle of
+//! one logical page within the stripe: which `page_idx` was allocated
+//! out of the [`crate::bufferpool::Backing`], whether the I/O is
+//! still pending, how many [`crate::bufferpool::PageGuard`]s are
+//! holding the bytes, and whether the tee `BlockStore::write_page`
+//! is still draining.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::task::Waker;
+
+use crate::bufferpool::types::Error;
+pub(super) struct StripeFetch {
+    pub pages: HashMap<u64, Rc<PageSlot>>,
+    /// Number of live `ReadStream`s subscribed to this stripe.
+    pub stream_refcount: u32,
+}
+
+impl StripeFetch {
+    pub fn new() -> Self {
+        Self {
+            pages: HashMap::new(),
+            stream_refcount: 0,
+        }
+    }
+}
+
+pub(super) struct PageSlot {
+    #[allow(dead_code)]
+    pub page_no: u64,
+    pub state: RefCell<SlotState>,
+    /// Allocated page index in the backing. `None` until the leader
+    /// successfully claims a free page.
+    pub page_idx: Cell<Option<u32>>,
+    /// Live `PageGuard`s currently holding the bytes.
+    pub consumer_holds: Cell<u32>,
+    /// True while the tee `BlockStore::write_page` is outstanding;
+    /// the page index cannot be recycled until both this flag is
+    /// false and `consumer_holds == 0`.
+    pub tee_pending: Cell<bool>,
+}
+
+impl PageSlot {
+    pub fn new(page_no: u64) -> Self {
+        Self {
+            page_no,
+            state: RefCell::new(SlotState::Idle),
+            page_idx: Cell::new(None),
+            consumer_holds: Cell::new(0),
+            tee_pending: Cell::new(false),
+        }
+    }
+
+    /// `true` when the slot's page index can safely be returned to
+    /// the free list and the slot itself can be removed from the
+    /// `StripeFetch`.
+    pub fn is_recyclable(&self) -> bool {
+        self.consumer_holds.get() == 0 && !self.tee_pending.get()
+    }
+}
+
+pub(super) enum SlotState {
+    /// Newly created; no leader has taken it yet.
+    Idle,
+    /// A leader is driving the I/O. `wakers` parks late subscribers
+    /// (and the next-leader candidate) until state transitions away
+    /// from `Loading`. If the leader's future is dropped before
+    /// reaching `Ready`, the leader's RAII guard in `pool::fetch_page`
+    /// resets the slot to `Idle` and wakes the parked list so the
+    /// next subscriber takes over.
+    Loading(Vec<Waker>),
+    Ready,
+    Error(Error),
+}

--- a/cmd/unbounded-storage/src/bufferpool/mod.rs
+++ b/cmd/unbounded-storage/src/bufferpool/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+mod free_list;
+mod inflight;
+pub mod pool;
+pub mod stream;
+mod traits;
+mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use pool::Pool;
+pub use stream::{PageGuard, ReadStream};
+pub use traits::{BlockStore, BufferPool, Req, Transport};
+pub use types::{
+    Backing, BulkRef, Error, NodeId, PageRef, PeerId, PoolConfig, StripeKey, TraceCtx,
+};

--- a/cmd/unbounded-storage/src/bufferpool/pool.rs
+++ b/cmd/unbounded-storage/src/bufferpool/pool.rs
@@ -1,0 +1,605 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll};
+
+use crate::bufferpool::free_list::FreeList;
+use crate::bufferpool::inflight::{PageSlot, SlotState, StripeFetch};
+use crate::bufferpool::stream::{LocalBoxFuture, ReadStream, StreamSrc};
+use crate::bufferpool::traits::{BlockStore, BufferPool, Req, Transport};
+use crate::bufferpool::types::{Backing, BulkRef, Error, PageRef, PoolConfig, StripeKey};
+
+/// One per shard. Per the design's runtime model, a single `Pool`
+/// runs single-threaded inside its NUMA shard; the embedder pins
+/// the executor and is expected to construct the pool off-thread
+/// before handing it to the pinned executor for service.
+pub struct Pool<T, S, R>
+where
+    T: Transport<R>,
+    S: BlockStore,
+    R: Req,
+{
+    inner: Rc<PoolInner<T, S, R>>,
+}
+
+pub(super) struct PoolInner<T, S, R>
+where
+    T: Transport<R>,
+    S: BlockStore,
+    R: Req,
+{
+    pub(super) cfg: PoolConfig,
+    pub(super) backing: Backing,
+    pub(super) page_size: usize,
+    pub(super) free: FreeList,
+    pub(super) inflight: RefCell<HashMap<StripeKey, Rc<RefCell<StripeFetch>>>>,
+    pub(super) stream_count: Cell<usize>,
+    pub(super) transport: T,
+    pub(super) blockstore: S,
+    _r: PhantomData<R>,
+}
+
+impl<T, S, R> Pool<T, S, R>
+where
+    T: Transport<R> + 'static,
+    S: BlockStore + 'static,
+    R: Req + 'static,
+{
+    /// One per NUMA shard. Carves `backing` into pages, calls
+    /// `transport.register_pages(...)` and
+    /// `blockstore.register_pages(...)` exactly once. No async I/O
+    /// happens here; on a real RDMA `Transport` the synchronous
+    /// `ibv_reg_mr` is the dominant cost (see the design's
+    /// "Page registration" section). Embedders should run
+    /// `Pool::new` off the pinned executor thread before handing
+    /// the constructed `Pool` to the per-shard executor for
+    /// service.
+    pub fn new(
+        cfg: PoolConfig,
+        backing: Backing,
+        transport: T,
+        blockstore: S,
+    ) -> Result<Self, Error> {
+        if backing.page_size == 0 || !backing.page_size.is_power_of_two() {
+            return Err(Error::BadConfig("page_size must be a power of two"));
+        }
+        if backing.page_count == 0 {
+            return Err(Error::BadConfig("page_count must be > 0"));
+        }
+        if backing.page_count > u32::MAX as usize {
+            return Err(Error::BadConfig("page_count exceeds u32 (see design)"));
+        }
+        if backing.base.is_null() {
+            return Err(Error::BadConfig("backing.base is null"));
+        }
+
+        transport.register_pages(backing.base, backing.page_size, backing.page_count)?;
+        blockstore.register_pages(backing.base, backing.page_size, backing.page_count)?;
+
+        let page_count_u32 = backing.page_count as u32;
+        let page_size = backing.page_size;
+        let inner = Rc::new(PoolInner {
+            cfg,
+            backing,
+            page_size,
+            free: FreeList::new(page_count_u32),
+            inflight: RefCell::new(HashMap::new()),
+            stream_count: Cell::new(0),
+            transport,
+            blockstore,
+            _r: PhantomData,
+        });
+        Ok(Self { inner })
+    }
+
+    /// Test-only accessor for the free list size.
+    #[cfg(test)]
+    pub(super) fn free_pages(&self) -> usize {
+        self.inner.free.available()
+    }
+
+    /// Test-only accessor for the inflight map size.
+    #[cfg(test)]
+    pub(super) fn inflight_entries(&self) -> usize {
+        self.inner.inflight.borrow().len()
+    }
+}
+
+impl<T, S, R> BufferPool for Pool<T, S, R>
+where
+    T: Transport<R> + 'static,
+    S: BlockStore + 'static,
+    R: Req + 'static,
+{
+    type Req = R;
+
+    async fn read<'p>(
+        &'p self,
+        req: &'p Self::Req,
+        offset: u64,
+        len: u64,
+    ) -> Result<ReadStream<'p>, Error> {
+        let cur = self.inner.stream_count.get();
+        if cur >= self.inner.cfg.max_concurrent_streams {
+            return Err(Error::StreamLimit);
+        }
+        self.inner.stream_count.set(cur + 1);
+
+        let key = req.key();
+        let fetch = {
+            let mut inflight = self.inner.inflight.borrow_mut();
+            inflight
+                .entry(key)
+                .or_insert_with(|| Rc::new(RefCell::new(StripeFetch::new())))
+                .clone()
+        };
+        fetch.borrow_mut().stream_refcount += 1;
+
+        let end = offset.saturating_add(len);
+        let src: Rc<dyn StreamSrc + 'p> =
+            Rc::new(StreamSrcImpl::new(self.inner.clone(), req, key, fetch));
+        Ok(ReadStream::new(src, offset, end, self.inner.page_size))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StreamSrc: type-erased per-stream view onto the typed PoolInner.
+// ---------------------------------------------------------------------------
+
+pub(super) struct StreamSrcImpl<'p, T, S, R>
+where
+    T: Transport<R> + 'static,
+    S: BlockStore + 'static,
+    R: Req + 'static,
+{
+    inner: Rc<PoolInner<T, S, R>>,
+    req: &'p R,
+    key: StripeKey,
+    fetch: Rc<RefCell<StripeFetch>>,
+    /// Tracks whether `decrement_stream` has already run (it must
+    /// happen exactly once per `ReadStream`). Drop ordering of
+    /// `Rc<StreamSrcImpl>` is "last `PageGuard` or last
+    /// `ReadStream` reference"; the cleanup belongs to the stream,
+    /// not to outstanding guards, so we do it eagerly via
+    /// `decrement_stream`.
+    stream_decremented: Cell<bool>,
+}
+
+impl<'p, T, S, R> StreamSrcImpl<'p, T, S, R>
+where
+    T: Transport<R> + 'static,
+    S: BlockStore + 'static,
+    R: Req + 'static,
+{
+    pub(super) fn new(
+        inner: Rc<PoolInner<T, S, R>>,
+        req: &'p R,
+        key: StripeKey,
+        fetch: Rc<RefCell<StripeFetch>>,
+    ) -> Self {
+        Self {
+            inner,
+            req,
+            key,
+            fetch,
+            stream_decremented: Cell::new(false),
+        }
+    }
+}
+
+impl<'p, T, S, R> StreamSrc for StreamSrcImpl<'p, T, S, R>
+where
+    T: Transport<R> + 'static,
+    S: BlockStore + 'static,
+    R: Req + 'static,
+{
+    fn page_size(&self) -> usize {
+        self.inner.page_size
+    }
+
+    fn base(&self) -> *mut u8 {
+        self.inner.backing.base
+    }
+
+    fn key(&self) -> StripeKey {
+        self.key
+    }
+
+    fn fetch_page<'a>(&'a self, page_no: u64) -> LocalBoxFuture<'a, Result<u32, Error>> {
+        Box::pin(fetch_page(
+            self.inner.clone(),
+            self.fetch.clone(),
+            self.key,
+            self.req,
+            page_no,
+        ))
+    }
+
+    fn release_guard(&self, page_no: u64) {
+        release_guard(&self.inner, self.key, &self.fetch, page_no);
+    }
+
+    fn decrement_stream(&self) {
+        if self.stream_decremented.replace(true) {
+            return;
+        }
+        decrement_stream(&self.inner, self.key, &self.fetch);
+        let prev = self.inner.stream_count.get();
+        self.inner.stream_count.set(prev.saturating_sub(1));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup helpers.
+// ---------------------------------------------------------------------------
+
+fn release_guard<T, S, R>(
+    inner: &Rc<PoolInner<T, S, R>>,
+    key: StripeKey,
+    fetch: &Rc<RefCell<StripeFetch>>,
+    page_no: u64,
+) where
+    T: Transport<R>,
+    S: BlockStore,
+    R: Req,
+{
+    let slot = match fetch.borrow().pages.get(&page_no).cloned() {
+        Some(s) => s,
+        None => return,
+    };
+    let prev = slot.consumer_holds.get();
+    slot.consumer_holds.set(prev.saturating_sub(1));
+    recycle_if_terminal(inner, key, fetch, &slot, page_no);
+}
+
+/// Returns `slot`'s page to the free list and removes the slot
+/// (and possibly the entire `StripeFetch`) if it is in a terminal
+/// state and no one is holding it. Shared between [`release_guard`]
+/// and [`TeeGuard::drop`] so the cleanup invariant lives in one
+/// place.
+fn recycle_if_terminal<T, S, R>(
+    inner: &Rc<PoolInner<T, S, R>>,
+    key: StripeKey,
+    fetch: &Rc<RefCell<StripeFetch>>,
+    slot: &Rc<PageSlot>,
+    page_no: u64,
+) where
+    T: Transport<R>,
+    S: BlockStore,
+    R: Req,
+{
+    if !(slot.is_recyclable() && slot_is_terminal(slot)) {
+        return;
+    }
+    let release_pi = {
+        let mut f = fetch.borrow_mut();
+        // Re-check under the borrow to guard against a concurrent
+        // (re-entrant) update; in single-threaded use this is just
+        // defensive but it is cheap.
+        match f.pages.get(&page_no) {
+            Some(s) if Rc::ptr_eq(s, slot) && s.is_recyclable() && slot_is_terminal(s) => {
+                f.pages.remove(&page_no).and_then(|s| s.page_idx.get())
+            }
+            _ => None,
+        }
+    };
+    if let Some(pi) = release_pi {
+        inner.free.release(pi);
+    }
+    let should_remove = {
+        let f = fetch.borrow();
+        f.stream_refcount == 0 && f.pages.is_empty()
+    };
+    if should_remove {
+        inner.inflight.borrow_mut().remove(&key);
+    }
+}
+
+fn decrement_stream<T, S, R>(
+    inner: &Rc<PoolInner<T, S, R>>,
+    key: StripeKey,
+    fetch: &Rc<RefCell<StripeFetch>>,
+) where
+    T: Transport<R>,
+    S: BlockStore,
+    R: Req,
+{
+    let to_release: Vec<u32> = {
+        let mut f = fetch.borrow_mut();
+        f.stream_refcount = f.stream_refcount.saturating_sub(1);
+        let mut released = Vec::new();
+        if f.stream_refcount == 0 {
+            f.pages.retain(|_, slot| {
+                if slot.is_recyclable() && slot_is_terminal(slot) {
+                    if let Some(pi) = slot.page_idx.get() {
+                        released.push(pi);
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        released
+    };
+
+    for pi in to_release {
+        inner.free.release(pi);
+    }
+
+    let should_remove = {
+        let f = fetch.borrow();
+        f.stream_refcount == 0 && f.pages.is_empty()
+    };
+    if should_remove {
+        inner.inflight.borrow_mut().remove(&key);
+    }
+}
+
+fn slot_is_terminal(slot: &PageSlot) -> bool {
+    matches!(*slot.state.borrow(), SlotState::Ready | SlotState::Error(_))
+}
+
+// ---------------------------------------------------------------------------
+// Single-flight fetch.
+// ---------------------------------------------------------------------------
+
+/// Drives one logical page's I/O through the single-flight state
+/// machine. Cooperative leadership: the first poller to find the
+/// slot in `Idle` becomes the leader and runs the I/O; later
+/// pollers park in `Loading`. If the leader's future drops before
+/// completing, the [`LeaderGuard`] flips state back to `Idle`,
+/// wakes parked subscribers, and the next one takes over.
+async fn fetch_page<T, S, R>(
+    inner: Rc<PoolInner<T, S, R>>,
+    fetch: Rc<RefCell<StripeFetch>>,
+    key: StripeKey,
+    req: &R,
+    page_no: u64,
+) -> Result<u32, Error>
+where
+    T: Transport<R>,
+    S: BlockStore,
+    R: Req,
+{
+    let slot: Rc<PageSlot> = {
+        let mut f = fetch.borrow_mut();
+        f.pages
+            .entry(page_no)
+            .or_insert_with(|| Rc::new(PageSlot::new(page_no)))
+            .clone()
+    };
+
+    loop {
+        let action = {
+            let mut st = slot.state.borrow_mut();
+            match &mut *st {
+                SlotState::Ready => Action::Ready,
+                SlotState::Error(e) => Action::Error(e.clone()),
+                SlotState::Loading(_) => Action::Park,
+                SlotState::Idle => {
+                    *st = SlotState::Loading(Vec::new());
+                    Action::Lead
+                }
+            }
+        };
+
+        match action {
+            Action::Ready => {
+                let pi = slot
+                    .page_idx
+                    .get()
+                    .expect("page_idx must be set when slot is Ready");
+                slot.consumer_holds.set(slot.consumer_holds.get() + 1);
+                return Ok(pi);
+            }
+            Action::Error(e) => return Err(e),
+            Action::Park => {
+                ParkOnSlot { slot: &slot }.await;
+                continue;
+            }
+            Action::Lead => {
+                let mut leader_guard = LeaderGuard {
+                    slot: &slot,
+                    completed: false,
+                };
+
+                if slot.page_idx.get().is_none() {
+                    let pi = inner.free.alloc().await;
+                    slot.page_idx.set(Some(pi));
+                }
+                let pi = slot.page_idx.get().expect("page_idx set above");
+                let dst = PageRef {
+                    page_idx: pi,
+                    offset: 0,
+                    len: inner.page_size as u32,
+                };
+                let stripe_off = page_no
+                    .checked_mul(inner.page_size as u64)
+                    .ok_or(Error::OffsetOutOfRange)?;
+
+                // Phase 1: get bytes into the page (blocking the
+                // leader; parked subscribers wait). On error,
+                // transition to `Error` and propagate.
+                let fetch_result: Result<bool, Error> = async {
+                    let hit = inner.blockstore.read_page(key, stripe_off, dst).await?;
+                    if !hit {
+                        let bulk = BulkRef {
+                            stripe: key,
+                            offset: stripe_off,
+                            len: inner.page_size as u32,
+                        };
+                        inner.transport.bulk_get(req, bulk, dst).await?;
+                    }
+                    Ok(hit)
+                }
+                .await;
+
+                let hit = match fetch_result {
+                    Ok(h) => h,
+                    Err(e) => {
+                        let wakers = take_loading_wakers(&slot);
+                        *slot.state.borrow_mut() = SlotState::Error(e.clone());
+                        leader_guard.completed = true;
+                        drop(leader_guard);
+                        for w in wakers {
+                            w.wake();
+                        }
+                        return Err(e);
+                    }
+                };
+
+                // Phase 2: mark Ready and wake parked subscribers
+                // BEFORE running the tee, so non-leader subscribers
+                // can consume bytes concurrently with the leader's
+                // `write_page` (matches designs/bufferpool.md
+                // "Pull-through with tee"). The page stays pinned
+                // across the tee via `tee_pending`.
+                let need_tee = !hit;
+                if need_tee {
+                    slot.tee_pending.set(true);
+                }
+                let wakers = take_loading_wakers(&slot);
+                *slot.state.borrow_mut() = SlotState::Ready;
+                slot.consumer_holds.set(slot.consumer_holds.get() + 1);
+                leader_guard.completed = true;
+                drop(leader_guard);
+                for w in wakers {
+                    w.wake();
+                }
+
+                // Phase 3: leader drives the tee. The leader keeps
+                // `consumer_holds` bumped above so the page stays
+                // pinned across the tee even if no other subscriber
+                // is around. If the leader's future is dropped here
+                // the `TeeGuard` clears `tee_pending` *and* releases
+                // the leader's pre-emptive consumer hold so the page
+                // can be recycled (the tee write is best-effort:
+                // data is still in the pool, only the on-disk cache
+                // fill is skipped).  `write_page` errors are also
+                // treated as best-effort for v1 (see
+                // designs/bufferpool.md TODO(partial-failure)).
+                if need_tee {
+                    let mut tee_guard = TeeGuard {
+                        slot: &slot,
+                        fetch: &fetch,
+                        inner: &inner,
+                        key,
+                        page_no,
+                        completed: false,
+                    };
+                    let _ = inner.blockstore.write_page(key, stripe_off, dst).await;
+                    slot.tee_pending.set(false);
+                    tee_guard.completed = true;
+                }
+
+                return Ok(pi);
+            }
+        }
+    }
+}
+
+enum Action {
+    Ready,
+    Error(Error),
+    Park,
+    Lead,
+}
+
+struct LeaderGuard<'a> {
+    slot: &'a Rc<PageSlot>,
+    completed: bool,
+}
+
+impl<'a> Drop for LeaderGuard<'a> {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        // Leader future was dropped before reaching Ready (during
+        // read_page or bulk_get). Reset to Idle so the next
+        // subscriber takes over leadership; preserve `page_idx` for
+        // reuse. v1 drain relaxation: see mod.rs.
+        let wakers = take_loading_wakers(self.slot);
+        *self.slot.state.borrow_mut() = SlotState::Idle;
+        for w in wakers {
+            w.wake();
+        }
+    }
+}
+
+/// RAII guard for the tee phase. If the leader's future is dropped
+/// while `BlockStore::write_page` is in flight, releases the
+/// leader's pre-emptive consumer hold and clears `tee_pending` so
+/// the page can be recycled. The bytes are already in the pool and
+/// any non-leader subscribers that observed Ready keep their copy;
+/// the on-disk cache fill is simply skipped.
+struct TeeGuard<'a, T, S, R>
+where
+    T: Transport<R>,
+    S: BlockStore,
+    R: Req,
+{
+    slot: &'a Rc<PageSlot>,
+    fetch: &'a Rc<RefCell<StripeFetch>>,
+    inner: &'a Rc<PoolInner<T, S, R>>,
+    key: StripeKey,
+    page_no: u64,
+    completed: bool,
+}
+
+impl<'a, T, S, R> Drop for TeeGuard<'a, T, S, R>
+where
+    T: Transport<R>,
+    S: BlockStore,
+    R: Req,
+{
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        // Drop the leader's pre-emptive consumer hold (it never got
+        // wrapped in a PageGuard) and clear `tee_pending`. Then run
+        // the same recycle path that `release_guard` uses so the
+        // page returns to the free list and the slot/inflight entry
+        // are cleaned up if appropriate.
+        let prev = self.slot.consumer_holds.get();
+        self.slot.consumer_holds.set(prev.saturating_sub(1));
+        self.slot.tee_pending.set(false);
+        recycle_if_terminal(self.inner, self.key, self.fetch, self.slot, self.page_no);
+    }
+}
+
+/// Drains the parked-waker list out of a slot in `Loading`. Returns
+/// an empty `Vec` if the slot has already moved on.
+fn take_loading_wakers(slot: &Rc<PageSlot>) -> Vec<std::task::Waker> {
+    let mut st = slot.state.borrow_mut();
+    match &mut *st {
+        SlotState::Loading(w) => std::mem::take(w),
+        _ => Vec::new(),
+    }
+}
+
+struct ParkOnSlot<'a> {
+    slot: &'a Rc<PageSlot>,
+}
+
+impl<'a> Future for ParkOnSlot<'a> {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let mut st = self.slot.state.borrow_mut();
+        match &mut *st {
+            SlotState::Loading(wakers) => {
+                wakers.push(cx.waker().clone());
+                Poll::Pending
+            }
+            _ => Poll::Ready(()),
+        }
+    }
+}

--- a/cmd/unbounded-storage/src/bufferpool/stream.rs
+++ b/cmd/unbounded-storage/src/bufferpool/stream.rs
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::rc::Rc;
+
+use crate::bufferpool::types::{Error, PageRef, StripeKey};
+
+/// `Box<dyn Future + 'a>` alias used by [`StreamSrc`] to keep the
+/// trait dyn-compatible without depending on the `futures` crate.
+pub type LocalBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+/// Type-erased view of a [`crate::bufferpool::Pool`]'s per-stream
+/// state. The implementor (`StreamSrcImpl` in `pool.rs`) owns an
+/// `Rc<PoolInner>` plus a borrow of the request, so the trait
+/// object hides the `T, S, R` generics from `ReadStream` and
+/// `PageGuard`.
+pub(super) trait StreamSrc {
+    #[allow(dead_code)]
+    fn page_size(&self) -> usize;
+    fn base(&self) -> *mut u8;
+    #[allow(dead_code)]
+    fn key(&self) -> StripeKey;
+    fn fetch_page<'a>(&'a self, page_no: u64) -> LocalBoxFuture<'a, Result<u32, Error>>;
+    fn release_guard(&self, page_no: u64);
+    fn decrement_stream(&self);
+}
+
+/// Single consumer surface; one page at a time, awaited explicitly.
+pub struct ReadStream<'pool> {
+    src: Rc<dyn StreamSrc + 'pool>,
+    cursor: u64,
+    end: u64,
+    page_size: u64,
+    _life: PhantomData<&'pool ()>,
+}
+
+impl<'pool> std::fmt::Debug for ReadStream<'pool> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadStream")
+            .field("cursor", &self.cursor)
+            .field("end", &self.end)
+            .field("page_size", &self.page_size)
+            .finish()
+    }
+}
+
+impl<'pool> ReadStream<'pool> {
+    pub(super) fn new(
+        src: Rc<dyn StreamSrc + 'pool>,
+        offset: u64,
+        end: u64,
+        page_size: usize,
+    ) -> Self {
+        Self {
+            src,
+            cursor: offset,
+            end,
+            page_size: page_size as u64,
+            _life: PhantomData,
+        }
+    }
+
+    /// Next page in the stream. Returns `None` at EOF. The returned
+    /// [`PageGuard`] borrows `&mut self`, so the caller must drop
+    /// it before calling `next_page` again; this enforces the
+    /// one-page-at-a-time contract at compile time.
+    pub async fn next_page<'s>(&'s mut self) -> Option<Result<PageGuard<'s>, Error>> {
+        if self.cursor >= self.end {
+            return None;
+        }
+
+        let page_size = self.page_size;
+        let page_no = self.cursor / page_size;
+        let intra_off = (self.cursor - page_no * page_size) as u32;
+        let max_in_page = page_size - intra_off as u64;
+        let remaining = self.end - self.cursor;
+        let intra_len = std::cmp::min(max_in_page, remaining) as u32;
+
+        let page_idx = match self.src.fetch_page(page_no).await {
+            Ok(pi) => pi,
+            Err(e) => return Some(Err(e)),
+        };
+
+        let base = self.src.base();
+        // SAFETY: `page_idx` was allocated out of the pool's pinned
+        // backing whose lifetime exceeds the `Rc<dyn StreamSrc>`
+        // we hold. `intra_off + intra_len <= page_size`. The byte
+        // range is read-only for the lifetime of the guard; the
+        // pool keeps the slot pinned via `consumer_holds`.
+        let bytes =
+            unsafe { base.add(page_idx as usize * page_size as usize + intra_off as usize) };
+        let page_ref = PageRef {
+            page_idx,
+            offset: intra_off,
+            len: intra_len,
+        };
+
+        // Clone the trait object for the guard. Coerce '`pool` to
+        // `'s` (covariant lifetime).
+        let src_for_guard: Rc<dyn StreamSrc + 's> = self.src.clone();
+        let guard = PageGuard {
+            src: src_for_guard,
+            page_no,
+            bytes,
+            len: intra_len,
+            page_ref,
+            _life: PhantomData,
+        };
+
+        self.cursor += intra_len as u64;
+        Some(Ok(guard))
+    }
+
+    /// Test-only: returns the current cursor.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn cursor(&self) -> u64 {
+        self.cursor
+    }
+}
+
+impl<'pool> Drop for ReadStream<'pool> {
+    fn drop(&mut self) {
+        self.src.decrement_stream();
+    }
+}
+
+/// Read-only view onto one page (or sub-page intra-window slice).
+/// Tied to `&'s mut ReadStream` so only one is outstanding per
+/// stream at a time.
+pub struct PageGuard<'a> {
+    src: Rc<dyn StreamSrc + 'a>,
+    page_no: u64,
+    bytes: *const u8,
+    len: u32,
+    page_ref: PageRef,
+    /// Invariant in `'a` so the borrow checker prevents extending
+    /// the guard's lifetime.
+    _life: PhantomData<&'a mut ()>,
+}
+
+impl<'a> std::fmt::Debug for PageGuard<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PageGuard")
+            .field("page_no", &self.page_no)
+            .field("page_ref", &self.page_ref)
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
+impl<'a> PageGuard<'a> {
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: `bytes` and `len` came from `next_page` above and
+        // refer to a sub-range of a pinned backing page. The slot
+        // is held pinned until this guard drops, so the bytes are
+        // valid for the lifetime of `&self`.
+        unsafe { std::slice::from_raw_parts(self.bytes, self.len as usize) }
+    }
+
+    pub fn page_ref(&self) -> PageRef {
+        self.page_ref
+    }
+
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl<'a> Drop for PageGuard<'a> {
+    fn drop(&mut self) {
+        self.src.release_guard(self.page_no);
+    }
+}

--- a/cmd/unbounded-storage/src/bufferpool/tests.rs
+++ b/cmd/unbounded-storage/src/bufferpool/tests.rs
@@ -1,0 +1,913 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! End-to-end tests for the bufferpool. The executor here is a
+//! deliberately tiny single-thread block-on built on a noop waker;
+//! mocks are pollable directly so we can drive concurrent reads
+//! without an external runtime.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::{Pin, pin};
+use std::rc::Rc;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+use crate::bufferpool::{
+    Backing, BlockStore, BufferPool, BulkRef, Error, PageRef, Pool, PoolConfig, Req, StripeKey,
+    Transport,
+};
+
+// ---------------------------------------------------------------------------
+// Tiny single-thread executor.
+// ---------------------------------------------------------------------------
+
+fn noop_waker() -> Waker {
+    fn raw() -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    static VTABLE: RawWakerVTable =
+        RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
+    // SAFETY: the vtable functions never dereference the data pointer.
+    unsafe { Waker::from_raw(raw()) }
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = pin!(future);
+    let mut spins: u64 = 0;
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(v) => return v,
+            Poll::Pending => {
+                spins += 1;
+                assert!(spins < 1_000_000, "block_on stuck (no progress)");
+            }
+        }
+    }
+}
+
+fn block_on_two<F1, F2>(f1: F1, f2: F2) -> (F1::Output, F2::Output)
+where
+    F1: Future,
+    F2: Future,
+{
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut f1 = pin!(f1);
+    let mut f2 = pin!(f2);
+    let mut o1: Option<F1::Output> = None;
+    let mut o2: Option<F2::Output> = None;
+    let mut spins: u64 = 0;
+    loop {
+        if o1.is_none() {
+            if let Poll::Ready(v) = f1.as_mut().poll(&mut cx) {
+                o1 = Some(v);
+            }
+        }
+        if o2.is_none() {
+            if let Poll::Ready(v) = f2.as_mut().poll(&mut cx) {
+                o2 = Some(v);
+            }
+        }
+        if o1.is_some() && o2.is_some() {
+            return (o1.unwrap(), o2.unwrap());
+        }
+        spins += 1;
+        assert!(spins < 1_000_000, "block_on_two stuck (no progress)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Heap-backed Backing for tests.
+// ---------------------------------------------------------------------------
+
+struct HeapOwner {
+    ptr: *mut u8,
+    layout: std::alloc::Layout,
+}
+
+// SAFETY: tests are single-threaded; the allocation lives for the
+// owner's lifetime.
+unsafe impl Send for HeapOwner {}
+unsafe impl Sync for HeapOwner {}
+
+impl Drop for HeapOwner {
+    fn drop(&mut self) {
+        // SAFETY: matches the alloc.
+        unsafe {
+            std::alloc::dealloc(self.ptr, self.layout);
+        }
+    }
+}
+
+fn heap_backing(page_size: usize, page_count: usize) -> Backing {
+    let layout = std::alloc::Layout::from_size_align(page_size * page_count, page_size).unwrap();
+    // SAFETY: layout is valid (size > 0, align is power of two).
+    let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+    assert!(!ptr.is_null(), "heap_backing alloc failed");
+    let owner = HeapOwner { ptr, layout };
+    Backing {
+        base: owner.ptr,
+        page_size,
+        page_count,
+        _own: Box::new(owner),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test request type.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct TestReq {
+    key: StripeKey,
+}
+
+impl Req for TestReq {
+    fn key(&self) -> StripeKey {
+        self.key
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock transport.
+// ---------------------------------------------------------------------------
+
+struct MockTransport {
+    /// `key -> stripe bytes`. Written into `dst` on `bulk_get`.
+    stripes: RefCell<HashMap<StripeKey, Vec<u8>>>,
+    /// Number of `bulk_get` calls completed.
+    calls: RefCell<u32>,
+    /// Pending `bulk_get`s pend this many polls before completing.
+    pend_polls: RefCell<usize>,
+    /// Force `bulk_get` to return an error instead of completing.
+    error_mode: RefCell<bool>,
+    /// Filled in by `register_pages`.
+    base: RefCell<Option<*mut u8>>,
+    page_size: RefCell<usize>,
+}
+
+impl MockTransport {
+    fn new() -> Self {
+        Self {
+            stripes: RefCell::new(HashMap::new()),
+            calls: RefCell::new(0),
+            pend_polls: RefCell::new(0),
+            error_mode: RefCell::new(false),
+            base: RefCell::new(None),
+            page_size: RefCell::new(0),
+        }
+    }
+
+    fn put_stripe(&self, key: StripeKey, bytes: Vec<u8>) {
+        self.stripes.borrow_mut().insert(key, bytes);
+    }
+
+    fn calls(&self) -> u32 {
+        *self.calls.borrow()
+    }
+
+    fn set_pend_polls(&self, n: usize) {
+        *self.pend_polls.borrow_mut() = n;
+    }
+
+    fn set_error_mode(&self, on: bool) {
+        *self.error_mode.borrow_mut() = on;
+    }
+}
+
+impl Transport<TestReq> for MockTransport {
+    fn register_pages(
+        &self,
+        base: *mut u8,
+        page_size: usize,
+        _page_count: usize,
+    ) -> Result<(), Error> {
+        *self.base.borrow_mut() = Some(base);
+        *self.page_size.borrow_mut() = page_size;
+        Ok(())
+    }
+
+    async fn bulk_get(
+        &self,
+        _req: &TestReq,
+        src: BulkRef,
+        dst: PageRef,
+    ) -> Result<(), Error> {
+        // Pend the configured number of polls (one polling round
+        // per pend, decremented on each call).
+        for _ in 0..*self.pend_polls.borrow() {
+            PendOnce { fired: false }.await;
+        }
+        *self.pend_polls.borrow_mut() = 0;
+
+        if *self.error_mode.borrow() {
+            return Err(Error::from("forced error"));
+        }
+
+        let stripes = self.stripes.borrow();
+        let bytes = stripes.get(&src.stripe).expect("stripe not configured");
+        let start = src.offset as usize;
+        let end = start + src.len as usize;
+        assert!(end <= bytes.len(), "src out of range");
+
+        let base = self.base.borrow().expect("registered");
+        let page_size = *self.page_size.borrow();
+        let dst_ptr = unsafe {
+            base.add(dst.page_idx as usize * page_size + dst.offset as usize)
+        };
+        // SAFETY: dst is a pool page, src is a Vec<u8>, both valid.
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr().add(start), dst_ptr, src.len as usize);
+        }
+        *self.calls.borrow_mut() += 1;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock blockstore.
+// ---------------------------------------------------------------------------
+
+struct MockBlockStore {
+    cache: RefCell<HashMap<(StripeKey, u64), Vec<u8>>>,
+    reads: RefCell<u32>,
+    writes: RefCell<u32>,
+    /// `write_page` pends this many polls before completing.
+    write_pend_polls: RefCell<usize>,
+    base: RefCell<Option<*mut u8>>,
+    page_size: RefCell<usize>,
+}
+
+impl MockBlockStore {
+    fn new() -> Self {
+        Self {
+            cache: RefCell::new(HashMap::new()),
+            reads: RefCell::new(0),
+            writes: RefCell::new(0),
+            write_pend_polls: RefCell::new(0),
+            base: RefCell::new(None),
+            page_size: RefCell::new(0),
+        }
+    }
+
+    fn preload(&self, key: StripeKey, off: u64, bytes: Vec<u8>) {
+        self.cache.borrow_mut().insert((key, off), bytes);
+    }
+
+    fn writes(&self) -> u32 {
+        *self.writes.borrow()
+    }
+
+    fn reads(&self) -> u32 {
+        *self.reads.borrow()
+    }
+
+    fn set_write_pend_polls(&self, n: usize) {
+        *self.write_pend_polls.borrow_mut() = n;
+    }
+}
+
+impl BlockStore for MockBlockStore {
+    fn register_pages(
+        &self,
+        base: *mut u8,
+        page_size: usize,
+        _page_count: usize,
+    ) -> Result<(), Error> {
+        *self.base.borrow_mut() = Some(base);
+        *self.page_size.borrow_mut() = page_size;
+        Ok(())
+    }
+
+    async fn read_page(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        dst: PageRef,
+    ) -> Result<bool, Error> {
+        *self.reads.borrow_mut() += 1;
+        let cache = self.cache.borrow();
+        let Some(bytes) = cache.get(&(key, stripe_off)) else {
+            return Ok(false);
+        };
+        let base = self.base.borrow().expect("registered");
+        let page_size = *self.page_size.borrow();
+        let dst_ptr = unsafe {
+            base.add(dst.page_idx as usize * page_size + dst.offset as usize)
+        };
+        // SAFETY: dst is a pool page.
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst_ptr, bytes.len());
+        }
+        Ok(true)
+    }
+
+    async fn write_page(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        page: PageRef,
+    ) -> Result<(), Error> {
+        let pend = *self.write_pend_polls.borrow();
+        for _ in 0..pend {
+            PendOnce { fired: false }.await;
+        }
+        *self.write_pend_polls.borrow_mut() = 0;
+        *self.writes.borrow_mut() += 1;
+        let base = self.base.borrow().expect("registered");
+        let page_size = *self.page_size.borrow();
+        let src_ptr = unsafe {
+            base.add(page.page_idx as usize * page_size + page.offset as usize)
+        };
+        let mut buf = vec![0u8; page.len as usize];
+        // SAFETY: src is a pool page.
+        unsafe {
+            std::ptr::copy_nonoverlapping(src_ptr, buf.as_mut_ptr(), page.len as usize);
+        }
+        self.cache.borrow_mut().insert((key, stripe_off), buf);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PendOnce: yields once before completing. Used by mocks to model
+// asynchronous progress without an external runtime.
+// ---------------------------------------------------------------------------
+
+struct PendOnce {
+    fired: bool,
+}
+
+impl Future for PendOnce {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let me = self.get_mut();
+        if me.fired {
+            Poll::Ready(())
+        } else {
+            me.fired = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+fn key(b: u8) -> StripeKey {
+    StripeKey([b; 32])
+}
+
+/// Pool owns the mocks via these adapters; tests retain a clone of
+/// the inner `Rc` so they can poke the mocks directly.
+struct TransportRc(Rc<MockTransport>);
+struct BlockStoreRc(Rc<MockBlockStore>);
+
+impl Transport<TestReq> for TransportRc {
+    fn register_pages(
+        &self,
+        base: *mut u8,
+        page_size: usize,
+        page_count: usize,
+    ) -> Result<(), Error> {
+        self.0.register_pages(base, page_size, page_count)
+    }
+    async fn bulk_get(
+        &self,
+        req: &TestReq,
+        src: BulkRef,
+        dst: PageRef,
+    ) -> Result<(), Error> {
+        self.0.bulk_get(req, src, dst).await
+    }
+}
+
+impl BlockStore for BlockStoreRc {
+    fn register_pages(
+        &self,
+        base: *mut u8,
+        page_size: usize,
+        page_count: usize,
+    ) -> Result<(), Error> {
+        self.0.register_pages(base, page_size, page_count)
+    }
+    async fn read_page(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        dst: PageRef,
+    ) -> Result<bool, Error> {
+        self.0.read_page(key, stripe_off, dst).await
+    }
+    async fn write_page(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        page: PageRef,
+    ) -> Result<(), Error> {
+        self.0.write_page(key, stripe_off, page).await
+    }
+}
+
+fn make_pool_v2(
+    page_size: usize,
+    page_count: usize,
+) -> (
+    Pool<TransportRc, BlockStoreRc, TestReq>,
+    Rc<MockTransport>,
+    Rc<MockBlockStore>,
+) {
+    let backing = heap_backing(page_size, page_count);
+    let t = Rc::new(MockTransport::new());
+    let s = Rc::new(MockBlockStore::new());
+    let pool = Pool::new(
+        PoolConfig::default(),
+        backing,
+        TransportRc(t.clone()),
+        BlockStoreRc(s.clone()),
+    )
+    .unwrap();
+    (pool, t, s)
+}
+
+// ---------------------------------------------------------------------------
+// Tests.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn disk_hit_returns_bytes_no_transport_call() {
+    const P: usize = 4096;
+    let (pool, transport, store) = make_pool_v2(P, 4);
+    let k = key(0xAA);
+    let mut data = vec![0u8; P];
+    for (i, b) in data.iter_mut().enumerate() {
+        *b = (i & 0xff) as u8;
+    }
+    store.preload(k, 0, data.clone());
+
+    let req = TestReq { key: k };
+    let bytes = block_on(async {
+        let mut s = pool.read(&req, 0, P as u64).await.unwrap();
+        let g = s.next_page().await.unwrap().unwrap();
+        let v = g.as_slice().to_vec();
+        drop(g);
+        assert!(s.next_page().await.is_none(), "EOF");
+        v
+    });
+    assert_eq!(bytes, data);
+    assert_eq!(transport.calls(), 0, "no transport call on disk hit");
+    assert_eq!(store.reads(), 1);
+    assert_eq!(store.writes(), 0);
+    assert_eq!(pool.free_pages(), 4, "all pages returned");
+    assert_eq!(pool.inflight_entries(), 0, "inflight cleaned up");
+}
+
+#[test]
+fn disk_miss_peer_fetch_with_tee_writes_blockstore() {
+    const P: usize = 4096;
+    let (pool, transport, store) = make_pool_v2(P, 4);
+    let k = key(0xBB);
+    let mut stripe = vec![0u8; P * 2];
+    for (i, b) in stripe.iter_mut().enumerate() {
+        *b = ((i + 7) & 0xff) as u8;
+    }
+    transport.put_stripe(k, stripe.clone());
+
+    let req = TestReq { key: k };
+    let bytes = block_on(async {
+        let mut s = pool.read(&req, 0, P as u64).await.unwrap();
+        let g = s.next_page().await.unwrap().unwrap();
+        g.as_slice().to_vec()
+    });
+    assert_eq!(bytes, stripe[..P]);
+    assert_eq!(transport.calls(), 1);
+    assert_eq!(store.writes(), 1, "tee landed");
+    assert_eq!(pool.free_pages(), 4);
+    assert_eq!(pool.inflight_entries(), 0);
+}
+
+#[test]
+fn multi_page_window_with_intra_page_offsets() {
+    const P: usize = 1024;
+    let (pool, transport, _store) = make_pool_v2(P, 8);
+    let k = key(0xCC);
+    let mut stripe = vec![0u8; P * 4];
+    for (i, b) in stripe.iter_mut().enumerate() {
+        *b = (i & 0xff) as u8;
+    }
+    transport.put_stripe(k, stripe.clone());
+
+    // Read [P/2, 2*P + P/2): straddles three pages, intra offsets
+    // on first and last.
+    let off = (P / 2) as u64;
+    let len = (P + P) as u64; // total 2*P bytes; spans 3 pages
+    let req = TestReq { key: k };
+    let bytes = block_on(async {
+        let mut out = Vec::new();
+        let mut s = pool.read(&req, off, len).await.unwrap();
+        while let Some(r) = s.next_page().await {
+            out.extend_from_slice(r.unwrap().as_slice());
+        }
+        out
+    });
+    assert_eq!(bytes.len(), len as usize);
+    assert_eq!(bytes, stripe[off as usize..(off + len) as usize]);
+    assert_eq!(transport.calls(), 3);
+    assert_eq!(pool.free_pages(), 8);
+}
+
+#[test]
+fn single_flight_coalesces_concurrent_reads() {
+    const P: usize = 4096;
+    let (pool, transport, _store) = make_pool_v2(P, 4);
+    let k = key(0xDD);
+    let mut stripe = vec![0u8; P];
+    for (i, b) in stripe.iter_mut().enumerate() {
+        *b = (i & 0xff) as u8;
+    }
+    transport.put_stripe(k, stripe.clone());
+    transport.set_pend_polls(2);
+
+    let req1 = TestReq { key: k };
+    let req2 = TestReq { key: k };
+    let f1 = async {
+        let mut s = pool.read(&req1, 0, P as u64).await.unwrap();
+        s.next_page().await.unwrap().unwrap().as_slice().to_vec()
+    };
+    let f2 = async {
+        let mut s = pool.read(&req2, 0, P as u64).await.unwrap();
+        s.next_page().await.unwrap().unwrap().as_slice().to_vec()
+    };
+    let (b1, b2) = block_on_two(f1, f2);
+    assert_eq!(b1, stripe);
+    assert_eq!(b2, stripe);
+    assert_eq!(transport.calls(), 1, "single-flight coalesced");
+    assert_eq!(pool.free_pages(), 4);
+    assert_eq!(pool.inflight_entries(), 0);
+}
+
+#[test]
+fn eof_terminates_with_none() {
+    const P: usize = 4096;
+    let (pool, _transport, store) = make_pool_v2(P, 4);
+    let k = key(1);
+    store.preload(k, 0, vec![9u8; P]);
+    let req = TestReq { key: k };
+    block_on(async {
+        let mut s = pool.read(&req, 0, P as u64).await.unwrap();
+        let g = s.next_page().await.unwrap().unwrap();
+        assert_eq!(g.len(), P);
+        drop(g);
+        assert!(s.next_page().await.is_none());
+    });
+}
+
+#[test]
+fn transport_error_propagates_and_recycles_pages() {
+    const P: usize = 4096;
+    let (pool, transport, _store) = make_pool_v2(P, 4);
+    let k = key(2);
+    transport.put_stripe(k, vec![0u8; P]);
+    transport.set_error_mode(true);
+    let req = TestReq { key: k };
+    let r: Result<(), Error> = block_on(async {
+        let mut s = pool.read(&req, 0, P as u64).await.unwrap();
+        match s.next_page().await {
+            Some(Err(e)) => Err(e),
+            Some(Ok(_)) => panic!("expected error"),
+            None => panic!("unexpected EOF"),
+        }
+    });
+    match r {
+        Err(Error::Transport(_)) => {}
+        other => panic!("expected transport error, got {other:?}"),
+    }
+    assert_eq!(pool.free_pages(), 4, "page returned after error");
+    assert_eq!(pool.inflight_entries(), 0);
+}
+
+#[test]
+fn dropped_leader_promotes_new_leader() {
+    // First read becomes leader, drops mid-fetch (we just drop the
+    // future before completion). Second read starts fresh and
+    // completes. We assert the second read still gets the bytes.
+    const P: usize = 4096;
+    let (pool, transport, _store) = make_pool_v2(P, 4);
+    let k = key(3);
+    let mut stripe = vec![0u8; P];
+    for (i, b) in stripe.iter_mut().enumerate() {
+        *b = (i & 0xff) as u8;
+    }
+    transport.put_stripe(k, stripe.clone());
+    transport.set_pend_polls(2);
+
+    let req = TestReq { key: k };
+
+    // Start reader 1; poll once so it becomes leader and parks
+    // on bulk_get (pend_polls=2 -> pends twice).
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    let fut1 = pool.read(&req, 0, P as u64);
+    let mut fut1 = pin!(fut1);
+    let mut s1 = match fut1.as_mut().poll(&mut cx) {
+        Poll::Ready(Ok(s)) => s,
+        other => panic!("read should be ready synchronously: {other:?}"),
+    };
+    // Begin polling next_page; this becomes leader and pends.
+    {
+        let np = s1.next_page();
+        let mut np = pin!(np);
+        for _ in 0..2 {
+            match np.as_mut().poll(&mut cx) {
+                Poll::Pending => {}
+                Poll::Ready(_) => panic!("should be pending"),
+            }
+        }
+        // Drop the next_page future mid-fetch; LeaderGuard runs.
+    }
+    drop(s1);
+
+    // Now a fresh reader picks up. pend_polls is back to 2 (set on
+    // the mock), so transport will pend another two rounds. The
+    // pool will retry the I/O cleanly.
+    transport.set_pend_polls(2);
+    let bytes = block_on(async {
+        let mut s = pool.read(&req, 0, P as u64).await.unwrap();
+        s.next_page().await.unwrap().unwrap().as_slice().to_vec()
+    });
+    assert_eq!(bytes, stripe);
+    assert_eq!(pool.free_pages(), 4);
+    assert_eq!(pool.inflight_entries(), 0);
+}
+
+#[test]
+fn free_list_parking_unblocks_on_release() {
+    // 1-page pool. First read holds the page (does not drop the
+    // guard); second read parks waiting for a free page; on first
+    // guard drop, second read proceeds.
+    const P: usize = 4096;
+    let (pool, _transport, store) = make_pool_v2(P, 1);
+    let k1 = key(0x10);
+    let k2 = key(0x20);
+    store.preload(k1, 0, vec![1u8; P]);
+    store.preload(k2, 0, vec![2u8; P]);
+
+    let req1 = TestReq { key: k1 };
+    let req2 = TestReq { key: k2 };
+
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    // Reader 1: get a guard and HOLD it.
+    let fut1 = async {
+        let mut s = pool.read(&req1, 0, P as u64).await.unwrap();
+        let g = s.next_page().await.unwrap().unwrap();
+        g.as_slice().to_vec()
+    };
+    let mut fut1 = pin!(fut1);
+    // Reader 2: should park waiting for a free page.
+    let fut2 = async {
+        let mut s = pool.read(&req2, 0, P as u64).await.unwrap();
+        s.next_page().await.unwrap().unwrap().as_slice().to_vec()
+    };
+    let mut fut2 = pin!(fut2);
+
+    // Drive fut1 to ready while fut2 pends.
+    let v1 = loop {
+        if let Poll::Ready(v) = fut1.as_mut().poll(&mut cx) {
+            break v;
+        }
+        // Also poll fut2 so any side-effects happen, but it should
+        // not complete until fut1's guard drops (and fut1 here
+        // returns the bytes after dropping its guard at end of
+        // async block).
+        let _ = fut2.as_mut().poll(&mut cx);
+    };
+    assert_eq!(v1, vec![1u8; P]);
+
+    // Now drive fut2 to completion.
+    let v2 = loop {
+        if let Poll::Ready(v) = fut2.as_mut().poll(&mut cx) {
+            break v;
+        }
+    };
+    assert_eq!(v2, vec![2u8; P]);
+    assert_eq!(pool.free_pages(), 1);
+}
+
+#[test]
+fn stream_limit_enforced() {
+    const P: usize = 4096;
+    let backing = heap_backing(P, 2);
+    let t = Rc::new(MockTransport::new());
+    let s = Rc::new(MockBlockStore::new());
+    s.preload(key(0), 0, vec![0u8; P]);
+    let cfg = PoolConfig {
+        max_concurrent_streams: 1,
+    };
+    let pool = Pool::new(cfg, backing, TransportRc(t.clone()), BlockStoreRc(s.clone())).unwrap();
+    let req = TestReq { key: key(0) };
+    block_on(async {
+        let s1 = pool.read(&req, 0, P as u64).await.unwrap();
+        let r2 = pool.read(&req, 0, P as u64).await;
+        match r2 {
+            Err(Error::StreamLimit) => {}
+            other => panic!("expected StreamLimit, got {other:?}"),
+        }
+        drop(s1);
+        // After dropping s1, slot is released and a new stream is admissible.
+        let _s3 = pool.read(&req, 0, P as u64).await.unwrap();
+    });
+}
+
+#[test]
+fn rejects_bad_backing() {
+    let backing = Backing {
+        base: 0x1000 as *mut u8,
+        page_size: 0,
+        page_count: 1,
+        _own: Box::new(()),
+    };
+    let t = TransportRc(Rc::new(MockTransport::new()));
+    let s = BlockStoreRc(Rc::new(MockBlockStore::new()));
+    let r = Pool::<_, _, TestReq>::new(PoolConfig::default(), backing, t, s);
+    assert!(matches!(r, Err(Error::BadConfig(_))));
+}
+
+#[test]
+fn non_leader_consumes_concurrently_with_tee() {
+    // Reader 1 is the leader: bulk_get completes instantly, slot
+    // transitions to Ready, then leader awaits a slow write_page.
+    // Reader 2 (subscribed on the same key) must be able to obtain
+    // and consume its PageGuard while the tee is still in flight.
+    const P: usize = 4096;
+    let (pool, transport, store) = make_pool_v2(P, 4);
+    let k = key(0xEE);
+    let mut stripe = vec![0u8; P];
+    for (i, b) in stripe.iter_mut().enumerate() {
+        *b = (i & 0xff) as u8;
+    }
+    transport.put_stripe(k, stripe.clone());
+    store.set_write_pend_polls(8);
+
+    let req1 = TestReq { key: k };
+    let req2 = TestReq { key: k };
+
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    let f1 = async {
+        let mut s = pool.read(&req1, 0, P as u64).await.unwrap();
+        s.next_page().await.unwrap().unwrap().as_slice().to_vec()
+    };
+    let f2 = async {
+        let mut s = pool.read(&req2, 0, P as u64).await.unwrap();
+        s.next_page().await.unwrap().unwrap().as_slice().to_vec()
+    };
+    let mut f1 = pin!(f1);
+    let mut f2 = pin!(f2);
+
+    // Drive both. Reader 2 must complete BEFORE reader 1 (leader is
+    // still awaiting write_page).
+    let mut o2: Option<Vec<u8>> = None;
+    let mut spins = 0u64;
+    loop {
+        let _ = f1.as_mut().poll(&mut cx);
+        if o2.is_none()
+            && let Poll::Ready(v) = f2.as_mut().poll(&mut cx)
+        {
+            o2 = Some(v);
+            break;
+        }
+        spins += 1;
+        assert!(spins < 1_000_000, "reader 2 stuck behind tee");
+    }
+    assert_eq!(o2.unwrap(), stripe);
+    // Tee should still be pending.
+    assert_eq!(store.writes(), 0, "tee should not have completed yet");
+
+    // Now drive reader 1 to completion (tee finishes too).
+    let v1 = loop {
+        if let Poll::Ready(v) = f1.as_mut().poll(&mut cx) {
+            break v;
+        }
+    };
+    assert_eq!(v1, stripe);
+    assert_eq!(store.writes(), 1);
+    assert_eq!(transport.calls(), 1);
+    assert_eq!(pool.free_pages(), 4);
+    assert_eq!(pool.inflight_entries(), 0);
+}
+
+#[test]
+fn page_pinned_across_tee_until_subscriber_drops() {
+    // 1-page pool. Non-leader consumes its bytes during the tee
+    // and drops the PageGuard while tee_pending is still true; the
+    // page must NOT be recycled until the tee completes.
+    const P: usize = 4096;
+    let (pool, transport, store) = make_pool_v2(P, 1);
+    let k = key(0xAB);
+    transport.put_stripe(k, vec![0xAAu8; P]);
+    store.set_write_pend_polls(4);
+
+    let req1 = TestReq { key: k };
+    let req2 = TestReq { key: k };
+
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    let f1 = async {
+        let mut s = pool.read(&req1, 0, P as u64).await.unwrap();
+        // Consume the leader's bytes (this only completes after the
+        // tee since the leader awaits write_page).
+        let g = s.next_page().await.unwrap().unwrap();
+        g.as_slice().to_vec()
+    };
+    let f2 = async {
+        let mut s = pool.read(&req2, 0, P as u64).await.unwrap();
+        let g = s.next_page().await.unwrap().unwrap();
+        let v = g.as_slice().to_vec();
+        // Drop the guard immediately; tee is still in flight.
+        drop(g);
+        v
+    };
+    let mut f1 = pin!(f1);
+    let mut f2 = pin!(f2);
+
+    // Drive both until reader 2 finishes (its guard drops while tee
+    // is pending).
+    let mut o2: Option<Vec<u8>> = None;
+    let mut spins = 0u64;
+    loop {
+        let _ = f1.as_mut().poll(&mut cx);
+        if o2.is_none()
+            && let Poll::Ready(v) = f2.as_mut().poll(&mut cx)
+        {
+            o2 = Some(v);
+            break;
+        }
+        spins += 1;
+        assert!(spins < 1_000_000, "reader 2 stuck");
+    }
+    assert_eq!(o2.unwrap(), vec![0xAAu8; P]);
+    // The single backing page must still be held by the leader's
+    // tee even though reader 2 dropped its guard.
+    assert_eq!(pool.free_pages(), 0, "page must stay pinned across tee");
+
+    // Drain reader 1; tee completes, page recycles.
+    let v1 = loop {
+        if let Poll::Ready(v) = f1.as_mut().poll(&mut cx) {
+            break v;
+        }
+    };
+    assert_eq!(v1, vec![0xAAu8; P]);
+    assert_eq!(store.writes(), 1);
+    assert_eq!(pool.free_pages(), 1);
+    assert_eq!(pool.inflight_entries(), 0);
+}
+
+#[test]
+fn leader_drop_during_tee_releases_page() {
+    // Leader drops its future while the tee is in flight. The
+    // TeeGuard must clear `tee_pending` so the page returns to the
+    // free list once consumer holds drain.
+    const P: usize = 4096;
+    let (pool, transport, store) = make_pool_v2(P, 1);
+    let k = key(0xCD);
+    transport.put_stripe(k, vec![0xCDu8; P]);
+    store.set_write_pend_polls(8);
+
+    let req = TestReq { key: k };
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    {
+        let f = async {
+            let mut s = pool.read(&req, 0, P as u64).await.unwrap();
+            let _g = s.next_page().await.unwrap().unwrap();
+            // Hold guard, then drop everything mid-tee.
+        };
+        let mut f = pin!(f);
+        // Poll a bounded number of times: enough for the leader to
+        // mark Ready and start the tee, but not enough to finish
+        // the 8-poll write_page.
+        for _ in 0..3 {
+            let _ = f.as_mut().poll(&mut cx);
+        }
+        // Drop f mid-tee.
+    }
+
+    // Tee was abandoned; page must be back in the free list.
+    assert_eq!(pool.free_pages(), 1, "page recycled after leader drop");
+    assert_eq!(pool.inflight_entries(), 0);
+    // bulk_get completed before the drop.
+    assert_eq!(transport.calls(), 1);
+    // write_page never completed (best-effort tee).
+    assert_eq!(store.writes(), 0);
+}

--- a/cmd/unbounded-storage/src/bufferpool/traits.rs
+++ b/cmd/unbounded-storage/src/bufferpool/traits.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(async_fn_in_trait)]
+
+use crate::bufferpool::stream::ReadStream;
+use crate::bufferpool::types::{BulkRef, Error, PageRef, StripeKey};
+
+pub trait Req {
+    fn key(&self) -> StripeKey;
+}
+
+pub trait Transport<R: Req> {
+    /// Called once at pool init with the full pinned backing. The
+    /// impl records whatever it needs (e.g. an RDMA MR) so it can
+    /// translate `page_idx` into a wire-side handle later.
+    fn register_pages(
+        &self,
+        base: *mut u8,
+        page_size: usize,
+        page_count: usize,
+    ) -> Result<(), Error>;
+
+    /// Fetch the byte range described by `src` from a peer derived
+    /// from `req` into the page identified by `dst.page_idx`.
+    /// Resolves when the data has landed in `dst`.
+    async fn bulk_get(&self, req: &R, src: BulkRef, dst: PageRef) -> Result<(), Error>;
+    // TODO(jordan): Are both src and dst actually needed here?
+}
+
+pub trait BlockStore {
+    /// Symmetric with [`Transport::register_pages`]. Impls that don't
+    /// need pre-registration (plain `pwrite` on a regular file) can
+    /// no-op; impls that do (io_uring fixed buffers, NVMe DMA
+    /// mapping) record their per-page handles here.
+    fn register_pages(
+        &self,
+        base: *mut u8,
+        page_size: usize,
+        page_count: usize,
+    ) -> Result<(), Error>;
+
+    /// Local-disk lookup. `Ok(true)` if `dst` was filled from disk;
+    /// `Ok(false)` if the key is not present (pool then falls back
+    /// to `Transport::bulk_get`).
+    async fn read_page(&self, key: StripeKey, stripe_off: u64, dst: PageRef)
+    -> Result<bool, Error>;
+
+    /// Persist `page` for `(key, stripe_off)`. Used as the tee on a
+    /// miss after the peer fetch lands.
+    async fn write_page(&self, key: StripeKey, stripe_off: u64, page: PageRef)
+    -> Result<(), Error>;
+}
+
+pub trait BufferPool {
+    type Req: Req;
+
+    async fn read<'p>(
+        &'p self,
+        req: &'p Self::Req,
+        offset: u64,
+        len: u64,
+    ) -> Result<ReadStream<'p>, Error>;
+}

--- a/cmd/unbounded-storage/src/bufferpool/types.rs
+++ b/cmd/unbounded-storage/src/bufferpool/types.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::fmt;
+use std::sync::Arc;
+
+/// Pinned, NUMA-local backing. The embedder allocates it (e.g.
+/// `mmap(MAP_HUGETLB | MAP_HUGE_2MB)`); the pool just carves pages
+/// out of it. `_own` holds the Drop handle for the underlying
+/// allocation; the pool never touches it.
+///
+/// `base` is a raw pointer, so `Backing` is `!Send + !Sync` by
+/// default. The pool relies on the embedder upholding the per-NUMA
+/// pinning invariant and adds `unsafe impl Send + Sync` so
+/// `Pool<T, S>` can be constructed off the executor thread before
+/// being handed to the pinned executor for service.
+pub struct Backing {
+    pub base: *mut u8,
+    pub page_size: usize,
+    pub page_count: usize,
+    /// Drop carrier for the underlying allocation. The pool never
+    /// touches this; it exists so the mapping outlives the pool.
+    pub _own: Box<dyn Send + Sync>,
+}
+
+// SAFETY: per-NUMA pinning is the embedder's responsibility (see
+// the design's "Constraints" section). Inside its NUMA shard the
+// `Backing` is owned by a single-threaded `Pool`; we mark it
+// `Send + Sync` so the constructed `Pool` can be moved onto the
+// pinned executor thread.
+unsafe impl Send for Backing {}
+unsafe impl Sync for Backing {}
+
+impl fmt::Debug for Backing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Backing")
+            .field("base", &self.base)
+            .field("page_size", &self.page_size)
+            .field("page_count", &self.page_count)
+            .finish()
+    }
+}
+
+/// Stable page identity. `page_idx` indexes into the pool's backing
+/// as `u32`; `u16` would cap the backing at 128 GiB at 2 MiB pages,
+/// which is smaller than a single Grace socket. `offset` and `len`
+/// are intra-page (bounded by `page_size`, which is 2 MiB in v1),
+/// so they fit in `u32`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PageRef {
+    pub page_idx: u32,
+    pub offset: u32,
+    pub len: u32,
+}
+
+/// Opaque content-addressed identifier for a 1 GiB stripe. The pool
+/// uses it only for `==`/`hash` in single-flight coalescing.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct StripeKey(pub [u8; 32]);
+
+/// A byte range within a peer-side stripe, passed to
+/// `Transport::bulk_get`. `len` is bounded by `page_size`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BulkRef {
+    pub stripe: StripeKey,
+    pub offset: u64,
+    pub len: u32,
+}
+
+/// Opaque peer identifier minted by the p2p layer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PeerId(pub u64);
+
+/// Opaque node identifier minted by the p2p layer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NodeId(pub u64);
+
+/// Opaque tracing handle. The pool does not inspect it.
+#[derive(Clone, Debug, Default)]
+pub struct TraceCtx;
+
+/// Pool tunables. Most of the design's TODO knobs are still TBD;
+/// see `designs/bufferpool.md` "TODO(config)".
+#[derive(Clone, Debug)]
+pub struct PoolConfig {
+    /// Caps the number of concurrent `ReadStream`s the pool will
+    /// admit. v1 enforces this only at `read()` time.
+    pub max_concurrent_streams: usize,
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_streams: 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Error {
+    BadConfig(&'static str),
+    Io(i32),
+    BackingFull,
+    PageOutOfRange,
+    OffsetOutOfRange,
+    StreamLimit,
+    Transport(Arc<dyn std::error::Error + Send + Sync>),
+    BlockStore(Arc<dyn std::error::Error + Send + Sync>),
+}
+
+impl Error {
+    pub fn transport<E>(e: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Error::Transport(Arc::new(e))
+    }
+
+    pub fn blockstore<E>(e: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Error::BlockStore(Arc::new(e))
+    }
+}
+
+impl From<&'static str> for Error {
+    fn from(s: &'static str) -> Self {
+        // Convenient for tests and embedders that just need a message.
+        Error::Transport(Arc::new(StrError(s)))
+    }
+}
+
+#[derive(Debug)]
+struct StrError(&'static str);
+
+impl fmt::Display for StrError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl std::error::Error for StrError {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::BadConfig(s) => write!(f, "bad config: {s}"),
+            Error::Io(e) => write!(f, "io error: errno={e}"),
+            Error::BackingFull => write!(f, "backing full"),
+            Error::PageOutOfRange => write!(f, "page index out of range"),
+            Error::OffsetOutOfRange => write!(f, "read offset out of range"),
+            Error::StreamLimit => write!(f, "max_concurrent_streams reached"),
+            Error::Transport(e) => write!(f, "transport error: {e}"),
+            Error::BlockStore(e) => write!(f, "block store error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/cmd/unbounded-storage/src/hugetlb.rs
+++ b/cmd/unbounded-storage/src/hugetlb.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::bufferpool::{Backing, Error};
+
+#[cfg(target_os = "linux")]
+const PAGE_SIZE_2MB: usize = 2 * 1024 * 1024;
+
+/// Allocate `page_count` 2 MiB hugepages and wrap them in a
+/// [`Backing`]. Fails fast if the host has not reserved enough
+/// hugepages on the calling NUMA domain (via `MADV_POPULATE_WRITE`,
+/// Linux 5.14+).
+///
+/// `MADV_DONTFORK` is applied to the backing on the way out so the
+/// post-fork CoW hazard is neutralised before any RDMA MR registers
+/// the range. NUMA pinning of the calling thread (e.g.
+/// `sched_setaffinity` or `MPOL_BIND` on the VMA) remains the
+/// embedder's responsibility.
+#[cfg(target_os = "linux")]
+pub fn allocate_2mb_backing(page_count: usize) -> Result<Backing, Error> {
+    allocate_with(PAGE_SIZE_2MB, page_count, libc::MAP_HUGE_2MB)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn allocate_2mb_backing(_page_count: usize) -> Result<Backing, Error> {
+    Err(Error::BadConfig("hugepages only available on linux"))
+}
+
+#[cfg(target_os = "linux")]
+fn allocate_with(page_size: usize, page_count: usize, huge_flag: i32) -> Result<Backing, Error> {
+    if page_count == 0 {
+        return Err(Error::BadConfig("hugepage count must be > 0"));
+    }
+    let len = page_size
+        .checked_mul(page_count)
+        .ok_or(Error::BadConfig("hugepage allocation overflow"))?;
+
+    // SAFETY: arguments are valid; we check the return value.
+    let ptr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            len,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGETLB | huge_flag,
+            -1,
+            0,
+        )
+    };
+    if ptr == libc::MAP_FAILED {
+        return Err(Error::Io(io_errno()));
+    }
+
+    let owner = HugepageOwner {
+        base: ptr as *mut u8,
+        len,
+    };
+
+    // Fail-fast on hugepage shortage. `MAP_POPULATE` is not
+    // sufficient on hugetlb mappings (mmap(2) explicitly notes the
+    // call does not fail when the pool is exhausted; the caller
+    // would later trip a SIGBUS at first touch). MADV_POPULATE_WRITE
+    // (Linux 5.14+, mm/madvise.c) walks the range now and surfaces
+    // the shortage as a syscall error. See designs/bufferpool.md
+    // "Constraints" point 2.
+    //
+    // SAFETY: `owner.base` is the live mmap returned above; `len`
+    // matches; the call only faults pages, never invalidates the
+    // mapping.
+    let rc = unsafe {
+        libc::madvise(
+            owner.base as *mut libc::c_void,
+            len,
+            libc::MADV_POPULATE_WRITE,
+        )
+    };
+    if rc != 0 {
+        return Err(Error::Io(io_errno()));
+    }
+
+    // Neutralise the post-fork CoW hazard before any RDMA MR
+    // registers the range. MADV_DONTFORK detaches the mapping from
+    // child address spaces; libibverbs' alternative is
+    // ibv_fork_init() / RDMAV_FORK_SAFE which apply the same hint
+    // internally. We apply it unconditionally so embedders that do
+    // not pull in libibverbs still get the guarantee. See
+    // designs/bufferpool.md "Constraints" point 3.
+    //
+    // SAFETY: same as above. MADV_DONTFORK does not change current
+    // process page tables; only fork()'s behaviour for this VMA.
+    let rc = unsafe { libc::madvise(owner.base as *mut libc::c_void, len, libc::MADV_DONTFORK) };
+    if rc != 0 {
+        return Err(Error::Io(io_errno()));
+    }
+
+    Ok(Backing {
+        base: owner.base,
+        page_size,
+        page_count,
+        _own: Box::new(owner),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn io_errno() -> i32 {
+    std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+
+/// Drop carrier for the mmap'd region. Holds the bookkeeping the
+/// pool itself never inspects (per the design's `Backing._own`
+/// contract).
+#[cfg(target_os = "linux")]
+struct HugepageOwner {
+    base: *mut u8,
+    len: usize,
+}
+
+// SAFETY: hugepages are pinned by the kernel and the mapping lives
+// for the lifetime of the owner. The owner is sent only as part of
+// `Backing` whose `Send + Sync` impls already document the
+// per-NUMA pinning invariant.
+#[cfg(target_os = "linux")]
+unsafe impl Send for HugepageOwner {}
+#[cfg(target_os = "linux")]
+unsafe impl Sync for HugepageOwner {}
+
+#[cfg(target_os = "linux")]
+impl Drop for HugepageOwner {
+    fn drop(&mut self) {
+        // SAFETY: matches the `mmap` above.
+        unsafe {
+            libc::munmap(self.base as *mut libc::c_void, self.len);
+        }
+    }
+}

--- a/cmd/unbounded-storage/src/lib.rs
+++ b/cmd/unbounded-storage/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+pub mod bufferpool;
+pub mod hugetlb;
+pub mod p2p;

--- a/cmd/unbounded-storage/src/p2p.rs
+++ b/cmd/unbounded-storage/src/p2p.rs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::bufferpool::{NodeId, Req, StripeKey, TraceCtx};
+use std::time::Instant;
+
+#[derive(Clone, Debug)]
+pub struct P2pReq {
+    pub key: StripeKey,
+    pub deadline: Instant,
+    pub trace: TraceCtx,
+    pub path: Vec<NodeId>,
+}
+
+impl P2pReq {
+    pub fn new(key: StripeKey, deadline: Instant, trace: TraceCtx, path: Vec<NodeId>) -> Self {
+        Self {
+            key,
+            deadline,
+            trace,
+            path,
+        }
+    }
+
+    /// The next hop, if any. `None` means "fetch from regional storage".
+    pub fn next_hop(&self) -> Option<NodeId> {
+        self.path.first().copied()
+    }
+
+    /// Pop the head of `path` and return a forwardable request for
+    /// the next relay.
+    pub fn pop_hop(mut self) -> (Option<NodeId>, Self) {
+        let head = if self.path.is_empty() {
+            None
+        } else {
+            Some(self.path.remove(0))
+        };
+        (head, self)
+    }
+
+    /// Inherent accessor; see `designs/bufferpool.md`. Deadlines
+    /// live on `P2pReq` itself rather than on the [`Req`] trait
+    /// because the pool does not need them for single-flight
+    /// coalescing.
+    pub fn deadline(&self) -> Instant {
+        self.deadline
+    }
+
+    /// Inherent accessor for the opaque tracing context.
+    pub fn trace(&self) -> &TraceCtx {
+        &self.trace
+    }
+}
+
+impl Req for P2pReq {
+    fn key(&self) -> StripeKey {
+        self.key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn pop_hop_advances_path() {
+        let key = StripeKey([0u8; 32]);
+        let now = Instant::now() + Duration::from_secs(1);
+        let req = P2pReq::new(
+            key,
+            now,
+            TraceCtx::default(),
+            vec![NodeId(2), NodeId(1), NodeId(0)],
+        );
+        assert_eq!(req.next_hop(), Some(NodeId(2)));
+        let (head, rest) = req.pop_hop();
+        assert_eq!(head, Some(NodeId(2)));
+        assert_eq!(rest.next_hop(), Some(NodeId(1)));
+        assert_eq!(rest.path.len(), 2);
+    }
+
+    #[test]
+    fn empty_path_means_owner_fetch() {
+        let key = StripeKey([0u8; 32]);
+        let now = Instant::now() + Duration::from_secs(1);
+        let req = P2pReq::new(key, now, TraceCtx::default(), Vec::new());
+        assert!(req.next_hop().is_none());
+    }
+}


### PR DESCRIPTION
This buffer pool is the core of the storage cache: it will sit between the RDMA transport and the block layer while providing an interface for frontends (e.g. FUSE).

The implementation is critical to the performance of the cache, so it isn't exactly simple. It pre-allocates pools of buffers in each of the host's NUMA node, register the memory with io_uring/rdma and carefully manages thread affinity so callers always get memory in their (pinned) thread's NUMA node.