### PR TITLE
ci(net-ebpf): pin clang version and add verify-bpf-binary gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,7 +218,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            clang llvm libbpf-dev
+            clang-18 llvm-18 libbpf-dev
 
       - name: Verify BPF CO-RE pin artifacts
         run: make net-ebpf-verify
@@ -230,6 +230,58 @@ jobs:
         run: |
           if ! git diff --exit-code; then
             echo "::error::Generated files are out of date. Run 'make generate' and commit the results."
+            exit 1
+          fi
+
+  # ---------- Verify BPF binary reproducibility ----------
+  #
+  # Recompiles bpf/unbounded_encap.c via bpf2go using the pinned clang
+  # version (bpf/clang-version) and diffs the result against the
+  # committed internal/net/ebpf/unboundedencap_bpfel.{go,o}. Catches any
+  # PR that edits the BPF source (or its CO-RE inputs in bpf/vmlinux.h)
+  # without re-running `make generate` and committing the updated
+  # bindings.
+  #
+  # Reproducibility relies on every build path using the same clang
+  # binary: contributors invoke clang-18 via `make generate`, this CI
+  # job installs the same package. Bump the pin by updating
+  # bpf/clang-version and the references it documents.
+  verify-bpf-binary:
+    name: Verify BPF Binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Verify pinned clang version
+        run: |
+          pinned="$(grep -v '^#' bpf/clang-version | grep -v '^$' | head -n1)"
+          if [ "$pinned" != "clang-18" ]; then
+            echo "::error::bpf/clang-version pins '$pinned' but this CI job installs clang-18."
+            echo "::error::Update the apt-get line in .github/workflows/ci.yaml (verify-bpf-binary job) to match."
+            exit 1
+          fi
+
+      - name: Install pinned clang for bpf2go
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang-18 libbpf-dev
+
+      - name: Recompile BPF bindings via bpf2go
+        run: go generate ./internal/net/ebpf/...
+
+      - name: Check for drift in bpf2go output
+        run: |
+          if ! git diff --exit-code -- internal/net/ebpf/ bpf/; then
+            echo "::error::Committed BPF bindings are out of date."
+            echo "::error::Run 'make generate' locally (with $(grep -v '^#' bpf/clang-version | grep -v '^$' | head -n1) installed) and commit the updated"
+            echo "::error::internal/net/ebpf/unboundedencap_bpfel.{go,o}."
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ help: ## Show this help
 	@echo "  net-frontend-clean               Remove node_modules and dist artifacts"
 	@echo ""
 	@echo "Net eBPF:"
-	@echo "  net-ebpf-build                   Compile bpf/unbounded_encap.c (requires clang)"
+	@echo "  net-ebpf-build                   Compile bpf/unbounded_encap.c (requires clang-18; see bpf/clang-version)"
 	@echo "  net-ebpf-generate                Regenerate bpf/vmlinux.h from pinned Ubuntu kernel (requires bpftool, curl, dpkg-deb, python3)"
 	@echo "  net-ebpf-verify                  Verify bpf/vmlinux.h matches bpf/btf-kernel-pin{,-hashes} (no extra tools)"
 	@echo ""
@@ -753,9 +753,9 @@ net-frontend-clean: ## Remove frontend node_modules and dist artifacts
 
 ##@ Net eBPF
 
-net-ebpf-build: ## Compile bpf/unbounded_encap.c to internal/net/ebpf/unbounded_encap_bpfel.o (requires clang)
+net-ebpf-build: ## Compile bpf/unbounded_encap.c to internal/net/ebpf/unbounded_encap_bpfel.o (requires clang-18; see bpf/clang-version)
 	@echo "Compiling eBPF programs..."
-	@clang -O2 -g -target bpf \
+	@clang-18 -O2 -g -target bpf \
 		-I/usr/include \
 		-c bpf/unbounded_encap.c \
 		-o internal/net/ebpf/unbounded_encap_bpfel.o

--- a/bpf/clang-version
+++ b/bpf/clang-version
@@ -1,0 +1,19 @@
+# Clang binary used to compile bpf/unbounded_encap.c via bpf2go.
+#
+# Pinned so the committed internal/net/ebpf/unboundedencap_bpfel.o is
+# byte-reproducible across local development and CI. Different clang
+# versions emit different debug info and instruction selection, which
+# changes the .o bytes and would otherwise trigger spurious drift in
+# the verify-bpf-binary CI job.
+#
+# The value below is the binary name to invoke (typically the package
+# name on Debian/Ubuntu). To bump:
+#   1. Install the new clang-N locally.
+#   2. Update this file and references in:
+#        internal/net/ebpf/gen.go        (bpf2go -cc flag)
+#        hack/scripts/net-ebpf-generate.sh  (CLANG default)
+#        Makefile                        (net-ebpf-build target)
+#        .github/workflows/ci.yaml       (apt-get install clang-N)
+#   3. Run `make generate` and commit the new
+#      internal/net/ebpf/unboundedencap_bpfel.{go,o}.
+clang-18

--- a/hack/scripts/net-ebpf-generate.sh
+++ b/hack/scripts/net-ebpf-generate.sh
@@ -31,7 +31,7 @@ bpf_src="$repo_root/bpf/unbounded_encap.c"
 extract="$repo_root/hack/scripts/extract-vmlinux.py"
 
 : "${BPFTOOL:=bpftool}"
-: "${CLANG:=clang}"
+: "${CLANG:=clang-18}"
 : "${CURL:=curl}"
 
 for tool in "$BPFTOOL" "$CLANG" "$CURL" dpkg-deb sha256sum; do

--- a/internal/net/ebpf/gen.go
+++ b/internal/net/ebpf/gen.go
@@ -14,7 +14,12 @@ package ebpf
 // bpf/btf-kernel-pin); contributors do not edit it by hand.
 //
 // Prerequisites for regenerating bindings (the .o + _bpfel.go pair):
-//   - clang in $PATH (Debian/Ubuntu: apt-get install clang)
+//   - The specific clang binary pinned in bpf/clang-version
+//     (currently clang-18; Debian/Ubuntu: apt-get install clang-18).
+//     The version is pinned so the committed .o is byte-reproducible
+//     between local development and the verify-bpf-binary CI gate;
+//     different clang versions emit different debug info / instruction
+//     selection.
 //
 // Prerequisites for regenerating bpf/vmlinux.h (only when bumping the pin
 // or adding new BPF types):
@@ -28,4 +33,4 @@ package ebpf
 // The generated files (*_bpfel.go and *_bpfel.o) are committed alongside
 // the source so a normal `go build` does not require clang.
 //
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang -cflags "-O2 -g -Wall -I../../../bpf" unboundedEncap ../../../bpf/unbounded_encap.c
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang-18 -cflags "-O2 -g -Wall -I../../../bpf" unboundedEncap ../../../bpf/unbounded_encap.c


### PR DESCRIPTION
The bpf2go-generated `internal/net/ebpf/unboundedencap_bpfel.{go,o}` are sensitive to the clang version: different versions emit different debug info and instruction selection, changing the `.o` bytes and triggering spurious "generated files are out of date" diffs.

Today's CI happens to work only because `ubuntu-latest` (24.04) ships `clang` → `clang-18` by default; this breaks the moment Ubuntu rolls the `clang` meta-package forward, and offers no signal to contributors who have a different clang installed locally.

## Pin the toolchain explicitly

- New `bpf/clang-version` documents the pinned binary (`clang-18`) and the list of files that reference it.
- `internal/net/ebpf/gen.go` now uses `-cc clang-18` so `go generate` is reproducible regardless of which clang(s) are installed.
- `hack/scripts/net-ebpf-generate.sh` defaults `CLANG=clang-18`.
- `Makefile` `net-ebpf-build` target invokes `clang-18` directly.
- `verify-generated` job installs `clang-18`/`llvm-18` instead of the unversioned meta-packages.

## New verify-bpf-binary CI job

A dedicated, focused gate that:
1. Asserts `bpf/clang-version` pins exactly `clang-18` (so a contributor bumping the pin without updating CI fails fast with a clear error).
2. Installs `clang-18` on the runner.
3. Runs `go generate ./internal/net/ebpf/...` (bpf2go only - faster and clearer than recompiling all generated artifacts).
4. Diffs `internal/net/ebpf/` and `bpf/` for any drift and emits a remediation message naming the exact clang version.

`verify-generated` continues to catch drift across all other generated outputs; `verify-bpf-binary` is a focused, fast (~30s) gate with a BPF-specific error message.

## Validation

Locally, `go generate ./internal/net/ebpf/...` with `clang-18` reproduces the committed `internal/net/ebpf/unboundedencap_bpfel.o` byte-for-byte.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>