### PR TITLE
feat: adding HostReplace capabilities for OCI

### DIFF
--- a/cmd/machine-ops-controller/main.go
+++ b/cmd/machine-ops-controller/main.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -96,9 +97,13 @@ func run(ctx context.Context, cfg config) error {
 	if err != nil {
 		return fmt.Errorf("create kubernetes client: %w", err)
 	}
+	directClient, err := client.New(restConfig, client.Options{Scheme: scheme, Mapper: mgr.GetRESTMapper()})
+	if err != nil {
+		return fmt.Errorf("create direct client: %w", err)
+	}
 
 	if err := (&machineops.MachineOperationReconciler{
-		Client: mgr.GetClient(),
+		Client: directClient,
 		Providers: []machineops.Provider{
 			&azurevm.Provider{},
 			&ociinstance.Provider{ConfigFile: cfg.ociConfigFile, ConfigProfile: cfg.ociConfigProfile, Auth: cfg.ociAuth},

--- a/deploy/machine-ops/02-rbac.yaml.tmpl
+++ b/deploy/machine-ops/02-rbac.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
 rules:
   - apiGroups: ["unbounded-cloud.io"]
     resources: ["machines"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["unbounded-cloud.io"]
     resources: ["machineoperations"]
     verbs: ["get", "list", "watch", "delete"]
@@ -53,7 +53,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["kube-root-ca.crt"]
+    resourceNames: ["aks-cluster-metadata", "kube-root-ca.crt"]
     verbs: ["get"]
 
 ---

--- a/deploy/machine-ops/02-rbac.yaml.tmpl
+++ b/deploy/machine-ops/02-rbac.yaml.tmpl
@@ -53,7 +53,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["aks-cluster-metadata", "kube-root-ca.crt"]
+    resourceNames: ["kube-root-ca.crt"]
     verbs: ["get"]
 
 ---

--- a/docs/content/reference/machina-crd.md
+++ b/docs/content/reference/machina-crd.md
@@ -147,8 +147,11 @@ The OCI instance provider handles:
 | `HostReboot` | `RESET` |
 | `HostPowerOff` | `STOP` |
 | `HostPowerOn` | `START` |
+| `HostReplace` | `STOP` old instance, `LaunchInstance` replacement, patch `Machine.spec.providerID`, then terminate old instance |
 
-`HostReplace` is not currently supported for `OCIInstance` because an identity-preserving OCI replacement flow with fresh `user_data` injection has not been verified.
+`HostReplace` for `OCIInstance` creates a replacement instance because OCI launch `user_data` is immutable after instance creation. The controller stops the old instance, launches a new instance in the same availability domain, subnet, shape, and fault domain, requests a public IP for bootstrap egress, patches `Machine.spec.providerID` to the new instance OCID after the replacement reaches `RUNNING`, and then terminates the old instance. The replacement reuses the original `Machine` name as the kubelet node name so it rejoins through the existing Kubernetes `Node` object. Operation completion means the replacement is running, provider ID handoff succeeded, and old-instance cleanup succeeded; it does not wait for the Kubernetes `Node` to become Ready.
+
+The OCI replacement flow copies display name, defined tags, freeform tags, selected agent/availability/shape settings, and primary VNIC subnet/NSG/source-destination-check settings. It adds Unbounded freeform tags for idempotent retry lookup. It does not preserve the exact private IP, boot volume, or attached data volumes; active attached data volumes fail the operation before the old instance is stopped. By default, the replacement uses the latest compatible `Canonical Ubuntu` `24.04` image for the source instance shape. Set `spec.parameters.imageID` to use a specific OCI image OCID. Set `spec.parameters.sshAuthorizedKeys` to append SSH authorized keys to replacement metadata for break-glass debugging.
 
 ### status
 

--- a/internal/machineops/bootstrap.go
+++ b/internal/machineops/bootstrap.go
@@ -117,6 +117,7 @@ func (r *MachineOperationReconciler) buildReplaceAgentConfig(ctx context.Context
 		},
 		ProviderLabels: clusterInfo.ProviderLabels,
 		BootstrapToken: bootstrapToken,
+		NodeName:       machine.Name,
 	}), nil
 }
 

--- a/internal/machineops/controller.go
+++ b/internal/machineops/controller.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,17 +32,27 @@ const (
 // OperationRequest is the generic provider-facing view of a MachineOperation.
 type OperationRequest struct {
 	Machine         *unboundedv1alpha3.Machine
+	OperationName   string
+	OperationUID    types.UID
 	ProviderID      string
 	Operation       unboundedv1alpha3.OperationKind
 	Parameters      map[string]string
 	ReplaceUserData string
 }
 
+// OperationResult describes provider-side changes that must be reflected after
+// execution, such as replacement of an underlying cloud resource identity.
+type OperationResult struct {
+	ProviderID        string
+	CleanupProviderID string
+}
+
 // Provider executes MachineOperation requests for a specific external provider.
 type Provider interface {
 	Name() string
 	Supports(operation unboundedv1alpha3.OperationKind) bool
-	Execute(ctx context.Context, request OperationRequest) error
+	Execute(ctx context.Context, request OperationRequest) (OperationResult, error)
+	Cleanup(ctx context.Context, request OperationRequest, result OperationResult) error
 }
 
 // MachineOperationReconciler reconciles MachineOperation objects that target
@@ -59,7 +70,7 @@ type MachineOperationReconciler struct {
 // +kubebuilder:rbac:groups=unbounded-cloud.io,resources=machineoperations,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=unbounded-cloud.io,resources=machineoperations/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=unbounded-cloud.io,resources=machineoperations/finalizers,verbs=update
-// +kubebuilder:rbac:groups=unbounded-cloud.io,resources=machines,verbs=get;list;watch
+// +kubebuilder:rbac:groups=unbounded-cloud.io,resources=machines,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list
 // +kubebuilder:rbac:groups="",resources=configmaps;services;secrets,verbs=get
 // +kubebuilder:rbac:nonResourceURLs=/version,verbs=get
@@ -131,7 +142,14 @@ func (r *MachineOperationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	operationRequest := OperationRequest{Machine: &machine, ProviderID: providerMatch.providerID, Operation: op.Spec.OperationKind, Parameters: op.Spec.Parameters}
+	operationRequest := OperationRequest{
+		Machine:       &machine,
+		OperationName: op.Name,
+		OperationUID:  op.UID,
+		ProviderID:    providerMatch.providerID,
+		Operation:     op.Spec.OperationKind,
+		Parameters:    op.Spec.Parameters,
+	}
 	if op.Spec.OperationKind == unboundedv1alpha3.OperationHostReplace {
 		userData, err := r.buildReplaceUserData(ctx, &machine)
 		if err != nil {
@@ -141,11 +159,50 @@ func (r *MachineOperationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		operationRequest.ReplaceUserData = userData
 	}
 
-	if err := providerMatch.provider.Execute(ctx, operationRequest); err != nil {
+	operationResult, err := providerMatch.provider.Execute(ctx, operationRequest)
+	if err != nil {
 		return r.failOperation(ctx, &op, "ExecutionFailed", err.Error())
 	}
 
+	if operationResult.ProviderID != "" && operationResult.ProviderID != machine.Spec.ProviderID {
+		updatedGeneration, err := r.updateMachineProviderID(ctx, &machine, operationResult.ProviderID)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		machine.Spec.ProviderID = operationResult.ProviderID
+		machine.Generation = updatedGeneration
+	}
+
+	if err := providerMatch.provider.Cleanup(ctx, operationRequest, operationResult); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cleanup %s via %s: %w", op.Spec.OperationKind, providerMatch.provider.Name(), err)
+	}
+
 	return r.completeOperation(ctx, &op, machine.Generation, fmt.Sprintf("%s completed via %s", op.Spec.OperationKind, providerMatch.provider.Name()))
+}
+
+func (r *MachineOperationReconciler) updateMachineProviderID(ctx context.Context, machine *unboundedv1alpha3.Machine, providerID string) (int64, error) {
+	updatedGeneration := machine.Generation
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latest unboundedv1alpha3.Machine
+		if err := r.Get(ctx, client.ObjectKeyFromObject(machine), &latest); err != nil {
+			return err
+		}
+
+		patch := client.MergeFrom(latest.DeepCopy())
+		latest.Spec.ProviderID = providerID
+		if err := r.Patch(ctx, &latest, patch); err != nil {
+			return fmt.Errorf("patch Machine providerID: %w", err)
+		}
+
+		if err := r.Get(ctx, client.ObjectKeyFromObject(machine), &latest); err != nil {
+			return err
+		}
+		updatedGeneration = latest.Generation
+
+		return nil
+	})
+	return updatedGeneration, err
 }
 
 func shouldExecuteOperation(op *unboundedv1alpha3.MachineOperation) bool {

--- a/internal/machineops/controller_test.go
+++ b/internal/machineops/controller_test.go
@@ -18,6 +18,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 )
@@ -83,6 +84,7 @@ func TestMachineOperationReconciler_BuildsReplaceUserData(t *testing.T) {
 	require.Len(t, provider.replaceUserData, 1)
 	require.Contains(t, provider.replaceUserData[0], "#cloud-config")
 	require.Contains(t, provider.replaceUserData[0], "abc123.secret456")
+	require.Contains(t, provider.replaceUserData[0], `"NodeName": "machine-1"`)
 
 	var updated unboundedv1alpha3.MachineOperation
 	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "op-1"}, &updated))
@@ -144,6 +146,61 @@ func TestMachineOperationReconciler_ReexecutesInProgressHostReplace(t *testing.T
 	var updated unboundedv1alpha3.MachineOperation
 	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "op-1"}, &updated))
 	require.Equal(t, unboundedv1alpha3.OperationPhaseComplete, updated.Status.Phase)
+}
+
+func TestMachineOperationReconciler_PatchesReplacementProviderIDBeforeCleanup(t *testing.T) {
+	t.Parallel()
+
+	s := newOperationTestScheme(t)
+	require.NoError(t, corev1.AddToScheme(s))
+
+	machine := newExternalMachine("machine-1", unboundedv1alpha3.ExternalProviderOCIInstance)
+	machine.Spec.ProviderID = "oci://old-instance"
+	machine.Spec.Kubernetes = &unboundedv1alpha3.KubernetesSpec{BootstrapTokenRef: unboundedv1alpha3.LocalObjectReference{Name: "bootstrap-token-test"}}
+	op := newMachineOperation("op-1", "machine-1", unboundedv1alpha3.OperationHostReplace)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "bootstrap-token-test"},
+		Data: map[string][]byte{
+			"token-id":     []byte("abc123"),
+			"token-secret": []byte("secret456"),
+		},
+	}
+	provider := &recordingProvider{
+		provider:  unboundedv1alpha3.ExternalProviderOCIInstance,
+		supported: map[unboundedv1alpha3.OperationKind]bool{unboundedv1alpha3.OperationHostReplace: true},
+		result:    OperationResult{ProviderID: "oci://new-instance", CleanupProviderID: "oci://old-instance"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, op, secret).WithStatusSubresource(op).WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if err := c.Patch(ctx, obj, patch, opts...); err != nil {
+				return err
+			}
+
+			if updated, ok := obj.(*unboundedv1alpha3.Machine); ok {
+				updated.Generation = 2
+				return c.Update(ctx, updated)
+			}
+
+			return nil
+		},
+	}).Build()
+	reconciler := &MachineOperationReconciler{Client: c, Providers: []Provider{provider}, Now: fixedOperationNow, ClusterInfo: testClusterInfo()}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "op-1"}})
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	var updatedMachine unboundedv1alpha3.Machine
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "machine-1"}, &updatedMachine))
+	require.Equal(t, "oci://new-instance", updatedMachine.Spec.ProviderID)
+	require.Equal(t, []string{"HostReplace:machine-1:oci://old-instance"}, provider.calls)
+	require.Equal(t, []string{"HostReplace:machine-1:oci://old-instance"}, provider.cleanupCalls)
+
+	var updatedOp unboundedv1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "op-1"}, &updatedOp))
+	require.Equal(t, unboundedv1alpha3.OperationPhaseComplete, updatedOp.Status.Phase)
+	require.Equal(t, int64(2), updatedOp.Status.ObservedMachineGeneration)
 }
 
 func TestMachineOperationReconciler_UnsupportedOperationIsIgnored(t *testing.T) {
@@ -312,8 +369,11 @@ type recordingProvider struct {
 	provider        string
 	supported       map[unboundedv1alpha3.OperationKind]bool
 	calls           []string
+	cleanupCalls    []string
 	replaceUserData []string
+	result          OperationResult
 	err             error
+	cleanupErr      error
 }
 
 func (p *recordingProvider) Name() string {
@@ -324,13 +384,18 @@ func (p *recordingProvider) Supports(operation unboundedv1alpha3.OperationKind) 
 	return p.supported[operation]
 }
 
-func (p *recordingProvider) Execute(_ context.Context, request OperationRequest) error {
+func (p *recordingProvider) Execute(_ context.Context, request OperationRequest) (OperationResult, error) {
 	p.calls = append(p.calls, fmt.Sprintf("%s:%s:%s", request.Operation, request.Machine.Name, request.ProviderID))
 	if request.ReplaceUserData != "" {
 		p.replaceUserData = append(p.replaceUserData, request.ReplaceUserData)
 	}
 
-	return p.err
+	return p.result, p.err
+}
+
+func (p *recordingProvider) Cleanup(_ context.Context, request OperationRequest, result OperationResult) error {
+	p.cleanupCalls = append(p.cleanupCalls, fmt.Sprintf("%s:%s:%s", request.Operation, request.Machine.Name, result.CleanupProviderID))
+	return p.cleanupErr
 }
 
 func newOperationTestScheme(t *testing.T) *runtime.Scheme {

--- a/internal/machineops/providers/azurevm/provider.go
+++ b/internal/machineops/providers/azurevm/provider.go
@@ -67,15 +67,15 @@ func (p *Provider) Supports(operation unboundedv1alpha3.OperationKind) bool {
 	return ok
 }
 
-func (p *Provider) Execute(ctx context.Context, request machineops.OperationRequest) error {
+func (p *Provider) Execute(ctx context.Context, request machineops.OperationRequest) (machineops.OperationResult, error) {
 	operation, ok := azureVMOperations[request.Operation]
 	if !ok {
-		return fmt.Errorf("unsupported Azure VM operation %q", request.Operation)
+		return machineops.OperationResult{}, fmt.Errorf("unsupported Azure VM operation %q", request.Operation)
 	}
 
 	ref, err := parseAzureVMProviderID(request.ProviderID)
 	if err != nil {
-		return err
+		return machineops.OperationResult{}, err
 	}
 
 	ref.ReplaceUserData = request.ReplaceUserData
@@ -87,10 +87,14 @@ func (p *Provider) Execute(ctx context.Context, request machineops.OperationRequ
 
 	client, err := newClient(ref.SubscriptionID)
 	if err != nil {
-		return fmt.Errorf("create Azure VM client: %w", err)
+		return machineops.OperationResult{}, fmt.Errorf("create Azure VM client: %w", err)
 	}
 
-	return operation(ctx, client, ref)
+	return machineops.OperationResult{}, operation(ctx, client, ref)
+}
+
+func (p *Provider) Cleanup(context.Context, machineops.OperationRequest, machineops.OperationResult) error {
+	return nil
 }
 
 type azureVMResourceRef struct {

--- a/internal/machineops/providers/azurevm/provider_test.go
+++ b/internal/machineops/providers/azurevm/provider_test.go
@@ -99,7 +99,7 @@ func TestProviderExecute(t *testing.T) {
 				},
 			}
 
-			err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1", Operation: tt.operation, ReplaceUserData: "cloud-init"})
+			_, err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1", Operation: tt.operation, ReplaceUserData: "cloud-init"})
 
 			require.NoError(t, err)
 			require.Equal(t, tt.wantCalls, client.calls)
@@ -116,7 +116,7 @@ func TestProviderExecuteHostReplaceRequiresUserData(t *testing.T) {
 	}}
 
 	require.True(t, provider.Supports(unboundedv1alpha3.OperationHostReplace))
-	err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1", Operation: unboundedv1alpha3.OperationHostReplace})
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1", Operation: unboundedv1alpha3.OperationHostReplace})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "replacement user data is required")
 }

--- a/internal/machineops/providers/ociinstance/oci_client.go
+++ b/internal/machineops/providers/ociinstance/oci_client.go
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package ociinstance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/core"
+)
+
+func (p *Provider) newDefaultComputeClient() (computeClient, error) {
+	// The controller defaults to long-lived API keys but keeps security-token auth
+	// for local/e2e workflows that mount an OCI CLI config file.
+	profile := strings.TrimSpace(p.ConfigProfile)
+	if profile == "" {
+		profile = defaultConfigProfile
+	}
+	auth := strings.TrimSpace(p.Auth)
+	if auth == "" {
+		auth = AuthAPIKey
+	}
+	if auth != AuthAPIKey && auth != AuthSecurityToken {
+		return nil, fmt.Errorf("unsupported OCI auth mode %q", p.Auth)
+	}
+
+	provider := common.DefaultConfigProvider()
+	if strings.TrimSpace(p.ConfigFile) != "" {
+		switch auth {
+		case AuthAPIKey:
+			provider = common.CustomProfileConfigProvider(p.ConfigFile, profile)
+		case AuthSecurityToken:
+			provider = common.CustomProfileSessionTokenConfigProvider(p.ConfigFile, profile)
+		}
+	} else if auth != AuthAPIKey {
+		return nil, fmt.Errorf("oci auth mode %q requires --oci-config-file", auth)
+	}
+
+	computeClient, err := core.NewComputeClientWithConfigurationProvider(provider)
+	if err != nil {
+		return nil, fmt.Errorf("create compute client: %w", err)
+	}
+	networkClient, err := core.NewVirtualNetworkClientWithConfigurationProvider(provider)
+	if err != nil {
+		return nil, fmt.Errorf("create virtual network client: %w", err)
+	}
+
+	return &ociComputeClient{compute: computeClient, network: networkClient}, nil
+}
+
+type ociComputeClient struct {
+	compute core.ComputeClient
+	network core.VirtualNetworkClient
+}
+
+// ociComputeClient is intentionally a thin SDK adapter. It keeps OCI paging and
+// request structs out of Host Operation orchestration code.
+
+func (c *ociComputeClient) InstanceAction(ctx context.Context, instanceID, action string) error {
+	_, err := c.compute.InstanceAction(ctx, core.InstanceActionRequest{
+		InstanceId: &instanceID,
+		Action:     core.InstanceActionActionEnum(action),
+	})
+	if err != nil {
+		return fmt.Errorf("run OCI instance action %s on %s: %w", action, instanceID, err)
+	}
+
+	return nil
+}
+
+func (c *ociComputeClient) GetInstance(ctx context.Context, instanceID string) (core.Instance, error) {
+	response, err := c.compute.GetInstance(ctx, core.GetInstanceRequest{InstanceId: &instanceID})
+	if err != nil {
+		return core.Instance{}, err
+	}
+
+	return response.Instance, nil
+}
+
+func (c *ociComputeClient) ListInstances(ctx context.Context, compartmentID, availabilityDomain string) ([]core.Instance, error) {
+	var instances []core.Instance
+	var page *string
+	for {
+		response, err := c.compute.ListInstances(ctx, core.ListInstancesRequest{
+			CompartmentId:      &compartmentID,
+			AvailabilityDomain: &availabilityDomain,
+			Page:               page,
+		})
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, response.Items...)
+		if response.OpcNextPage == nil {
+			return instances, nil
+		}
+		page = response.OpcNextPage
+	}
+}
+
+func (c *ociComputeClient) LaunchInstance(ctx context.Context, details core.LaunchInstanceDetails, retryToken string) (core.Instance, error) {
+	response, err := c.compute.LaunchInstance(ctx, core.LaunchInstanceRequest{
+		LaunchInstanceDetails: details,
+		OpcRetryToken:         &retryToken,
+	})
+	if err != nil {
+		return core.Instance{}, err
+	}
+
+	return response.Instance, nil
+}
+
+func (c *ociComputeClient) TerminateInstance(ctx context.Context, instanceID, retryToken string) error {
+	preserveBootVolume := false
+	_, err := c.compute.TerminateInstance(ctx, core.TerminateInstanceRequest{
+		InstanceId:         &instanceID,
+		PreserveBootVolume: &preserveBootVolume,
+		OpcRequestId:       &retryToken,
+	})
+	if err != nil {
+		return fmt.Errorf("terminate OCI instance %s: %w", instanceID, err)
+	}
+
+	return nil
+}
+
+func (c *ociComputeClient) ListImages(ctx context.Context, compartmentID, shape string) ([]core.Image, error) {
+	var images []core.Image
+	var page *string
+	for {
+		response, err := c.compute.ListImages(ctx, core.ListImagesRequest{
+			CompartmentId:          &compartmentID,
+			OperatingSystem:        ptrTo(defaultUbuntuOS),
+			OperatingSystemVersion: ptrTo(defaultUbuntuOSVersion),
+			Shape:                  &shape,
+			LifecycleState:         core.ImageLifecycleStateAvailable,
+			SortBy:                 core.ListImagesSortByTimecreated,
+			SortOrder:              core.ListImagesSortOrderDesc,
+			Page:                   page,
+		})
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, response.Items...)
+		if response.OpcNextPage == nil {
+			return images, nil
+		}
+		page = response.OpcNextPage
+	}
+}
+
+func (c *ociComputeClient) ListVnicAttachments(ctx context.Context, compartmentID, instanceID string) ([]core.VnicAttachment, error) {
+	var attachments []core.VnicAttachment
+	var page *string
+	for {
+		response, err := c.compute.ListVnicAttachments(ctx, core.ListVnicAttachmentsRequest{
+			CompartmentId: &compartmentID,
+			InstanceId:    &instanceID,
+			Page:          page,
+		})
+		if err != nil {
+			return nil, err
+		}
+		attachments = append(attachments, response.Items...)
+		if response.OpcNextPage == nil {
+			return attachments, nil
+		}
+		page = response.OpcNextPage
+	}
+}
+
+func (c *ociComputeClient) GetVnic(ctx context.Context, vnicID string) (core.Vnic, error) {
+	response, err := c.network.GetVnic(ctx, core.GetVnicRequest{VnicId: &vnicID})
+	if err != nil {
+		return core.Vnic{}, err
+	}
+
+	return response.Vnic, nil
+}
+
+func (c *ociComputeClient) ListVolumeAttachments(ctx context.Context, compartmentID, instanceID string) ([]core.VolumeAttachment, error) {
+	var attachments []core.VolumeAttachment
+	var page *string
+	for {
+		response, err := c.compute.ListVolumeAttachments(ctx, core.ListVolumeAttachmentsRequest{
+			CompartmentId: &compartmentID,
+			InstanceId:    &instanceID,
+			Page:          page,
+		})
+		if err != nil {
+			return nil, err
+		}
+		attachments = append(attachments, response.Items...)
+		if response.OpcNextPage == nil {
+			return attachments, nil
+		}
+		page = response.OpcNextPage
+	}
+}

--- a/internal/machineops/providers/ociinstance/oci_client.go
+++ b/internal/machineops/providers/ociinstance/oci_client.go
@@ -81,23 +81,14 @@ func (c *ociComputeClient) GetInstance(ctx context.Context, instanceID string) (
 }
 
 func (c *ociComputeClient) ListInstances(ctx context.Context, compartmentID, availabilityDomain string) ([]core.Instance, error) {
-	var instances []core.Instance
-	var page *string
-	for {
+	return listOCI(ctx, func(ctx context.Context, page *string) ([]core.Instance, *string, error) {
 		response, err := c.compute.ListInstances(ctx, core.ListInstancesRequest{
 			CompartmentId:      &compartmentID,
 			AvailabilityDomain: &availabilityDomain,
 			Page:               page,
 		})
-		if err != nil {
-			return nil, err
-		}
-		instances = append(instances, response.Items...)
-		if response.OpcNextPage == nil {
-			return instances, nil
-		}
-		page = response.OpcNextPage
-	}
+		return response.Items, response.OpcNextPage, err
+	})
 }
 
 func (c *ociComputeClient) LaunchInstance(ctx context.Context, details core.LaunchInstanceDetails, retryToken string) (core.Instance, error) {
@@ -127,9 +118,7 @@ func (c *ociComputeClient) TerminateInstance(ctx context.Context, instanceID, re
 }
 
 func (c *ociComputeClient) ListImages(ctx context.Context, compartmentID, shape string) ([]core.Image, error) {
-	var images []core.Image
-	var page *string
-	for {
+	return listOCI(ctx, func(ctx context.Context, page *string) ([]core.Image, *string, error) {
 		response, err := c.compute.ListImages(ctx, core.ListImagesRequest{
 			CompartmentId:          &compartmentID,
 			OperatingSystem:        ptrTo(defaultUbuntuOS),
@@ -140,35 +129,19 @@ func (c *ociComputeClient) ListImages(ctx context.Context, compartmentID, shape 
 			SortOrder:              core.ListImagesSortOrderDesc,
 			Page:                   page,
 		})
-		if err != nil {
-			return nil, err
-		}
-		images = append(images, response.Items...)
-		if response.OpcNextPage == nil {
-			return images, nil
-		}
-		page = response.OpcNextPage
-	}
+		return response.Items, response.OpcNextPage, err
+	})
 }
 
 func (c *ociComputeClient) ListVnicAttachments(ctx context.Context, compartmentID, instanceID string) ([]core.VnicAttachment, error) {
-	var attachments []core.VnicAttachment
-	var page *string
-	for {
+	return listOCI(ctx, func(ctx context.Context, page *string) ([]core.VnicAttachment, *string, error) {
 		response, err := c.compute.ListVnicAttachments(ctx, core.ListVnicAttachmentsRequest{
 			CompartmentId: &compartmentID,
 			InstanceId:    &instanceID,
 			Page:          page,
 		})
-		if err != nil {
-			return nil, err
-		}
-		attachments = append(attachments, response.Items...)
-		if response.OpcNextPage == nil {
-			return attachments, nil
-		}
-		page = response.OpcNextPage
-	}
+		return response.Items, response.OpcNextPage, err
+	})
 }
 
 func (c *ociComputeClient) GetVnic(ctx context.Context, vnicID string) (core.Vnic, error) {
@@ -181,21 +154,29 @@ func (c *ociComputeClient) GetVnic(ctx context.Context, vnicID string) (core.Vni
 }
 
 func (c *ociComputeClient) ListVolumeAttachments(ctx context.Context, compartmentID, instanceID string) ([]core.VolumeAttachment, error) {
-	var attachments []core.VolumeAttachment
-	var page *string
-	for {
+	return listOCI(ctx, func(ctx context.Context, page *string) ([]core.VolumeAttachment, *string, error) {
 		response, err := c.compute.ListVolumeAttachments(ctx, core.ListVolumeAttachmentsRequest{
 			CompartmentId: &compartmentID,
 			InstanceId:    &instanceID,
 			Page:          page,
 		})
+		return response.Items, response.OpcNextPage, err
+	})
+}
+
+func listOCI[T any](ctx context.Context, listPage func(context.Context, *string) ([]T, *string, error)) ([]T, error) {
+	var items []T
+	var page *string
+	for {
+		pageItems, nextPage, err := listPage(ctx, page)
 		if err != nil {
 			return nil, err
 		}
-		attachments = append(attachments, response.Items...)
-		if response.OpcNextPage == nil {
-			return attachments, nil
+
+		items = append(items, pageItems...)
+		if nextPage == nil {
+			return items, nil
 		}
-		page = response.OpcNextPage
+		page = nextPage
 	}
 }

--- a/internal/machineops/providers/ociinstance/provider.go
+++ b/internal/machineops/providers/ociinstance/provider.go
@@ -7,15 +7,22 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
-	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	"github.com/Azure/unbounded/internal/machineops"
 )
 
-const defaultConfigProfile = "DEFAULT"
+const (
+	defaultConfigProfile    = "DEFAULT"
+	defaultUbuntuOS         = "Canonical Ubuntu"
+	defaultUbuntuOSVersion  = "24.04"
+	ociMetadataMaxBytes     = 32000
+	replacementPollInterval = 15 * time.Second
+	replacementPollTimeout  = 20 * time.Minute
+)
 
 const (
 	// AuthAPIKey uses the standard OCI config-file API key fields.
@@ -30,9 +37,31 @@ const (
 	instanceActionStop  = "STOP"
 )
 
-// computeClient contains the OCI instance actions used by the provider.
+const (
+	parameterImageID           = "imageID"
+	parameterSSHAuthorizedKeys = "sshAuthorizedKeys"
+
+	tagMachine       = "unbounded_machine"
+	tagOperation     = "unbounded_machine_operation"
+	tagOperationUID  = "unbounded_machine_operation_uid"
+	tagOldProviderID = "unbounded_old_provider_id"
+	retryTokenPrefix = "unbounded-machine-op"
+	providerIDPrefix = "oci://"
+)
+
+// computeClient is the test seam for OCI calls. The provider logic stays in
+// terms of Machine operations while the SDK adapter owns pagination and request
+// types.
 type computeClient interface {
 	InstanceAction(ctx context.Context, instanceID, action string) error
+	GetInstance(ctx context.Context, instanceID string) (core.Instance, error)
+	ListInstances(ctx context.Context, compartmentID, availabilityDomain string) ([]core.Instance, error)
+	LaunchInstance(ctx context.Context, details core.LaunchInstanceDetails, retryToken string) (core.Instance, error)
+	TerminateInstance(ctx context.Context, instanceID, retryToken string) error
+	ListImages(ctx context.Context, compartmentID, shape string) ([]core.Image, error)
+	ListVnicAttachments(ctx context.Context, compartmentID, instanceID string) ([]core.VnicAttachment, error)
+	GetVnic(ctx context.Context, vnicID string) (core.Vnic, error)
+	ListVolumeAttachments(ctx context.Context, compartmentID, instanceID string) ([]core.VolumeAttachment, error)
 }
 
 type computeClientFactory func() (computeClient, error)
@@ -53,24 +82,73 @@ func (p *Provider) Supports(operation unboundedv1alpha3.OperationKind) bool {
 	switch operation {
 	case unboundedv1alpha3.OperationHostReboot,
 		unboundedv1alpha3.OperationHostPowerOff,
-		unboundedv1alpha3.OperationHostPowerOn:
+		unboundedv1alpha3.OperationHostPowerOn,
+		unboundedv1alpha3.OperationHostReplace:
 		return true
 	default:
 		return false
 	}
 }
 
-func (p *Provider) Execute(ctx context.Context, request machineops.OperationRequest) error {
+func (p *Provider) Execute(ctx context.Context, request machineops.OperationRequest) (machineops.OperationResult, error) {
+	instanceID, err := parseOCIInstanceProviderID(request.ProviderID)
+	if err != nil {
+		return machineops.OperationResult{}, err
+	}
+
+	client, err := p.client()
+	if err != nil {
+		return machineops.OperationResult{}, err
+	}
+
+	if request.Operation == unboundedv1alpha3.OperationHostReplace {
+		return p.executeReplace(ctx, client, instanceID, request)
+	}
+
 	action, err := actionForOperation(request.Operation)
+	if err != nil {
+		return machineops.OperationResult{}, err
+	}
+
+	return machineops.OperationResult{}, client.InstanceAction(ctx, instanceID, action)
+}
+
+func (p *Provider) Cleanup(ctx context.Context, request machineops.OperationRequest, result machineops.OperationResult) error {
+	if result.CleanupProviderID == "" {
+		return nil
+	}
+
+	instanceID, err := parseOCIInstanceProviderID(result.CleanupProviderID)
 	if err != nil {
 		return err
 	}
 
-	instanceID := strings.TrimSpace(strings.TrimPrefix(request.ProviderID, "oci://"))
-	if instanceID == "" {
-		return fmt.Errorf("oci providerID is required")
+	if request.Machine != nil {
+		currentInstanceID, err := parseOCIInstanceProviderID(request.Machine.Spec.ProviderID)
+		if err == nil && currentInstanceID == instanceID {
+			// ProviderID handoff must happen before old-instance cleanup; otherwise a
+			// retry could delete the replacement that the Machine still references.
+			return fmt.Errorf("refusing to terminate cleanup target %s because Machine still points to it", result.CleanupProviderID)
+		}
 	}
 
+	client, err := p.client()
+	if err != nil {
+		return err
+	}
+
+	instance, err := client.GetInstance(ctx, instanceID)
+	if err == nil && isTerminalInstance(instance) {
+		return nil
+	}
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "notfound") {
+		return nil
+	}
+
+	return client.TerminateInstance(ctx, instanceID, retryToken(request, "terminate-old"))
+}
+
+func (p *Provider) client() (computeClient, error) {
 	newClient := p.NewClient
 	if newClient == nil {
 		newClient = p.newDefaultComputeClient
@@ -78,10 +156,10 @@ func (p *Provider) Execute(ctx context.Context, request machineops.OperationRequ
 
 	client, err := newClient()
 	if err != nil {
-		return fmt.Errorf("create OCI compute client: %w", err)
+		return nil, fmt.Errorf("create OCI compute client: %w", err)
 	}
 
-	return client.InstanceAction(ctx, instanceID, action)
+	return client, nil
 }
 
 func actionForOperation(operation unboundedv1alpha3.OperationKind) (string, error) {
@@ -97,51 +175,11 @@ func actionForOperation(operation unboundedv1alpha3.OperationKind) (string, erro
 	}
 }
 
-func (p *Provider) newDefaultComputeClient() (computeClient, error) {
-	profile := strings.TrimSpace(p.ConfigProfile)
-	if profile == "" {
-		profile = defaultConfigProfile
-	}
-	auth := strings.TrimSpace(p.Auth)
-	if auth == "" {
-		auth = AuthAPIKey
-	}
-	if auth != AuthAPIKey && auth != AuthSecurityToken {
-		return nil, fmt.Errorf("unsupported OCI auth mode %q", p.Auth)
+func parseOCIInstanceProviderID(providerID string) (string, error) {
+	instanceID := strings.TrimSpace(strings.TrimPrefix(providerID, providerIDPrefix))
+	if instanceID == "" {
+		return "", fmt.Errorf("oci providerID is required")
 	}
 
-	provider := common.DefaultConfigProvider()
-	if strings.TrimSpace(p.ConfigFile) != "" {
-		switch auth {
-		case AuthAPIKey:
-			provider = common.CustomProfileConfigProvider(p.ConfigFile, profile)
-		case AuthSecurityToken:
-			provider = common.CustomProfileSessionTokenConfigProvider(p.ConfigFile, profile)
-		}
-	} else if auth != AuthAPIKey {
-		return nil, fmt.Errorf("oci auth mode %q requires --oci-config-file", auth)
-	}
-
-	client, err := core.NewComputeClientWithConfigurationProvider(provider)
-	if err != nil {
-		return nil, fmt.Errorf("create compute client: %w", err)
-	}
-
-	return &ociComputeClient{client: client}, nil
-}
-
-type ociComputeClient struct {
-	client core.ComputeClient
-}
-
-func (c *ociComputeClient) InstanceAction(ctx context.Context, instanceID, action string) error {
-	_, err := c.client.InstanceAction(ctx, core.InstanceActionRequest{
-		InstanceId: &instanceID,
-		Action:     core.InstanceActionActionEnum(action),
-	})
-	if err != nil {
-		return fmt.Errorf("run OCI instance action %s on %s: %w", action, instanceID, err)
-	}
-
-	return nil
+	return instanceID, nil
 }

--- a/internal/machineops/providers/ociinstance/provider_test.go
+++ b/internal/machineops/providers/ociinstance/provider_test.go
@@ -5,10 +5,15 @@ package ociinstance
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	"github.com/Azure/unbounded/internal/machineops"
@@ -38,7 +43,7 @@ func TestProviderExecute(t *testing.T) {
 				},
 			}
 
-			err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci://ocid1.instance.oc1.test", Operation: tt.operation})
+			_, err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci://ocid1.instance.oc1.test", Operation: tt.operation})
 
 			require.NoError(t, err)
 			require.Equal(t, []string{tt.wantCall}, client.calls)
@@ -53,20 +58,22 @@ func TestProviderExecuteRequiresProviderID(t *testing.T) {
 		return &recordingComputeClient{}, nil
 	}}
 
-	err := provider.Execute(context.Background(), machineops.OperationRequest{Operation: unboundedv1alpha3.OperationHostPowerOn})
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{Operation: unboundedv1alpha3.OperationHostPowerOn})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "providerID is required")
 }
 
-func TestProviderExecuteHostReplaceUnsupported(t *testing.T) {
+func TestProviderExecuteHostReplaceRequiresUserData(t *testing.T) {
 	t.Parallel()
 
-	provider := &Provider{}
+	provider := &Provider{NewClient: func() (computeClient, error) {
+		return &recordingComputeClient{}, nil
+	}}
 
-	require.False(t, provider.Supports(unboundedv1alpha3.OperationHostReplace))
-	err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci://ocid1.instance.oc1.test", Operation: unboundedv1alpha3.OperationHostReplace})
+	require.True(t, provider.Supports(unboundedv1alpha3.OperationHostReplace))
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci://old-instance", Operation: unboundedv1alpha3.OperationHostReplace})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unsupported OCI instance operation")
+	require.Contains(t, err.Error(), "replacement user data is required")
 }
 
 func TestProviderExecuteRequiresNonEmptyProviderID(t *testing.T) {
@@ -76,7 +83,7 @@ func TestProviderExecuteRequiresNonEmptyProviderID(t *testing.T) {
 		return &recordingComputeClient{}, nil
 	}}
 
-	err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci:// ", Operation: unboundedv1alpha3.OperationHostPowerOn})
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci:// ", Operation: unboundedv1alpha3.OperationHostPowerOn})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "providerID is required")
 }
@@ -88,9 +95,239 @@ func TestProviderExecuteReturnsClientError(t *testing.T) {
 		return nil, fmt.Errorf("boom")
 	}}
 
-	err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci://ocid1.instance.oc1.test", Operation: unboundedv1alpha3.OperationHostPowerOn})
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci://ocid1.instance.oc1.test", Operation: unboundedv1alpha3.OperationHostPowerOn})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "create OCI compute client")
+}
+
+func TestProviderExecuteHostReplaceLaunchesDefaultUbuntuReplacement(t *testing.T) {
+	t.Parallel()
+
+	client := newReplacementClient()
+	provider := &Provider{NewClient: func() (computeClient, error) { return client, nil }}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://old-instance"
+
+	result, err := provider.Execute(context.Background(), machineops.OperationRequest{
+		Machine:         machine,
+		OperationName:   "replace-machine-1",
+		OperationUID:    types.UID("operation-uid"),
+		ProviderID:      "oci://old-instance",
+		Operation:       unboundedv1alpha3.OperationHostReplace,
+		Parameters:      map[string]string{parameterSSHAuthorizedKeys: "ssh-rsa debug-key"},
+		ReplaceUserData: "#cloud-config\n",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, machineops.OperationResult{ProviderID: "oci://new-instance", CleanupProviderID: "oci://old-instance"}, result)
+	require.Equal(t, []string{"STOP:old-instance"}, client.calls)
+	require.Len(t, client.launches, 1)
+	launch := client.launches[0]
+	require.Equal(t, "image-new", *launch.SourceDetails.(core.InstanceSourceViaImageDetails).ImageId)
+	require.Equal(t, "subnet-1", *launch.CreateVnicDetails.SubnetId)
+	require.Equal(t, []string{"nsg-1"}, launch.CreateVnicDetails.NsgIds)
+	require.True(t, *launch.CreateVnicDetails.AssignPublicIp)
+	require.Nil(t, launch.CreateVnicDetails.PrivateIp)
+	require.Nil(t, launch.LaunchOptions)
+	require.Contains(t, launch.Metadata["ssh_authorized_keys"], "ssh-rsa debug-key")
+	require.Equal(t, "machine-1", launch.FreeformTags[tagMachine])
+	require.Equal(t, "replace-machine-1", launch.FreeformTags[tagOperation])
+	require.Equal(t, "operation-uid", launch.FreeformTags[tagOperationUID])
+	require.Equal(t, "oci://old-instance", launch.FreeformTags[tagOldProviderID])
+	for key := range launch.FreeformTags {
+		require.NotContains(t, key, "/")
+	}
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("#cloud-config\n")), launch.Metadata["user_data"])
+}
+
+func TestProviderExecuteHostReplaceImageIDOverride(t *testing.T) {
+	t.Parallel()
+
+	client := newReplacementClient()
+	provider := &Provider{NewClient: func() (computeClient, error) { return client, nil }}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://old-instance"
+
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{
+		Machine:         machine,
+		OperationName:   "replace-machine-1",
+		OperationUID:    types.UID("operation-uid"),
+		ProviderID:      "oci://old-instance",
+		Operation:       unboundedv1alpha3.OperationHostReplace,
+		Parameters:      map[string]string{parameterImageID: "custom-image"},
+		ReplaceUserData: "#cloud-config\n",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "custom-image", *client.launches[0].SourceDetails.(core.InstanceSourceViaImageDetails).ImageId)
+	require.Empty(t, client.listImagesCalls)
+}
+
+func TestProviderExecuteHostReplacePreflightsBeforeStop(t *testing.T) {
+	t.Parallel()
+
+	client := newReplacementClient()
+	client.images = nil
+	provider := &Provider{NewClient: func() (computeClient, error) { return client, nil }}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://old-instance"
+
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{
+		Machine:         machine,
+		OperationName:   "replace-machine-1",
+		OperationUID:    types.UID("operation-uid"),
+		ProviderID:      "oci://old-instance",
+		Operation:       unboundedv1alpha3.OperationHostReplace,
+		ReplaceUserData: "#cloud-config\n",
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no compatible")
+	require.Empty(t, client.calls)
+	require.Empty(t, client.launches)
+}
+
+func TestProviderExecuteHostReplaceWaitsForStoppingInstance(t *testing.T) {
+	t.Parallel()
+
+	client := newReplacementClient()
+	client.instances[0].LifecycleState = core.InstanceLifecycleStateStopping
+	client.stopAfterGet = map[string]int{"old-instance": 2}
+	provider := &Provider{NewClient: func() (computeClient, error) { return client, nil }}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://old-instance"
+
+	result, err := provider.Execute(context.Background(), machineops.OperationRequest{
+		Machine:         machine,
+		OperationName:   "replace-machine-1",
+		OperationUID:    types.UID("operation-uid"),
+		ProviderID:      "oci://old-instance",
+		Operation:       unboundedv1alpha3.OperationHostReplace,
+		ReplaceUserData: "#cloud-config\n",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, machineops.OperationResult{ProviderID: "oci://new-instance", CleanupProviderID: "oci://old-instance"}, result)
+	require.Empty(t, client.calls)
+	require.Len(t, client.launches, 1)
+	require.GreaterOrEqual(t, client.getCalls["old-instance"], 2)
+}
+
+func TestProviderExecuteHostReplaceFailsWithDataVolume(t *testing.T) {
+	t.Parallel()
+
+	client := newReplacementClient()
+	client.volumeAttachments = []core.VolumeAttachment{core.ParavirtualizedVolumeAttachment{LifecycleState: core.VolumeAttachmentLifecycleStateAttached}}
+	provider := &Provider{NewClient: func() (computeClient, error) { return client, nil }}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://old-instance"
+
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{
+		Machine:         machine,
+		OperationName:   "replace-machine-1",
+		OperationUID:    types.UID("operation-uid"),
+		ProviderID:      "oci://old-instance",
+		Operation:       unboundedv1alpha3.OperationHostReplace,
+		ReplaceUserData: "#cloud-config\n",
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not support preserving attached data volumes")
+	require.Empty(t, client.launches)
+}
+
+func TestProviderExecuteHostReplaceReusesTaggedReplacement(t *testing.T) {
+	t.Parallel()
+
+	client := newReplacementClient()
+	client.instances = append(client.instances, core.Instance{
+		Id:                 ptrTo("existing-replacement"),
+		LifecycleState:     core.InstanceLifecycleStateRunning,
+		CompartmentId:      ptrTo("compartment-1"),
+		AvailabilityDomain: ptrTo("ad-1"),
+		Shape:              ptrTo("VM.Standard.E4.Flex"),
+		FreeformTags: map[string]string{
+			tagOperationUID:  "operation-uid",
+			tagOldProviderID: "oci://old-instance",
+		},
+	})
+	provider := &Provider{NewClient: func() (computeClient, error) { return client, nil }}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://old-instance"
+
+	result, err := provider.Execute(context.Background(), machineops.OperationRequest{
+		Machine:         machine,
+		OperationName:   "replace-machine-1",
+		OperationUID:    types.UID("operation-uid"),
+		ProviderID:      "oci://old-instance",
+		Operation:       unboundedv1alpha3.OperationHostReplace,
+		ReplaceUserData: "#cloud-config\n",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "oci://existing-replacement", result.ProviderID)
+	require.Empty(t, client.launches)
+	require.Empty(t, client.calls)
+}
+
+func TestProviderExecuteHostReplaceAfterProviderIDHandoffReturnsCleanup(t *testing.T) {
+	t.Parallel()
+
+	client := newReplacementClient()
+	client.instances = append(client.instances, core.Instance{
+		Id:                 ptrTo("new-instance"),
+		LifecycleState:     core.InstanceLifecycleStateRunning,
+		CompartmentId:      ptrTo("compartment-1"),
+		AvailabilityDomain: ptrTo("ad-1"),
+		Shape:              ptrTo("VM.Standard.E4.Flex"),
+		FreeformTags: map[string]string{
+			tagOperationUID:  "operation-uid",
+			tagOldProviderID: "oci://old-instance",
+		},
+	})
+	provider := &Provider{NewClient: func() (computeClient, error) { return client, nil }}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://new-instance"
+
+	result, err := provider.Execute(context.Background(), machineops.OperationRequest{
+		Machine:         machine,
+		OperationName:   "replace-machine-1",
+		OperationUID:    types.UID("operation-uid"),
+		ProviderID:      "oci://new-instance",
+		Operation:       unboundedv1alpha3.OperationHostReplace,
+		ReplaceUserData: "#cloud-config\n",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, machineops.OperationResult{ProviderID: "oci://new-instance", CleanupProviderID: "oci://old-instance"}, result)
+	require.Empty(t, client.launches)
+	require.Empty(t, client.calls)
+}
+
+func TestProviderCleanupTerminatesOldInstance(t *testing.T) {
+	t.Parallel()
+
+	client := newReplacementClient()
+	provider := &Provider{NewClient: func() (computeClient, error) { return client, nil }}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://new-instance"
+
+	err := provider.Cleanup(context.Background(), machineops.OperationRequest{
+		Machine:       machine,
+		OperationName: "replace-machine-1",
+		OperationUID:  types.UID("operation-uid"),
+	}, machineops.OperationResult{CleanupProviderID: "oci://old-instance"})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"old-instance"}, client.terminated)
 }
 
 func TestNewDefaultComputeClientValidatesAuth(t *testing.T) {
@@ -126,11 +363,130 @@ func TestActionForOperation(t *testing.T) {
 }
 
 type recordingComputeClient struct {
-	calls []string
-	err   error
+	calls             []string
+	err               error
+	instances         []core.Instance
+	vnics             map[string]core.Vnic
+	volumeAttachments []core.VolumeAttachment
+	images            []core.Image
+	launches          []core.LaunchInstanceDetails
+	terminated        []string
+	listImagesCalls   []string
+	getCalls          map[string]int
+	stopAfterGet      map[string]int
 }
 
 func (c *recordingComputeClient) InstanceAction(_ context.Context, instanceID, action string) error {
 	c.calls = append(c.calls, fmt.Sprintf("%s:%s", action, instanceID))
+	for i := range c.instances {
+		if c.instances[i].Id != nil && *c.instances[i].Id == instanceID && action == instanceActionStop {
+			c.instances[i].LifecycleState = core.InstanceLifecycleStateStopped
+		}
+	}
+
 	return c.err
+}
+
+func (c *recordingComputeClient) GetInstance(_ context.Context, instanceID string) (core.Instance, error) {
+	if c.getCalls == nil {
+		c.getCalls = map[string]int{}
+	}
+	c.getCalls[instanceID]++
+	for i, instance := range c.instances {
+		if instance.Id != nil && *instance.Id == instanceID {
+			if stopAt := c.stopAfterGet[instanceID]; stopAt > 0 && c.getCalls[instanceID] >= stopAt {
+				c.instances[i].LifecycleState = core.InstanceLifecycleStateStopped
+				return c.instances[i], nil
+			}
+
+			return instance, nil
+		}
+	}
+
+	return core.Instance{}, fmt.Errorf("not found")
+}
+
+func (c *recordingComputeClient) ListInstances(_ context.Context, _, _ string) ([]core.Instance, error) {
+	return c.instances, nil
+}
+
+func (c *recordingComputeClient) LaunchInstance(_ context.Context, details core.LaunchInstanceDetails, _ string) (core.Instance, error) {
+	c.launches = append(c.launches, details)
+	replacement := core.Instance{
+		Id:                 ptrTo("new-instance"),
+		LifecycleState:     core.InstanceLifecycleStateRunning,
+		CompartmentId:      details.CompartmentId,
+		AvailabilityDomain: details.AvailabilityDomain,
+		Shape:              details.Shape,
+		FreeformTags:       details.FreeformTags,
+	}
+	c.instances = append(c.instances, replacement)
+
+	return replacement, nil
+}
+
+func (c *recordingComputeClient) TerminateInstance(_ context.Context, instanceID, _ string) error {
+	c.terminated = append(c.terminated, instanceID)
+	return nil
+}
+
+func (c *recordingComputeClient) ListImages(_ context.Context, compartmentID, shape string) ([]core.Image, error) {
+	c.listImagesCalls = append(c.listImagesCalls, fmt.Sprintf("%s:%s", compartmentID, shape))
+	return c.images, nil
+}
+
+func (c *recordingComputeClient) ListVnicAttachments(_ context.Context, _, instanceID string) ([]core.VnicAttachment, error) {
+	return []core.VnicAttachment{{InstanceId: &instanceID, VnicId: ptrTo("vnic-1"), LifecycleState: core.VnicAttachmentLifecycleStateAttached}}, nil
+}
+
+func (c *recordingComputeClient) GetVnic(_ context.Context, vnicID string) (core.Vnic, error) {
+	vnic, ok := c.vnics[vnicID]
+	if !ok {
+		return core.Vnic{}, fmt.Errorf("not found")
+	}
+
+	return vnic, nil
+}
+
+func (c *recordingComputeClient) ListVolumeAttachments(_ context.Context, _, _ string) ([]core.VolumeAttachment, error) {
+	return c.volumeAttachments, nil
+}
+
+func newReplacementClient() *recordingComputeClient {
+	return &recordingComputeClient{
+		instances: []core.Instance{{
+			Id:                 ptrTo("old-instance"),
+			LifecycleState:     core.InstanceLifecycleStateRunning,
+			CompartmentId:      ptrTo("compartment-1"),
+			AvailabilityDomain: ptrTo("ad-1"),
+			Shape:              ptrTo("VM.Standard.E4.Flex"),
+			DisplayName:        ptrTo("machine-1"),
+			FreeformTags:       map[string]string{"existing": "tag"},
+		}},
+		vnics: map[string]core.Vnic{
+			"vnic-1": {
+				Id:                  ptrTo("vnic-1"),
+				IsPrimary:           ptrTo(true),
+				SubnetId:            ptrTo("subnet-1"),
+				NsgIds:              []string{"nsg-1"},
+				SkipSourceDestCheck: ptrTo(true),
+			},
+		},
+		images: []core.Image{
+			{
+				Id:                     ptrTo("image-old"),
+				LifecycleState:         core.ImageLifecycleStateAvailable,
+				OperatingSystem:        ptrTo(defaultUbuntuOS),
+				OperatingSystemVersion: ptrTo(defaultUbuntuOSVersion),
+				TimeCreated:            &common.SDKTime{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			{
+				Id:                     ptrTo("image-new"),
+				LifecycleState:         core.ImageLifecycleStateAvailable,
+				OperatingSystem:        ptrTo(defaultUbuntuOS),
+				OperatingSystemVersion: ptrTo(defaultUbuntuOSVersion),
+				TimeCreated:            &common.SDKTime{Time: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
+			},
+		},
+	}
 }

--- a/internal/machineops/providers/ociinstance/provider_test.go
+++ b/internal/machineops/providers/ociinstance/provider_test.go
@@ -63,7 +63,7 @@ func TestProviderExecuteRequiresProviderID(t *testing.T) {
 	require.Contains(t, err.Error(), "providerID is required")
 }
 
-func TestProviderExecuteHostReplaceRequiresUserData(t *testing.T) {
+func TestProviderExecuteHostReplaceRequiresMachine(t *testing.T) {
 	t.Parallel()
 
 	provider := &Provider{NewClient: func() (computeClient, error) {
@@ -72,6 +72,21 @@ func TestProviderExecuteHostReplaceRequiresUserData(t *testing.T) {
 
 	require.True(t, provider.Supports(unboundedv1alpha3.OperationHostReplace))
 	_, err := provider.Execute(context.Background(), machineops.OperationRequest{ProviderID: "oci://old-instance", Operation: unboundedv1alpha3.OperationHostReplace})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "machine is required")
+}
+
+func TestProviderExecuteHostReplaceRequiresUserData(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{NewClient: func() (computeClient, error) {
+		return &recordingComputeClient{}, nil
+	}}
+	machine := &unboundedv1alpha3.Machine{}
+	machine.Name = "machine-1"
+	machine.Spec.ProviderID = "oci://old-instance"
+
+	_, err := provider.Execute(context.Background(), machineops.OperationRequest{Machine: machine, ProviderID: "oci://old-instance", Operation: unboundedv1alpha3.OperationHostReplace})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "replacement user data is required")
 }

--- a/internal/machineops/providers/ociinstance/replace.go
+++ b/internal/machineops/providers/ociinstance/replace.go
@@ -15,21 +15,21 @@ import (
 )
 
 func (p *Provider) executeReplace(ctx context.Context, client computeClient, instanceID string, request machineops.OperationRequest) (machineops.OperationResult, error) {
+	if request.Machine == nil {
+		return machineops.OperationResult{}, fmt.Errorf("machine is required for OCI HostReplace")
+	}
+
 	// Reconcile retries may happen after providerID handoff but before cleanup.
 	// Detect that state from replacement tags and return the pending cleanup work.
-	if request.Machine != nil {
-		currentID, err := parseOCIInstanceProviderID(request.Machine.Spec.ProviderID)
-		if err == nil && currentID != "" {
-			if currentID != instanceID {
-				current, getErr := client.GetInstance(ctx, currentID)
-				if getErr == nil && isReplacementFor(current, request, request.ProviderID) {
-					return machineops.OperationResult{ProviderID: providerIDPrefix + currentID, CleanupProviderID: request.ProviderID}, nil
-				}
-			} else {
-				current, getErr := client.GetInstance(ctx, currentID)
-				if getErr == nil && isReplacementFor(current, request, current.FreeformTags[tagOldProviderID]) {
-					return machineops.OperationResult{ProviderID: providerIDPrefix + currentID, CleanupProviderID: current.FreeformTags[tagOldProviderID]}, nil
-				}
+	currentID, err := parseOCIInstanceProviderID(request.Machine.Spec.ProviderID)
+	if err == nil && currentID != "" {
+		current, getErr := client.GetInstance(ctx, currentID)
+		if getErr == nil {
+			if currentID != instanceID && isReplacementFor(current, request, request.ProviderID) {
+				return machineops.OperationResult{ProviderID: providerIDPrefix + currentID, CleanupProviderID: request.ProviderID}, nil
+			}
+			if currentID == instanceID && isReplacementFor(current, request, current.FreeformTags[tagOldProviderID]) {
+				return machineops.OperationResult{ProviderID: providerIDPrefix + currentID, CleanupProviderID: current.FreeformTags[tagOldProviderID]}, nil
 			}
 		}
 	}
@@ -40,9 +40,6 @@ func (p *Provider) executeReplace(ctx context.Context, client computeClient, ins
 func (p *Provider) replaceHost(ctx context.Context, client computeClient, oldInstanceID string, request machineops.OperationRequest) (machineops.OperationResult, error) {
 	if strings.TrimSpace(request.ReplaceUserData) == "" {
 		return machineops.OperationResult{}, fmt.Errorf("replacement user data is required for OCI HostReplace")
-	}
-	if request.Machine == nil {
-		return machineops.OperationResult{}, fmt.Errorf("machine is required for OCI HostReplace")
 	}
 
 	oldInstance, err := replacementSourceInstance(ctx, client, oldInstanceID)
@@ -110,15 +107,13 @@ func waitForInstanceState(ctx context.Context, client computeClient, instance co
 		return instance, nil
 	}
 
-	deadline := time.Now().Add(replacementPollTimeout)
-	for {
-		if time.Now().After(deadline) {
-			return core.Instance{}, fmt.Errorf("timed out waiting for OCI instance %s to reach %s", *instance.Id, target)
-		}
+	waitCtx, cancel := context.WithTimeout(ctx, replacementPollTimeout)
+	defer cancel()
 
+	for {
 		// Poll before sleeping so tests and fast OCI transitions do not wait a full
 		// interval after the target state has already been reached.
-		updated, err := client.GetInstance(ctx, *instance.Id)
+		updated, err := client.GetInstance(waitCtx, *instance.Id)
 		if err != nil {
 			return core.Instance{}, fmt.Errorf("get OCI instance %s while waiting for %s: %w", *instance.Id, target, err)
 		}
@@ -130,8 +125,12 @@ func waitForInstanceState(ctx context.Context, client computeClient, instance co
 		}
 
 		select {
-		case <-ctx.Done():
-			return core.Instance{}, ctx.Err()
+		case <-waitCtx.Done():
+			if waitCtx.Err() == context.DeadlineExceeded {
+				return core.Instance{}, fmt.Errorf("timed out waiting for OCI instance %s to reach %s", *instance.Id, target)
+			}
+
+			return core.Instance{}, waitCtx.Err()
 		case <-time.After(replacementPollInterval):
 		}
 	}

--- a/internal/machineops/providers/ociinstance/replace.go
+++ b/internal/machineops/providers/ociinstance/replace.go
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package ociinstance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/core"
+
+	"github.com/Azure/unbounded/internal/machineops"
+)
+
+func (p *Provider) executeReplace(ctx context.Context, client computeClient, instanceID string, request machineops.OperationRequest) (machineops.OperationResult, error) {
+	// Reconcile retries may happen after providerID handoff but before cleanup.
+	// Detect that state from replacement tags and return the pending cleanup work.
+	if request.Machine != nil {
+		currentID, err := parseOCIInstanceProviderID(request.Machine.Spec.ProviderID)
+		if err == nil && currentID != "" {
+			if currentID != instanceID {
+				current, getErr := client.GetInstance(ctx, currentID)
+				if getErr == nil && isReplacementFor(current, request, request.ProviderID) {
+					return machineops.OperationResult{ProviderID: providerIDPrefix + currentID, CleanupProviderID: request.ProviderID}, nil
+				}
+			} else {
+				current, getErr := client.GetInstance(ctx, currentID)
+				if getErr == nil && isReplacementFor(current, request, current.FreeformTags[tagOldProviderID]) {
+					return machineops.OperationResult{ProviderID: providerIDPrefix + currentID, CleanupProviderID: current.FreeformTags[tagOldProviderID]}, nil
+				}
+			}
+		}
+	}
+
+	return p.replaceHost(ctx, client, instanceID, request)
+}
+
+func (p *Provider) replaceHost(ctx context.Context, client computeClient, oldInstanceID string, request machineops.OperationRequest) (machineops.OperationResult, error) {
+	if strings.TrimSpace(request.ReplaceUserData) == "" {
+		return machineops.OperationResult{}, fmt.Errorf("replacement user data is required for OCI HostReplace")
+	}
+	if request.Machine == nil {
+		return machineops.OperationResult{}, fmt.Errorf("machine is required for OCI HostReplace")
+	}
+
+	oldInstance, err := replacementSourceInstance(ctx, client, oldInstanceID)
+	if err != nil {
+		return machineops.OperationResult{}, err
+	}
+	if err := rejectAttachedDataVolumes(ctx, client, oldInstance); err != nil {
+		return machineops.OperationResult{}, err
+	}
+
+	primaryVNIC, err := primaryVNIC(ctx, client, oldInstance)
+	if err != nil {
+		return machineops.OperationResult{}, err
+	}
+
+	replacement, ok, err := p.findExistingReplacement(ctx, client, oldInstance, request)
+	if err != nil {
+		return machineops.OperationResult{}, err
+	}
+	if !ok {
+		// Build all launch inputs before stopping the old host so validation
+		// failures do not create an avoidable outage.
+		launchDetails, err := p.buildReplacementLaunchDetails(ctx, client, oldInstance, primaryVNIC, request)
+		if err != nil {
+			return machineops.OperationResult{}, err
+		}
+
+		// STOPPING still owns the old Node identity. Wait for STOPPED before
+		// launching a replacement that will use the same kubelet node name.
+		if !isStopped(oldInstance) && !isStopping(oldInstance) {
+			if err := client.InstanceAction(ctx, oldInstanceID, instanceActionStop); err != nil {
+				return machineops.OperationResult{}, err
+			}
+		}
+		_, err = waitForInstanceState(ctx, client, oldInstance, core.InstanceLifecycleStateStopped)
+		if err != nil {
+			return machineops.OperationResult{}, err
+		}
+
+		replacement, err = client.LaunchInstance(ctx, launchDetails, retryToken(request, "launch-replacement"))
+		if err != nil {
+			return machineops.OperationResult{}, fmt.Errorf("launch OCI replacement instance: %w", err)
+		}
+	}
+
+	running, err := waitForInstanceState(ctx, client, replacement, core.InstanceLifecycleStateRunning)
+	if err != nil {
+		return machineops.OperationResult{}, err
+	}
+	if running.Id == nil || *running.Id == "" {
+		return machineops.OperationResult{}, fmt.Errorf("OCI replacement instance has no ID")
+	}
+
+	return machineops.OperationResult{
+		ProviderID:        providerIDPrefix + *running.Id,
+		CleanupProviderID: providerIDPrefix + oldInstanceID,
+	}, nil
+}
+
+func waitForInstanceState(ctx context.Context, client computeClient, instance core.Instance, target core.InstanceLifecycleStateEnum) (core.Instance, error) {
+	if instance.Id == nil || *instance.Id == "" {
+		return core.Instance{}, fmt.Errorf("OCI instance has no ID")
+	}
+	if instance.LifecycleState == target {
+		return instance, nil
+	}
+
+	deadline := time.Now().Add(replacementPollTimeout)
+	for {
+		if time.Now().After(deadline) {
+			return core.Instance{}, fmt.Errorf("timed out waiting for OCI instance %s to reach %s", *instance.Id, target)
+		}
+
+		// Poll before sleeping so tests and fast OCI transitions do not wait a full
+		// interval after the target state has already been reached.
+		updated, err := client.GetInstance(ctx, *instance.Id)
+		if err != nil {
+			return core.Instance{}, fmt.Errorf("get OCI instance %s while waiting for %s: %w", *instance.Id, target, err)
+		}
+		if updated.LifecycleState == target {
+			return updated, nil
+		}
+		if isTerminalInstance(updated) {
+			return core.Instance{}, fmt.Errorf("OCI instance %s reached terminal state %s while waiting for %s", *instance.Id, updated.LifecycleState, target)
+		}
+
+		select {
+		case <-ctx.Done():
+			return core.Instance{}, ctx.Err()
+		case <-time.After(replacementPollInterval):
+		}
+	}
+}
+
+func isStopped(instance core.Instance) bool {
+	return instance.LifecycleState == core.InstanceLifecycleStateStopped
+}
+
+func isStopping(instance core.Instance) bool {
+	return instance.LifecycleState == core.InstanceLifecycleStateStopping
+}
+
+func isTerminalInstance(instance core.Instance) bool {
+	return instance.LifecycleState == core.InstanceLifecycleStateTerminated || instance.LifecycleState == core.InstanceLifecycleStateTerminating
+}
+
+func isReplacementFor(instance core.Instance, request machineops.OperationRequest, oldProviderID string) bool {
+	// Operation UID plus old providerID makes replacement lookup restart-safe and
+	// prevents matching an unrelated instance from another Host Operation.
+	return instance.FreeformTags[tagOperationUID] == string(request.OperationUID) && instance.FreeformTags[tagOldProviderID] == oldProviderID
+}
+
+func retryToken(request machineops.OperationRequest, action string) string {
+	operationID := string(request.OperationUID)
+	if operationID == "" {
+		operationID = request.OperationName
+	}
+
+	return fmt.Sprintf("%s-%s-%s", retryTokenPrefix, action, operationID)
+}

--- a/internal/machineops/providers/ociinstance/replacement_launch.go
+++ b/internal/machineops/providers/ociinstance/replacement_launch.go
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package ociinstance
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/core"
+
+	"github.com/Azure/unbounded/internal/machineops"
+)
+
+func replacementSourceInstance(ctx context.Context, client computeClient, instanceID string) (core.Instance, error) {
+	// These fields are required to recreate the host in the same OCI placement
+	// and shape without making later helpers handle nil pointer cases.
+	instance, err := client.GetInstance(ctx, instanceID)
+	if err != nil {
+		return core.Instance{}, fmt.Errorf("get OCI instance %s: %w", instanceID, err)
+	}
+	if instance.CompartmentId == nil || *instance.CompartmentId == "" {
+		return core.Instance{}, fmt.Errorf("OCI instance %s has no compartment ID", instanceID)
+	}
+	if instance.AvailabilityDomain == nil || *instance.AvailabilityDomain == "" {
+		return core.Instance{}, fmt.Errorf("OCI instance %s has no availability domain", instanceID)
+	}
+	if instance.Shape == nil || *instance.Shape == "" {
+		return core.Instance{}, fmt.Errorf("OCI instance %s has no shape", instanceID)
+	}
+
+	return instance, nil
+}
+
+func rejectAttachedDataVolumes(ctx context.Context, client computeClient, instance core.Instance) error {
+	// v1 replacement intentionally handles only disposable root disks. Data volume
+	// preservation needs explicit detach/attach semantics before it is safe.
+	volumeAttachments, err := client.ListVolumeAttachments(ctx, *instance.CompartmentId, *instance.Id)
+	if err != nil {
+		return fmt.Errorf("list OCI volume attachments for %s: %w", *instance.Id, err)
+	}
+	if hasActiveVolumeAttachment(volumeAttachments) {
+		return fmt.Errorf("OCI HostReplace does not support preserving attached data volumes")
+	}
+
+	return nil
+}
+
+func primaryVNIC(ctx context.Context, client computeClient, instance core.Instance) (core.Vnic, error) {
+	// OCI launch uses CreateVnicDetails, so we copy only the network placement
+	// fields needed for the replacement rather than cloning every VNIC property.
+	attachments, err := client.ListVnicAttachments(ctx, *instance.CompartmentId, *instance.Id)
+	if err != nil {
+		return core.Vnic{}, fmt.Errorf("list OCI VNIC attachments for %s: %w", *instance.Id, err)
+	}
+
+	for _, attachment := range attachments {
+		if attachment.LifecycleState == core.VnicAttachmentLifecycleStateDetached || attachment.VnicId == nil || *attachment.VnicId == "" {
+			continue
+		}
+
+		vnic, err := client.GetVnic(ctx, *attachment.VnicId)
+		if err != nil {
+			return core.Vnic{}, fmt.Errorf("get OCI VNIC %s: %w", *attachment.VnicId, err)
+		}
+		if vnic.IsPrimary != nil && *vnic.IsPrimary {
+			if vnic.SubnetId == nil || *vnic.SubnetId == "" {
+				return core.Vnic{}, fmt.Errorf("OCI primary VNIC %s has no subnet ID", *attachment.VnicId)
+			}
+
+			return vnic, nil
+		}
+	}
+
+	return core.Vnic{}, fmt.Errorf("OCI instance %s has no primary VNIC", *instance.Id)
+}
+
+func (p *Provider) findExistingReplacement(ctx context.Context, client computeClient, oldInstance core.Instance, request machineops.OperationRequest) (core.Instance, bool, error) {
+	// LaunchInstance retry tokens are not enough after controller restarts. Tags
+	// give us an OCI-visible idempotency record for replacement lookup.
+	instances, err := client.ListInstances(ctx, *oldInstance.CompartmentId, *oldInstance.AvailabilityDomain)
+	if err != nil {
+		return core.Instance{}, false, fmt.Errorf("list OCI instances for replacement lookup: %w", err)
+	}
+
+	oldProviderID := providerIDPrefix + *oldInstance.Id
+	operationUID := string(request.OperationUID)
+	for _, instance := range instances {
+		if isTerminalInstance(instance) {
+			continue
+		}
+		if instance.FreeformTags[tagOperationUID] == operationUID && instance.FreeformTags[tagOldProviderID] == oldProviderID {
+			return instance, true, nil
+		}
+	}
+
+	return core.Instance{}, false, nil
+}
+
+func (p *Provider) buildReplacementLaunchDetails(ctx context.Context, client computeClient, oldInstance core.Instance, primaryVNIC core.Vnic, request machineops.OperationRequest) (core.LaunchInstanceDetails, error) {
+	imageID, err := p.resolveImageID(ctx, client, oldInstance, request.Parameters)
+	if err != nil {
+		return core.LaunchInstanceDetails{}, err
+	}
+
+	return buildReplacementLaunchDetails(oldInstance, primaryVNIC, imageID, request)
+}
+
+func (p *Provider) resolveImageID(ctx context.Context, client computeClient, oldInstance core.Instance, parameters map[string]string) (string, error) {
+	// Operators can pin an image for controlled rollout; otherwise choose the
+	// newest Ubuntu image OCI reports as compatible with the source shape.
+	if imageID := strings.TrimSpace(parameters[parameterImageID]); imageID != "" {
+		return imageID, nil
+	}
+
+	images, err := client.ListImages(ctx, *oldInstance.CompartmentId, *oldInstance.Shape)
+	if err != nil {
+		return "", fmt.Errorf("list OCI images: %w", err)
+	}
+	sort.SliceStable(images, func(i, j int) bool {
+		if images[i].TimeCreated == nil {
+			return false
+		}
+		if images[j].TimeCreated == nil {
+			return true
+		}
+
+		return images[i].TimeCreated.After(images[j].TimeCreated.Time)
+	})
+
+	for _, image := range images {
+		if image.Id == nil || image.LifecycleState != core.ImageLifecycleStateAvailable {
+			continue
+		}
+		if image.OperatingSystem == nil || image.OperatingSystemVersion == nil {
+			continue
+		}
+		if *image.OperatingSystem == defaultUbuntuOS && *image.OperatingSystemVersion == defaultUbuntuOSVersion {
+			return *image.Id, nil
+		}
+	}
+
+	return "", fmt.Errorf("no compatible %s %s image found for shape %s; set spec.parameters.%s", defaultUbuntuOS, defaultUbuntuOSVersion, *oldInstance.Shape, parameterImageID)
+}
+
+func buildReplacementLaunchDetails(oldInstance core.Instance, primaryVNIC core.Vnic, imageID string, request machineops.OperationRequest) (core.LaunchInstanceDetails, error) {
+	// OCI cannot update launch user_data in place, so HostReplace recreates the
+	// instance with fresh bootstrap metadata and a new providerID.
+	metadata := copyStringMap(oldInstance.Metadata)
+	if extraKeys := strings.TrimSpace(request.Parameters[parameterSSHAuthorizedKeys]); extraKeys != "" {
+		metadata["ssh_authorized_keys"] = strings.TrimSpace(metadata["ssh_authorized_keys"] + "\n" + extraKeys)
+	}
+	metadata["user_data"] = base64.StdEncoding.EncodeToString([]byte(request.ReplaceUserData))
+	if metadataSize(metadata, oldInstance.ExtendedMetadata) > ociMetadataMaxBytes {
+		return core.LaunchInstanceDetails{}, fmt.Errorf("replacement metadata exceeds OCI limit of %d bytes", ociMetadataMaxBytes)
+	}
+
+	freeformTags := copyStringMap(oldInstance.FreeformTags)
+	// OCI freeform tag keys cannot use slash-delimited Kubernetes-style names.
+	// These tags are also the restart-safe replacement lookup keys.
+	freeformTags[tagMachine] = request.Machine.Name
+	freeformTags[tagOperation] = request.OperationName
+	freeformTags[tagOperationUID] = string(request.OperationUID)
+	freeformTags[tagOldProviderID] = request.ProviderID
+
+	details := core.LaunchInstanceDetails{
+		AvailabilityDomain:      oldInstance.AvailabilityDomain,
+		CompartmentId:           oldInstance.CompartmentId,
+		CapacityReservationId:   oldInstance.CapacityReservationId,
+		DefinedTags:             oldInstance.DefinedTags,
+		DisplayName:             oldInstance.DisplayName,
+		ExtendedMetadata:        oldInstance.ExtendedMetadata,
+		FaultDomain:             oldInstance.FaultDomain,
+		ClusterPlacementGroupId: oldInstance.ClusterPlacementGroupId,
+		FreeformTags:            freeformTags,
+		IpxeScript:              oldInstance.IpxeScript,
+		InstanceOptions:         oldInstance.InstanceOptions,
+		Metadata:                metadata,
+		Shape:                   oldInstance.Shape,
+		SourceDetails: core.InstanceSourceViaImageDetails{
+			ImageId: &imageID,
+		},
+		CreateVnicDetails: &core.CreateVnicDetails{
+			AssignPublicIp:      ptrTo(true),
+			AssignIpv6Ip:        ptrTo(false),
+			NsgIds:              primaryVNIC.NsgIds,
+			SkipSourceDestCheck: primaryVNIC.SkipSourceDestCheck,
+			SubnetId:            primaryVNIC.SubnetId,
+		},
+	}
+	if oldInstance.ShapeConfig != nil {
+		details.ShapeConfig = &core.LaunchInstanceShapeConfigDetails{
+			Ocpus:       oldInstance.ShapeConfig.Ocpus,
+			Vcpus:       oldInstance.ShapeConfig.Vcpus,
+			MemoryInGBs: oldInstance.ShapeConfig.MemoryInGBs,
+		}
+	}
+	if oldInstance.AvailabilityConfig != nil {
+		details.AvailabilityConfig = &core.LaunchInstanceAvailabilityConfigDetails{
+			IsLiveMigrationPreferred: oldInstance.AvailabilityConfig.IsLiveMigrationPreferred,
+		}
+		if oldInstance.AvailabilityConfig.RecoveryAction != "" {
+			details.AvailabilityConfig.RecoveryAction = core.LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum(oldInstance.AvailabilityConfig.RecoveryAction)
+		}
+	}
+	if oldInstance.AgentConfig != nil {
+		details.AgentConfig = &core.LaunchInstanceAgentConfigDetails{
+			IsMonitoringDisabled:  oldInstance.AgentConfig.IsMonitoringDisabled,
+			IsManagementDisabled:  oldInstance.AgentConfig.IsManagementDisabled,
+			AreAllPluginsDisabled: oldInstance.AgentConfig.AreAllPluginsDisabled,
+			PluginsConfig:         oldInstance.AgentConfig.PluginsConfig,
+		}
+	}
+
+	return details, nil
+}
+
+func hasActiveVolumeAttachment(attachments []core.VolumeAttachment) bool {
+	for _, attachment := range attachments {
+		switch attachment.GetLifecycleState() {
+		case core.VolumeAttachmentLifecycleStateAttached, core.VolumeAttachmentLifecycleStateAttaching:
+			return true
+		}
+	}
+
+	return false
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in)+4)
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
+func metadataSize(metadata map[string]string, extended map[string]interface{}) int {
+	total := 0
+	for k, v := range metadata {
+		total += len(k) + len(v)
+	}
+	for k := range extended {
+		total += len(k)
+	}
+
+	return total
+}
+
+func ptrTo[T any](value T) *T { return &value }

--- a/internal/machineops/providers/ociinstance/replacement_launch.go
+++ b/internal/machineops/providers/ociinstance/replacement_launch.go
@@ -147,24 +147,10 @@ func (p *Provider) resolveImageID(ctx context.Context, client computeClient, old
 }
 
 func buildReplacementLaunchDetails(oldInstance core.Instance, primaryVNIC core.Vnic, imageID string, request machineops.OperationRequest) (core.LaunchInstanceDetails, error) {
-	// OCI cannot update launch user_data in place, so HostReplace recreates the
-	// instance with fresh bootstrap metadata and a new providerID.
-	metadata := copyStringMap(oldInstance.Metadata)
-	if extraKeys := strings.TrimSpace(request.Parameters[parameterSSHAuthorizedKeys]); extraKeys != "" {
-		metadata["ssh_authorized_keys"] = strings.TrimSpace(metadata["ssh_authorized_keys"] + "\n" + extraKeys)
+	metadata, err := replacementMetadata(oldInstance, request)
+	if err != nil {
+		return core.LaunchInstanceDetails{}, err
 	}
-	metadata["user_data"] = base64.StdEncoding.EncodeToString([]byte(request.ReplaceUserData))
-	if metadataSize(metadata, oldInstance.ExtendedMetadata) > ociMetadataMaxBytes {
-		return core.LaunchInstanceDetails{}, fmt.Errorf("replacement metadata exceeds OCI limit of %d bytes", ociMetadataMaxBytes)
-	}
-
-	freeformTags := copyStringMap(oldInstance.FreeformTags)
-	// OCI freeform tag keys cannot use slash-delimited Kubernetes-style names.
-	// These tags are also the restart-safe replacement lookup keys.
-	freeformTags[tagMachine] = request.Machine.Name
-	freeformTags[tagOperation] = request.OperationName
-	freeformTags[tagOperationUID] = string(request.OperationUID)
-	freeformTags[tagOldProviderID] = request.ProviderID
 
 	details := core.LaunchInstanceDetails{
 		AvailabilityDomain:      oldInstance.AvailabilityDomain,
@@ -175,7 +161,7 @@ func buildReplacementLaunchDetails(oldInstance core.Instance, primaryVNIC core.V
 		ExtendedMetadata:        oldInstance.ExtendedMetadata,
 		FaultDomain:             oldInstance.FaultDomain,
 		ClusterPlacementGroupId: oldInstance.ClusterPlacementGroupId,
-		FreeformTags:            freeformTags,
+		FreeformTags:            replacementTags(oldInstance, request),
 		IpxeScript:              oldInstance.IpxeScript,
 		InstanceOptions:         oldInstance.InstanceOptions,
 		Metadata:                metadata,
@@ -183,14 +169,51 @@ func buildReplacementLaunchDetails(oldInstance core.Instance, primaryVNIC core.V
 		SourceDetails: core.InstanceSourceViaImageDetails{
 			ImageId: &imageID,
 		},
-		CreateVnicDetails: &core.CreateVnicDetails{
-			AssignPublicIp:      ptrTo(true),
-			AssignIpv6Ip:        ptrTo(false),
-			NsgIds:              primaryVNIC.NsgIds,
-			SkipSourceDestCheck: primaryVNIC.SkipSourceDestCheck,
-			SubnetId:            primaryVNIC.SubnetId,
-		},
+		CreateVnicDetails: replacementVNIC(primaryVNIC),
 	}
+	copyOptionalLaunchSettings(&details, oldInstance)
+
+	return details, nil
+}
+
+func replacementMetadata(oldInstance core.Instance, request machineops.OperationRequest) (map[string]string, error) {
+	// OCI cannot update launch user_data in place, so HostReplace recreates the
+	// instance with fresh bootstrap metadata and a new providerID.
+	metadata := copyStringMap(oldInstance.Metadata)
+	if extraKeys := strings.TrimSpace(request.Parameters[parameterSSHAuthorizedKeys]); extraKeys != "" {
+		metadata["ssh_authorized_keys"] = strings.TrimSpace(metadata["ssh_authorized_keys"] + "\n" + extraKeys)
+	}
+	metadata["user_data"] = base64.StdEncoding.EncodeToString([]byte(request.ReplaceUserData))
+	if metadataSize(metadata, oldInstance.ExtendedMetadata) > ociMetadataMaxBytes {
+		return nil, fmt.Errorf("replacement metadata exceeds OCI limit of %d bytes", ociMetadataMaxBytes)
+	}
+
+	return metadata, nil
+}
+
+func replacementTags(oldInstance core.Instance, request machineops.OperationRequest) map[string]string {
+	freeformTags := copyStringMap(oldInstance.FreeformTags)
+	// OCI freeform tag keys cannot use slash-delimited Kubernetes-style names.
+	// These tags are also the restart-safe replacement lookup keys.
+	freeformTags[tagMachine] = request.Machine.Name
+	freeformTags[tagOperation] = request.OperationName
+	freeformTags[tagOperationUID] = string(request.OperationUID)
+	freeformTags[tagOldProviderID] = request.ProviderID
+
+	return freeformTags
+}
+
+func replacementVNIC(primaryVNIC core.Vnic) *core.CreateVnicDetails {
+	return &core.CreateVnicDetails{
+		AssignPublicIp:      ptrTo(true),
+		AssignIpv6Ip:        ptrTo(false),
+		NsgIds:              primaryVNIC.NsgIds,
+		SkipSourceDestCheck: primaryVNIC.SkipSourceDestCheck,
+		SubnetId:            primaryVNIC.SubnetId,
+	}
+}
+
+func copyOptionalLaunchSettings(details *core.LaunchInstanceDetails, oldInstance core.Instance) {
 	if oldInstance.ShapeConfig != nil {
 		details.ShapeConfig = &core.LaunchInstanceShapeConfigDetails{
 			Ocpus:       oldInstance.ShapeConfig.Ocpus,
@@ -214,8 +237,6 @@ func buildReplacementLaunchDetails(oldInstance core.Instance, primaryVNIC core.V
 			PluginsConfig:         oldInstance.AgentConfig.PluginsConfig,
 		}
 	}
-
-	return details, nil
 }
 
 func hasActiveVolumeAttachment(attachments []core.VolumeAttachment) bool {

--- a/internal/provision/agent_config.go
+++ b/internal/provision/agent_config.go
@@ -118,6 +118,10 @@ type BuildAgentConfigParams struct {
 	// TPM-based attestation (e.g. "http://10.0.0.1:8880"). When non-empty
 	// an Attest section is included in the config.
 	AttestURL string
+
+	// NodeName overrides the Kubernetes Node name used by kubelet. When empty,
+	// the agent resolves the node name from the host hostname.
+	NodeName string
 }
 
 // BuildAgentConfig constructs an AgentConfig from a Machine and cluster-level
@@ -176,6 +180,7 @@ func BuildAgentConfig(params BuildAgentConfigParams) UnboundedAgentConfig {
 	cfg := UnboundedAgentConfig{
 		AgentConfig: config.AgentConfig{
 			MachineName: machine.Name,
+			NodeName:    params.NodeName,
 			Cluster: AgentClusterConfig{
 				CaCertBase64: params.Cluster.CACertBase64,
 				ClusterDNS:   params.Cluster.ClusterDNS,

--- a/internal/provision/agent_config_test.go
+++ b/internal/provision/agent_config_test.go
@@ -230,6 +230,7 @@ func TestBuildAgentConfig(t *testing.T) {
 			},
 			assert: func(t *testing.T, cfg UnboundedAgentConfig) {
 				require.Equal(t, "my-machine", cfg.MachineName)
+				require.Empty(t, cfg.NodeName)
 				require.Equal(t, "dGVzdC1jYQ==", cfg.Cluster.CaCertBase64)
 				require.Equal(t, "10.0.0.10", cfg.Cluster.ClusterDNS)
 				require.Equal(t, "v1.34.0", cfg.Cluster.Version) // Machine spec overrides KubeVersion
@@ -244,6 +245,19 @@ func TestBuildAgentConfig(t *testing.T) {
 				require.Equal(t, "provider-val", cfg.Kubelet.Labels["provider-key"])
 
 				require.Equal(t, []string{"dedicated=gpu:NoSchedule"}, cfg.Kubelet.RegisterWithTaints)
+			},
+		},
+		{
+			name: "node name override",
+			params: BuildAgentConfigParams{
+				Machine: &v1alpha3.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "machine-name"},
+				},
+				NodeName: "node-name",
+			},
+			assert: func(t *testing.T, cfg UnboundedAgentConfig) {
+				require.Equal(t, "machine-name", cfg.MachineName)
+				require.Equal(t, "node-name", cfg.NodeName)
 			},
 		},
 		{


### PR DESCRIPTION
This pull request introduces significant improvements to the machine operation reconciliation and provider interfaces, especially to support safe and atomic replacement of cloud instances (such as OCI and Azure VM) and ensure proper patching of the `Machine.spec.providerID` during replacement flows. The changes also include enhancements to RBAC permissions, documentation, and testing. 

Key changes include:

**Machine Operation Reconciliation and Provider Interface Enhancements:**

* Introduced `OperationResult` and extended the `Provider` interface with `Execute` (now returning `OperationResult`) and a new `Cleanup` method, enabling providers to communicate post-operation changes such as new provider IDs and to perform cleanup actions after successful operations. (`internal/machineops/controller.go`, `internal/machineops/providers/azurevm/provider.go`, `internal/machineops/controller_test.go`) [[1]](diffhunk://#diff-0497c2694df803a18e6f7a7631c84370341eac6bae9c15c35ab990ff44db54bcR35-R55) [[2]](diffhunk://#diff-0497c2694df803a18e6f7a7631c84370341eac6bae9c15c35ab990ff44db54bcL144-R207) [[3]](diffhunk://#diff-b6ac439ccc53fcd3dd1d08c4c1af598050276dce8e74466503a6420a2b1636bbL70-R78) [[4]](diffhunk://#diff-b6ac439ccc53fcd3dd1d08c4c1af598050276dce8e74466503a6420a2b1636bbL90-R97) [[5]](diffhunk://#diff-06ad9817399c962f40baa558de268fee624095dc66186b2531b3bc716a26352dR372-R376) [[6]](diffhunk://#diff-06ad9817399c962f40baa558de268fee624095dc66186b2531b3bc716a26352dL327-R398)
* The reconciler now atomically patches the `Machine.spec.providerID` when a replacement occurs, using a direct client and retry-on-conflict logic to ensure the update is persisted before cleanup. (`cmd/machine-ops-controller/main.go`, `internal/machineops/controller.go`) [[1]](diffhunk://#diff-a2366037a069777a1eb656eadc18410c38dd06d32dd2033d142eef9cef5425e7R100-R106) [[2]](diffhunk://#diff-0497c2694df803a18e6f7a7631c84370341eac6bae9c15c35ab990ff44db54bcL144-R207)
* The `OperationRequest` struct now includes `OperationName` and `OperationUID` for better traceability and idempotency. (`internal/machineops/controller.go`) [[1]](diffhunk://#diff-0497c2694df803a18e6f7a7631c84370341eac6bae9c15c35ab990ff44db54bcR35-R55) [[2]](diffhunk://#diff-0497c2694df803a18e6f7a7631c84370341eac6bae9c15c35ab990ff44db54bcL134-R152)

**RBAC and Permissions:**

* Expanded RBAC permissions to allow `patch` on `machines`. (`deploy/machine-ops/02-rbac.yaml.tmpl`, `internal/machineops/controller.go`) [[1]](diffhunk://#diff-2581601d4b5066949568f185851144948e837f448b7ce6fba074ab18cbe76615L11-R11) [[2]](diffhunk://#diff-2581601d4b5066949568f185851144948e837f448b7ce6fba074ab18cbe76615L56-R56) [[3]](diffhunk://#diff-0497c2694df803a18e6f7a7631c84370341eac6bae9c15c35ab990ff44db54bcL62-R73)

**Documentation Updates:**

* Updated documentation to describe the new OCI instance replacement flow, including details about how the replacement is performed, what is preserved, and the semantics of operation completion. (`docs/content/reference/machina-crd.md`)

**Testing Improvements:**

* Added and extended tests to verify that the provider ID is patched before cleanup during replacement, and updated the test provider to support the new interface. (`internal/machineops/controller_test.go`) [[1]](diffhunk://#diff-06ad9817399c962f40baa558de268fee624095dc66186b2531b3bc716a26352dR87) [[2]](diffhunk://#diff-06ad9817399c962f40baa558de268fee624095dc66186b2531b3bc716a26352dR151-R205) [[3]](diffhunk://#diff-06ad9817399c962f40baa558de268fee624095dc66186b2531b3bc716a26352dR372-R376) [[4]](diffhunk://#diff-06ad9817399c962f40baa558de268fee624095dc66186b2531b3bc716a26352dL327-R398)
* Updated Azure VM provider and its tests to match the new interface. (`internal/machineops/providers/azurevm/provider.go`, `internal/machineops/providers/azurevm/provider_test.go`) [[1]](diffhunk://#diff-b6ac439ccc53fcd3dd1d08c4c1af598050276dce8e74466503a6420a2b1636bbL70-R78) [[2]](diffhunk://#diff-b6ac439ccc53fcd3dd1d08c4c1af598050276dce8e74466503a6420a2b1636bbL90-R97) [[3]](diffhunk://#diff-b4eeba203c9323cba62bcdef572c71a52c225e4be815e68dd8e66311866b9718L102-R102) [[4]](diffhunk://#diff-b4eeba203c9323cba62bcdef572c71a52c225e4be815e68dd8e66311866b9718L119-R119)

**Other Enhancements:**

* The replacement cloud-init user data now includes the `NodeName` for correct node identity during replacement. (`internal/machineops/bootstrap.go`, `internal/machineops/controller_test.go`) [[1]](diffhunk://#diff-5d4dd19e3d97bfdf838c67c6fe15f69579b78d2b4f0331bb700bb706dc82acd9R120) [[2]](diffhunk://#diff-06ad9817399c962f40baa558de268fee624095dc66186b2531b3bc716a26352dR87)
* Switched to using a direct controller-runtime client for patching to avoid cache staleness during critical updates. (`cmd/machine-ops-controller/main.go`) [[1]](diffhunk://#diff-a2366037a069777a1eb656eadc18410c38dd06d32dd2033d142eef9cef5425e7R19) [[2]](diffhunk://#diff-a2366037a069777a1eb656eadc18410c38dd06d32dd2033d142eef9cef5425e7R100-R106)

These changes collectively improve the safety, observability, and correctness of machine replacement operations and lay the groundwork for robust multi-cloud support.