### PR TITLE
Add RPC over RDMA transport for unbounded-storage

### DIFF
--- a/.github/workflows/unbounded-storage-sim.yaml
+++ b/.github/workflows/unbounded-storage-sim.yaml
@@ -24,25 +24,48 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Keep in sync with the default in the Makefile / install-mercury.sh and
+  # the unbounded-storage.yaml workflow.
+  MERCURY_VERSION: v2.3.1
+
 jobs:
   sim:
     name: DST soak
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    defaults:
-      run:
-        working-directory: cmd/unbounded-storage
     env:
       DST_DURATION: ${{ github.event.inputs.duration || '20m' }}
       PROPTEST_CASES: ${{ github.event.inputs.proptest_cases || '4096' }}
+      # Mercury env: cargo/build.rs and the resulting binary both need these.
+      # We set them at the job level so every cargo invocation (including the
+      # inner `bash -c` loop) inherits them without per-step plumbing.
+      MERCURY_PKG_CONFIG_PATH: ${{ github.workspace }}/tmp/mercury-prefix/lib/pkgconfig
+      PKG_CONFIG_PATH: ${{ github.workspace }}/tmp/mercury-prefix/lib/pkgconfig
+      LD_LIBRARY_PATH: ${{ github.workspace }}/tmp/mercury-prefix/lib
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Mercury build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake pkg-config libfabric-dev
 
       - name: Set up Rust toolchain
         run: |
           rustup show active-toolchain || rustup toolchain install stable --profile minimal
           rustup default stable
+
+      - name: Cache Mercury prefix
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: tmp/mercury-prefix
+          key: mercury-${{ runner.os }}-${{ env.MERCURY_VERSION }}-${{ hashFiles('hack/scripts/install-mercury.sh') }}
+
+      - name: Build Mercury (if not cached)
+        run: make mercury
 
       - name: Cache cargo registry and target
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -51,15 +74,26 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             cmd/unbounded-storage/target
-          key: cargo-unbounded-storage-sim-${{ runner.os }}-${{ hashFiles('cmd/unbounded-storage/Cargo.lock', 'cmd/unbounded-storage/Cargo.toml') }}
+          # Key on lockfile + manifest plus the native build inputs (build.rs
+          # and the Mercury C shim), since changes to either invalidate
+          # compiled artifacts under target/. Also bind to MERCURY_VERSION so
+          # a Mercury bump rebuilds the FFI layer cleanly. The `-sim-` tier
+          # lets the soak job share a key space with the PR job's restore
+          # keys while keeping a dedicated primary key for release-mode
+          # artifacts.
+          key: cargo-unbounded-storage-sim-${{ runner.os }}-mercury-${{ env.MERCURY_VERSION }}-${{ hashFiles('cmd/unbounded-storage/Cargo.lock', 'cmd/unbounded-storage/Cargo.toml', 'cmd/unbounded-storage/build.rs', 'cmd/unbounded-storage/src/mercury/shim.c') }}
           restore-keys: |
+            cargo-unbounded-storage-sim-${{ runner.os }}-mercury-${{ env.MERCURY_VERSION }}-
             cargo-unbounded-storage-sim-${{ runner.os }}-
+            cargo-unbounded-storage-${{ runner.os }}-mercury-${{ env.MERCURY_VERSION }}-
             cargo-unbounded-storage-${{ runner.os }}-
 
       - name: Build DST test binary
+        working-directory: cmd/unbounded-storage
         run: cargo test --release --locked --test dst --no-run
 
       - name: Run DST soak
+        working-directory: cmd/unbounded-storage
         # Loop `cargo test` against the `dst` integration test until
         # the wall-clock budget expires. Each iteration uses a fresh
         # PROPTEST_SEED so the soak keeps exploring new (seed, workload)

--- a/.github/workflows/unbounded-storage.yaml
+++ b/.github/workflows/unbounded-storage.yaml
@@ -7,11 +7,15 @@ on:
   pull_request:
     paths:
       - cmd/unbounded-storage/**
+      - hack/scripts/install-mercury.sh
+      - Makefile
       - .github/workflows/unbounded-storage.yaml
   push:
     branches: [main]
     paths:
       - cmd/unbounded-storage/**
+      - hack/scripts/install-mercury.sh
+      - Makefile
       - .github/workflows/unbounded-storage.yaml
   workflow_dispatch:
 
@@ -22,21 +26,37 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Keep in sync with the default in the Makefile / install-mercury.sh.
+  MERCURY_VERSION: v2.3.1
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: cmd/unbounded-storage
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Mercury build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake pkg-config libfabric-dev
 
       - name: Set up Rust toolchain
         run: |
           rustup show active-toolchain || rustup toolchain install stable --profile minimal
           rustup default stable
+
+      - name: Cache Mercury prefix
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: tmp/mercury-prefix
+          key: mercury-${{ runner.os }}-${{ env.MERCURY_VERSION }}-${{ hashFiles('hack/scripts/install-mercury.sh') }}
+
+      - name: Build Mercury (if not cached)
+        run: make mercury
 
       - name: Cache cargo registry and target
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -45,8 +65,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             cmd/unbounded-storage/target
-          key: cargo-unbounded-storage-${{ runner.os }}-${{ hashFiles('cmd/unbounded-storage/Cargo.lock', 'cmd/unbounded-storage/Cargo.toml') }}
+          # Key on lockfile + manifest plus the native build inputs (build.rs
+          # and the Mercury C shim), since changes to either invalidate
+          # compiled artifacts under target/. Also bind to MERCURY_VERSION so
+          # a Mercury bump rebuilds the FFI layer cleanly.
+          key: cargo-unbounded-storage-${{ runner.os }}-mercury-${{ env.MERCURY_VERSION }}-${{ hashFiles('cmd/unbounded-storage/Cargo.lock', 'cmd/unbounded-storage/Cargo.toml', 'cmd/unbounded-storage/build.rs', 'cmd/unbounded-storage/src/mercury/shim.c') }}
           restore-keys: |
+            cargo-unbounded-storage-${{ runner.os }}-mercury-${{ env.MERCURY_VERSION }}-
             cargo-unbounded-storage-${{ runner.os }}-
 
       - name: Test
@@ -59,4 +84,4 @@ jobs:
           # than the local default. Bump via workflow_dispatch or set
           # `PROPTEST_CASES` locally for soak runs.
           PROPTEST_CASES: "4096"
-        run: cargo test --locked --all-targets
+        run: make unbounded-storage-test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ unbounded-kube is organized into several directories:
   - `unbounded-net-controller` - sources for the unbounded-net network controller.
   - `unbounded-net-node` - sources for the unbounded-net node agent.
   - `unbounded-net-routeplan-debug` - debugging tool for route plans.
+  - `unbounded-storage` - sources for the unbounded-storage daemon. **This is the only Rust crate in the repository** and is a special case: it has its own conventions for layout, build, and testing (in particular a deterministic simulation testing harness under `cmd/unbounded-storage/tests/`). Agents working on anything under `cmd/unbounded-storage/` must read `cmd/unbounded-storage/AGENTS.md` first; the rules in this file are Go-oriented and largely do not apply there.
   - `unping` - health check probe utility.
   - `unroute` - eBPF route inspection utility.
 - `deploy/` - component manifests for deploying on a Kubernetes cluster.

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,16 @@ UNBOUNDED_STORAGE_BIN=bin/unbounded-storage
 UNBOUNDED_STORAGE_CRATE=./cmd/unbounded-storage
 CARGO ?= cargo
 
+# Mercury (mercury-hpc) is a native dependency of the unbounded-storage crate.
+# We build a pinned version from source into a project-local prefix; the
+# unbounded-storage build.rs honours $MERCURY_PKG_CONFIG_PATH so it picks up
+# our local install ahead of any system copy.
+MERCURY_VERSION ?= v2.3.1
+MERCURY_PREFIX  ?= $(CURDIR)/tmp/mercury-prefix
+MERCURY_SRC     ?= $(CURDIR)/tmp/mercury-src
+MERCURY_PC_FILE := $(MERCURY_PREFIX)/lib/pkgconfig/mercury.pc
+MERCURY_INSTALL_SCRIPT := hack/scripts/install-mercury.sh
+
 # Version is derived from the latest git tag. Override with: make VERSION=v1.0.0
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
@@ -127,7 +137,7 @@ REACT_DEV ?= false
 .PHONY: net-frontend net-frontend-clean net-ebpf-build net-ebpf-generate net-ebpf-verify net-manifests release-manifests
 .PHONY: image-machina-local image-machine-ops-controller-local image-metalman-local image-net-controller-local image-net-node-local images-local
 .PHONY: image-net-controller-push image-net-node-push images-net-all images-net-all-push
-.PHONY: unbounded-storage unbounded-storage-build unbounded-storage-test
+.PHONY: unbounded-storage unbounded-storage-build unbounded-storage-test unbounded-storage-check mercury mercury-clean
 
 ##@ General
 
@@ -177,6 +187,9 @@ help: ## Show this help
 	@echo "Rust Binaries:"
 	@echo "  unbounded-storage | unbounded-storage-build  Build unbounded-storage (with/without test)"
 	@echo "  unbounded-storage-test           Run cargo tests for unbounded-storage"
+	@echo "  unbounded-storage-check          Run cargo check for unbounded-storage"
+	@echo "  mercury                          Build pinned Mercury into \$$(MERCURY_PREFIX)"
+	@echo "  mercury-clean                    Remove the local Mercury prefix and source tree"
 	@echo ""
 	@echo "Container Images (local, single-arch):"
 	@echo "  image-inventory-all-local        Build all local inventory container images"
@@ -449,11 +462,36 @@ unroute: test unroute-build ## Build the unroute utility (implies test)
 
 ##@ Rust Binaries
 
-unbounded-storage-test: ## Run cargo tests for unbounded-storage
-	$(CARGO) test --manifest-path $(UNBOUNDED_STORAGE_CRATE)/Cargo.toml --locked --all-targets
+# Mercury env: prepend our local prefix so cargo/build.rs find the right .pc
+# files and so the resulting binaries/tests can dlopen libmercury at runtime.
+# Targets that invoke cargo must export these via `$(UNBOUNDED_STORAGE_ENV)`.
+UNBOUNDED_STORAGE_ENV = \
+	MERCURY_PKG_CONFIG_PATH="$(MERCURY_PREFIX)/lib/pkgconfig" \
+	PKG_CONFIG_PATH="$(MERCURY_PREFIX)/lib/pkgconfig:$${PKG_CONFIG_PATH}" \
+	LD_LIBRARY_PATH="$(MERCURY_PREFIX)/lib:$${LD_LIBRARY_PATH}"
 
-unbounded-storage-build: ## Build the unbounded-storage binary (no test)
-	$(CARGO) build --manifest-path $(UNBOUNDED_STORAGE_CRATE)/Cargo.toml --release --locked
+mercury: $(MERCURY_PC_FILE) ## Build pinned Mercury into $(MERCURY_PREFIX) (idempotent)
+
+# The install script is itself idempotent: if mercury.pc already advertises the
+# pinned version it exits immediately. We still gate on the .pc file as the
+# Make-level sentinel so a cached prefix avoids invoking the script at all.
+$(MERCURY_PC_FILE): $(MERCURY_INSTALL_SCRIPT)
+	MERCURY_VERSION=$(MERCURY_VERSION) \
+	MERCURY_PREFIX=$(MERCURY_PREFIX) \
+	MERCURY_SRC=$(MERCURY_SRC) \
+		$(MERCURY_INSTALL_SCRIPT)
+
+mercury-clean: ## Remove the local Mercury prefix and source tree
+	rm -rf "$(MERCURY_PREFIX)" "$(MERCURY_SRC)"
+
+unbounded-storage-check: mercury ## Run cargo check for unbounded-storage
+	$(UNBOUNDED_STORAGE_ENV) $(CARGO) check --manifest-path $(UNBOUNDED_STORAGE_CRATE)/Cargo.toml --locked --all-targets
+
+unbounded-storage-test: mercury ## Run cargo tests for unbounded-storage
+	$(UNBOUNDED_STORAGE_ENV) $(CARGO) test --manifest-path $(UNBOUNDED_STORAGE_CRATE)/Cargo.toml --locked --all-targets
+
+unbounded-storage-build: mercury ## Build the unbounded-storage binary (no test)
+	$(UNBOUNDED_STORAGE_ENV) $(CARGO) build --manifest-path $(UNBOUNDED_STORAGE_CRATE)/Cargo.toml --release --locked
 	@mkdir -p $(dir $(UNBOUNDED_STORAGE_BIN))
 	cp $(UNBOUNDED_STORAGE_CRATE)/target/release/unbounded-storage $(UNBOUNDED_STORAGE_BIN)
 

--- a/cmd/unbounded-storage/AGENTS.md
+++ b/cmd/unbounded-storage/AGENTS.md
@@ -1,0 +1,232 @@
+# unbounded-storage
+
+`unbounded-storage` is the only Rust crate in this repository. The rest of
+the project is Go, so the conventions below intentionally diverge from
+the top-level `AGENTS.md` where they need to. Read this file before
+touching anything under `cmd/unbounded-storage/`.
+
+## Crate layout
+
+- Each subsystem is a directory module:
+  - `src/<area>/mod.rs` declares its private and public child modules
+    and re-exports the public surface (`pub use ...`).
+  - Internal submodules (`free_list`, `inflight`, `types`, `traits`,
+    ...) are declared without `pub` and only their selected types are
+    re-exported from `mod.rs`.
+  - Public-facing submodules (`pool`, `stream`, ...) may be `pub mod`
+    when their types are referenced by path elsewhere.
+- Inline unit tests live at the bottom of the `src/` file that defines
+  the construct under test, inside a `#[cfg(test)] mod tests { ... }`
+  block.
+- Module integration tests live next to the code as
+  `src/<area>/tests.rs`, gated behind `#[cfg(test)] mod tests;` in
+  `mod.rs`.
+- Integration / DST tests live under `tests/` (see below).
+- `target/` is gitignored.
+- There is no `clippy.toml` or `rustfmt.toml`; use defaults.
+
+## File headers
+
+Every `.rs` file - source and test - starts with:
+
+```
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+```
+
+Add it to any new file.
+
+## Code style
+
+These rules are about keeping the crate legible for the next human
+or agent that opens a file cold. They are deliberately stricter than
+`rustfmt`/`clippy` defaults because those tools do not enforce
+structure.
+
+- **File length.** Keep `.rs` files under 1500 lines. If a file is
+  approaching that limit, that is a strong signal it is doing too
+  much; split it along concept boundaries rather than mechanical
+  ones (e.g. by trait or subsystem, not "types A-M vs N-Z").
+- **Comments.** Avoid commentary that restates what the code already
+  says. Reserve comments for invariants, non-obvious reasoning,
+  cross-references, and intentional deviations. Doc comments on
+  public items are encouraged; running narration inside function
+  bodies is not.
+- **Declaration order.** Order items within a file so a human reader
+  encounters concepts in the order they need to understand them:
+  primary type(s) first, then their `impl` blocks, then closely
+  related helper types, then free functions, then tests. Inside an
+  `impl`, group constructors before mutators before accessors. The
+  goal is that someone skimming top-to-bottom builds a mental model
+  without having to jump around.
+- **Separation of concerns per file.** Every file should have a
+  short, human-legible answer to "what is this file about?". If you
+  cannot summarize a file's responsibility in one sentence, it
+  probably needs to be split. Conversely, do not shatter a single
+  concept across many tiny files just to keep file counts down per
+  type - a module with twenty one-screen files is as hard to
+  navigate as a single 3000-line file. Aim for a small number of
+  files per module, each with a distinct concern (for example
+  `types.rs`, `traits.rs`, `free_list.rs`, `inflight.rs`), and
+  resist adding a new file unless it carves out a concern the
+  existing files genuinely do not own.
+
+When in doubt, optimize for the reader who has never seen this code
+before.
+
+## Build and test
+
+Use the top-level Makefile targets, not raw `cargo` invocations, so CI
+and local runs stay aligned:
+
+- `make unbounded-storage` - format, lint (currently implicit via
+  `cargo`), test, then release build. This is the default "did I break
+  it" target.
+- `make unbounded-storage-test` -
+  `cargo test --manifest-path cmd/unbounded-storage/Cargo.toml --locked --all-targets`.
+  `--all-targets` is required because the proptest-driven DST tests live
+  in `tests/` and would otherwise be skipped from some invocations.
+- `make unbounded-storage-build` - release build only, no tests.
+
+Always pass `--locked` for any direct `cargo` use; the lockfile is the
+source of truth.
+
+## Testing patterns
+
+There are three distinct test styles in this crate and they are not
+interchangeable. Pick the one that matches what you are testing.
+
+### 1. Inline unit tests (bottom of `src/<area>/<file>.rs`)
+
+Used for specific, targeted unit tests of constructs declared in the
+same file. Reach for these when you want to pin down the behavior of
+one type, function, or small helper in isolation, without exercising
+the surrounding subsystem.
+
+Conventions:
+
+- Tests live in a `#[cfg(test)] mod tests { ... }` block at the bottom
+  of the file that declares the construct under test. Do not put
+  cross-file or cross-module tests here; that is what `tests.rs` is
+  for.
+- Keep these tests synchronous where possible. If the construct is
+  async, use the same noop-waker `block_on` pattern as the module
+  integration tests rather than pulling in an async runtime.
+- Scope tests narrowly to the file's public and private surface. If a
+  test needs types or behavior from sibling files in the same module,
+  promote it to `src/<area>/tests.rs`.
+
+### 2. Module integration tests (`src/<area>/tests.rs`)
+
+Used for broader exercises of a subsystem that span multiple files
+within the module, against hand-written mocks where deterministic
+scheduling is not required. Focus on user-facing scenarios: drive the
+module through its public surface the way a caller would and assert
+on observable outcomes.
+
+Conventions:
+
+- The module is private (`mod tests;`) and gated with `#[cfg(test)]`
+  in the parent `mod.rs`.
+- The test file defines its own minimal `block_on` (and friends like
+  `block_on_two`) built on a noop `RawWaker`/`RawWakerVTable`. Do not
+  pull in `tokio` or any other async runtime; the crate is runtime
+  agnostic by design.
+- `block_on` loops include a spin counter with a generous bound
+  (`< 1_000_000`) and `assert!` on no-progress to fail loudly instead
+  of hanging.
+- Mocks are heap-backed and live in the same file as the tests.
+- Tests in this style are not deterministic across schedules - they
+  validate behavior under a single, fixed polling order. Use the DST
+  harness when you need schedule coverage.
+
+### 3. Deterministic Simulation Testing (`tests/`)
+
+The integration test target wires every subsystem into a single
+deterministic, seeded executor and drives randomized workloads through
+proptest. This is the primary correctness gate for concurrent code.
+
+Layout:
+
+- `tests/dst.rs` - the only file at the root of the integration test
+  target. It exists solely to declare `mod blockstore; mod bufferpool;
+  mod framework;` so all of the modules below compile as a single
+  test binary. Add new top-level DST areas here.
+- `tests/framework/` - generic, project-agnostic DST primitives.
+  - `executor.rs` - the single-threaded executor: seeded
+    `ChaCha8Rng`, thread-local `SimState`, a ready queue from which
+    one task is picked uniformly at random on every step, a
+    `step_budget` for liveness, and an explicit `Deadlock` error when
+    no task is ready while tasks remain alive. Public surface:
+    `Executor`, `SimState`, `RunError`, `with_sim`, `yield_once`,
+    `yield_n`. **Do not** add subsystem-specific knobs here - the
+    framework only knows about scheduling and the PRNG; latency, fault
+    rates, cache-hit rates, etc. belong in per-area mock configs.
+- `tests/<area>/` - per-subsystem DST plug-in. Each contains:
+  - `mod.rs` - module declarations and any `#![allow(...)]` attributes
+    needed for the test build (e.g. `arc_with_non_send_sync` because
+    production types are `Send + Sync` but the single-threaded mocks
+    are intentionally `!Send`).
+  - `mocks.rs` - DST-aware implementations of the subsystem's traits.
+    Mocks must pull all randomness from `framework::executor::with_sim`
+    and route "I/O latency" through `yield_n` with a count drawn from
+    the same PRNG. Per-area knobs (delay bound, fault rate, hit rate,
+    corruption rate, ...) live on a local `*SimCfg` struct held behind
+    `Rc`, not on `SimState`.
+  - `workload.rs` (or equivalent) - the workload model
+    (`Workload`/`ClientSpec`/...), the proptest strategy
+    (`workload_strategy()`), and a `run`/`run_workload` driver that
+    constructs the executor, installs the mocks, spawns tasks, runs to
+    completion, and returns a `RunReport`.
+  - `oracle.rs` (when relevant) - reference model tracked alongside
+    the system under test. The oracle constrains what successful reads
+    must observe; it does not constrain what the system may evict or
+    drop.
+  - `tests.rs` - the proptest entrypoints. A single `proptest!` block
+    is preferred per area; inside, one `#[test]` function calls
+    `run_workload` once and then dispatches to a series of small
+    `assert_<invariant>` helpers that return
+    `Result<(), TestCaseError>`. Each invariant is documented with a
+    short comment naming what it covers.
+  - `recovery.rs` (or other explicit-state files) - hand-rolled
+    scenarios that pin down specific behaviors the proptest only
+    covers end-to-end. Use these when a particular sequence is too
+    rare for proptest to reliably exercise or when the failure mode is
+    easier to read as a scripted test.
+  - `tests.proptest-regressions` - generated by proptest on failure;
+    commit it so the regression case is replayed on every run.
+
+Required properties of any DST mock or workload code:
+
+- All randomness flows through `framework::executor::with_sim` so the
+  `(seed, workload)` pair fully determines the run. Do not call
+  `rand::thread_rng()` or use `SystemTime` from inside a mock.
+- Every async I/O point in a mock yields a random number of times via
+  `yield_n` so the executor can interleave it with other tasks. Mocks
+  that complete synchronously hide bugs.
+- `run_workload`-style drivers must return the underlying `RunError`
+  (or convert it into a panic at the call site) so a deadlock or
+  step-budget exhaustion is surfaced as a test failure, not a hang.
+- `ProptestConfig { cases: 256, .. }` is the current default; bump it
+  locally or via `PROPTEST_CASES` for soak runs but keep the committed
+  value modest so CI stays fast.
+- Prefer many small invariants over one giant assertion. Each
+  invariant function takes `&RunReport` and returns
+  `Result<(), TestCaseError>`; this keeps shrinking output legible.
+
+### Adding a new subsystem
+
+1. Add `pub mod <area>;` to `src/lib.rs` and create `src/<area>/mod.rs`
+   with private submodules and a curated public re-export list.
+2. For targeted tests of an individual construct, add a
+   `#[cfg(test)] mod tests { ... }` block at the bottom of the file
+   that defines it.
+3. For user-facing scenarios that span multiple files in the module,
+   add `#[cfg(test)] mod tests;` to `mod.rs` and a `tests.rs` sibling
+   using the noop-waker `block_on` pattern.
+4. For concurrent behavior, add `tests/<area>/` with `mod.rs`,
+   `mocks.rs`, a workload module, optional `oracle.rs`, and `tests.rs`,
+   then register it in `tests/dst.rs`.
+5. Reuse `tests/framework/` as-is. If you find yourself wanting to add
+   a subsystem-specific knob there, put it in the per-area `*SimCfg`
+   instead.

--- a/cmd/unbounded-storage/Cargo.lock
+++ b/cmd/unbounded-storage/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +43,16 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -62,6 +81,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -200,6 +225,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -387,6 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -423,6 +455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,10 +494,14 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 name = "unbounded-storage"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "cc",
  "libc",
+ "pkg-config",
  "proptest",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
+ "serde",
 ]
 
 [[package]]

--- a/cmd/unbounded-storage/Cargo.toml
+++ b/cmd/unbounded-storage/Cargo.toml
@@ -13,6 +13,12 @@ name = "unbounded_storage"
 path = "src/lib.rs"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+bincode = "1.3"
+
+[build-dependencies]
+cc = "1"
+pkg-config = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/cmd/unbounded-storage/build.rs
+++ b/cmd/unbounded-storage/build.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Locates Mercury via `pkg-config` and compiles the small C shim that
+//! exposes Mercury's `static HG_INLINE` proc helpers as real symbols
+//! our Rust FFI can call. The shim is the only C we write; everything
+//! else is plain Rust `extern "C"`.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // Allow developers to point at a local mercury install (e.g. the
+    // in-tree `tmp/mercury-prefix/`) without touching system pkg-config
+    // paths.
+    if let Ok(extra) = env::var("MERCURY_PKG_CONFIG_PATH") {
+        let cur = env::var("PKG_CONFIG_PATH").unwrap_or_default();
+        let combined = if cur.is_empty() {
+            extra
+        } else {
+            format!("{extra}:{cur}")
+        };
+        // SAFETY: build scripts run single-threaded before any Rust code
+        // in this crate links against libc; setting an env var here is
+        // standard practice in Cargo build scripts.
+        unsafe {
+            env::set_var("PKG_CONFIG_PATH", combined);
+        }
+    }
+
+    let mercury = pkg_config::Config::new()
+        .probe("mercury")
+        .expect("pkg-config could not locate `mercury` (try setting MERCURY_PKG_CONFIG_PATH)");
+    pkg_config::Config::new()
+        .probe("na")
+        .expect("pkg-config could not locate `na` (Mercury Network Abstraction)");
+
+    let include_paths: Vec<PathBuf> = mercury.include_paths.clone();
+
+    let mut build = cc::Build::new();
+    build.file("src/mercury/shim.c");
+    for p in &include_paths {
+        build.include(p);
+    }
+    build.warnings(true).compile("unbounded_mercury_shim");
+
+    println!("cargo:rerun-if-changed=src/mercury/shim.c");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=MERCURY_PKG_CONFIG_PATH");
+    println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
+}

--- a/cmd/unbounded-storage/src/backing.rs
+++ b/cmd/unbounded-storage/src/backing.rs
@@ -1,0 +1,360 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::fmt;
+
+use unbounded_storage::bufferpool::Backing;
+
+/// 2 MiB hugepage size in bytes. Hard-coded; 1 GiB hugepages are
+/// intentionally out of scope.
+pub const HUGEPAGE_2MB: usize = 2 * 1024 * 1024;
+
+/// Which allocator to use for a shard's backing.
+#[derive(Copy, Clone, Debug)]
+pub enum BackingKind {
+    /// `mmap(MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB)`. Fails
+    /// hard if the kernel's 2 MiB hugepage pool cannot satisfy the
+    /// request; there is no automatic fallback.
+    Hugepage2Mb,
+    /// `std::alloc::alloc_zeroed` with 2 MiB alignment. Use only on
+    /// hosts where reserving hugepages is not feasible (CI, dev).
+    Heap,
+}
+
+/// Request to allocate a shard backing. `bytes` is rounded up to a
+/// multiple of the chosen page size; the resulting `Backing` may
+/// therefore be larger than requested.
+#[derive(Copy, Clone, Debug)]
+pub struct BackingRequest {
+    pub kind: BackingKind,
+    pub bytes: usize,
+    pub numa: Option<u16>,
+}
+
+#[derive(Debug)]
+pub enum BackingError {
+    /// `mmap` for hugepages failed. `free_hugepages` is the value
+    /// read from `/sys/kernel/mm/hugepages/hugepages-2048kB/free_hugepages`
+    /// at failure time (or `None` if that file could not be read);
+    /// surfacing it inline saves the operator a second hop.
+    HugepageMmap {
+        errno: i32,
+        free_hugepages: Option<u64>,
+    },
+    /// `mbind` failed after a successful `mmap`. The mapping is
+    /// already unmapped by the time this error is returned.
+    NumaBind { errno: i32 },
+    /// Heap allocator returned null for the requested layout.
+    HeapAlloc,
+    /// `bytes` was zero, or rounding overflowed `usize`.
+    InvalidSize,
+}
+
+impl fmt::Display for BackingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BackingError::HugepageMmap {
+                errno,
+                free_hugepages,
+            } => {
+                let err = std::io::Error::from_raw_os_error(*errno);
+                match free_hugepages {
+                    Some(n) => write!(f, "hugepage mmap failed: {err} (free 2MiB hugepages={n})"),
+                    None => write!(f, "hugepage mmap failed: {err}"),
+                }
+            }
+            BackingError::NumaBind { errno } => {
+                let err = std::io::Error::from_raw_os_error(*errno);
+                write!(f, "mbind failed: {err}")
+            }
+            BackingError::HeapAlloc => write!(f, "heap allocation returned null"),
+            BackingError::InvalidSize => write!(f, "invalid backing size"),
+        }
+    }
+}
+
+impl std::error::Error for BackingError {}
+
+/// Allocate a `Backing` per `req`. The page size used to populate
+/// `Backing::page_size` is the allocator's native page size
+/// (2 MiB for both current variants).
+pub fn allocate(req: BackingRequest) -> Result<Backing, BackingError> {
+    let page_size = HUGEPAGE_2MB;
+    let size = round_up_to(req.bytes, page_size).ok_or(BackingError::InvalidSize)?;
+    if size == 0 {
+        return Err(BackingError::InvalidSize);
+    }
+    let page_count = size / page_size;
+    match req.kind {
+        BackingKind::Hugepage2Mb => allocate_hugepage(size, page_size, page_count, req.numa),
+        BackingKind::Heap => allocate_heap(size, page_size, page_count),
+    }
+}
+
+/// Round `bytes` up to the next multiple of `page_size`. Returns
+/// `None` on overflow. Pure; exposed for testing.
+fn round_up_to(bytes: usize, page_size: usize) -> Option<usize> {
+    if page_size == 0 {
+        return None;
+    }
+    let rem = bytes % page_size;
+    if rem == 0 {
+        Some(bytes)
+    } else {
+        bytes.checked_add(page_size - rem)
+    }
+}
+
+fn allocate_hugepage(
+    size: usize,
+    page_size: usize,
+    page_count: usize,
+    numa: Option<u16>,
+) -> Result<Backing, BackingError> {
+    // SAFETY: standard anonymous mmap. We check for MAP_FAILED and
+    // never dereference the returned pointer here.
+    let ptr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGETLB | libc::MAP_HUGE_2MB,
+            -1,
+            0,
+        )
+    };
+    if ptr == libc::MAP_FAILED {
+        let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        return Err(BackingError::HugepageMmap {
+            errno,
+            free_hugepages: read_free_hugepages_2mb(),
+        });
+    }
+
+    if let Some(node) = numa {
+        if let Err(errno) = mbind_to_node(ptr, size, node) {
+            // SAFETY: ptr/size came from the mmap above; munmap is
+            // the matching teardown.
+            unsafe {
+                libc::munmap(ptr, size);
+            }
+            return Err(BackingError::NumaBind { errno });
+        }
+    }
+
+    Ok(Backing {
+        base: ptr as *mut u8,
+        page_size,
+        page_count,
+        _own: Box::new(HugepageOwner { ptr, size }),
+    })
+}
+
+fn mbind_to_node(ptr: *mut libc::c_void, size: usize, node: u16) -> Result<(), i32> {
+    // MPOL_BIND: strictly allocate from the named node. Stronger
+    // than the `MPOL_PREFERRED` used by the per-thread runtime
+    // policy because hugepages are reserved up front and we want a
+    // hard failure if the reservation cannot be satisfied locally.
+    const MPOL_BIND: libc::c_int = 2;
+    const MPOL_MF_STRICT: libc::c_uint = 1;
+
+    let bits_per_word = std::mem::size_of::<libc::c_ulong>() * 8;
+    let bit = node as usize;
+    let words = bit / bits_per_word + 1;
+    let mut mask = vec![0 as libc::c_ulong; words];
+    mask[bit / bits_per_word] |= (1 as libc::c_ulong) << (bit % bits_per_word);
+    let maxnode = (words * bits_per_word) as libc::c_ulong;
+
+    // SAFETY: mask is a valid bitmask sized at `maxnode` bits.
+    let rc = unsafe {
+        libc::syscall(
+            libc::SYS_mbind,
+            ptr as libc::c_long,
+            size as libc::c_long,
+            MPOL_BIND as libc::c_long,
+            mask.as_ptr() as libc::c_long,
+            maxnode as libc::c_long,
+            MPOL_MF_STRICT as libc::c_long,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(0));
+    }
+    Ok(())
+}
+
+/// Best-effort read of the free 2 MiB hugepage count. The path is
+/// the kernel's canonical sysfs entry; we return `None` if it is
+/// unreadable rather than masking the original mmap failure.
+fn read_free_hugepages_2mb() -> Option<u64> {
+    let s =
+        std::fs::read_to_string("/sys/kernel/mm/hugepages/hugepages-2048kB/free_hugepages").ok()?;
+    s.trim().parse::<u64>().ok()
+}
+
+fn allocate_heap(
+    size: usize,
+    page_size: usize,
+    page_count: usize,
+) -> Result<Backing, BackingError> {
+    let layout = std::alloc::Layout::from_size_align(size, page_size)
+        .map_err(|_| BackingError::InvalidSize)?;
+    // SAFETY: layout has nonzero size (checked by `allocate`) and a
+    // power-of-two alignment (page_size is 2 MiB).
+    let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+    if ptr.is_null() {
+        return Err(BackingError::HeapAlloc);
+    }
+    Ok(Backing {
+        base: ptr,
+        page_size,
+        page_count,
+        _own: Box::new(HeapOwner { ptr, layout }),
+    })
+}
+
+/// Drop carrier for a `mmap`-backed hugepage region.
+struct HugepageOwner {
+    ptr: *mut libc::c_void,
+    size: usize,
+}
+
+// SAFETY: the owner is moved into `Backing._own`; the mapping is
+// only accessed through `Backing::base` whose synchronization is
+// upheld by the `Pool` invariants.
+unsafe impl Send for HugepageOwner {}
+unsafe impl Sync for HugepageOwner {}
+
+impl Drop for HugepageOwner {
+    fn drop(&mut self) {
+        // SAFETY: ptr/size are the values returned from mmap; no
+        // other reference into the region remains.
+        unsafe {
+            libc::munmap(self.ptr, self.size);
+        }
+    }
+}
+
+/// Drop carrier for a heap-allocated region.
+struct HeapOwner {
+    ptr: *mut u8,
+    layout: std::alloc::Layout,
+}
+
+// SAFETY: see `HugepageOwner`. The allocation lives as long as the
+// pool that references it.
+unsafe impl Send for HeapOwner {}
+unsafe impl Sync for HeapOwner {}
+
+impl Drop for HeapOwner {
+    fn drop(&mut self) {
+        // SAFETY: matches the `alloc_zeroed` call in `allocate_heap`.
+        unsafe {
+            std::alloc::dealloc(self.ptr, self.layout);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_up_already_aligned() {
+        assert_eq!(round_up_to(HUGEPAGE_2MB, HUGEPAGE_2MB), Some(HUGEPAGE_2MB));
+        assert_eq!(
+            round_up_to(4 * HUGEPAGE_2MB, HUGEPAGE_2MB),
+            Some(4 * HUGEPAGE_2MB)
+        );
+    }
+
+    #[test]
+    fn round_up_rounds_partial() {
+        assert_eq!(round_up_to(1, HUGEPAGE_2MB), Some(HUGEPAGE_2MB));
+        assert_eq!(
+            round_up_to(HUGEPAGE_2MB + 1, HUGEPAGE_2MB),
+            Some(2 * HUGEPAGE_2MB),
+        );
+    }
+
+    #[test]
+    fn round_up_zero() {
+        assert_eq!(round_up_to(0, HUGEPAGE_2MB), Some(0));
+    }
+
+    #[test]
+    fn round_up_overflow_returns_none() {
+        assert_eq!(round_up_to(usize::MAX, HUGEPAGE_2MB), None);
+    }
+
+    #[test]
+    fn heap_backing_alloc_and_drop() {
+        let b = allocate(BackingRequest {
+            kind: BackingKind::Heap,
+            bytes: HUGEPAGE_2MB,
+            numa: None,
+        })
+        .expect("heap alloc");
+        assert_eq!(b.page_size, HUGEPAGE_2MB);
+        assert_eq!(b.page_count, 1);
+        assert!(!b.base.is_null());
+        // Touch the first and last byte to confirm the mapping is
+        // writable; alloc_zeroed promises zero-init so reads should
+        // return 0.
+        // SAFETY: bytes inside the allocation.
+        unsafe {
+            assert_eq!(*b.base, 0);
+            *b.base = 0xAB;
+            let last = b.base.add(HUGEPAGE_2MB - 1);
+            assert_eq!(*last, 0);
+            *last = 0xCD;
+        }
+        drop(b);
+    }
+
+    #[test]
+    fn heap_rounds_up_to_page() {
+        let b = allocate(BackingRequest {
+            kind: BackingKind::Heap,
+            bytes: 1,
+            numa: None,
+        })
+        .expect("heap alloc");
+        assert_eq!(b.page_size, HUGEPAGE_2MB);
+        assert_eq!(b.page_count, 1);
+    }
+
+    #[test]
+    fn zero_bytes_is_invalid() {
+        let err = allocate(BackingRequest {
+            kind: BackingKind::Heap,
+            bytes: 0,
+            numa: None,
+        })
+        .err()
+        .expect("zero must reject");
+        assert!(matches!(err, BackingError::InvalidSize));
+    }
+
+    // Hugepage path requires reserved 2 MiB pages on the host;
+    // opt-in via `UB_STORAGE_HUGEPAGE_TEST=1` so CI without
+    // reservations does not flap.
+    #[test]
+    fn hugepage_backing_when_enabled() {
+        if std::env::var_os("UB_STORAGE_HUGEPAGE_TEST").is_none() {
+            return;
+        }
+        let b = allocate(BackingRequest {
+            kind: BackingKind::Hugepage2Mb,
+            bytes: HUGEPAGE_2MB,
+            numa: None,
+        })
+        .expect("hugepage alloc with UB_STORAGE_HUGEPAGE_TEST=1");
+        assert_eq!(b.page_size, HUGEPAGE_2MB);
+        assert_eq!(b.page_count, 1);
+        // SAFETY: bytes inside the mapping.
+        unsafe {
+            *b.base = 0xAB;
+        }
+    }
+}

--- a/cmd/unbounded-storage/src/bufferpool/group.rs
+++ b/cmd/unbounded-storage/src/bufferpool/group.rs
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::sync::Arc;
+
+use crate::bufferpool::traits::Req;
+use crate::runtime::WorkerIdx;
+
+/// Static metadata about one NUMA shard. Cheap to clone; held by
+/// `PoolGroup` so cross-shard routing can answer "which shard
+/// owns request R?" without touching the shard's `Pool` (which
+/// lives only inside the shard thread).
+#[derive(Clone, Debug)]
+pub struct ShardDescriptor {
+    /// Worker slot this shard runs on. Matches the `WorkerIdx`
+    /// passed to `Threading::run_worker` for the shard's thread.
+    pub worker_idx: WorkerIdx,
+    /// NUMA node this shard is pinned against, if the runtime is
+    /// NUMA-aware. `None` for the TCP-fallback / non-pinning case.
+    pub numa: Option<u16>,
+}
+
+/// Routing function: `req -> shard index`. Returns an index into
+/// the `PoolGroup`'s shard table. Implementations should be pure
+/// (no I/O, no interior mutability) so a single request always
+/// routes to the same shard for the lifetime of the group.
+pub trait ShardRouter<R: Req>: Send + Sync + 'static {
+    fn route(&self, req: &R) -> usize;
+}
+
+impl<R, F> ShardRouter<R> for F
+where
+    R: Req,
+    F: Fn(&R) -> usize + Send + Sync + 'static,
+{
+    fn route(&self, req: &R) -> usize {
+        (self)(req)
+    }
+}
+
+/// Per-process fan-out over NUMA shards. `R` is the bufferpool
+/// request type; the embedder selects the shard for each request
+/// via [`ShardRouter`].
+///
+/// Construction: build a `Vec<ShardDescriptor>` mirroring whatever
+/// per-shard threads the embedder spawned, then wrap in a
+/// `PoolGroup` together with a router closure. The descriptors are
+/// authoritative for membership; the router is authoritative for
+/// "which one for this request."
+pub struct PoolGroup<R: Req + 'static> {
+    shards: Arc<[ShardDescriptor]>,
+    router: Arc<dyn ShardRouter<R>>,
+}
+
+impl<R: Req + 'static> PoolGroup<R> {
+    pub fn new<S>(shards: Vec<ShardDescriptor>, router: S) -> Self
+    where
+        S: ShardRouter<R>,
+    {
+        assert!(!shards.is_empty(), "PoolGroup requires at least one shard");
+        Self {
+            shards: Arc::from(shards.into_boxed_slice()),
+            router: Arc::new(router),
+        }
+    }
+
+    pub fn shards(&self) -> &[ShardDescriptor] {
+        &self.shards
+    }
+
+    pub fn len(&self) -> usize {
+        self.shards.len()
+    }
+
+    /// Returns `true` iff [`Self::len`] is zero. Provided to match
+    /// clippy's `len_zero` lint expectation; `PoolGroup::new`
+    /// panics on empty input so in practice this always returns
+    /// `false`.
+    pub fn is_empty(&self) -> bool {
+        self.shards.is_empty()
+    }
+
+    /// Resolve a request to the descriptor of the shard that owns
+    /// it. Routing is delegated to the embedder's `ShardRouter`;
+    /// `PoolGroup` only enforces that the returned index is in
+    /// range and panics otherwise (a routing bug is a programming
+    /// error, not a runtime error).
+    pub fn route(&self, req: &R) -> &ShardDescriptor {
+        let idx = self.router.route(req);
+        assert!(
+            idx < self.shards.len(),
+            "ShardRouter returned out-of-range index: {idx} >= {}",
+            self.shards.len(),
+        );
+        &self.shards[idx]
+    }
+}
+
+impl<R: Req + 'static> Clone for PoolGroup<R> {
+    fn clone(&self) -> Self {
+        Self {
+            shards: self.shards.clone(),
+            router: self.router.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bufferpool::types::StripeKey;
+
+    #[derive(Clone)]
+    struct K(u8);
+    impl Req for K {
+        fn key(&self) -> StripeKey {
+            StripeKey([self.0; 32])
+        }
+    }
+
+    #[test]
+    fn route_dispatches_by_closure() {
+        let shards = vec![
+            ShardDescriptor {
+                worker_idx: WorkerIdx(0),
+                numa: Some(0),
+            },
+            ShardDescriptor {
+                worker_idx: WorkerIdx(1),
+                numa: Some(1),
+            },
+        ];
+        let g: PoolGroup<K> = PoolGroup::new(shards, |k: &K| (k.0 as usize) % 2);
+        assert_eq!(g.len(), 2);
+        assert_eq!(g.route(&K(0)).worker_idx, WorkerIdx(0));
+        assert_eq!(g.route(&K(1)).worker_idx, WorkerIdx(1));
+        assert_eq!(g.route(&K(4)).worker_idx, WorkerIdx(0));
+    }
+
+    #[test]
+    #[should_panic(expected = "out-of-range index")]
+    fn route_panics_on_out_of_range_index() {
+        let shards = vec![ShardDescriptor {
+            worker_idx: WorkerIdx(0),
+            numa: None,
+        }];
+        let g: PoolGroup<K> = PoolGroup::new(shards, |_: &K| 7);
+        let _ = g.route(&K(0));
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one shard")]
+    fn new_panics_on_empty() {
+        let _: PoolGroup<K> = PoolGroup::new(Vec::new(), |_: &K| 0);
+    }
+
+    #[test]
+    fn descriptor_clone_and_len() {
+        let shards = vec![ShardDescriptor {
+            worker_idx: WorkerIdx(3),
+            numa: None,
+        }];
+        let g: PoolGroup<K> = PoolGroup::new(shards, |_: &K| 0);
+        assert_eq!(g.len(), 1);
+        assert!(!g.is_empty());
+        let g2 = g.clone();
+        assert_eq!(g2.shards()[0].worker_idx, WorkerIdx(3));
+    }
+}

--- a/cmd/unbounded-storage/src/bufferpool/mod.rs
+++ b/cmd/unbounded-storage/src/bufferpool/mod.rs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 mod free_list;
+mod group;
 mod inflight;
+mod null;
 pub mod pool;
 pub mod stream;
 mod traits;
@@ -11,6 +13,8 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+pub use group::{PoolGroup, ShardDescriptor, ShardRouter};
+pub use null::NullBlockStore;
 pub use pool::Pool;
 pub use stream::{PageGuard, ReadStream};
 pub use traits::{BlockStore, BufferPool, Req, Transport};

--- a/cmd/unbounded-storage/src/bufferpool/null.rs
+++ b/cmd/unbounded-storage/src/bufferpool/null.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Placeholder `BlockStore` for embedders that have no local cache
+//! tier yet. Every `read_page` reports a miss, so the pool always
+//! falls through to `Transport::bulk_get`; `write_page` is a no-op,
+//! so the tee silently drops bytes on the floor.
+//!
+//! This exists so the binary can construct a `Pool` per shard
+//! before a production blockstore lands. Replace with a real
+//! io_uring or NVMe-backed impl as soon as one is available.
+
+use crate::bufferpool::traits::BlockStore;
+use crate::bufferpool::types::{Error, PageRef, StripeKey};
+
+#[derive(Default)]
+pub struct NullBlockStore;
+
+impl NullBlockStore {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl BlockStore for NullBlockStore {
+    fn register_pages(
+        &self,
+        _base: *mut u8,
+        _page_size: usize,
+        _page_count: usize,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn read_page(
+        &self,
+        _key: StripeKey,
+        _stripe_off: u64,
+        _dst: PageRef,
+    ) -> Result<bool, Error> {
+        // Always-miss. Pool falls through to `Transport::bulk_get`.
+        Ok(false)
+    }
+
+    async fn write_page(
+        &self,
+        _key: StripeKey,
+        _stripe_off: u64,
+        _page: PageRef,
+    ) -> Result<(), Error> {
+        // Drop the tee silently. A real blockstore will persist.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::pin;
+    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+    use super::*;
+
+    fn noop_waker() -> Waker {
+        fn raw() -> RawWaker {
+            RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
+        // SAFETY: vtable never dereferences the data pointer.
+        unsafe { Waker::from_raw(raw()) }
+    }
+
+    fn block_on<F: Future>(f: F) -> F::Output {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = pin!(f);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[test]
+    fn read_always_misses_write_is_noop() {
+        let s = NullBlockStore::new();
+        let key = StripeKey([0; 32]);
+        let dst = PageRef {
+            page_idx: 0,
+            offset: 0,
+            len: 0,
+        };
+        assert!(matches!(block_on(s.read_page(key, 0, dst)), Ok(false)));
+        assert!(block_on(s.write_page(key, 0, dst)).is_ok());
+    }
+
+    #[test]
+    fn register_pages_accepts_anything() {
+        let s = NullBlockStore::new();
+        assert!(s.register_pages(std::ptr::null_mut(), 4096, 0).is_ok());
+    }
+}

--- a/cmd/unbounded-storage/src/bufferpool/pool.rs
+++ b/cmd/unbounded-storage/src/bufferpool/pool.rs
@@ -51,15 +51,17 @@ where
     S: BlockStore + 'static,
     R: Req + 'static,
 {
-    /// One per NUMA shard. Carves `backing` into pages, calls
-    /// `transport.register_pages(...)` and
-    /// `blockstore.register_pages(...)` exactly once. No async I/O
-    /// happens here; on a real RDMA `Transport` the synchronous
-    /// `ibv_reg_mr` is the dominant cost (see the design's
-    /// "Page registration" section). Embedders should run
-    /// `Pool::new` off the pinned executor thread before handing
-    /// the constructed `Pool` to the per-shard executor for
-    /// service.
+    /// One per NUMA shard. Carves `backing` into pages and calls
+    /// `blockstore.register_pages(...)` exactly once. The
+    /// `Transport` is expected to have been bound to the same
+    /// `backing` out-of-band by the embedder before this call (e.g.
+    /// via `mercury::Class::register_backing`); the pool no longer
+    /// drives that handshake. No async I/O happens here; on a real
+    /// RDMA `Transport` the synchronous `ibv_reg_mr` is the
+    /// dominant cost (see the design's "Page registration"
+    /// section). Embedders should run `Pool::new` off the pinned
+    /// executor thread before handing the constructed `Pool` to the
+    /// per-shard executor for service.
     pub fn new(
         cfg: PoolConfig,
         backing: Backing,
@@ -79,7 +81,6 @@ where
             return Err(Error::BadConfig("backing.base is null"));
         }
 
-        transport.register_pages(backing.base, backing.page_size, backing.page_count)?;
         blockstore.register_pages(backing.base, backing.page_size, backing.page_count)?;
 
         let page_count_u32 = backing.page_count as u32;

--- a/cmd/unbounded-storage/src/bufferpool/tests.rs
+++ b/cmd/unbounded-storage/src/bufferpool/tests.rs
@@ -26,8 +26,7 @@ fn noop_waker() -> Waker {
     fn raw() -> RawWaker {
         RawWaker::new(std::ptr::null(), &VTABLE)
     }
-    static VTABLE: RawWakerVTable =
-        RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
     // SAFETY: the vtable functions never dereference the data pointer.
     unsafe { Waker::from_raw(raw()) }
 }
@@ -144,20 +143,21 @@ struct MockTransport {
     pend_polls: RefCell<usize>,
     /// Force `bulk_get` to return an error instead of completing.
     error_mode: RefCell<bool>,
-    /// Filled in by `register_pages`.
-    base: RefCell<Option<*mut u8>>,
-    page_size: RefCell<usize>,
+    /// Bound at construction (the embedder pre-registers the
+    /// backing; `Transport` no longer carries a registration hook).
+    base: *mut u8,
+    page_size: usize,
 }
 
 impl MockTransport {
-    fn new() -> Self {
+    fn new(base: *mut u8, page_size: usize) -> Self {
         Self {
             stripes: RefCell::new(HashMap::new()),
             calls: RefCell::new(0),
             pend_polls: RefCell::new(0),
             error_mode: RefCell::new(false),
-            base: RefCell::new(None),
-            page_size: RefCell::new(0),
+            base,
+            page_size,
         }
     }
 
@@ -179,23 +179,7 @@ impl MockTransport {
 }
 
 impl Transport<TestReq> for MockTransport {
-    fn register_pages(
-        &self,
-        base: *mut u8,
-        page_size: usize,
-        _page_count: usize,
-    ) -> Result<(), Error> {
-        *self.base.borrow_mut() = Some(base);
-        *self.page_size.borrow_mut() = page_size;
-        Ok(())
-    }
-
-    async fn bulk_get(
-        &self,
-        _req: &TestReq,
-        src: BulkRef,
-        dst: PageRef,
-    ) -> Result<(), Error> {
+    async fn bulk_get(&self, _req: &TestReq, src: BulkRef, dst: PageRef) -> Result<(), Error> {
         // Pend the configured number of polls (one polling round
         // per pend, decremented on each call).
         for _ in 0..*self.pend_polls.borrow() {
@@ -213,10 +197,10 @@ impl Transport<TestReq> for MockTransport {
         let end = start + src.len as usize;
         assert!(end <= bytes.len(), "src out of range");
 
-        let base = self.base.borrow().expect("registered");
-        let page_size = *self.page_size.borrow();
+        let page_size = self.page_size;
         let dst_ptr = unsafe {
-            base.add(dst.page_idx as usize * page_size + dst.offset as usize)
+            self.base
+                .add(dst.page_idx as usize * page_size + dst.offset as usize)
         };
         // SAFETY: dst is a pool page, src is a Vec<u8>, both valid.
         unsafe {
@@ -295,9 +279,7 @@ impl BlockStore for MockBlockStore {
         };
         let base = self.base.borrow().expect("registered");
         let page_size = *self.page_size.borrow();
-        let dst_ptr = unsafe {
-            base.add(dst.page_idx as usize * page_size + dst.offset as usize)
-        };
+        let dst_ptr = unsafe { base.add(dst.page_idx as usize * page_size + dst.offset as usize) };
         // SAFETY: dst is a pool page.
         unsafe {
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst_ptr, bytes.len());
@@ -319,9 +301,8 @@ impl BlockStore for MockBlockStore {
         *self.writes.borrow_mut() += 1;
         let base = self.base.borrow().expect("registered");
         let page_size = *self.page_size.borrow();
-        let src_ptr = unsafe {
-            base.add(page.page_idx as usize * page_size + page.offset as usize)
-        };
+        let src_ptr =
+            unsafe { base.add(page.page_idx as usize * page_size + page.offset as usize) };
         let mut buf = vec![0u8; page.len as usize];
         // SAFETY: src is a pool page.
         unsafe {
@@ -369,20 +350,7 @@ struct TransportRc(Rc<MockTransport>);
 struct BlockStoreRc(Rc<MockBlockStore>);
 
 impl Transport<TestReq> for TransportRc {
-    fn register_pages(
-        &self,
-        base: *mut u8,
-        page_size: usize,
-        page_count: usize,
-    ) -> Result<(), Error> {
-        self.0.register_pages(base, page_size, page_count)
-    }
-    async fn bulk_get(
-        &self,
-        req: &TestReq,
-        src: BulkRef,
-        dst: PageRef,
-    ) -> Result<(), Error> {
+    async fn bulk_get(&self, req: &TestReq, src: BulkRef, dst: PageRef) -> Result<(), Error> {
         self.0.bulk_get(req, src, dst).await
     }
 }
@@ -423,7 +391,10 @@ fn make_pool_v2(
     Rc<MockBlockStore>,
 ) {
     let backing = heap_backing(page_size, page_count);
-    let t = Rc::new(MockTransport::new());
+    // `Transport` is now constructed already aware of the backing's
+    // base/page_size (embedder pre-registration model); `BlockStore`
+    // still receives the backing via `Pool::new -> register_pages`.
+    let t = Rc::new(MockTransport::new(backing.base, backing.page_size));
     let s = Rc::new(MockBlockStore::new());
     let pool = Pool::new(
         PoolConfig::default(),
@@ -705,13 +676,19 @@ fn free_list_parking_unblocks_on_release() {
 fn stream_limit_enforced() {
     const P: usize = 4096;
     let backing = heap_backing(P, 2);
-    let t = Rc::new(MockTransport::new());
+    let t = Rc::new(MockTransport::new(backing.base, backing.page_size));
     let s = Rc::new(MockBlockStore::new());
     s.preload(key(0), 0, vec![0u8; P]);
     let cfg = PoolConfig {
         max_concurrent_streams: 1,
     };
-    let pool = Pool::new(cfg, backing, TransportRc(t.clone()), BlockStoreRc(s.clone())).unwrap();
+    let pool = Pool::new(
+        cfg,
+        backing,
+        TransportRc(t.clone()),
+        BlockStoreRc(s.clone()),
+    )
+    .unwrap();
     let req = TestReq { key: key(0) };
     block_on(async {
         let s1 = pool.read(&req, 0, P as u64).await.unwrap();
@@ -734,7 +711,13 @@ fn rejects_bad_backing() {
         page_count: 1,
         _own: Box::new(()),
     };
-    let t = TransportRc(Rc::new(MockTransport::new()));
+    let t = TransportRc(Rc::new(MockTransport::new(
+        backing.base,
+        // `backing.page_size` is 0 here on purpose; the test only
+        // exercises Pool::new's BadConfig early-return, which fires
+        // before any `bulk_get` runs.
+        1,
+    )));
     let s = BlockStoreRc(Rc::new(MockBlockStore::new()));
     let r = Pool::<_, _, TestReq>::new(PoolConfig::default(), backing, t, s);
     assert!(matches!(r, Err(Error::BadConfig(_))));

--- a/cmd/unbounded-storage/src/bufferpool/traits.rs
+++ b/cmd/unbounded-storage/src/bufferpool/traits.rs
@@ -11,28 +11,27 @@ pub trait Req {
 }
 
 pub trait Transport<R: Req> {
-    /// Called once at pool init with the full pinned backing. The
-    /// impl records whatever it needs (e.g. an RDMA MR) so it can
-    /// translate `page_idx` into a wire-side handle later.
-    fn register_pages(
-        &self,
-        base: *mut u8,
-        page_size: usize,
-        page_count: usize,
-    ) -> Result<(), Error>;
-
     /// Fetch the byte range described by `src` from a peer derived
     /// from `req` into the page identified by `dst.page_idx`.
     /// Resolves when the data has landed in `dst`.
+    ///
+    /// The transport is constructed already aware of the pool's
+    /// pinned backing and page geometry: the embedder registers the
+    /// backing with whatever wire-side resource is needed (e.g. an
+    /// RDMA MR via `Class::register_backing`) before handing the
+    /// transport to `Pool::new`. The `Pool` calls only this method
+    /// at runtime.
     async fn bulk_get(&self, req: &R, src: BulkRef, dst: PageRef) -> Result<(), Error>;
     // TODO(jordan): Are both src and dst actually needed here?
 }
 
 pub trait BlockStore {
-    /// Symmetric with [`Transport::register_pages`]. Impls that don't
-    /// need pre-registration (plain `pwrite` on a regular file) can
-    /// no-op; impls that do (io_uring fixed buffers, NVMe DMA
-    /// mapping) record their per-page handles here.
+    /// Symmetric with the transport's NUMA registration handshake
+    /// (which the embedder performs out-of-band before constructing
+    /// the transport): impls that don't need pre-registration
+    /// (plain `pwrite` on a regular file) can no-op; impls that do
+    /// (io_uring fixed buffers, NVMe DMA mapping) record their
+    /// per-page handles here.
     fn register_pages(
         &self,
         base: *mut u8,

--- a/cmd/unbounded-storage/src/lib.rs
+++ b/cmd/unbounded-storage/src/lib.rs
@@ -2,4 +2,7 @@
 // Licensed under the MIT License.
 
 pub mod bufferpool;
+pub mod mercury;
 pub mod p2p;
+pub mod runtime;
+pub mod topology;

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -1,13 +1,514 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod backing;
+
+use std::process::ExitCode;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-fn main() {
-    println!("hello world");
+use serde::{Deserialize, Serialize};
 
-    loop {
-        thread::sleep(Duration::from_secs(u64::MAX));
+use unbounded_storage::bufferpool::{
+    NullBlockStore, Pool, PoolConfig, PoolGroup, Req, ShardDescriptor, StripeKey,
+};
+use unbounded_storage::mercury::{Class, MercuryTransport, PeerEntry, StaticPeer, TransportConfig};
+use unbounded_storage::runtime::{PinnedRuntime, Threading, WorkerIdx, WorkerSpec};
+use unbounded_storage::topology::{
+    NicShard, ProgressSlot, discover_nic_shards, fallback_shard, flatten_shards,
+};
+
+use crate::backing::{BackingKind, BackingRequest, HUGEPAGE_2MB, allocate};
+
+/// Threads per NIC in the TCP fallback case. RDMA shards size
+/// themselves via the topology discovery path; the fallback is a
+/// single best-effort progress thread because there is no NIC pool
+/// to spread across.
+const FALLBACK_THREADS: usize = 1;
+
+const PROGRESS_POLL_MS: u32 = 100;
+const MAX_INFLIGHT: usize = 1024;
+const SHUTDOWN_POLL: Duration = Duration::from_millis(100);
+
+/// Per-shard buffer-pool sizing. The page size is fixed at 2 MiB
+/// to match the hugepage allocator; the byte budget per shard is
+/// configurable via `--bytes-per-shard` (default 128 MiB == 64
+/// hugepages). The allocator rounds the requested size up to a
+/// whole number of pages, so non-multiples of 2 MiB are tolerated
+/// but discouraged.
+const DEFAULT_BYTES_PER_SHARD: usize = 128 * 1024 * 1024;
+
+/// Process-wide shutdown flag. Set by the signal handler (which
+/// is restricted to async-signal-safe operations) and polled by
+/// the main thread plus every shard thread.
+static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+/// Placeholder request type for the per-shard `Pool`. Carries a
+/// `StripeKey` and satisfies the trait bounds required by
+/// `MercuryTransport` (`Serialize`). No reads are issued against
+/// the pool today; this exists so `Pool::new` type-checks.
+#[derive(Clone, Serialize, Deserialize)]
+struct PlaceholderReq {
+    key: [u8; 32],
+}
+
+impl Req for PlaceholderReq {
+    fn key(&self) -> StripeKey {
+        StripeKey(self.key)
+    }
+}
+
+type ShardPool = Pool<MercuryTransport<PlaceholderReq, StaticPeer>, NullBlockStore, PlaceholderReq>;
+
+fn main() -> ExitCode {
+    let cli = match Cli::parse(std::env::args().skip(1)) {
+        Ok(CliAction::Run(cli)) => cli,
+        Ok(CliAction::Help) => {
+            print_help();
+            return ExitCode::SUCCESS;
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            eprintln!();
+            print_help();
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let shards = enumerate_shards();
+    let slots = flatten_shards(&shards);
+    if slots.is_empty() {
+        eprintln!("no progress slots after topology flatten; exiting");
+        return ExitCode::FAILURE;
+    }
+    let specs: Vec<WorkerSpec> = slots
+        .iter()
+        .map(|s| WorkerSpec::new(s.cpu, s.numa))
+        .collect();
+    let runtime = PinnedRuntime::new(specs);
+    install_signal_handler();
+
+    // Each shard thread reports either an error or a populated
+    // `ShardDescriptor` on this channel. The main thread aggregates
+    // descriptors into a `PoolGroup` once every shard has reported.
+    let (ready_tx, ready_rx) = mpsc::channel::<ShardReady>();
+    let mut joins = Vec::with_capacity(slots.len());
+    for (i, slot) in slots.iter().enumerate() {
+        let worker = WorkerIdx(u16::try_from(i).expect("worker index fits in u16"));
+        let parent = &shards[slot.shard];
+        let dev_name = parent.dev_name.clone();
+        let na_info = match &dev_name {
+            // Placeholder until the per-NIC config-parsing follow-up
+            // wires through provider-specific `domain=`, listen port,
+            // etc.
+            Some(_) => "ofi+verbs;ofi_rxm://".to_string(),
+            None => "ofi+tcp://0.0.0.0:0".to_string(),
+        };
+        let slot = *slot;
+        let runtime = runtime.clone();
+        let tx = ready_tx.clone();
+        let backing_kind = cli.backing_kind;
+        let bytes_per_shard = cli.bytes_per_shard;
+        joins.push(
+            thread::Builder::new()
+                .name(format!("ub-storage-shard-{i}"))
+                .spawn(move || {
+                    let rt = runtime.clone();
+                    rt.run_worker(
+                        worker,
+                        Box::new(move || {
+                            run_shard(
+                                worker,
+                                slot,
+                                dev_name,
+                                na_info,
+                                runtime,
+                                tx,
+                                backing_kind,
+                                bytes_per_shard,
+                            );
+                        }),
+                    );
+                })
+                .expect("spawn shard thread"),
+        );
+    }
+    drop(ready_tx);
+
+    // Drain shard readiness messages, separating successes from
+    // failures. We wait for every shard so a partial bring-up
+    // produces a coherent error path rather than a half-built
+    // `PoolGroup`.
+    let mut descriptors: Vec<ShardDescriptor> = Vec::with_capacity(joins.len());
+    let mut errors: Vec<String> = Vec::new();
+    for msg in ready_rx {
+        match msg {
+            ShardReady::Up(d) => descriptors.push(d),
+            ShardReady::Failed(err) => {
+                eprintln!("shard failed: {err}");
+                errors.push(err);
+                SHUTDOWN.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+
+    // Build the process-wide `PoolGroup` over the successful
+    // shards. Routing is content-addressed: hash the request's
+    // `StripeKey` into the shard index. This is the simplest
+    // routing that distributes load uniformly across shards and
+    // is replaceable per design once topology-aware peer routing
+    // lands.
+    if errors.is_empty() && !descriptors.is_empty() {
+        descriptors.sort_by_key(|d| d.worker_idx.0);
+        let shard_count = descriptors.len();
+        let _group: PoolGroup<PlaceholderReq> =
+            PoolGroup::new(descriptors, move |req: &PlaceholderReq| {
+                stripe_key_to_shard(&req.key(), shard_count)
+            });
+        // No consumer yet; the group is built to validate the
+        // bring-up surface. A future change will hand it to
+        // whichever subsystem first needs cross-shard fan-out.
+        eprintln!("pool group up: shards={}", shard_count);
+    }
+
+    // Wait for shutdown
+    wait_for_shutdown();
+    eprintln!("shutdown signaled; tearing down shards");
+
+    // (reverse order so the last-built shard tears down first)
+    for h in joins.into_iter().rev() {
+        if let Err(e) = h.join() {
+            eprintln!("shard thread panicked: {e:?}");
+            errors.push(format!("panic: {e:?}"));
+        }
+    }
+
+    if errors.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+/// Body of one shard thread. Runs on the pinned executor: builds
+/// the Mercury `Class`, registers a NUMA-local `Backing`, wires up
+/// the `Pool`, reports readiness, then idles until shutdown so the
+/// `Class` (and its progress thread) plus the `Pool` are dropped
+/// together.
+fn run_shard(
+    worker: WorkerIdx,
+    slot: ProgressSlot,
+    dev_name: Option<String>,
+    na_info: String,
+    runtime: std::sync::Arc<dyn unbounded_storage::runtime::Threading>,
+    tx: mpsc::Sender<ShardReady>,
+    backing_kind: BackingKind,
+    bytes_per_shard: usize,
+) {
+    let cfg = TransportConfig {
+        na_info,
+        listen: true,
+        peers: Vec::<PeerEntry>::new(),
+        max_inflight: MAX_INFLIGHT,
+        progress_poll_ms: PROGRESS_POLL_MS,
+        runtime,
+        worker_idx: worker,
+    };
+    let class = match Class::new(cfg).and_then(|c| c.self_address().map(|a| (c, a))) {
+        Ok((class, self_addr)) => {
+            println!(
+                "shard up: worker={} dev={} numa={} cpu={} self_addr={}",
+                worker.0,
+                dev_name.as_deref().unwrap_or("tcp-fallback"),
+                slot.numa
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "none".into()),
+                slot.cpu,
+                self_addr,
+            );
+            class
+        }
+        Err(e) => {
+            let _ = tx.send(ShardReady::Failed(format!("worker={}: {e}", worker.0)));
+            return;
+        }
+    };
+
+    // NUMA-local backing. Allocated on the pinned shard thread so
+    // the `PinnedRuntime`'s `set_mempolicy` keeps the pages on the
+    // intended node; the hugepage variant additionally pins via
+    // `mbind` when `slot.numa` is known. Register it with the
+    // Mercury class before building the transport (the new
+    // embedder-pre-registers model replaces the old
+    // `Transport::register_pages` handshake).
+    let backing = match allocate(BackingRequest {
+        kind: backing_kind,
+        bytes: bytes_per_shard,
+        numa: slot.numa,
+    }) {
+        Ok(b) => b,
+        Err(e) => {
+            let _ = tx.send(ShardReady::Failed(format!(
+                "worker={}: backing allocation failed: {e}",
+                worker.0,
+            )));
+            return;
+        }
+    };
+    let backing_bytes = backing.page_size * backing.page_count;
+    let page_size = backing.page_size;
+    if let Err(e) = class.register_backing(backing.base, backing_bytes) {
+        let _ = tx.send(ShardReady::Failed(format!(
+            "worker={}: register_backing: {e}",
+            worker.0,
+        )));
+        return;
+    }
+
+    // `StaticPeer(PeerId(0))` is a placeholder: with `peers`
+    // empty, no `bulk_get` will resolve, but constructing the
+    // transport is harmless. A real router will be installed when
+    // peer discovery lands.
+    let transport = MercuryTransport::<PlaceholderReq, _>::new(
+        &class,
+        StaticPeer(unbounded_storage::bufferpool::PeerId(0)),
+        page_size,
+    );
+    let blockstore = NullBlockStore::new();
+    let pool: ShardPool = match Pool::new(PoolConfig::default(), backing, transport, blockstore) {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = tx.send(ShardReady::Failed(format!(
+                "worker={}: Pool::new: {e}",
+                worker.0,
+            )));
+            return;
+        }
+    };
+
+    let _ = tx.send(ShardReady::Up(ShardDescriptor {
+        worker_idx: worker,
+        numa: slot.numa,
+    }));
+
+    wait_for_shutdown();
+
+    // Drop order matters: drop the `Pool` first so the
+    // `MercuryTransport` (which holds an `Arc<ClassInner>`) goes
+    // away before the owning `Class` runs its own drop. `Class::drop`
+    // closes the server queue and signals the progress thread; the
+    // last `Arc` release inside `ClassInner::drop` joins that thread
+    // and finalizes Mercury.
+    drop(pool);
+    drop(class);
+}
+
+/// Hash a `StripeKey` into a shard index. The first eight bytes of
+/// the 32-byte key are interpreted as a little-endian `u64`; that
+/// distributes uniformly under a content-addressed key (which is
+/// already a hash) and avoids pulling in a hash crate. The modulus
+/// is the shard count; `shard_count` is asserted non-zero by
+/// `PoolGroup::new`.
+fn stripe_key_to_shard(key: &StripeKey, shard_count: usize) -> usize {
+    let bytes = &key.0[..8];
+    let h = u64::from_le_bytes(bytes.try_into().expect("8 bytes"));
+    (h as usize) % shard_count
+}
+
+/// Status a shard thread reports once it has either come up or
+/// failed during bring-up.
+enum ShardReady {
+    Up(ShardDescriptor),
+    Failed(String),
+}
+
+/// Parsed command-line options for one run of the daemon.
+#[derive(Copy, Clone, Debug)]
+struct Cli {
+    backing_kind: BackingKind,
+    bytes_per_shard: usize,
+}
+
+enum CliAction {
+    Run(Cli),
+    Help,
+}
+
+impl Cli {
+    fn parse<I: IntoIterator<Item = String>>(args: I) -> Result<CliAction, String> {
+        let mut backing_kind = BackingKind::Hugepage2Mb;
+        let mut bytes_per_shard = DEFAULT_BYTES_PER_SHARD;
+        let mut it = args.into_iter();
+        while let Some(arg) = it.next() {
+            match arg.as_str() {
+                "-h" | "--help" => return Ok(CliAction::Help),
+                "--no-hugepages" => backing_kind = BackingKind::Heap,
+                s if s.starts_with("--bytes-per-shard=") => {
+                    let v = &s["--bytes-per-shard=".len()..];
+                    bytes_per_shard = parse_bytes(v)?;
+                }
+                "--bytes-per-shard" => {
+                    let v = it
+                        .next()
+                        .ok_or_else(|| "--bytes-per-shard requires a value".to_string())?;
+                    bytes_per_shard = parse_bytes(&v)?;
+                }
+                other => return Err(format!("unknown argument: {other}")),
+            }
+        }
+        if bytes_per_shard == 0 {
+            return Err("--bytes-per-shard must be > 0".into());
+        }
+        Ok(CliAction::Run(Cli {
+            backing_kind,
+            bytes_per_shard,
+        }))
+    }
+}
+
+/// Parse a byte count with an optional `K`/`M`/`G` suffix (powers
+/// of 1024). Bare integers are bytes.
+fn parse_bytes(s: &str) -> Result<usize, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("empty byte count".into());
+    }
+    let (num, mult) = match s.as_bytes().last().copied() {
+        Some(b'K') | Some(b'k') => (&s[..s.len() - 1], 1024usize),
+        Some(b'M') | Some(b'm') => (&s[..s.len() - 1], 1024 * 1024),
+        Some(b'G') | Some(b'g') => (&s[..s.len() - 1], 1024 * 1024 * 1024),
+        _ => (s, 1usize),
+    };
+    let n: usize = num
+        .parse()
+        .map_err(|e| format!("invalid byte count {s:?}: {e}"))?;
+    n.checked_mul(mult)
+        .ok_or_else(|| format!("byte count {s:?} overflows usize"))
+}
+
+fn print_help() {
+    let default_mib = DEFAULT_BYTES_PER_SHARD / (1024 * 1024);
+    let hp_mib = HUGEPAGE_2MB / (1024 * 1024);
+    eprintln!("Usage: unbounded-storage [OPTIONS]");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --no-hugepages              Allocate the per-shard backing with the");
+    eprintln!("                              global allocator instead of {hp_mib} MiB");
+    eprintln!("                              hugepages. The default requires reserved");
+    eprintln!("                              hugepages on the host; there is no");
+    eprintln!("                              automatic fallback.");
+    eprintln!("  --bytes-per-shard=<BYTES>   Per-shard buffer pool size. Accepts a");
+    eprintln!("                              K/M/G suffix (powers of 1024). Rounded");
+    eprintln!("                              up to a multiple of the {hp_mib} MiB page");
+    eprintln!("                              size. Default: {default_mib} MiB.");
+    eprintln!("  -h, --help                  Print this help and exit.");
+}
+
+fn enumerate_shards() -> Vec<NicShard> {
+    let mut shards = discover_nic_shards();
+    if shards.is_empty() {
+        eprintln!(
+            "no RDMA NICs discovered under /sys/class/infiniband; \
+             falling back to a single TCP shard"
+        );
+        shards.push(fallback_shard(FALLBACK_THREADS));
+    }
+    shards
+}
+
+fn wait_for_shutdown() {
+    while !SHUTDOWN.load(Ordering::Acquire) {
+        thread::sleep(SHUTDOWN_POLL);
+    }
+}
+
+/// Install a SIGINT/SIGTERM handler that flips [`SHUTDOWN`]. The
+/// handler is async-signal-safe (only a relaxed atomic store).
+/// All threads observe the flag via their poll loops.
+fn install_signal_handler() {
+    unsafe extern "C" fn handler(_sig: libc::c_int) {
+        // SAFETY: AtomicBool::store with Relaxed compiles to a
+        // single machine store on every supported arch; it is
+        // async-signal-safe. Readers synchronize via their own
+        // Acquire loads.
+        SHUTDOWN.store(true, Ordering::Relaxed);
+    }
+    // SAFETY: sigaction is invoked once at startup with a
+    // zero-initialized sigaction whose handler does not touch
+    // any non-async-signal-safe state.
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        sa.sa_sigaction = handler as *const () as usize;
+        libc::sigemptyset(&mut sa.sa_mask);
+        sa.sa_flags = 0;
+        for sig in [libc::SIGINT, libc::SIGTERM] {
+            if libc::sigaction(sig, &sa, std::ptr::null_mut()) != 0 {
+                let e = std::io::Error::last_os_error();
+                eprintln!("failed to install signal handler for sig={sig}: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<Cli, String> {
+        match Cli::parse(args.iter().map(|s| s.to_string()))? {
+            CliAction::Run(c) => Ok(c),
+            CliAction::Help => Err("unexpected help".into()),
+        }
+    }
+
+    #[test]
+    fn defaults_to_hugepages() {
+        let c = parse(&[]).unwrap();
+        assert!(matches!(c.backing_kind, BackingKind::Hugepage2Mb));
+        assert_eq!(c.bytes_per_shard, DEFAULT_BYTES_PER_SHARD);
+    }
+
+    #[test]
+    fn no_hugepages_selects_heap() {
+        let c = parse(&["--no-hugepages"]).unwrap();
+        assert!(matches!(c.backing_kind, BackingKind::Heap));
+    }
+
+    #[test]
+    fn bytes_per_shard_equals_form() {
+        let c = parse(&["--bytes-per-shard=64M"]).unwrap();
+        assert_eq!(c.bytes_per_shard, 64 * 1024 * 1024);
+    }
+
+    #[test]
+    fn bytes_per_shard_space_form() {
+        let c = parse(&["--bytes-per-shard", "2G"]).unwrap();
+        assert_eq!(c.bytes_per_shard, 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn bytes_plain_integer_is_bytes() {
+        let c = parse(&["--bytes-per-shard=4194304"]).unwrap();
+        assert_eq!(c.bytes_per_shard, 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn help_flag_returns_help_action() {
+        let action = Cli::parse(["--help".to_string()].into_iter()).unwrap();
+        assert!(matches!(action, CliAction::Help));
+    }
+
+    #[test]
+    fn unknown_arg_is_rejected() {
+        let err = parse(&["--nope"]).err().unwrap();
+        assert!(err.contains("unknown argument"), "got: {err}");
+    }
+
+    #[test]
+    fn zero_bytes_rejected() {
+        let err = parse(&["--bytes-per-shard=0"]).err().unwrap();
+        assert!(err.contains("must be > 0"), "got: {err}");
     }
 }

--- a/cmd/unbounded-storage/src/mercury/bulk.rs
+++ b/cmd/unbounded-storage/src/mercury/bulk.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::mercury::error::{Result, check};
+use crate::mercury::ffi;
+
+/// Local bulk handle covering a single contiguous registered region.
+pub(crate) struct LocalBulk {
+    handle: ffi::hg_bulk_t,
+    base: *mut u8,
+    size: usize,
+}
+
+impl LocalBulk {
+    pub(crate) fn register(
+        hg_class: ffi::hg_class_t,
+        base: *mut u8,
+        size: usize,
+        flags: ffi::hg_uint8_t,
+    ) -> Result<Self> {
+        let mut bufs: [*mut std::ffi::c_void; 1] = [base.cast()];
+        let sizes: [ffi::hg_size_t; 1] = [size as ffi::hg_size_t];
+        let mut handle: ffi::hg_bulk_t = std::ptr::null_mut();
+
+        // SAFETY: `hg_class` is live; `bufs` and `sizes` are valid
+        // for the duration of the call; `handle` is an out-pointer.
+        let ret = unsafe {
+            ffi::HG_Bulk_create(
+                hg_class,
+                1,
+                bufs.as_mut_ptr(),
+                sizes.as_ptr(),
+                flags,
+                &mut handle,
+            )
+        };
+        check(ret, "HG_Bulk_create")?;
+        Ok(Self { handle, base, size })
+    }
+
+    pub(crate) fn handle(&self) -> ffi::hg_bulk_t {
+        self.handle
+    }
+
+    pub(crate) fn covers(&self, base: *mut u8, size: usize) -> bool {
+        std::ptr::eq(self.base, base) && self.size == size
+    }
+}
+
+impl Drop for LocalBulk {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            // SAFETY: handle came from HG_Bulk_create and is freed
+            // exactly once here.
+            unsafe {
+                ffi::HG_Bulk_free(self.handle);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `LocalBulk` without touching Mercury so `covers` can
+    /// be exercised in isolation. The null `handle` skips
+    /// `HG_Bulk_free` in `Drop`.
+    fn synthetic(base: *mut u8, size: usize) -> LocalBulk {
+        LocalBulk {
+            handle: std::ptr::null_mut(),
+            base,
+            size,
+        }
+    }
+
+    #[test]
+    fn covers_exact_match_is_true() {
+        let mut buf = [0u8; 16];
+        let b = synthetic(buf.as_mut_ptr(), buf.len());
+        assert!(b.covers(buf.as_mut_ptr(), buf.len()));
+    }
+
+    #[test]
+    fn covers_rejects_different_size() {
+        let mut buf = [0u8; 16];
+        let b = synthetic(buf.as_mut_ptr(), buf.len());
+        assert!(!b.covers(buf.as_mut_ptr(), buf.len() - 1));
+        assert!(!b.covers(buf.as_mut_ptr(), buf.len() + 1));
+    }
+
+    #[test]
+    fn covers_rejects_different_base() {
+        let mut a = [0u8; 16];
+        let mut b = [0u8; 16];
+        let bulk = synthetic(a.as_mut_ptr(), a.len());
+        assert!(!bulk.covers(b.as_mut_ptr(), b.len()));
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/class.rs
+++ b/cmd/unbounded-storage/src/mercury/class.rs
@@ -1,0 +1,396 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Mercury class lifecycle. One `Class` per NUMA shard. It owns
+//! the `hg_class_t`, the `hg_context_t`, the registered RPC ID,
+//! the pinned-backing bulk handle, the peer table, the completion
+//! registry that bridges the progress thread to the client-side
+//! future, and the optional server-job queue that bridges the
+//! progress thread to the executor-side server task.
+//!
+//! Construction is the only place that allocates a thread; drop
+//! tears it down cleanly. Everything else is thin wrappers over the
+//! FFI.
+
+use std::ffi::CString;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::bufferpool::PeerId;
+use crate::mercury::bulk::LocalBulk;
+use crate::mercury::config::TransportConfig;
+use crate::mercury::error::{HgError, Result, check};
+use crate::mercury::ffi;
+use crate::mercury::peer::PeerTable;
+use crate::mercury::progress::{CompletionRegistry, ServerJobQueue};
+use crate::mercury::rpc;
+use crate::runtime::{JoinHandle, Threading, WorkerIdx};
+
+/// A live Mercury class plus the progress thread driving it. Held
+/// behind `Arc` so transport, server, and futures can all share a
+/// single instance without ownership gymnastics.
+pub struct Class {
+    inner: Arc<ClassInner>,
+}
+
+pub(crate) struct ClassInner {
+    pub(crate) hg_class: ffi::hg_class_t,
+    pub(crate) hg_context: ffi::hg_context_t,
+    pub(crate) rpc_id: ffi::hg_id_t,
+    /// Wrapped in `Option` purely so `Drop` can `take()` it and run
+    /// `HG_Addr_free` against the still-live class before
+    /// `HG_Finalize`. In every other code path this is `Some`.
+    peers: Option<PeerTable>,
+    pub(crate) completions: Arc<CompletionRegistry>,
+    pub(crate) server: Option<Arc<ServerJobQueue>>,
+    pub(crate) local_bulk: Mutex<Option<LocalBulk>>,
+    shutdown: Arc<AtomicBool>,
+    progress: Mutex<Option<JoinHandle>>,
+    progress_poll_ms: u32,
+}
+
+// SAFETY: `hg_class_t`, `hg_context_t`, and `hg_id_t` are documented
+// as thread-safe to use from any thread once initialized. The
+// progress thread is the only consumer of `HG_Progress` / `HG_Trigger`,
+// per Mercury's documented threading model. The completion registry
+// and server queue are themselves `Send + Sync`.
+unsafe impl Send for ClassInner {}
+unsafe impl Sync for ClassInner {}
+
+impl ClassInner {
+    /// Register the bufferpool's pinned backing on this class.
+    /// Idempotent against the same `(base, size)`; rejected if a
+    /// different region was previously registered.
+    pub(crate) fn register_backing(&self, base: *mut u8, size: usize) -> Result<()> {
+        let mut slot = self.local_bulk.lock().expect("local_bulk mutex");
+        if let Some(existing) = slot.as_ref() {
+            if existing.covers(base, size) {
+                return Ok(());
+            }
+            return Err(HgError::new(
+                0,
+                "class already bound to a different backing",
+            ));
+        }
+        let bulk = LocalBulk::register(self.hg_class, base, size, ffi::HG_BULK_READWRITE)?;
+        *slot = Some(bulk);
+        Ok(())
+    }
+
+    /// Resolve a peer id to its `hg_addr_t`. Always succeeds while
+    /// the class is alive; the `peers` field is only `None` during
+    /// `Drop`.
+    pub(crate) fn peer_addr(&self, peer: PeerId) -> Result<ffi::hg_addr_t> {
+        self.peers
+            .as_ref()
+            .expect("peer table dropped")
+            .lookup(peer)
+    }
+}
+
+impl Drop for ClassInner {
+    fn drop(&mut self) {
+        // By the time the last `Arc<ClassInner>` drops, all
+        // `MercuryTransport` / `MercuryServer` handles that referenced
+        // this class are gone. The `Class` wrapper has already called
+        // `close()` on the server queue and set `shutdown` (see
+        // `Class::drop`), but we also handle the case where someone
+        // built a `ClassInner` outside that wrapper.
+        if let Some(q) = self.server.as_ref() {
+            q.close();
+        }
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(handle) = self.progress.lock().expect("progress mutex").take() {
+            let _ = handle.join();
+        }
+        // Drop local_bulk and the peer table before HG_Finalize so
+        // `HG_Bulk_free` / `HG_Addr_free` both run against a live
+        // class. Field-drop order would run them *after* this body,
+        // i.e. after `HG_Finalize`, so we must do it explicitly.
+        *self.local_bulk.lock().expect("local_bulk mutex") = None;
+        drop(self.peers.take());
+        // SAFETY: each FFI resource was allocated by Mercury and is
+        // freed exactly once here.
+        unsafe {
+            let _ = ffi::HG_Context_destroy(self.hg_context);
+            let _ = ffi::HG_Finalize(self.hg_class);
+        }
+    }
+}
+
+impl Class {
+    /// Build a class from `cfg`. Spawns the progress thread before
+    /// returning so the class is fully active on success.
+    pub fn new(cfg: TransportConfig) -> Result<Self> {
+        rpc::assert_layouts().map_err(|s| HgError::new(0, s))?;
+
+        let na_info = CString::new(cfg.na_info.as_str())
+            .map_err(|_| HgError::new(0, "na_info contains NUL"))?;
+
+        // SAFETY: `na_info` is valid for the call; we check the
+        // returned pointer for null below.
+        let hg_class = unsafe {
+            ffi::HG_Init(
+                na_info.as_ptr(),
+                if cfg.listen {
+                    ffi::HG_TRUE
+                } else {
+                    ffi::HG_FALSE
+                },
+            )
+        };
+        if hg_class.is_null() {
+            return Err(HgError::new(0, "HG_Init returned null"));
+        }
+
+        // From here on we must clean up `hg_class` on any error
+        // path. Wrap everything below in a guard pattern.
+        let result = (|| -> Result<Class> {
+            // SAFETY: hg_class is non-null and valid.
+            let hg_context = unsafe { ffi::HG_Context_create(hg_class) };
+            if hg_context.is_null() {
+                return Err(HgError::new(0, "HG_Context_create returned null"));
+            }
+
+            // SAFETY: hg_class and the two proc callbacks are live.
+            // The `rpc_cb` is `Some(server_rpc_cb)` only when the
+            // class is listening, so client-only classes never
+            // accept incoming RPCs.
+            let rpc_cb = if cfg.listen {
+                Some(crate::mercury::server::server_rpc_cb as ffi::hg_rpc_cb_t)
+            } else {
+                None
+            };
+            let rpc_id = unsafe {
+                ffi::HG_Register_name(
+                    hg_class,
+                    rpc::RPC_NAME.as_ptr() as *const _,
+                    Some(rpc::in_proc()),
+                    Some(rpc::out_proc()),
+                    rpc_cb,
+                )
+            };
+            if rpc_id == 0 {
+                // SAFETY: hg_context is live.
+                unsafe {
+                    let _ = ffi::HG_Context_destroy(hg_context);
+                }
+                return Err(HgError::new(0, "HG_Register_name failed"));
+            }
+
+            let peers = PeerTable::new(hg_class, &cfg.peers).map_err(|e| {
+                // SAFETY: cleanup; ignore errors.
+                unsafe {
+                    let _ = ffi::HG_Context_destroy(hg_context);
+                }
+                e
+            })?;
+
+            let completions = CompletionRegistry::new(cfg.max_inflight);
+            let server = if cfg.listen {
+                let queue = ServerJobQueue::new();
+                if let Err(e) = attach_server_queue(hg_class, rpc_id, &queue) {
+                    // SAFETY: cleanup; ignore errors.
+                    unsafe {
+                        let _ = ffi::HG_Context_destroy(hg_context);
+                    }
+                    return Err(e);
+                }
+                Some(queue)
+            } else {
+                None
+            };
+
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let inner = Arc::new(ClassInner {
+                hg_class,
+                hg_context,
+                rpc_id,
+                peers: Some(peers),
+                completions,
+                server,
+                local_bulk: Mutex::new(None),
+                shutdown: shutdown.clone(),
+                progress: Mutex::new(None),
+                progress_poll_ms: cfg.progress_poll_ms,
+            });
+
+            let thread = spawn_progress_thread(
+                inner.clone(),
+                shutdown,
+                cfg.runtime.as_ref(),
+                cfg.worker_idx,
+            );
+            *inner.progress.lock().expect("progress mutex") = Some(thread);
+
+            Ok(Class { inner })
+        })();
+
+        match result {
+            Ok(c) => Ok(c),
+            Err(e) => {
+                // SAFETY: hg_class was non-null; finalize once on error.
+                unsafe {
+                    let _ = ffi::HG_Finalize(hg_class);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Register the bufferpool's pinned backing. Idempotent against
+    /// the same `(base, size)`; rejected if a different region was
+    /// previously registered (a class is fundamentally bound to one
+    /// backing for its lifetime).
+    pub fn register_backing(&self, base: *mut u8, size: usize) -> Result<()> {
+        self.inner.register_backing(base, size)
+    }
+
+    /// Returns the local Mercury address (formatted) so it can be
+    /// shared with peers. Only meaningful when `listen` was true.
+    pub fn self_address(&self) -> Result<String> {
+        let mut addr: ffi::hg_addr_t = std::ptr::null_mut();
+        // SAFETY: hg_class is live; addr is an out-pointer.
+        let ret = unsafe { ffi::HG_Addr_self(self.inner.hg_class, &mut addr) };
+        check(ret, "HG_Addr_self")?;
+        if addr.is_null() {
+            return Err(HgError::new(0, "HG_Addr_self returned null"));
+        }
+        let mut size: ffi::hg_size_t = 0;
+        // SAFETY: probing for buffer size with a null buffer is the
+        // documented Mercury idiom.
+        let ret = unsafe {
+            ffi::HG_Addr_to_string(self.inner.hg_class, std::ptr::null_mut(), &mut size, addr)
+        };
+        check(ret, "HG_Addr_to_string (size probe)").map_err(|e| {
+            // SAFETY: free addr before returning.
+            unsafe {
+                let _ = ffi::HG_Addr_free(self.inner.hg_class, addr);
+            }
+            e
+        })?;
+        let mut buf = vec![0u8; size as usize];
+        // SAFETY: buf has `size` bytes capacity; Mercury writes a
+        // NUL-terminated C string into it.
+        let ret = unsafe {
+            ffi::HG_Addr_to_string(
+                self.inner.hg_class,
+                buf.as_mut_ptr() as *mut _,
+                &mut size,
+                addr,
+            )
+        };
+        let chk = check(ret, "HG_Addr_to_string");
+        // SAFETY: free addr regardless of conversion result.
+        unsafe {
+            let _ = ffi::HG_Addr_free(self.inner.hg_class, addr);
+        }
+        chk?;
+        // Strip trailing NUL.
+        if let Some(nul) = buf.iter().position(|&b| b == 0) {
+            buf.truncate(nul);
+        }
+        String::from_utf8(buf).map_err(|_| HgError::new(0, "self address not valid UTF-8"))
+    }
+
+    pub(crate) fn inner(&self) -> &Arc<ClassInner> {
+        &self.inner
+    }
+
+    /// Resolve a peer id to its `hg_addr_t`.
+    #[allow(dead_code)]
+    pub(crate) fn peer_addr(&self, peer: PeerId) -> Result<ffi::hg_addr_t> {
+        self.inner.peer_addr(peer)
+    }
+
+    /// Access the server job queue for embedders that drove
+    /// `listen = true`. Returns `None` for client-only classes.
+    pub fn server_queue(&self) -> Option<Arc<ServerJobQueue>> {
+        self.inner.server.clone()
+    }
+}
+
+impl Drop for Class {
+    fn drop(&mut self) {
+        // Always close the server queue and flag shutdown so any
+        // outstanding `MercuryTransport` / `MercuryServer` Arcs
+        // observe the wind-down. The actual FFI teardown happens in
+        // `ClassInner::drop` whenever the last strong reference
+        // releases, which may be now or later depending on whether
+        // the transport/server outlive their owning `Class`.
+        if let Some(q) = self.inner.server.as_ref() {
+            q.close();
+        }
+        self.inner.shutdown.store(true, Ordering::Release);
+    }
+}
+
+fn spawn_progress_thread(
+    inner: Arc<ClassInner>,
+    shutdown: Arc<AtomicBool>,
+    runtime: &dyn Threading,
+    worker_idx: WorkerIdx,
+) -> JoinHandle {
+    runtime.spawn_aux(
+        worker_idx,
+        "mercury-progress",
+        Box::new(move || progress_loop(inner, shutdown)),
+    )
+}
+
+/// Body of the Mercury progress thread. Pulled out of
+/// `spawn_progress_thread` so the spawn site reads as a one-liner
+/// against the runtime trait.
+fn progress_loop(inner: Arc<ClassInner>, shutdown: Arc<AtomicBool>) {
+    let timeout = inner.progress_poll_ms;
+    while !shutdown.load(Ordering::Acquire) {
+        // SAFETY: hg_context lives until shutdown is set and the
+        // class is dropped, which happens after the thread joins.
+        unsafe {
+            let _ = ffi::HG_Progress(inner.hg_context, timeout);
+            loop {
+                let mut actual: std::ffi::c_uint = 0;
+                let ret = ffi::HG_Trigger(inner.hg_context, 0, 16, &mut actual);
+                if ret != ffi::HG_SUCCESS || actual == 0 {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Attach `queue` to `(hg_class, rpc_id)` as the registered data so
+/// the C-level RPC callback can recover it via `HG_Registered_data`
+/// without a global. The queue's strong-ref count is bumped here
+/// and decremented by [`free_server_queue`] at `HG_Finalize` time.
+fn attach_server_queue(
+    hg_class: ffi::hg_class_t,
+    rpc_id: ffi::hg_id_t,
+    queue: &Arc<ServerJobQueue>,
+) -> Result<()> {
+    let raw = Arc::into_raw(queue.clone()) as *mut std::ffi::c_void;
+    // SAFETY: hg_class and rpc_id are live; raw is a freshly-leaked
+    // Arc that the free callback reclaims at HG_Finalize time.
+    let ret = unsafe { ffi::HG_Register_data(hg_class, rpc_id, raw, Some(free_server_queue)) };
+    if ret != ffi::HG_SUCCESS {
+        // SAFETY: `raw` came from `Arc::into_raw` directly above.
+        unsafe {
+            let _ = Arc::from_raw(raw as *const ServerJobQueue);
+        }
+        return Err(HgError::new(ret as i32, "HG_Register_data"));
+    }
+    Ok(())
+}
+
+/// Frees the `ServerJobQueue` Arc handed to `HG_Register_data`.
+/// Invoked exactly once by Mercury at `HG_Finalize` time.
+unsafe extern "C" fn free_server_queue(data: *mut std::ffi::c_void) {
+    if data.is_null() {
+        return;
+    }
+    // SAFETY: `data` is the Arc<ServerJobQueue> raw pointer we
+    // leaked at registration time; reclaim and drop exactly once.
+    unsafe {
+        let _ = Arc::from_raw(data as *const ServerJobQueue);
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/config.rs
+++ b/cmd/unbounded-storage/src/mercury/config.rs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Construction-time configuration for a single Mercury class +
+//! progress thread (one per NUMA shard in the bufferpool model).
+//! Holds only the inputs needed to bring the transport up; runtime
+//! tunables (page registration, in-flight bounds) live alongside
+//! the components that use them.
+
+use std::sync::Arc;
+
+use crate::bufferpool::PeerId;
+use crate::runtime::{Threading, WorkerIdx};
+
+/// Configuration for one Mercury class. Construct one per NUMA
+/// shard; the embedder is responsible for ensuring `peers` is the
+/// bounded neighbor set selected by its topology layer, not a full
+/// mesh (see `designs/storage-high-level.md`).
+pub struct TransportConfig {
+    /// Mercury NA info string. Examples:
+    ///   - `"na+sm://"`               in-process shared-memory (tests)
+    ///   - `"ofi+tcp://0.0.0.0:0"`    TCP via libfabric
+    ///   - `"ofi+verbs;ofi_rxm://"`   IB / RoCE via libfabric
+    /// The string is consumed verbatim by `HG_Init_opt2`.
+    pub na_info: String,
+
+    /// Listen for incoming RPCs. `false` means client-only (no
+    /// server can be attached). With `true`, the local address can
+    /// be obtained via `Class::self_address` after init for sharing
+    /// with peers out-of-band.
+    pub listen: bool,
+
+    /// Bounded neighbor set. Each entry is eagerly looked up at
+    /// class construction; failures abort the construction.
+    pub peers: Vec<PeerEntry>,
+
+    /// Maximum number of concurrent in-flight `bulk_get` RPCs the
+    /// transport will accept. Bounds the completion slab; new
+    /// requests fail fast when full rather than queueing
+    /// unboundedly.
+    pub max_inflight: usize,
+
+    /// `HG_Progress` blocking timeout in milliseconds. Larger
+    /// values reduce wake overhead on idle classes; smaller values
+    /// shorten shutdown latency. 100 ms is a reasonable default.
+    pub progress_poll_ms: u32,
+
+    /// Worker-placement runtime. Used to spawn the progress thread
+    /// pinned to the same NUMA node as the worker that drives this
+    /// class. The same `Arc` is shared with the bufferpool and the
+    /// blockstore.
+    pub runtime: Arc<dyn Threading>,
+
+    /// Worker slot this class is bound to. Identifies which NUMA
+    /// node the progress thread is pinned against and matches the
+    /// `WorkerIdx` the executor running this transport runs on.
+    pub worker_idx: WorkerIdx,
+}
+
+impl TransportConfig {
+    /// Minimal constructor for a client-only configuration. Tests
+    /// and embedders that want listen + custom peers build on top
+    /// via field assignments.
+    pub fn new(
+        na_info: impl Into<String>,
+        runtime: Arc<dyn Threading>,
+        worker_idx: WorkerIdx,
+    ) -> Self {
+        Self {
+            na_info: na_info.into(),
+            listen: false,
+            peers: Vec::new(),
+            max_inflight: 1024,
+            progress_poll_ms: 100,
+            runtime,
+            worker_idx,
+        }
+    }
+}
+
+/// Peer address. `peer_id` is the embedder's opaque handle; `addr`
+/// is the Mercury-format address string returned by the peer's
+/// `Class::self_address`.
+pub struct PeerEntry {
+    pub peer_id: PeerId,
+    pub addr: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::DefaultRuntime;
+
+    #[test]
+    fn new_sets_minimal_client_defaults() {
+        let rt = DefaultRuntime::new(1);
+        let cfg = TransportConfig::new("na+sm://", rt, WorkerIdx(0));
+        assert_eq!(cfg.na_info, "na+sm://");
+        assert!(!cfg.listen);
+        assert!(cfg.peers.is_empty());
+        assert_eq!(cfg.max_inflight, 1024);
+        assert_eq!(cfg.progress_poll_ms, 100);
+        assert_eq!(cfg.worker_idx, WorkerIdx(0));
+    }
+
+    #[test]
+    fn fields_are_writable_after_new() {
+        let rt = DefaultRuntime::new(1);
+        let mut cfg = TransportConfig::new("na+sm://", rt, WorkerIdx(0));
+        cfg.listen = true;
+        cfg.max_inflight = 4;
+        cfg.progress_poll_ms = 5;
+        cfg.peers.push(PeerEntry {
+            peer_id: PeerId(1),
+            addr: "na+sm://1/2".into(),
+        });
+        assert!(cfg.listen);
+        assert_eq!(cfg.max_inflight, 4);
+        assert_eq!(cfg.progress_poll_ms, 5);
+        assert_eq!(cfg.peers.len(), 1);
+        assert_eq!(cfg.peers[0].peer_id, PeerId(1));
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/error.rs
+++ b/cmd/unbounded-storage/src/mercury/error.rs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Errors returned by the Mercury transport. Mercury returns `int`
+//! status codes from every C entry point; we wrap the failure path
+//! in a single struct that implements `std::error::Error` so it
+//! flows cleanly through `bufferpool::Error::transport`.
+
+use std::fmt;
+
+use crate::mercury::ffi;
+
+/// Result alias for the Mercury transport.
+pub type Result<T> = std::result::Result<T, HgError>;
+
+/// Failure returned from a Mercury entry point. `code` is the raw
+/// `hg_return_t`; `ctx` names the call site so log messages identify
+/// which step failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HgError {
+    pub code: i32,
+    pub ctx: &'static str,
+}
+
+impl HgError {
+    pub fn new(code: i32, ctx: &'static str) -> Self {
+        Self { code, ctx }
+    }
+}
+
+impl fmt::Display for HgError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "mercury {ctx} failed: code {code}",
+            ctx = self.ctx,
+            code = self.code
+        )
+    }
+}
+
+impl std::error::Error for HgError {}
+
+/// Translate a Mercury return code into `Result<()>`. Use at every
+/// FFI boundary; the `ctx` argument is a static string identifying
+/// the caller so error messages are debuggable without backtraces.
+pub fn check(ret: ffi::hg_return_t, ctx: &'static str) -> Result<()> {
+    if ret == ffi::HG_SUCCESS {
+        Ok(())
+    } else {
+        Err(HgError::new(ret as i32, ctx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_success_returns_ok() {
+        assert!(check(ffi::HG_SUCCESS, "ctx").is_ok());
+    }
+
+    #[test]
+    fn check_nonzero_returns_error_with_code_and_ctx() {
+        let e = check(-7, "did-fail").unwrap_err();
+        assert_eq!(e.code, -7);
+        assert_eq!(e.ctx, "did-fail");
+    }
+
+    #[test]
+    fn display_includes_code_and_ctx() {
+        let e = HgError::new(42, "site");
+        let s = format!("{e}");
+        assert!(s.contains("42"), "missing code: {s}");
+        assert!(s.contains("site"), "missing ctx: {s}");
+    }
+
+    #[test]
+    fn error_implements_std_error() {
+        fn assert_err<E: std::error::Error>(_: &E) {}
+        assert_err(&HgError::new(0, "x"));
+    }
+
+    #[test]
+    fn equality_is_by_code_and_ctx() {
+        assert_eq!(HgError::new(1, "a"), HgError::new(1, "a"));
+        assert_ne!(HgError::new(1, "a"), HgError::new(2, "a"));
+        assert_ne!(HgError::new(1, "a"), HgError::new(1, "b"));
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/ffi.rs
+++ b/cmd/unbounded-storage/src/mercury/ffi.rs
@@ -1,0 +1,306 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+use std::os::raw::{c_char, c_int, c_uint, c_void};
+
+pub type hg_return_t = c_int;
+pub type hg_size_t = u64;
+pub type hg_id_t = u64;
+pub type hg_uint8_t = u8;
+pub type hg_uint32_t = u32;
+pub type hg_uint64_t = u64;
+pub type hg_bool_t = u8;
+
+#[repr(C)]
+pub struct hg_class {
+    _private: [u8; 0],
+}
+#[repr(C)]
+pub struct hg_context {
+    _private: [u8; 0],
+}
+#[repr(C)]
+pub struct hg_handle {
+    _private: [u8; 0],
+}
+#[repr(C)]
+pub struct hg_addr_s {
+    _private: [u8; 0],
+}
+#[repr(C)]
+pub struct hg_bulk_s {
+    _private: [u8; 0],
+}
+#[repr(C)]
+pub struct hg_op_id_s {
+    _private: [u8; 0],
+}
+#[repr(C)]
+pub struct hg_proc_s {
+    _private: [u8; 0],
+}
+
+pub type hg_class_t = *mut hg_class;
+pub type hg_context_t = *mut hg_context;
+pub type hg_handle_t = *mut hg_handle;
+pub type hg_addr_t = *mut hg_addr_s;
+pub type hg_bulk_t = *mut hg_bulk_s;
+pub type hg_op_id_t = *mut hg_op_id_s;
+pub type hg_proc_t = *mut hg_proc_s;
+
+pub const HG_SUCCESS: hg_return_t = 0;
+pub const HG_TRUE: hg_bool_t = 1;
+pub const HG_FALSE: hg_bool_t = 0;
+
+// hg_cb_type_t values (mercury_core_types.h).
+pub const HG_CB_LOOKUP: c_int = 0;
+pub const HG_CB_FORWARD: c_int = 1;
+pub const HG_CB_RESPOND: c_int = 2;
+pub const HG_CB_BULK: c_int = 3;
+
+// hg_bulk_op_t values (mercury_types.h).
+pub const HG_BULK_PUSH: c_int = 0;
+pub const HG_BULK_PULL: c_int = 1;
+
+// Bulk permission flags (mercury_bulk.h).
+pub const HG_BULK_READ_ONLY: hg_uint8_t = 1 << 0;
+pub const HG_BULK_WRITE_ONLY: hg_uint8_t = 1 << 1;
+pub const HG_BULK_READWRITE: hg_uint8_t = HG_BULK_READ_ONLY | HG_BULK_WRITE_ONLY;
+
+// hg_cb_info layout - large union with a tagged variant. We project
+// it as a fixed buffer because (1) we only care about a few fields
+// and (2) layout-stable cross-version access via field offsets is
+// risky. `hg_cb_info` is documented as having `ret`, `type`, `arg`
+// at the end; `info` is the union at the front. We inspect what we
+// need by knowing which `cb_type` we registered for the call.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct hg_cb_info_forward {
+    pub handle: hg_handle_t,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct hg_cb_info_respond {
+    pub handle: hg_handle_t,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct hg_cb_info_lookup {
+    pub addr: hg_addr_t,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct hg_cb_info_bulk {
+    pub origin_handle: hg_bulk_t,
+    pub local_handle: hg_bulk_t,
+    pub op: c_int,
+    pub size: hg_size_t,
+}
+
+#[repr(C)]
+pub union hg_cb_info_payload {
+    pub lookup: hg_cb_info_lookup,
+    pub forward: hg_cb_info_forward,
+    pub respond: hg_cb_info_respond,
+    pub bulk: hg_cb_info_bulk,
+}
+
+#[repr(C)]
+pub struct hg_cb_info {
+    pub info: hg_cb_info_payload,
+    pub arg: *mut c_void,
+    pub ty: c_int,
+    pub ret: hg_return_t,
+}
+
+pub type hg_cb_t = unsafe extern "C" fn(callback_info: *const hg_cb_info) -> hg_return_t;
+pub type hg_rpc_cb_t = unsafe extern "C" fn(handle: hg_handle_t) -> hg_return_t;
+pub type hg_proc_cb_t = unsafe extern "C" fn(proc: hg_proc_t, data: *mut c_void) -> hg_return_t;
+
+unsafe extern "C" {
+    pub fn HG_Init_opt2(
+        na_info_string: *const c_char,
+        na_listen: hg_bool_t,
+        version: c_uint,
+        hg_init_info: *const c_void,
+    ) -> hg_class_t;
+    pub fn HG_Init(na_info_string: *const c_char, na_listen: hg_bool_t) -> hg_class_t;
+    pub fn HG_Finalize(hg_class: hg_class_t) -> hg_return_t;
+
+    pub fn HG_Context_create(hg_class: hg_class_t) -> hg_context_t;
+    pub fn HG_Context_destroy(context: hg_context_t) -> hg_return_t;
+
+    pub fn HG_Register_name(
+        hg_class: hg_class_t,
+        func_name: *const c_char,
+        in_proc_cb: Option<hg_proc_cb_t>,
+        out_proc_cb: Option<hg_proc_cb_t>,
+        rpc_cb: Option<hg_rpc_cb_t>,
+    ) -> hg_id_t;
+    pub fn HG_Register_data(
+        hg_class: hg_class_t,
+        id: hg_id_t,
+        data: *mut c_void,
+        free_callback: Option<unsafe extern "C" fn(*mut c_void)>,
+    ) -> hg_return_t;
+    pub fn HG_Registered_data(hg_class: hg_class_t, id: hg_id_t) -> *mut c_void;
+
+    pub fn HG_Addr_lookup2(
+        hg_class: hg_class_t,
+        name: *const c_char,
+        addr_p: *mut hg_addr_t,
+    ) -> hg_return_t;
+    pub fn HG_Addr_self(hg_class: hg_class_t, addr_p: *mut hg_addr_t) -> hg_return_t;
+    pub fn HG_Addr_free(hg_class: hg_class_t, addr: hg_addr_t) -> hg_return_t;
+    pub fn HG_Addr_to_string(
+        hg_class: hg_class_t,
+        buf: *mut c_char,
+        buf_size_p: *mut hg_size_t,
+        addr: hg_addr_t,
+    ) -> hg_return_t;
+
+    pub fn HG_Create(
+        context: hg_context_t,
+        addr: hg_addr_t,
+        id: hg_id_t,
+        handle_p: *mut hg_handle_t,
+    ) -> hg_return_t;
+    pub fn HG_Destroy(handle: hg_handle_t) -> hg_return_t;
+    pub fn HG_Forward(
+        handle: hg_handle_t,
+        callback: Option<hg_cb_t>,
+        arg: *mut c_void,
+        in_struct: *mut c_void,
+    ) -> hg_return_t;
+    pub fn HG_Respond(
+        handle: hg_handle_t,
+        callback: Option<hg_cb_t>,
+        arg: *mut c_void,
+        out_struct: *mut c_void,
+    ) -> hg_return_t;
+    pub fn HG_Cancel(handle: hg_handle_t) -> hg_return_t;
+    pub fn HG_Get_input(handle: hg_handle_t, in_struct: *mut c_void) -> hg_return_t;
+    pub fn HG_Free_input(handle: hg_handle_t, in_struct: *mut c_void) -> hg_return_t;
+    pub fn HG_Get_output(handle: hg_handle_t, out_struct: *mut c_void) -> hg_return_t;
+    pub fn HG_Free_output(handle: hg_handle_t, out_struct: *mut c_void) -> hg_return_t;
+
+    pub fn HG_Progress(context: hg_context_t, timeout: c_uint) -> hg_return_t;
+    pub fn HG_Trigger(
+        context: hg_context_t,
+        timeout: c_uint,
+        max_count: c_uint,
+        actual_count_p: *mut c_uint,
+    ) -> hg_return_t;
+
+    pub fn HG_Bulk_create(
+        hg_class: hg_class_t,
+        count: hg_uint32_t,
+        buf_ptrs: *mut *mut c_void,
+        buf_sizes: *const hg_size_t,
+        flags: hg_uint8_t,
+        handle: *mut hg_bulk_t,
+    ) -> hg_return_t;
+    pub fn HG_Bulk_free(handle: hg_bulk_t) -> hg_return_t;
+    pub fn HG_Bulk_transfer(
+        context: hg_context_t,
+        callback: Option<hg_cb_t>,
+        arg: *mut c_void,
+        op: c_int,
+        origin_addr: hg_addr_t,
+        origin_handle: hg_bulk_t,
+        origin_offset: hg_size_t,
+        local_handle: hg_bulk_t,
+        local_offset: hg_size_t,
+        size: hg_size_t,
+        op_id: *mut hg_op_id_t,
+    ) -> hg_return_t;
+}
+
+// Mercury's `struct hg_info` carries the class, context, and addr for
+// a handle; we only need the first three fields. Their layout is
+// stable and documented in `mercury.h`.
+#[repr(C)]
+pub struct HgInfo {
+    pub hg_class: hg_class_t,
+    pub context: hg_context_t,
+    pub addr: hg_addr_t,
+    pub id: hg_id_t,
+    pub context_id: hg_uint8_t,
+}
+
+// Shim symbols compiled from `shim.c`.
+unsafe extern "C" {
+    pub fn ub_proc_bulk_get_in(proc: hg_proc_t, data: *mut c_void) -> hg_return_t;
+    pub fn ub_proc_bulk_get_out(proc: hg_proc_t, data: *mut c_void) -> hg_return_t;
+    pub fn ub_sizeof_bulk_get_in() -> usize;
+    pub fn ub_sizeof_bulk_get_out() -> usize;
+    pub fn ub_handle_info(handle: hg_handle_t) -> *const HgInfo;
+}
+
+// ---------------------------------------------------------------------------
+// Callback dispatch helpers.
+//
+// Every Mercury completion callback shares the same boilerplate: null-check
+// `info`, deref it, and project out the fields the handler actually needs.
+// The forward variant also has to read the `forward.handle` member of the
+// tagged union. Centralizing the unsafe deref here means individual
+// callbacks in `transport.rs` and `server.rs` no longer touch raw pointers
+// or union fields.
+// ---------------------------------------------------------------------------
+
+/// Fields surfaced from a forward-RPC completion `hg_cb_info`.
+pub struct ForwardCbInfo {
+    pub handle: hg_handle_t,
+    pub ret: hg_return_t,
+    pub arg: *mut c_void,
+}
+
+/// Dispatch a forward-RPC completion callback. Null-checks `info`,
+/// projects out the `forward` variant of the union, and hands it to `f`.
+///
+/// Safe to call from any `unsafe extern "C" fn` that Mercury invokes as a
+/// forward callback. Mercury guarantees `info`, if non-null, points to a
+/// valid `hg_cb_info` for the duration of the call.
+pub fn dispatch_forward_cb(
+    info: *const hg_cb_info,
+    f: impl FnOnce(ForwardCbInfo) -> hg_return_t,
+) -> hg_return_t {
+    if info.is_null() {
+        return HG_SUCCESS;
+    }
+    // SAFETY: per Mercury's callback contract, `info` is valid for the
+    // duration of the callback. We register only forward callbacks against
+    // forward RPCs, so the `forward` union variant is the live one.
+    let cb = unsafe {
+        let r = &*info;
+        ForwardCbInfo {
+            handle: r.info.forward.handle,
+            ret: r.ret,
+            arg: r.arg,
+        }
+    };
+    f(cb)
+}
+
+/// Dispatch a callback that only needs `ret` and `arg` (bulk transfers
+/// and respond completions). The union variant is not inspected.
+pub fn dispatch_simple_cb(
+    info: *const hg_cb_info,
+    f: impl FnOnce(hg_return_t, *mut c_void) -> hg_return_t,
+) -> hg_return_t {
+    if info.is_null() {
+        return HG_SUCCESS;
+    }
+    // SAFETY: same contract as `dispatch_forward_cb`.
+    let (ret, arg) = unsafe {
+        let r = &*info;
+        (r.ret, r.arg)
+    };
+    f(ret, arg)
+}

--- a/cmd/unbounded-storage/src/mercury/handle.rs
+++ b/cmd/unbounded-storage/src/mercury/handle.rs
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! RAII wrappers over Mercury's `hg_handle_t` and decoded output structs.
+//!
+//! The bare FFI threads handle lifetimes through every error path by hand:
+//! `HG_Create` produces a handle, `HG_Forward`/`HG_Respond` consume it on
+//! success, and the callback (or the caller) is responsible for `HG_Destroy`.
+//! Likewise `HG_Get_output` allocates proc-owned fields that must be paired
+//! with `HG_Free_output`. Both pairings become Rust ownership here so the
+//! transport and server code no longer carry one `unsafe` block per call.
+
+use std::ffi::c_void;
+use std::ops::Deref;
+
+use crate::mercury::class::ClassInner;
+use crate::mercury::error::{HgError, Result, check};
+use crate::mercury::ffi;
+
+/// RAII wrapper around an `hg_handle_t`. Dropping the wrapper calls
+/// `HG_Destroy`.
+///
+/// Ownership semantics intentionally mirror the FFI:
+///
+/// - `forward` consumes the wrapper because Mercury takes ownership of the
+///   handle for the duration of the in-flight RPC; the forward callback
+///   reconstructs a wrapper from the union variant and lets it drop.
+/// - `respond` borrows the wrapper because the server-side flow awaits the
+///   respond callback (which only signals completion) and then destroys the
+///   handle on the executor thread by dropping the wrapper.
+pub(crate) struct Handle(ffi::hg_handle_t);
+
+impl Handle {
+    /// Wrap an existing raw `hg_handle_t`.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a live handle that the caller now exclusively owns.
+    /// Typical sources: `Handle::into_raw`, the `forward.handle` field of
+    /// `hg_cb_info` inside a forward callback, or the handle argument to a
+    /// registered RPC callback.
+    pub(crate) unsafe fn from_raw(raw: ffi::hg_handle_t) -> Self {
+        Self(raw)
+    }
+
+    /// Borrow the raw handle without giving up ownership.
+    pub(crate) fn as_raw(&self) -> ffi::hg_handle_t {
+        self.0
+    }
+
+    /// Surrender ownership of the raw handle, suppressing `Drop`. The caller
+    /// is responsible for destruction (directly via `HG_Destroy` or by
+    /// reconstructing a `Handle` with `from_raw`).
+    pub(crate) fn into_raw(self) -> ffi::hg_handle_t {
+        let raw = self.0;
+        std::mem::forget(self);
+        raw
+    }
+
+    /// Create a client-side handle bound to `addr` on the class's context
+    /// and registered RPC id.
+    pub(crate) fn create(class: &ClassInner, addr: ffi::hg_addr_t) -> Result<Self> {
+        let mut h: ffi::hg_handle_t = std::ptr::null_mut();
+        // SAFETY: `hg_context` and `rpc_id` are class-owned and live for the
+        // lifetime of `ClassInner`; `addr` is owned by the peer table.
+        let ret = unsafe { ffi::HG_Create(class.hg_context, addr, class.rpc_id, &mut h) };
+        check(ret, "HG_Create")?;
+        Ok(Self(h))
+    }
+
+    /// Submit `HG_Forward`. Consumes `self`: on success the FFI owns the
+    /// handle until its callback fires; on error the handle is destroyed
+    /// by the wrapper's `Drop`.
+    pub(crate) fn forward<I>(
+        self,
+        cb: ffi::hg_cb_t,
+        arg: *mut c_void,
+        input: &mut I,
+    ) -> Result<()> {
+        // SAFETY: handle is live; `input` is borrowed for the duration of
+        // the call. Mercury copies any indirect bytes through the proc
+        // synchronously, so `input` does not need to outlive this call.
+        let ret = unsafe { ffi::HG_Forward(self.0, Some(cb), arg, input as *mut _ as *mut c_void) };
+        if ret != ffi::HG_SUCCESS {
+            // `self` drops here -> `HG_Destroy` runs.
+            return Err(HgError::new(ret as i32, "HG_Forward"));
+        }
+        // Ownership has transferred to the FFI/callback.
+        let _ = self.into_raw();
+        Ok(())
+    }
+
+    /// Submit `HG_Respond` without giving up ownership of the handle.
+    pub(crate) fn respond<O>(
+        &self,
+        cb: ffi::hg_cb_t,
+        arg: *mut c_void,
+        output: &mut O,
+    ) -> Result<()> {
+        // SAFETY: handle is live for the duration of `&self`; `output` is
+        // borrowed for the call and Mercury copies through the proc.
+        let ret =
+            unsafe { ffi::HG_Respond(self.0, Some(cb), arg, output as *mut _ as *mut c_void) };
+        check(ret, "HG_Respond")
+    }
+
+    /// Decode the incoming input struct via `HG_Get_input`. The caller is
+    /// responsible for the matching `HG_Free_input` because Mercury's
+    /// `HG_FREE` op also frees nested bulk handles, which the server
+    /// pipeline still needs to drive after this call returns.
+    pub(crate) fn get_input<I>(&self, out: &mut I) -> Result<()> {
+        // SAFETY: handle is live; `out` is borrowed for the call. Mercury
+        // decodes into `*out`.
+        let ret = unsafe { ffi::HG_Get_input(self.0, out as *mut _ as *mut c_void) };
+        check(ret, "HG_Get_input")
+    }
+
+    /// Free the proc-owned input previously decoded with `get_input`.
+    pub(crate) fn free_input<I>(&self, out: &mut I) {
+        // SAFETY: paired with a successful `get_input` on the same handle.
+        unsafe {
+            let _ = ffi::HG_Free_input(self.0, out as *mut _ as *mut c_void);
+        }
+    }
+
+    /// Decode the output struct into a guard that calls `HG_Free_output`
+    /// on drop.
+    pub(crate) fn get_output<O>(&self, mut init: O) -> Result<OutputGuard<'_, O>> {
+        // SAFETY: handle is live; `init` is owned by us until the guard
+        // takes it.
+        let ret = unsafe { ffi::HG_Get_output(self.0, &mut init as *mut _ as *mut c_void) };
+        check(ret, "HG_Get_output")?;
+        Ok(OutputGuard {
+            handle: self,
+            out: Some(init),
+        })
+    }
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was either produced by `HG_Create` or handed to
+        // us by Mercury and is destroyed exactly once here.
+        unsafe {
+            let _ = ffi::HG_Destroy(self.0);
+        }
+    }
+}
+
+/// RAII guard returned by `Handle::get_output`. Derefs to the decoded
+/// output struct; calls `HG_Free_output` on drop.
+pub(crate) struct OutputGuard<'a, O> {
+    handle: &'a Handle,
+    out: Option<O>,
+}
+
+impl<O> Deref for OutputGuard<'_, O> {
+    type Target = O;
+    fn deref(&self) -> &O {
+        self.out.as_ref().expect("output guard already consumed")
+    }
+}
+
+impl<O> Drop for OutputGuard<'_, O> {
+    fn drop(&mut self) {
+        if let Some(mut o) = self.out.take() {
+            // SAFETY: paired with the `HG_Get_output` call in
+            // `Handle::get_output`; the handle is still live because we
+            // hold a borrow of it.
+            unsafe {
+                let _ = ffi::HG_Free_output(self.handle.as_raw(), &mut o as *mut _ as *mut c_void);
+            }
+        }
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/mod.rs
+++ b/cmd/unbounded-storage/src/mercury/mod.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+mod bulk;
+mod class;
+mod config;
+mod error;
+mod ffi;
+mod handle;
+mod peer;
+pub mod progress;
+mod router;
+mod rpc;
+mod server;
+mod transport;
+
+pub use class::Class;
+pub use config::{PeerEntry, TransportConfig};
+pub use error::{HgError, Result};
+pub use router::{PeerRouter, StaticPeer};
+pub use server::{BulkSource, MercuryServer};
+pub use transport::MercuryTransport;
+
+#[cfg(test)]
+mod tests;

--- a/cmd/unbounded-storage/src/mercury/peer.rs
+++ b/cmd/unbounded-storage/src/mercury/peer.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Eager peer-address resolution. Mercury's `HG_Addr_lookup2` is
+//! synchronous on libfabric NA backends; we call it once per peer
+//! at class construction and stash the resulting `hg_addr_t` for
+//! the lifetime of the class.
+
+use std::ffi::CString;
+
+use crate::bufferpool::PeerId;
+use crate::mercury::config::PeerEntry;
+use crate::mercury::error::{HgError, Result, check};
+use crate::mercury::ffi;
+
+/// Resolved peer table. Holds owning references to Mercury
+/// addresses; freeing happens in `Drop`.
+pub(crate) struct PeerTable {
+    hg_class: ffi::hg_class_t,
+    entries: Vec<(PeerId, ffi::hg_addr_t)>,
+}
+
+impl PeerTable {
+    /// Look up every peer in `cfg`. On any failure the partial
+    /// table is freed and the error is returned.
+    pub(crate) fn new(hg_class: ffi::hg_class_t, peers: &[PeerEntry]) -> Result<Self> {
+        let mut table = Self {
+            hg_class,
+            entries: Vec::with_capacity(peers.len()),
+        };
+        for entry in peers {
+            let cname = CString::new(entry.addr.as_str())
+                .map_err(|_| HgError::new(0, "peer addr contains NUL"))?;
+            let mut addr: ffi::hg_addr_t = std::ptr::null_mut();
+            // SAFETY: `hg_class` is the live class returned by HG_Init;
+            // `cname` is a valid NUL-terminated string for the
+            // duration of the call; `addr` is a stack out-pointer.
+            let ret = unsafe { ffi::HG_Addr_lookup2(hg_class, cname.as_ptr(), &mut addr) };
+            check(ret, "HG_Addr_lookup2")?;
+            table.entries.push((entry.peer_id, addr));
+        }
+        Ok(table)
+    }
+
+    /// Resolve a `PeerId` to a Mercury address.
+    pub(crate) fn lookup(&self, peer: PeerId) -> Result<ffi::hg_addr_t> {
+        self.entries
+            .iter()
+            .find_map(|(id, addr)| if *id == peer { Some(*addr) } else { None })
+            .ok_or(HgError::new(0, "unknown PeerId"))
+    }
+}
+
+impl Drop for PeerTable {
+    fn drop(&mut self) {
+        for (_, addr) in self.entries.drain(..) {
+            if !addr.is_null() {
+                // SAFETY: addresses came from HG_Addr_lookup2 against
+                // the same class; freeing them once on drop is the
+                // documented contract. `ClassInner::drop` takes care
+                // to drop the table before calling `HG_Finalize`.
+                unsafe {
+                    ffi::HG_Addr_free(self.hg_class, addr);
+                }
+            }
+        }
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/progress.rs
+++ b/cmd/unbounded-storage/src/mercury/progress.rs
@@ -1,0 +1,677 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Cross-thread bridges between Mercury's progress thread and the
+//! single-threaded async executor that owns the bufferpool.
+//!
+//! Two flows cross the thread boundary:
+//!
+//!  1. *Completion bridge* (`CompletionRegistry`): client-side
+//!     `bulk_get` futures wait for forward-RPC callbacks fired by
+//!     `HG_Trigger` on the progress thread. The future allocates a
+//!     `CompletionSlot`, hands its raw pointer to `HG_Forward` as
+//!     the user arg, and parks via an `AtomicWaker`. The progress
+//!     thread writes the result into the slot and wakes the waker.
+//!
+//!  2. *Server-job bridge* (`ServerJobQueue`): the registered RPC
+//!     callback runs on the progress thread but the application's
+//!     bulk source lives on the executor thread. The callback
+//!     pushes a job onto the queue and the executor pulls jobs out
+//!     of it via the future returned by `next_job`.
+//!
+//! Both bridges are pure synchronization primitives - no Mercury
+//! calls happen here; that keeps the unsafe surface minimal and
+//! testable in isolation.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+use crate::mercury::error::{HgError, Result};
+
+const WAKER_NONE: u8 = 0;
+const WAKER_REGISTERED: u8 = 1;
+const WAKER_WOKEN: u8 = 3;
+
+/// Minimal `AtomicWaker`: register-store-wake state machine,
+/// avoiding a dependency on `futures-util`. Behaves like
+/// `futures_util::task::AtomicWaker` for our single-producer
+/// single-consumer use: the future registers on poll; the
+/// completer wakes exactly once.
+struct AtomicWaker {
+    state: AtomicU8,
+    waker: Mutex<Option<Waker>>,
+}
+
+impl AtomicWaker {
+    fn new() -> Self {
+        Self {
+            state: AtomicU8::new(WAKER_NONE),
+            waker: Mutex::new(None),
+        }
+    }
+
+    /// Register a fresh waker for later wakeup. Idempotent; safe to
+    /// call from successive polls.
+    fn register(&self, w: &Waker) {
+        // Fast path: if already woken, no need to store the waker.
+        if self.state.load(Ordering::Acquire) == WAKER_WOKEN {
+            w.wake_by_ref();
+            return;
+        }
+        if let Ok(mut slot) = self.waker.lock() {
+            *slot = Some(w.clone());
+        }
+        // Publish that a waker is now installed. If a wake raced us
+        // and saw WAKER_NONE, the state will already be WAKER_WOKEN,
+        // and the next caller path handles it.
+        let prev = self.state.swap(WAKER_REGISTERED, Ordering::AcqRel);
+        if prev == WAKER_WOKEN {
+            if let Ok(mut slot) = self.waker.lock() {
+                if let Some(w) = slot.take() {
+                    w.wake();
+                }
+            }
+        }
+    }
+
+    /// Wake the registered waker if any. Idempotent.
+    fn wake(&self) {
+        let prev = self.state.swap(WAKER_WOKEN, Ordering::AcqRel);
+        if prev == WAKER_REGISTERED {
+            if let Ok(mut slot) = self.waker.lock() {
+                if let Some(w) = slot.take() {
+                    w.wake();
+                }
+            }
+        }
+    }
+}
+
+/// State for one in-flight `bulk_get` future. `result` is `None`
+/// until the progress thread fills it in. `cancelled` short-circuits
+/// the future drop path so a callback that races a drop simply
+/// stores its result and finds nobody waiting.
+pub struct CompletionSlot {
+    pub(crate) result: Mutex<Option<Result<()>>>,
+    pub(crate) cancelled: AtomicBool,
+    waker: AtomicWaker,
+}
+
+impl CompletionSlot {
+    fn new() -> Self {
+        Self {
+            result: Mutex::new(None),
+            cancelled: AtomicBool::new(false),
+            waker: AtomicWaker::new(),
+        }
+    }
+
+    /// Called from the progress thread when a forward callback
+    /// fires. The slot retains the result regardless of cancellation
+    /// because the FFI guarantees the callback runs exactly once.
+    pub fn complete(&self, result: Result<()>) {
+        if let Ok(mut slot) = self.result.lock() {
+            *slot = Some(result);
+        }
+        self.waker.wake();
+    }
+
+    /// Returns whether the owning `CompletionFuture` has been dropped.
+    /// Visible to tests; production code does not need it because the
+    /// callback always runs to completion regardless.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Convert an owned `Arc<Self>` into a `*mut c_void` suitable as the
+    /// user-arg for an FFI callback. The returned pointer carries one
+    /// strong reference that must later be reclaimed via
+    /// [`from_callback_arg`].
+    pub fn into_callback_arg(self: Arc<Self>) -> *mut std::ffi::c_void {
+        Arc::into_raw(self) as *mut std::ffi::c_void
+    }
+
+    /// Reclaim the strong reference produced by [`into_callback_arg`].
+    ///
+    /// # Safety
+    ///
+    /// `arg` must be a pointer produced by [`into_callback_arg`], used
+    /// to reclaim that reference exactly once.
+    pub unsafe fn from_callback_arg(arg: *mut std::ffi::c_void) -> Arc<Self> {
+        unsafe { Arc::from_raw(arg as *const CompletionSlot) }
+    }
+}
+
+/// Bounded registry of in-flight completion slots. Slot identity is
+/// the `Arc<CompletionSlot>` itself; we don't hand opaque integer
+/// ids to C because the FFI accepts a `void *` user arg directly,
+/// which is much harder to misuse.
+///
+/// The "registry" exists to enforce `max_inflight` and to keep
+/// strong references alive while the FFI holds the raw pointer.
+pub struct CompletionRegistry {
+    cap: usize,
+    live: Mutex<Vec<Arc<CompletionSlot>>>,
+    /// Peak observed `live.len()` across the lifetime of this
+    /// registry. Used by DST tests to assert `max_inflight` was
+    /// honored; production code does not read this.
+    peak: AtomicUsize,
+}
+
+impl CompletionRegistry {
+    pub fn new(cap: usize) -> Arc<Self> {
+        Arc::new(Self {
+            cap: cap.max(1),
+            live: Mutex::new(Vec::with_capacity(cap.min(1024))),
+            peak: AtomicUsize::new(0),
+        })
+    }
+
+    /// Allocate a new slot. Fails with `HgError` if the registry is
+    /// full; this surfaces as `bufferpool::Error::Transport`.
+    pub fn alloc(&self) -> Result<Arc<CompletionSlot>> {
+        let mut live = self.live.lock().expect("completion registry mutex");
+        if live.len() >= self.cap {
+            return Err(HgError::new(0, "completion registry full"));
+        }
+        let slot = Arc::new(CompletionSlot::new());
+        live.push(slot.clone());
+        let now = live.len();
+        // Relaxed: we only need a monotonic upper bound for the
+        // peak; readers in tests fence via their own ordering.
+        let mut prev = self.peak.load(Ordering::Relaxed);
+        while now > prev {
+            match self
+                .peak
+                .compare_exchange_weak(prev, now, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => break,
+                Err(observed) => prev = observed,
+            }
+        }
+        Ok(slot)
+    }
+
+    /// Release a slot once the caller is done with it. The shared
+    /// `Arc<CompletionSlot>` only goes away when *both* the
+    /// registry-side and FFI-side references drop, so a late
+    /// callback never dereferences freed memory.
+    pub fn release(&self, slot: &Arc<CompletionSlot>) {
+        if let Ok(mut live) = self.live.lock() {
+            live.retain(|s| !Arc::ptr_eq(s, slot));
+        }
+    }
+
+    /// Number of slots currently held by the registry. Visible to
+    /// tests for the "no leak" invariant; production code does not
+    /// read this.
+    pub fn live_count(&self) -> usize {
+        self.live.lock().map(|g| g.len()).unwrap_or(0)
+    }
+
+    /// Highest `live_count` observed since construction. Test-only.
+    pub fn peak_inflight(&self) -> usize {
+        self.peak.load(Ordering::Relaxed)
+    }
+
+    /// Configured upper bound. Test-only accessor.
+    pub fn capacity(&self) -> usize {
+        self.cap
+    }
+}
+
+/// One-shot completion bundle. Bundles a fresh single-slot registry,
+/// the future the caller awaits, and the raw `*mut c_void` that the
+/// caller hands to an FFI submission as its user arg. If the
+/// submission fails synchronously, the caller must invoke
+/// [`Oneshot::reclaim`] on the arg so the leaked strong reference
+/// drops instead of leaking forever.
+pub(crate) struct Oneshot {
+    pub(crate) future: CompletionFuture,
+    pub(crate) arg: *mut std::ffi::c_void,
+}
+
+impl Oneshot {
+    /// Build a fresh oneshot bundle. The slot's strong-ref count is
+    /// two: one held by the future, one leaked into `arg`.
+    pub(crate) fn new() -> Self {
+        let registry = CompletionRegistry::new(1);
+        let slot = registry.alloc().expect("oneshot registry has capacity 1");
+        let arg = slot.clone().into_callback_arg();
+        Self {
+            future: CompletionFuture { slot, registry },
+            arg,
+        }
+    }
+
+    /// Reclaim the strong reference embedded in `arg` after an FFI
+    /// submission failed and its callback will not fire.
+    ///
+    /// # Safety
+    ///
+    /// `arg` must be the pointer returned by [`Oneshot::new`] from
+    /// the same bundle, and must not have been delivered to a
+    /// callback.
+    pub(crate) unsafe fn reclaim(arg: *mut std::ffi::c_void) {
+        // SAFETY: `arg` came from `CompletionSlot::into_callback_arg`
+        // in `Oneshot::new`.
+        unsafe {
+            let _ = CompletionSlot::from_callback_arg(arg);
+        }
+    }
+}
+
+/// Body shared by every one-shot FFI completion callback in the
+/// crate. Reclaims the slot from `arg`, resolves it with `Ok(())` on
+/// `HG_SUCCESS` or `Err(HgError::new(ret, ctx))` otherwise, and
+/// returns `HG_SUCCESS` so Mercury treats the callback as handled.
+///
+/// # Safety
+///
+/// `arg` must be a pointer previously produced by
+/// [`CompletionSlot::into_callback_arg`] (typically via
+/// [`Oneshot::new`]) and not yet reclaimed.
+pub(crate) unsafe fn complete_oneshot(
+    ret: crate::mercury::ffi::hg_return_t,
+    arg: *mut std::ffi::c_void,
+    ctx: &'static str,
+) -> crate::mercury::ffi::hg_return_t {
+    // SAFETY: caller contract.
+    let slot = unsafe { CompletionSlot::from_callback_arg(arg) };
+    let outcome = if ret == crate::mercury::ffi::HG_SUCCESS {
+        Ok(())
+    } else {
+        Err(HgError::new(ret as i32, ctx))
+    };
+    slot.complete(outcome);
+    crate::mercury::ffi::HG_SUCCESS
+}
+
+/// Future returned by the transport to its caller. Drops are safe:
+/// the `CompletionFuture` releases its slot through `release_on_drop`,
+/// and the FFI-side `Arc` (handed in as the forward user arg) is
+/// dropped from the C callback path regardless of caller liveness.
+pub struct CompletionFuture {
+    pub slot: Arc<CompletionSlot>,
+    pub registry: Arc<CompletionRegistry>,
+}
+
+impl Future for CompletionFuture {
+    type Output = Result<()>;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Register first so a wake that arrives between the check
+        // and the park stores into a queued waker, not the void.
+        self.slot.waker.register(cx.waker());
+        let mut result = self.slot.result.lock().expect("completion slot mutex");
+        if let Some(r) = result.take() {
+            Poll::Ready(r)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl Drop for CompletionFuture {
+    fn drop(&mut self) {
+        self.slot.cancelled.store(true, Ordering::Release);
+        self.registry.release(&self.slot);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server-job bridge.
+// ---------------------------------------------------------------------------
+
+/// One incoming RPC waiting for the executor to handle it. The
+/// `hg_handle` and the decoded input are wrapped in `Send` newtypes
+/// (`UnsafeSendPtr`) so the queue itself is `Send`; the executor
+/// thread is responsible for honoring Mercury's threading rules
+/// when it touches them (in practice we only call `HG_Bulk_transfer`
+/// and `HG_Respond` from the progress thread, never the executor).
+pub struct ServerJob {
+    pub handle: UnsafeSendPtr,
+    pub input_struct: UnsafeSendPtr,
+}
+
+/// Newtype that promises the embedder upholds Mercury's
+/// thread-safety contract for the wrapped pointer. We only use it to
+/// shuttle pointers across the bridge; no read or write happens
+/// inside the type.
+#[derive(Copy, Clone)]
+pub struct UnsafeSendPtr(pub *mut std::ffi::c_void);
+unsafe impl Send for UnsafeSendPtr {}
+unsafe impl Sync for UnsafeSendPtr {}
+
+/// MPSC queue feeding the executor-side server task. The progress
+/// thread pushes; the executor polls `next_job`.
+pub struct ServerJobQueue {
+    inner: Mutex<ServerJobInner>,
+    waker: AtomicWaker,
+}
+
+struct ServerJobInner {
+    jobs: VecDeque<ServerJob>,
+    closed: bool,
+}
+
+impl ServerJobQueue {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(ServerJobInner {
+                jobs: VecDeque::new(),
+                closed: false,
+            }),
+            waker: AtomicWaker::new(),
+        })
+    }
+
+    /// Called from the Mercury RPC callback on the progress thread.
+    #[doc(hidden)]
+    pub fn push(&self, job: ServerJob) {
+        if let Ok(mut inner) = self.inner.lock() {
+            if !inner.closed {
+                inner.jobs.push_back(job);
+            }
+        }
+        self.waker.wake();
+    }
+
+    /// Called by `Class::shutdown` so pending `next_job` futures
+    /// resolve to `None` and the executor-side server task exits.
+    pub fn close(&self) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.closed = true;
+        }
+        self.waker.wake();
+    }
+
+    /// Async pop, used by the executor-side server task to await
+    /// the next RPC. Returns `None` once the queue is closed and
+    /// drained.
+    pub fn next_job(self: &Arc<Self>) -> NextJob {
+        NextJob {
+            queue: self.clone(),
+        }
+    }
+}
+
+pub struct NextJob {
+    queue: Arc<ServerJobQueue>,
+}
+
+impl Future for NextJob {
+    type Output = Option<ServerJob>;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.queue.waker.register(cx.waker());
+        let mut inner = self.queue.inner.lock().expect("server queue mutex");
+        if let Some(job) = inner.jobs.pop_front() {
+            Poll::Ready(Some(job))
+        } else if inner.closed {
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::task::{RawWaker, RawWakerVTable, Waker};
+
+    fn noop_waker() -> Waker {
+        fn no(_: *const ()) {}
+        fn clone(_: *const ()) -> RawWaker {
+            RawWaker::new(std::ptr::null(), &VT)
+        }
+        static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
+        // SAFETY: the vtable's functions never dereference the data
+        // pointer, so a null data pointer is sound for this waker.
+        unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VT)) }
+    }
+
+    #[test]
+    fn completion_completes_and_wakes() {
+        let reg = CompletionRegistry::new(4);
+        let slot = reg.alloc().unwrap();
+        let mut fut = CompletionFuture {
+            slot: slot.clone(),
+            registry: reg.clone(),
+        };
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+        assert!(Pin::new(&mut fut).poll(&mut cx).is_pending());
+
+        slot.complete(Ok(()));
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(Ok(())) => {}
+            other => panic!(
+                "expected ready Ok, got {:?}",
+                matches!(other, Poll::Ready(_))
+            ),
+        }
+    }
+
+    #[test]
+    fn registry_full_returns_error() {
+        let reg = CompletionRegistry::new(2);
+        let a = reg.alloc().unwrap();
+        let _b = reg.alloc().unwrap();
+        assert!(reg.alloc().is_err());
+        // Releasing through the future-drop path frees a slot.
+        let fut = CompletionFuture {
+            slot: a.clone(),
+            registry: reg.clone(),
+        };
+        drop(fut);
+        assert!(reg.alloc().is_ok());
+    }
+
+    #[test]
+    fn server_queue_round_trips() {
+        let q = ServerJobQueue::new();
+        let q2 = q.clone();
+        let t = std::thread::spawn(move || {
+            q2.push(ServerJob {
+                handle: UnsafeSendPtr(0x1 as *mut _),
+                input_struct: UnsafeSendPtr(0x2 as *mut _),
+            });
+        });
+        t.join().unwrap();
+
+        let mut fut = q.next_job();
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(Some(job)) => {
+                assert_eq!(job.handle.0 as usize, 0x1);
+                assert_eq!(job.input_struct.0 as usize, 0x2);
+            }
+            _ => panic!("expected job"),
+        }
+
+        q.close();
+        let mut fut = q.next_job();
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(None) => {}
+            _ => panic!("expected None after close"),
+        }
+    }
+
+    #[test]
+    fn completion_error_propagates() {
+        let reg = CompletionRegistry::new(1);
+        let slot = reg.alloc().unwrap();
+        let mut fut = CompletionFuture {
+            slot: slot.clone(),
+            registry: reg.clone(),
+        };
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+        assert!(Pin::new(&mut fut).poll(&mut cx).is_pending());
+
+        slot.complete(Err(HgError::new(-3, "boom")));
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(Err(e)) => {
+                assert_eq!(e.code, -3);
+                assert_eq!(e.ctx, "boom");
+            }
+            _ => panic!("expected ready err"),
+        }
+    }
+
+    #[test]
+    fn registry_peak_tracks_highest_live() {
+        let reg = CompletionRegistry::new(4);
+        let _a = reg.alloc().unwrap();
+        let _b = reg.alloc().unwrap();
+        let c = reg.alloc().unwrap();
+        assert_eq!(reg.peak_inflight(), 3);
+        reg.release(&c);
+        drop(c);
+        // Releasing does not lower the peak.
+        let _d = reg.alloc().unwrap();
+        assert_eq!(reg.peak_inflight(), 3);
+        assert_eq!(reg.capacity(), 4);
+    }
+
+    #[test]
+    fn registry_release_via_future_drop_lowers_live_count() {
+        let reg = CompletionRegistry::new(2);
+        let a = reg.alloc().unwrap();
+        assert_eq!(reg.live_count(), 1);
+        let fut = CompletionFuture {
+            slot: a.clone(),
+            registry: reg.clone(),
+        };
+        drop(fut);
+        assert_eq!(reg.live_count(), 0);
+        assert!(a.is_cancelled());
+    }
+
+    #[test]
+    fn callback_arg_round_trip_preserves_strong_count() {
+        let reg = CompletionRegistry::new(1);
+        let slot = reg.alloc().unwrap();
+        // alloc returns one ref; registry retains another.
+        assert_eq!(Arc::strong_count(&slot), 2);
+        let arg = slot.clone().into_callback_arg();
+        assert_eq!(Arc::strong_count(&slot), 3);
+        // SAFETY: `arg` was just produced by `into_callback_arg`.
+        let reclaimed = unsafe { CompletionSlot::from_callback_arg(arg) };
+        assert!(Arc::ptr_eq(&reclaimed, &slot));
+        assert_eq!(Arc::strong_count(&slot), 3); // reclaim consumed the leaked ref
+        drop(reclaimed);
+        assert_eq!(Arc::strong_count(&slot), 2);
+    }
+
+    #[test]
+    fn oneshot_reclaim_releases_strong_ref() {
+        let oneshot = Oneshot::new();
+        // future holds one slot ref; arg holds another.
+        let slot_weak = Arc::downgrade(&oneshot.future.slot);
+        let arg = oneshot.arg;
+        // Drop future first so only the leaked Arc keeps the slot alive.
+        drop(oneshot.future);
+        assert!(slot_weak.strong_count() >= 1);
+        // SAFETY: `arg` came from `Oneshot::new` and has not been delivered.
+        unsafe {
+            Oneshot::reclaim(arg);
+        }
+        assert_eq!(slot_weak.strong_count(), 0);
+    }
+
+    #[test]
+    fn oneshot_future_completes_via_complete_oneshot() {
+        let oneshot = Oneshot::new();
+        let arg = oneshot.arg;
+        let mut fut = oneshot.future;
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+        assert!(Pin::new(&mut fut).poll(&mut cx).is_pending());
+
+        // SAFETY: `arg` came from `Oneshot::new`.
+        let ret = unsafe { complete_oneshot(crate::mercury::ffi::HG_SUCCESS, arg, "test-ctx") };
+        assert_eq!(ret, crate::mercury::ffi::HG_SUCCESS);
+
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(Ok(())) => {}
+            _ => panic!("expected Ready(Ok)"),
+        }
+    }
+
+    #[test]
+    fn complete_oneshot_propagates_error_with_ctx() {
+        let oneshot = Oneshot::new();
+        let arg = oneshot.arg;
+        let mut fut = oneshot.future;
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+        assert!(Pin::new(&mut fut).poll(&mut cx).is_pending());
+
+        // SAFETY: `arg` came from `Oneshot::new`.
+        let _ = unsafe { complete_oneshot(-9, arg, "site") };
+
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(Err(e)) => {
+                assert_eq!(e.code, -9);
+                assert_eq!(e.ctx, "site");
+            }
+            _ => panic!("expected Ready(Err)"),
+        }
+    }
+
+    #[test]
+    fn waker_wake_before_register_still_wakes() {
+        // Models the race the AtomicWaker is meant to handle.
+        let reg = CompletionRegistry::new(1);
+        let slot = reg.alloc().unwrap();
+        // Complete *before* anyone polls / registers a waker.
+        slot.complete(Ok(()));
+
+        let mut fut = CompletionFuture {
+            slot,
+            registry: reg.clone(),
+        };
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(Ok(())) => {}
+            _ => panic!("expected Ready(Ok) on first poll"),
+        }
+    }
+
+    #[test]
+    fn server_queue_post_close_pushes_are_dropped() {
+        let q = ServerJobQueue::new();
+        q.push(ServerJob {
+            handle: UnsafeSendPtr(0xAA as *mut _),
+            input_struct: UnsafeSendPtr(0xBB as *mut _),
+        });
+        q.close();
+        // Post-close push silently dropped.
+        q.push(ServerJob {
+            handle: UnsafeSendPtr(0xCC as *mut _),
+            input_struct: UnsafeSendPtr(0xDD as *mut _),
+        });
+
+        let mut fut = q.next_job();
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(Some(job)) => {
+                assert_eq!(job.handle.0 as usize, 0xAA);
+            }
+            _ => panic!("expected pre-close job"),
+        }
+        let mut fut = q.next_job();
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(None) => {}
+            _ => panic!("expected None: post-close push must be dropped"),
+        }
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/router.rs
+++ b/cmd/unbounded-storage/src/mercury/router.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::bufferpool::PeerId;
+use crate::mercury::error::Result;
+
+/// Maps a typed request to a peer. The transport calls this exactly
+/// once per `bulk_get` before forwarding.
+pub trait PeerRouter<R> {
+    fn route(&self, req: &R) -> Result<PeerId>;
+}
+
+/// Constant router: every request goes to the same peer. Convenient
+/// for unit tests and for simple two-node topologies.
+pub struct StaticPeer(pub PeerId);
+
+impl<R> PeerRouter<R> for StaticPeer {
+    fn route(&self, _req: &R) -> Result<PeerId> {
+        Ok(self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_peer_returns_configured_peer_for_any_request() {
+        let r = StaticPeer(PeerId(7));
+        assert_eq!(PeerRouter::<()>::route(&r, &()).unwrap(), PeerId(7));
+        assert_eq!(PeerRouter::<u32>::route(&r, &42).unwrap(), PeerId(7));
+        // Confirm it really is constant across distinct request values.
+        assert_eq!(PeerRouter::<u32>::route(&r, &0).unwrap(), PeerId(7));
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/rpc.rs
+++ b/cmd/unbounded-storage/src/mercury/rpc.rs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Wire schema for the single `ub.bufferpool.bulk_get.v1` RPC.
+//!
+//! The Rust side stages input/output through plain `#[repr(C)]`
+//! structs that mirror `shim.c` byte-for-byte. The C shim provides
+//! the two proc callbacks Mercury needs to walk these structs on
+//! encode / decode; we never poke at proc internals from Rust.
+//!
+//! The opaque `req_bytes` slice carries the bincode-encoded
+//! `R: Serialize`. Routing metadata (`stripe_key`, `stripe_off`,
+//! `len`) is duplicated on the wire so the server can dispatch a
+//! request without deserializing `R` if its source happens not to
+//! need it.
+
+use crate::mercury::ffi;
+
+/// Single registered RPC name. Bumping `v1` is the migration path
+/// if the wire ever needs to change.
+pub const RPC_NAME: &[u8] = b"ub.bufferpool.bulk_get.v1\0";
+
+/// Wire input. Field order and types match `struct ub_bulk_get_in`
+/// in `shim.c`; do not reorder without updating the shim.
+#[repr(C)]
+pub struct BulkGetIn {
+    pub stripe_key: [u8; 32],
+    pub stripe_off: u64,
+    pub dst_offset: u64,
+    pub len: u32,
+    pub req_bytes_len: u32,
+    /// On the client side, points into a `Box<[u8]>` owned by the
+    /// caller for the lifetime of the `HG_Forward` call. On the
+    /// server side, allocated by `malloc` inside the shim and freed
+    /// by `HG_Free_input` (which invokes the proc with `HG_FREE`).
+    pub req_bytes: *mut u8,
+    pub dst_bulk: ffi::hg_bulk_t,
+}
+
+impl BulkGetIn {
+    pub fn zeroed() -> Self {
+        Self {
+            stripe_key: [0u8; 32],
+            stripe_off: 0,
+            dst_offset: 0,
+            len: 0,
+            req_bytes_len: 0,
+            req_bytes: std::ptr::null_mut(),
+            dst_bulk: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// Wire output. Single status code; non-zero means the server-side
+/// bulk push failed or the source rejected the request.
+#[repr(C)]
+pub struct BulkGetOut {
+    pub status: i32,
+}
+
+impl BulkGetOut {
+    pub fn zeroed() -> Self {
+        Self { status: 0 }
+    }
+}
+
+/// Defensive check: the Rust `#[repr(C)]` struct must match the C
+/// shim's view of the same layout. Mismatch would corrupt every
+/// in-flight RPC; bail loudly at construction time instead.
+pub(crate) fn assert_layouts() -> Result<(), &'static str> {
+    // SAFETY: shim symbols return a `size_t` and have no side effects.
+    let in_c = unsafe { ffi::ub_sizeof_bulk_get_in() };
+    if in_c != std::mem::size_of::<BulkGetIn>() {
+        return Err("BulkGetIn size mismatches shim layout");
+    }
+    let out_c = unsafe { ffi::ub_sizeof_bulk_get_out() };
+    if out_c != std::mem::size_of::<BulkGetOut>() {
+        return Err("BulkGetOut size mismatches shim layout");
+    }
+    Ok(())
+}
+
+/// Re-export the shim proc callbacks at safe-ish types. Mercury
+/// invokes these on its progress thread; we never call them
+/// directly. The functions only touch their `data` pointer and the
+/// proc state, neither of which has Rust-visible aliasing concerns.
+pub(crate) fn in_proc() -> ffi::hg_proc_cb_t {
+    ffi::ub_proc_bulk_get_in
+}
+
+pub(crate) fn out_proc() -> ffi::hg_proc_cb_t {
+    ffi::ub_proc_bulk_get_out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_layout_matches_shim() {
+        assert_layouts().expect("layout mismatch");
+    }
+}

--- a/cmd/unbounded-storage/src/mercury/server.rs
+++ b/cmd/unbounded-storage/src/mercury/server.rs
@@ -1,0 +1,350 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Server-side glue for the `ub.bufferpool.bulk_get.v1` RPC.
+//!
+//! Sits opposite [`MercuryTransport`]: when a class is constructed
+//! with `listen = true`, the RPC handler runs on the progress
+//! thread, allocates a heap [`rpc::BulkGetIn`], decodes into it via
+//! `HG_Get_input`, and pushes a [`ServerJob`] onto the per-class
+//! [`ServerJobQueue`]. The executor-side server task polls the
+//! queue, dispatches to a [`BulkSource`], pushes the resulting
+//! bytes into the requester's pre-registered bulk handle, and
+//! responds.
+//!
+//! The chained pull-through model lives on top of this: the
+//! embedder supplies a `BulkSource` whose `fetch` may itself call
+//! back into the local bufferpool, which (on a miss) issues another
+//! [`MercuryTransport::bulk_get`] to the next hop.
+
+use std::sync::Arc;
+
+use serde::de::DeserializeOwned;
+
+use crate::mercury::class::{Class, ClassInner};
+use crate::mercury::error::{HgError, Result, check};
+use crate::mercury::ffi;
+use crate::mercury::handle::Handle;
+use crate::mercury::progress::{
+    Oneshot, ServerJob, ServerJobQueue, UnsafeSendPtr, complete_oneshot,
+};
+use crate::mercury::rpc::{BulkGetIn, BulkGetOut};
+
+/// Application-provided source for server-side fetches. The pool
+/// embedder implements this; in a chained topology it is just a
+/// thin shim around the local `BufferPool::read` path.
+pub trait BulkSource<R>: 'static
+where
+    R: DeserializeOwned,
+{
+    /// Provide `len` bytes for the request starting at `stripe_off`.
+    /// The returned vector is consumed by the server: it is pushed
+    /// into the requester's bulk handle and then dropped.
+    fn fetch(
+        &self,
+        req: R,
+        stripe_off: u64,
+        len: u32,
+    ) -> impl std::future::Future<Output = std::result::Result<Vec<u8>, HgError>>;
+}
+
+/// Server task driver. Hold this for as long as the class is
+/// listening; dropping it stops accepting new jobs but does not
+/// finalize the class.
+pub struct MercuryServer<R, B>
+where
+    R: DeserializeOwned,
+    B: BulkSource<R>,
+{
+    class: Arc<ClassInner>,
+    queue: Arc<ServerJobQueue>,
+    source: Arc<B>,
+    _r: std::marker::PhantomData<fn() -> R>,
+}
+
+impl<R, B> MercuryServer<R, B>
+where
+    R: DeserializeOwned,
+    B: BulkSource<R>,
+{
+    /// Wrap a listening [`Class`] with a source. Returns `None` if
+    /// the class was constructed without `listen = true`.
+    pub fn new(class: &Class, source: B) -> Option<Self> {
+        let queue = class.server_queue()?;
+        Some(Self {
+            class: class.inner().clone(),
+            queue,
+            source: Arc::new(source),
+            _r: std::marker::PhantomData,
+        })
+    }
+
+    /// Drive the server loop. Pulls one job at a time and awaits
+    /// `handle_job` so the pool's executor sees one in-flight RPC
+    /// per server task. Returns when the queue is closed (i.e. the
+    /// class is shutting down).
+    pub async fn run(self) {
+        loop {
+            let Some(job) = self.queue.next_job().await else {
+                return;
+            };
+            // Errors are logged via the response status; nothing to
+            // raise up the stack here.
+            let _ = handle_job(self.class.clone(), self.source.clone(), job).await;
+        }
+    }
+}
+
+/// Per-job dispatch. Decodes the request, invokes the source,
+/// pushes the bytes, and responds.
+async fn handle_job<R, B>(class: Arc<ClassInner>, source: Arc<B>, job: ServerJob) -> Result<()>
+where
+    R: DeserializeOwned,
+    B: BulkSource<R>,
+{
+    // SAFETY: `server_rpc_cb` transferred ownership of the handle into the
+    // job. We now own it and will destroy it by dropping `handle` at the
+    // end of this function (via `respond`).
+    let handle = unsafe { Handle::from_raw(job.handle.0 as ffi::hg_handle_t) };
+    let input_ptr = job.input_struct.0 as *mut BulkGetIn;
+
+    // Recover the decoded input. `req_bytes` is a `malloc`'d buffer
+    // owned by the proc; we copy it before calling `HG_Free_input`
+    // so the source's `await` lifetime is decoupled from Mercury's.
+    // SAFETY: the RPC callback decoded into `*input_ptr` via
+    // `HG_Get_input`; we have exclusive access until `HG_Free_input`
+    // runs.
+    let (stripe_off, dst_offset, len, req_bytes_vec, dst_bulk) = unsafe {
+        let in_ref = &*input_ptr;
+        let len = in_ref.req_bytes_len as usize;
+        let req_bytes_vec = if len > 0 && !in_ref.req_bytes.is_null() {
+            std::slice::from_raw_parts(in_ref.req_bytes, len).to_vec()
+        } else {
+            Vec::new()
+        };
+        (
+            in_ref.stripe_off,
+            in_ref.dst_offset,
+            in_ref.len,
+            req_bytes_vec,
+            in_ref.dst_bulk,
+        )
+    };
+    // NOTE: do NOT call `HG_Free_input` yet. The proc's `HG_FREE`
+    // op frees the decoded `dst_bulk` handle as well, which we
+    // still need to drive `HG_Bulk_transfer` below. We defer
+    // `HG_Free_input` until after the push completes.
+
+    let outcome = run_fetch_and_respond(
+        class,
+        source,
+        &handle,
+        stripe_off,
+        dst_offset,
+        len,
+        req_bytes_vec,
+        dst_bulk,
+    )
+    .await;
+
+    // Safe to free the decoded input now; the bulk transfer is complete
+    // (success or failure) and we no longer touch `dst_bulk`.
+    // SAFETY: `input_ptr` came from `Box::into_raw` in `server_rpc_cb`;
+    // reclaim and drop exactly once after freeing the proc-owned fields.
+    handle.free_input(unsafe { &mut *input_ptr });
+    unsafe {
+        let _ = Box::from_raw(input_ptr);
+    }
+
+    // Respond with the final status. A failure to bincode-decode,
+    // fetch, or push surfaces as a non-zero status code; the client
+    // future maps it to `HgError`.
+    let status: i32 = match outcome {
+        Ok(()) => 0,
+        Err(e) => {
+            if e.code == 0 {
+                -1
+            } else {
+                e.code
+            }
+        }
+    };
+    respond(handle, status).await
+}
+
+/// Glues fetch -> push -> respond. Splits out from `handle_job`
+/// only because the failure paths above still need to respond.
+async fn run_fetch_and_respond<R, B>(
+    class: Arc<ClassInner>,
+    source: Arc<B>,
+    handle: &Handle,
+    stripe_off: u64,
+    dst_offset: u64,
+    len: u32,
+    req_bytes: Vec<u8>,
+    dst_bulk: ffi::hg_bulk_t,
+) -> Result<()>
+where
+    R: DeserializeOwned,
+    B: BulkSource<R>,
+{
+    let req: R = bincode::deserialize(&req_bytes)
+        .map_err(|_| HgError::new(0, "server bincode decode failed"))?;
+    let bytes = source.fetch(req, stripe_off, len).await?;
+    if bytes.len() < len as usize {
+        return Err(HgError::new(0, "BulkSource returned short read"));
+    }
+    // The requester only owns `len` bytes at `dst_offset`; cap the
+    // transfer at `len` even if the source over-produced so we never
+    // push past the end of the requester's bulk handle.
+    let push_len = len as usize;
+
+    // Origin (requester) address for the push.
+    // SAFETY: handle is live; shim returns a stable info pointer.
+    let info = unsafe { ffi::ub_handle_info(handle.as_raw()) };
+    if info.is_null() {
+        return Err(HgError::new(0, "ub_handle_info returned null"));
+    }
+    let origin_addr = unsafe { (*info).addr };
+
+    // Register a temporary bulk handle covering exactly `push_len`
+    // bytes of the source buffer.
+    // SAFETY: bytes is pinned by the surrounding await frame for
+    // the duration of HG_Bulk_transfer; we drop it only after the
+    // push callback fires.
+    let mut bufs: [*mut std::ffi::c_void; 1] = [bytes.as_ptr() as *mut _];
+    let sizes: [ffi::hg_size_t; 1] = [push_len as ffi::hg_size_t];
+    let mut local_handle: ffi::hg_bulk_t = std::ptr::null_mut();
+    let ret = unsafe {
+        ffi::HG_Bulk_create(
+            class.hg_class,
+            1,
+            bufs.as_mut_ptr(),
+            sizes.as_ptr(),
+            ffi::HG_BULK_READ_ONLY,
+            &mut local_handle,
+        )
+    };
+    check(ret, "HG_Bulk_create (server)")?;
+
+    // Issue the push and await it via a one-shot completion slot.
+    let oneshot = Oneshot::new();
+    let mut op_id: ffi::hg_op_id_t = std::ptr::null_mut();
+    let ret = unsafe {
+        ffi::HG_Bulk_transfer(
+            class.hg_context,
+            Some(bulk_push_cb),
+            oneshot.arg,
+            ffi::HG_BULK_PUSH,
+            origin_addr,
+            dst_bulk,
+            dst_offset,
+            local_handle,
+            0,
+            push_len as ffi::hg_size_t,
+            &mut op_id,
+        )
+    };
+    if ret != ffi::HG_SUCCESS {
+        // The callback won't run; reclaim the leaked Arc and free the
+        // local bulk handle.
+        // SAFETY: `oneshot.arg` was produced by `Oneshot::new` above.
+        unsafe {
+            Oneshot::reclaim(oneshot.arg);
+            let _ = ffi::HG_Bulk_free(local_handle);
+        }
+        return Err(HgError::new(ret as i32, "HG_Bulk_transfer (push)"));
+    }
+
+    let push_result = oneshot.future.await;
+
+    // SAFETY: local bulk handle is freed exactly once here, after
+    // the push callback has fired.
+    unsafe {
+        let _ = ffi::HG_Bulk_free(local_handle);
+    }
+    drop(bytes);
+    push_result
+}
+
+/// Issues `HG_Respond` and awaits its callback. The handle is destroyed
+/// by dropping it at the end of this function regardless of success or
+/// failure.
+async fn respond(handle: Handle, status: i32) -> Result<()> {
+    let mut out = BulkGetOut { status };
+    let oneshot = Oneshot::new();
+    if let Err(e) = handle.respond(respond_cb, oneshot.arg, &mut out) {
+        // SAFETY: HG_Respond failed; the callback won't run. Reclaim the
+        // leaked Arc. `handle` drops here -> `HG_Destroy`.
+        unsafe { Oneshot::reclaim(oneshot.arg) };
+        return Err(e);
+    }
+    // `handle` drops at the end of this scope -> `HG_Destroy`.
+    oneshot.future.await
+}
+
+/// Bulk-push callback. Resolves the push completion slot with the
+/// transfer's return code. Runs on the progress thread.
+unsafe extern "C" fn bulk_push_cb(info: *const ffi::hg_cb_info) -> ffi::hg_return_t {
+    ffi::dispatch_simple_cb(info, |ret, arg| unsafe {
+        complete_oneshot(ret, arg, "bulk push failed")
+    })
+}
+
+/// Respond callback. Same pattern as `bulk_push_cb`.
+unsafe extern "C" fn respond_cb(info: *const ffi::hg_cb_info) -> ffi::hg_return_t {
+    ffi::dispatch_simple_cb(info, |ret, arg| unsafe {
+        complete_oneshot(ret, arg, "respond failed")
+    })
+}
+
+/// Mercury RPC callback. Runs on the progress thread inside
+/// `HG_Trigger`. Decodes the input into a fresh heap allocation and
+/// queues the job for the executor-side server task.
+pub(crate) unsafe extern "C" fn server_rpc_cb(handle: ffi::hg_handle_t) -> ffi::hg_return_t {
+    // Wrap the raw handle immediately so every error path destroys it
+    // via `Drop` instead of by hand.
+    // SAFETY: Mercury passes ownership of the handle to the RPC callback.
+    let handle = unsafe { Handle::from_raw(handle) };
+
+    // SAFETY: shim returns a stable info pointer for the lifetime of the
+    // handle.
+    let info = unsafe { ffi::ub_handle_info(handle.as_raw()) };
+    if info.is_null() {
+        return -1;
+    }
+    let (hg_class, rpc_id) = unsafe { ((*info).hg_class, (*info).id) };
+    // SAFETY: `hg_class` and `rpc_id` came from a live handle.
+    let data = unsafe { ffi::HG_Registered_data(hg_class, rpc_id) };
+    if data.is_null() {
+        return -1;
+    }
+    // The Arc lives until HG_Finalize via the free callback; we need a
+    // borrowed view here, not an owned clone of the slot.
+    // SAFETY: `data` is the `Arc::into_raw` pointer registered at class
+    // construction time.
+    let queue_ref: &ServerJobQueue = unsafe { &*(data as *const ServerJobQueue) };
+
+    // Allocate the input struct on the heap; HG_Get_input decodes into it.
+    let input = Box::new(BulkGetIn::zeroed());
+    let in_ptr = Box::into_raw(input);
+    // SAFETY: `in_ptr` is exclusively owned by us until we hand it to the
+    // queue below.
+    if let Err(e) = handle.get_input(unsafe { &mut *in_ptr }) {
+        // Reclaim the Box; `handle` drops -> `HG_Destroy`.
+        // SAFETY: `in_ptr` came from `Box::into_raw` and has not been freed.
+        unsafe {
+            let _ = Box::from_raw(in_ptr);
+        }
+        return e.code as ffi::hg_return_t;
+    }
+
+    // Transfer handle ownership to the queue; the executor-side server
+    // task will reconstruct a `Handle` in `handle_job`.
+    let raw_handle = handle.into_raw();
+    queue_ref.push(ServerJob {
+        handle: UnsafeSendPtr(raw_handle as *mut std::ffi::c_void),
+        input_struct: UnsafeSendPtr(in_ptr as *mut std::ffi::c_void),
+    });
+    ffi::HG_SUCCESS
+}

--- a/cmd/unbounded-storage/src/mercury/shim.c
+++ b/cmd/unbounded-storage/src/mercury/shim.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Minimal C shim for the unbounded-storage Mercury transport.
+ *
+ * Mercury exposes its serialization primitives (`hg_proc_hg_uint32_t`,
+ * `hg_proc_hg_uint64_t`, `hg_proc_bytes`, ...) as `static HG_INLINE`
+ * functions in `mercury_proc.h`. They have no exported symbols, so
+ * Rust FFI cannot call them directly. This file is the only piece of
+ * C we ship; everything above it is plain Rust.
+ *
+ * Two callbacks are registered against the single
+ * `ub.bufferpool.bulk_get.v1` RPC:
+ *   - `ub_proc_bulk_get_in`  encodes/decodes the request envelope
+ *     (stripe key, offsets, length, client-side bulk handle, plus a
+ *     length-prefixed opaque byte slice carrying the caller's
+ *     `R: Serialize`).
+ *   - `ub_proc_bulk_get_out` encodes/decodes a single `int32_t`
+ *     status code.
+ *
+ * The Rust side stages the input/output structs in heap allocations
+ * and passes pointers to them; this file just walks the bytes.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <mercury.h>
+#include <mercury_bulk.h>
+#include <mercury_proc.h>
+#include <mercury_proc_bulk.h>
+
+/*
+ * Mirrors `BulkGetIn` in `rpc.rs`. Field types match the Rust side
+ * byte-for-byte: `hg_uint32_t` = `u32`, `hg_uint64_t` = `u64`,
+ * `hg_bulk_t` is a pointer.
+ */
+struct ub_bulk_get_in {
+    uint8_t     stripe_key[32];
+    uint64_t    stripe_off;
+    uint64_t    dst_offset;
+    uint32_t    len;
+    /* `req_bytes_len` precedes the opaque `req_bytes` buffer on the
+     * wire; on the host side we keep the length in a separate field so
+     * the decoder can size the heap allocation before reading. */
+    uint32_t    req_bytes_len;
+    uint8_t    *req_bytes;
+    hg_bulk_t   dst_bulk;
+};
+
+struct ub_bulk_get_out {
+    int32_t status;
+};
+
+hg_return_t
+ub_proc_bulk_get_in(hg_proc_t proc, void *data);
+hg_return_t
+ub_proc_bulk_get_out(hg_proc_t proc, void *data);
+
+size_t
+ub_sizeof_bulk_get_in(void);
+size_t
+ub_sizeof_bulk_get_out(void);
+
+/* `HG_Get_info` is `static HG_INLINE` in `mercury.h`; expose it as a
+ * real symbol so the Rust side can resolve the handle's class /
+ * context / origin address without poking at struct internals. */
+const struct hg_info *
+ub_handle_info(hg_handle_t handle);
+
+const struct hg_info *
+ub_handle_info(hg_handle_t handle)
+{
+    return HG_Get_info(handle);
+}
+
+hg_return_t
+ub_proc_bulk_get_in(hg_proc_t proc, void *data)
+{
+    struct ub_bulk_get_in *in = (struct ub_bulk_get_in *) data;
+    hg_proc_op_t op = hg_proc_get_op(proc);
+    hg_return_t ret;
+
+    ret = hg_proc_bytes(proc, in->stripe_key, sizeof(in->stripe_key));
+    if (ret != HG_SUCCESS)
+        return ret;
+    ret = hg_proc_hg_uint64_t(proc, &in->stripe_off);
+    if (ret != HG_SUCCESS)
+        return ret;
+    ret = hg_proc_hg_uint64_t(proc, &in->dst_offset);
+    if (ret != HG_SUCCESS)
+        return ret;
+    ret = hg_proc_hg_uint32_t(proc, &in->len);
+    if (ret != HG_SUCCESS)
+        return ret;
+    ret = hg_proc_hg_uint32_t(proc, &in->req_bytes_len);
+    if (ret != HG_SUCCESS)
+        return ret;
+
+    /* Variable-length opaque tail. On decode we own the allocation
+     * and free it from HG_Free_input via the HG_FREE op below. */
+    if (in->req_bytes_len > 0) {
+        if (op == HG_DECODE) {
+            in->req_bytes = (uint8_t *) malloc(in->req_bytes_len);
+            if (in->req_bytes == NULL)
+                return HG_NOMEM;
+        }
+        if (op == HG_ENCODE || op == HG_DECODE) {
+            ret = hg_proc_bytes(proc, in->req_bytes, in->req_bytes_len);
+            if (ret != HG_SUCCESS)
+                return ret;
+        }
+        if (op == HG_FREE && in->req_bytes != NULL) {
+            free(in->req_bytes);
+            in->req_bytes = NULL;
+        }
+    } else if (op == HG_DECODE) {
+        in->req_bytes = NULL;
+    }
+
+    ret = hg_proc_hg_bulk_t(proc, &in->dst_bulk);
+    if (ret != HG_SUCCESS)
+        return ret;
+
+    return HG_SUCCESS;
+}
+
+hg_return_t
+ub_proc_bulk_get_out(hg_proc_t proc, void *data)
+{
+    struct ub_bulk_get_out *out = (struct ub_bulk_get_out *) data;
+    /* int32 has no platform-portable hg_proc helper exported, but
+     * uint32 round-trips bit-identically for our purposes. */
+    return hg_proc_hg_uint32_t(proc, (uint32_t *) &out->status);
+}
+
+size_t
+ub_sizeof_bulk_get_in(void)
+{
+    return sizeof(struct ub_bulk_get_in);
+}
+
+size_t
+ub_sizeof_bulk_get_out(void)
+{
+    return sizeof(struct ub_bulk_get_out);
+}

--- a/cmd/unbounded-storage/src/mercury/tests.rs
+++ b/cmd/unbounded-storage/src/mercury/tests.rs
@@ -1,0 +1,1020 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Module integration tests for the Mercury transport. Use Mercury's
+//! `na+sm://` (shared-memory) NA backend so the tests can run without
+//! any specialized hardware. The suite exercises:
+//!
+//! * happy-path bulk_get round trips,
+//! * routing / address / registration error paths,
+//! * server-side error propagation (decode, fetch, short read, over-production),
+//! * page-offset flattening with non-zero `page_idx` and `offset`,
+//! * concurrent in-flight RPCs and registry-full back-pressure,
+//! * teardown orderings (class-first vs no-traffic; server exits on close),
+//! * a stress loop that pushes 5,000 round trips through a single class pair.
+
+use std::future::Future;
+use std::pin::pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::thread;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::bufferpool::{BulkRef, Error as PoolError, PageRef, PeerId, Req, StripeKey, Transport};
+use crate::mercury::{
+    BulkSource, Class, HgError, MercuryServer, MercuryTransport, PeerEntry, PeerRouter, StaticPeer,
+    TransportConfig,
+};
+use crate::runtime::{DefaultRuntime, WorkerIdx};
+
+// ---------------------------------------------------------------------------
+// Tiny single-thread executor; same shape as bufferpool::tests but with a
+// short park between polls so the Mercury progress thread can advance.
+// ---------------------------------------------------------------------------
+
+fn noop_waker() -> Waker {
+    fn raw() -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
+    // SAFETY: the vtable functions never dereference the data pointer.
+    unsafe { Waker::from_raw(raw()) }
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    block_on_within(future, 300_000)
+}
+
+/// Like `block_on` but with a caller-tunable spin cap. Each spin is
+/// 100us, so `spins = 300_000` is ~30 s. Long-running tests use a
+/// larger cap.
+fn block_on_within<F: Future>(future: F, spin_cap: u64) -> F::Output {
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = pin!(future);
+    let mut spins: u64 = 0;
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(v) => return v,
+            Poll::Pending => {
+                spins += 1;
+                assert!(spins < spin_cap, "block_on stuck (no progress)");
+                thread::sleep(Duration::from_micros(100));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fake request and source.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Serialize, Deserialize)]
+struct TestReq {
+    key: [u8; 32],
+}
+
+impl Req for TestReq {
+    fn key(&self) -> StripeKey {
+        StripeKey(self.key)
+    }
+}
+
+/// Source that fills every reply with a fixed byte pattern. The
+/// `calls` counter lets tests assert how many server fetches actually
+/// fired.
+struct EchoSource {
+    pattern: u8,
+    calls: Arc<AtomicUsize>,
+}
+
+impl BulkSource<TestReq> for EchoSource {
+    async fn fetch(&self, _req: TestReq, _stripe_off: u64, len: u32) -> Result<Vec<u8>, HgError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(vec![self.pattern; len as usize])
+    }
+}
+
+/// Source whose first `fail_count` invocations return a configurable
+/// error and whose remaining invocations succeed with `pattern`.
+struct FlakySource {
+    pattern: u8,
+    fail_code: i32,
+    remaining_failures: AtomicUsize,
+    calls: Arc<AtomicUsize>,
+}
+
+impl BulkSource<TestReq> for FlakySource {
+    async fn fetch(&self, _req: TestReq, _stripe_off: u64, len: u32) -> Result<Vec<u8>, HgError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        let r = self.remaining_failures.load(Ordering::Relaxed);
+        if r > 0 {
+            self.remaining_failures.fetch_sub(1, Ordering::Relaxed);
+            return Err(HgError::new(self.fail_code, "flaky-source"));
+        }
+        Ok(vec![self.pattern; len as usize])
+    }
+}
+
+/// Source that returns fewer bytes than `len` so the server's short-
+/// read guard fires.
+struct ShortSource {
+    short_by: u32,
+    pattern: u8,
+}
+
+impl BulkSource<TestReq> for ShortSource {
+    async fn fetch(&self, _req: TestReq, _stripe_off: u64, len: u32) -> Result<Vec<u8>, HgError> {
+        let actual = (len - self.short_by) as usize;
+        Ok(vec![self.pattern; actual])
+    }
+}
+
+/// Source that returns *more* bytes than `len`. The server caps the
+/// push at `len`; verify trailing bytes are not written to the
+/// destination.
+struct LongSource {
+    over_by: u32,
+    pattern: u8,
+}
+
+impl BulkSource<TestReq> for LongSource {
+    async fn fetch(&self, _req: TestReq, _stripe_off: u64, len: u32) -> Result<Vec<u8>, HgError> {
+        Ok(vec![self.pattern; (len + self.over_by) as usize])
+    }
+}
+
+/// Source that resolves only when the caller flips `gate` true. The
+/// "slow" surface lets us race teardown against an in-flight fetch.
+struct GatedSource {
+    pattern: u8,
+    gate: Arc<AtomicBool>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl BulkSource<TestReq> for GatedSource {
+    async fn fetch(&self, _req: TestReq, _stripe_off: u64, len: u32) -> Result<Vec<u8>, HgError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        // Spin yielding via thread::sleep is fine here: the server
+        // task lives on a dedicated thread in these tests.
+        while !self.gate.load(Ordering::Acquire) {
+            thread::sleep(Duration::from_micros(200));
+        }
+        Ok(vec![self.pattern; len as usize])
+    }
+}
+
+/// Source we plug in when a test does not care about the surface but
+/// still needs a `BulkSource<TestReq>` type. Returns an error if ever
+/// invoked.
+struct NeverSource;
+
+impl BulkSource<TestReq> for NeverSource {
+    async fn fetch(&self, _req: TestReq, _stripe_off: u64, _len: u32) -> Result<Vec<u8>, HgError> {
+        Err(HgError::new(-99, "NeverSource invoked"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test harness helpers.
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE: usize = 4096;
+
+struct ServerHandle<B: BulkSource<TestReq> + Send + Sync + 'static> {
+    class: Option<Class>,
+    addr: String,
+    thread: Option<thread::JoinHandle<()>>,
+    _marker: std::marker::PhantomData<B>,
+}
+
+impl<B: BulkSource<TestReq> + Send + Sync + 'static> ServerHandle<B> {
+    fn join_after_drop(mut self) {
+        let class = self.class.take();
+        drop(class);
+        if let Some(t) = self.thread.take() {
+            t.join().expect("server thread");
+        }
+    }
+
+    fn addr(&self) -> &str {
+        &self.addr
+    }
+}
+
+impl<B: BulkSource<TestReq> + Send + Sync + 'static> Drop for ServerHandle<B> {
+    fn drop(&mut self) {
+        // Same teardown as `join_after_drop` but tolerated on the
+        // failure path: drop the class first to close the queue,
+        // then join the thread.
+        let class = self.class.take();
+        drop(class);
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+fn spawn_server<B>(source: B) -> ServerHandle<B>
+where
+    B: BulkSource<TestReq> + Send + Sync + 'static,
+{
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: true,
+        peers: Vec::new(),
+        max_inflight: 32,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    let class = Class::new(cfg).expect("server class");
+    let addr = class.self_address().expect("self_address");
+    let server = MercuryServer::<TestReq, _>::new(&class, source).expect("server attaches");
+    let thread = thread::spawn(move || {
+        block_on(server.run());
+    });
+    ServerHandle {
+        class: Some(class),
+        addr,
+        thread: Some(thread),
+        _marker: std::marker::PhantomData,
+    }
+}
+
+/// Build a client `Class` whose peer table contains exactly one entry
+/// for `peer_id` pointing at `addr`.
+fn make_client(addr: &str, peer_id: PeerId) -> Class {
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: false,
+        peers: vec![PeerEntry {
+            peer_id,
+            addr: addr.to_string(),
+        }],
+        max_inflight: 16,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    Class::new(cfg).expect("client class")
+}
+
+/// Build the standard client used by happy-path and most error-path
+/// tests: a `Class` with a single peer entry pointing at `server`,
+/// a registered backing region, and a `MercuryTransport` wired to a
+/// `StaticPeer(peer_id)` router. Tests that need a non-standard
+/// `max_inflight`, a custom router, or a deliberately missing backing
+/// continue to wire the pieces up by hand.
+fn make_client_with_transport<B>(
+    server: &ServerHandle<B>,
+    peer_id: PeerId,
+    backing: &mut [u8],
+    page_size: usize,
+) -> (Class, MercuryTransport<TestReq, StaticPeer>)
+where
+    B: BulkSource<TestReq> + Send + Sync + 'static,
+{
+    let class = make_client(server.addr(), peer_id);
+    class
+        .register_backing(backing.as_mut_ptr(), backing.len())
+        .expect("register_backing");
+    let transport = MercuryTransport::new(&class, StaticPeer(peer_id), page_size);
+    (class, transport)
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn round_trip_bulk_get_over_sm() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let server = spawn_server(EchoSource {
+        pattern: 0xAB,
+        calls: calls.clone(),
+    });
+    let mut backing = vec![0u8; PAGE_SIZE];
+    let (client_class, transport) =
+        make_client_with_transport(&server, PeerId(1), &mut backing, PAGE_SIZE);
+
+    let req = TestReq { key: [0u8; 32] };
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 64,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 64,
+    };
+    block_on(transport.bulk_get(&req, src, dst)).expect("bulk_get");
+
+    assert_eq!(&backing[..64], &[0xABu8; 64][..]);
+    assert_eq!(&backing[64..PAGE_SIZE], &vec![0u8; PAGE_SIZE - 64][..]);
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+    drop(transport);
+    drop(client_class);
+    server.join_after_drop();
+}
+
+// ---------------------------------------------------------------------------
+// 2. Routing / addressing / registration errors.
+// ---------------------------------------------------------------------------
+
+/// Router that always returns Err. Lets the test pin the
+/// `PoolError::Transport` mapping without depending on
+/// peer-table contents.
+struct ErrRouter;
+impl<R> PeerRouter<R> for ErrRouter {
+    fn route(&self, _: &R) -> crate::mercury::Result<PeerId> {
+        Err(HgError::new(-7, "router-says-no"))
+    }
+}
+
+#[test]
+fn router_error_surfaces_as_transport_error() {
+    let server = spawn_server(EchoSource {
+        pattern: 0xAA,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let client_class = make_client(server.addr(), PeerId(1));
+    let mut backing = vec![0u8; PAGE_SIZE];
+    client_class
+        .register_backing(backing.as_mut_ptr(), PAGE_SIZE)
+        .expect("register_backing");
+    let transport: MercuryTransport<TestReq, _> =
+        MercuryTransport::new(&client_class, ErrRouter, PAGE_SIZE);
+
+    let req = TestReq { key: [0u8; 32] };
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 8,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 8,
+    };
+    match block_on(transport.bulk_get(&req, src, dst)) {
+        Err(PoolError::Transport(_)) => {}
+        other => panic!("expected Transport error, got {:?}", other),
+    }
+}
+
+#[test]
+fn unknown_peer_id_returns_transport_error() {
+    let server = spawn_server(EchoSource {
+        pattern: 0xAA,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let client_class = make_client(server.addr(), PeerId(1));
+    let mut backing = vec![0u8; PAGE_SIZE];
+    client_class
+        .register_backing(backing.as_mut_ptr(), PAGE_SIZE)
+        .expect("register_backing");
+    // Router points at a peer not present in the table.
+    let transport: MercuryTransport<TestReq, _> =
+        MercuryTransport::new(&client_class, StaticPeer(PeerId(42)), PAGE_SIZE);
+    let req = TestReq { key: [0u8; 32] };
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 8,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 8,
+    };
+    match block_on(transport.bulk_get(&req, src, dst)) {
+        Err(PoolError::Transport(_)) => {}
+        other => panic!("expected Transport error, got {:?}", other),
+    }
+}
+
+#[test]
+fn offset_overflow_returns_out_of_range() {
+    // Build a client whose transport's page_size, combined with a
+    // u32::MAX page_idx, overflows u64. We do not register any
+    // backing because `bulk_get`'s overflow guard runs before the
+    // backing lookup; the router/class still need to be live.
+    let server = spawn_server(EchoSource {
+        pattern: 0xAA,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let client_class = make_client(server.addr(), PeerId(1));
+    // 2^33 byte pages: u32::MAX * 2^33 > u64::MAX.
+    let huge_page = 1usize << 33;
+    let transport: MercuryTransport<TestReq, _> =
+        MercuryTransport::new(&client_class, StaticPeer(PeerId(1)), huge_page);
+
+    let req = TestReq { key: [0u8; 32] };
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 8,
+    };
+    let dst = PageRef {
+        page_idx: u32::MAX,
+        offset: 0,
+        len: 8,
+    };
+    match block_on(transport.bulk_get(&req, src, dst)) {
+        Err(PoolError::OffsetOutOfRange) => {}
+        other => panic!("expected OffsetOutOfRange, got {:?}", other),
+    }
+}
+
+#[test]
+fn backing_not_registered_returns_transport_error() {
+    let server = spawn_server(EchoSource {
+        pattern: 0xAA,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let client_class = make_client(server.addr(), PeerId(1));
+    // Deliberately skip `register_backing`.
+    let transport: MercuryTransport<TestReq, _> =
+        MercuryTransport::new(&client_class, StaticPeer(PeerId(1)), PAGE_SIZE);
+    let req = TestReq { key: [0u8; 32] };
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 8,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 8,
+    };
+    match block_on(transport.bulk_get(&req, src, dst)) {
+        Err(PoolError::Transport(_)) => {}
+        other => panic!("expected Transport error, got {:?}", other),
+    }
+}
+
+#[test]
+fn register_backing_idempotent_and_rejects_other_region() {
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: false,
+        peers: Vec::new(),
+        max_inflight: 1,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    let class = Class::new(cfg).expect("class");
+    let mut a = vec![0u8; PAGE_SIZE];
+    let mut b = vec![0u8; PAGE_SIZE];
+
+    class
+        .register_backing(a.as_mut_ptr(), PAGE_SIZE)
+        .expect("first register_backing");
+    // Idempotent for the same (base, size).
+    class
+        .register_backing(a.as_mut_ptr(), PAGE_SIZE)
+        .expect("idempotent");
+    // Different region rejected.
+    assert!(class.register_backing(b.as_mut_ptr(), PAGE_SIZE).is_err());
+    // Different size, same base rejected.
+    assert!(
+        class
+            .register_backing(a.as_mut_ptr(), PAGE_SIZE * 2)
+            .is_err()
+    );
+}
+
+#[test]
+fn peer_table_partial_failure_aborts_class_construction() {
+    // The second entry has an embedded NUL, which fails the
+    // `CString::new` guard inside `PeerTable::new`; the first
+    // (well-formed) address must have its `hg_addr_t` freed via
+    // `PeerTable::drop` even though the table itself is not exposed.
+    // We cannot directly observe the free, but `Class::new` returning
+    // `Err` and the test process not leaking is the public guarantee
+    // and is what we pin here.
+    let server = spawn_server(EchoSource {
+        pattern: 0xAA,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: false,
+        peers: vec![
+            PeerEntry {
+                peer_id: PeerId(1),
+                addr: server.addr().to_string(),
+            },
+            PeerEntry {
+                peer_id: PeerId(2),
+                addr: "na+sm://has-nul\0/x".to_string(),
+            },
+        ],
+        max_inflight: 1,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    assert!(Class::new(cfg).is_err());
+}
+
+#[test]
+fn unresolvable_peer_aborts_class_construction() {
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: false,
+        peers: vec![PeerEntry {
+            peer_id: PeerId(1),
+            // Syntactically valid Mercury address that points at
+            // nothing. `HG_Addr_lookup2` against SM with a malformed
+            // tail typically returns non-zero.
+            addr: "na+sm://does-not-parse".to_string(),
+        }],
+        max_inflight: 1,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    assert!(Class::new(cfg).is_err());
+}
+
+#[test]
+fn self_address_round_trips_to_valid_utf8() {
+    let server = spawn_server(EchoSource {
+        pattern: 0xAA,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let addr = server.addr();
+    assert!(!addr.is_empty());
+    assert!(!addr.contains('\0'), "trailing NUL not stripped: {addr:?}");
+    assert!(addr.starts_with("na+sm://"), "unexpected: {addr:?}");
+}
+
+#[test]
+fn client_only_class_has_no_server_queue() {
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: false,
+        peers: Vec::new(),
+        max_inflight: 1,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    let class = Class::new(cfg).expect("class");
+    assert!(class.server_queue().is_none());
+    // `MercuryServer::new` against a client-only class returns None.
+    let s: Option<MercuryServer<TestReq, NeverSource>> = MercuryServer::new(&class, NeverSource);
+    assert!(s.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// 3. Server-side error propagation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn server_fetch_error_propagates_to_client_status() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let source = FlakySource {
+        pattern: 0xCC,
+        fail_code: 17,
+        remaining_failures: AtomicUsize::new(1),
+        calls: calls.clone(),
+    };
+    let server = spawn_server(source);
+    let mut backing = vec![0u8; PAGE_SIZE];
+    let (_client_class, transport) =
+        make_client_with_transport(&server, PeerId(1), &mut backing, PAGE_SIZE);
+
+    let req = TestReq { key: [0u8; 32] };
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 32,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 32,
+    };
+    // First call must fail with the server's status code (17).
+    let err =
+        block_on(transport.bulk_get(&req, src, dst)).expect_err("expected server-status error");
+    match err {
+        PoolError::Transport(e) => {
+            let msg = format!("{e}");
+            assert!(msg.contains("17"), "expected status 17 in {msg:?}");
+        }
+        _ => panic!("unexpected error variant"),
+    }
+    // Destination must be untouched on error.
+    assert!(backing.iter().take(32).all(|&b| b == 0));
+
+    // Second call succeeds and writes the pattern.
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 32,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 32,
+    };
+    block_on(transport.bulk_get(&req, src, dst)).expect("retry must succeed");
+    assert_eq!(&backing[..32], &[0xCC; 32]);
+    assert_eq!(calls.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn server_short_read_propagates_error() {
+    let server = spawn_server(ShortSource {
+        short_by: 4,
+        pattern: 0x55,
+    });
+    let mut backing = vec![0u8; PAGE_SIZE];
+    let (_client_class, transport) =
+        make_client_with_transport(&server, PeerId(1), &mut backing, PAGE_SIZE);
+    let req = TestReq { key: [0u8; 32] };
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 16,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 16,
+    };
+    assert!(matches!(
+        block_on(transport.bulk_get(&req, src, dst)),
+        Err(PoolError::Transport(_))
+    ));
+    // No partial write: destination stays zero.
+    assert!(backing.iter().take(16).all(|&b| b == 0));
+}
+
+#[test]
+fn server_over_production_is_capped_at_len() {
+    let server = spawn_server(LongSource {
+        over_by: 32,
+        pattern: 0x77,
+    });
+    let mut backing = vec![0u8; PAGE_SIZE];
+    let (_client_class, transport) =
+        make_client_with_transport(&server, PeerId(1), &mut backing, PAGE_SIZE);
+    let req = TestReq { key: [0u8; 32] };
+    let len = 16u32;
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len,
+    };
+    block_on(transport.bulk_get(&req, src, dst)).expect("over-production must still succeed");
+    // Exactly `len` bytes were written.
+    assert_eq!(&backing[..len as usize], &vec![0x77; len as usize][..]);
+    assert!(backing[len as usize..].iter().all(|&b| b == 0));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Geometry: non-zero page_idx and offset.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn page_offset_math_writes_to_correct_byte_range() {
+    let server = spawn_server(EchoSource {
+        pattern: 0xEE,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    // Multi-page backing so we can target page_idx = 2 specifically.
+    const PAGES: usize = 4;
+    let mut backing = vec![0u8; PAGE_SIZE * PAGES];
+    let (_client_class, transport) =
+        make_client_with_transport(&server, PeerId(1), &mut backing, PAGE_SIZE);
+    let req = TestReq { key: [0u8; 32] };
+    let len = 128u32;
+    let page_idx = 2u32;
+    let offset = 256u32;
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len,
+    };
+    let dst = PageRef {
+        page_idx,
+        offset,
+        len,
+    };
+    block_on(transport.bulk_get(&req, src, dst)).expect("bulk_get");
+
+    let start = page_idx as usize * PAGE_SIZE + offset as usize;
+    let end = start + len as usize;
+    // The targeted slice is the pattern; everything else stays zero.
+    for (i, &b) in backing.iter().enumerate() {
+        if (start..end).contains(&i) {
+            assert_eq!(b, 0xEE, "expected 0xEE at byte {i}");
+        } else {
+            assert_eq!(b, 0, "expected 0 at byte {i}, got {b:#x}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Concurrency: many in-flight, registry full.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn many_concurrent_bulk_gets_complete() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let server = spawn_server(EchoSource {
+        pattern: 0x33,
+        calls: calls.clone(),
+    });
+    const N: usize = 16;
+    let mut backing = vec![0u8; PAGE_SIZE * N];
+    let (_client_class, transport) =
+        make_client_with_transport(&server, PeerId(1), &mut backing, PAGE_SIZE);
+
+    let req = TestReq { key: [0u8; 32] };
+
+    // Issue them concurrently by polling many futures inside a single
+    // executor task. We round-robin a Vec of pinned futures until all
+    // complete; this stresses the completion registry against a real
+    // Mercury class.
+    block_on(async {
+        use std::pin::Pin;
+        let mut futs: Vec<Pin<Box<dyn Future<Output = Result<(), PoolError>>>>> = Vec::new();
+        for i in 0..N {
+            let src = BulkRef {
+                stripe: StripeKey([0u8; 32]),
+                offset: 0,
+                len: 64,
+            };
+            let dst = PageRef {
+                page_idx: i as u32,
+                offset: 0,
+                len: 64,
+            };
+            futs.push(Box::pin(transport.bulk_get(&req, src, dst)));
+        }
+        // Manually drive the futures until all are ready.
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut done = vec![false; N];
+        let mut remaining = N;
+        let mut spins: u64 = 0;
+        while remaining > 0 {
+            spins += 1;
+            assert!(spins < 600_000, "concurrent stuck");
+            for (i, fut) in futs.iter_mut().enumerate() {
+                if done[i] {
+                    continue;
+                }
+                if let Poll::Ready(r) = fut.as_mut().poll(&mut cx) {
+                    r.expect("concurrent bulk_get");
+                    done[i] = true;
+                    remaining -= 1;
+                }
+            }
+            if remaining > 0 {
+                thread::sleep(Duration::from_micros(100));
+            }
+        }
+    });
+
+    for i in 0..N {
+        let start = i * PAGE_SIZE;
+        assert_eq!(&backing[start..start + 64], &[0x33; 64][..], "page {i}");
+    }
+    assert_eq!(calls.load(Ordering::Relaxed), N);
+}
+
+#[test]
+fn registry_full_rejects_overflow_submission() {
+    // Build a client whose max_inflight is 1, then keep one forward
+    // gated by a slow server source so the second submission has
+    // nowhere to go.
+    let gate = Arc::new(AtomicBool::new(false));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let server = spawn_server(GatedSource {
+        pattern: 0x44,
+        gate: gate.clone(),
+        calls: calls.clone(),
+    });
+
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: false,
+        peers: vec![PeerEntry {
+            peer_id: PeerId(1),
+            addr: server.addr().to_string(),
+        }],
+        max_inflight: 1,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    let client_class = Class::new(cfg).expect("client class");
+
+    let mut backing = vec![0u8; PAGE_SIZE * 2];
+    client_class
+        .register_backing(backing.as_mut_ptr(), PAGE_SIZE * 2)
+        .expect("register_backing");
+    let transport: MercuryTransport<TestReq, _> =
+        MercuryTransport::new(&client_class, StaticPeer(PeerId(1)), PAGE_SIZE);
+    let req = TestReq { key: [0u8; 32] };
+
+    let first_src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 16,
+    };
+    let first_dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 16,
+    };
+    let second_src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 16,
+    };
+    let second_dst = PageRef {
+        page_idx: 1,
+        offset: 0,
+        len: 16,
+    };
+
+    block_on(async {
+        let mut first = Box::pin(transport.bulk_get(&req, first_src, first_dst));
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        // Poll the first one once to allocate its slot and submit
+        // the forward; the server is gated so it will not complete.
+        let _ = first.as_mut().poll(&mut cx);
+
+        // Spin until the server records that it has received the
+        // forward and is waiting on the gate. Otherwise the first
+        // bulk_get may not yet have allocated its slot.
+        for _ in 0..30_000 {
+            if calls.load(Ordering::Relaxed) >= 1 {
+                break;
+            }
+            thread::sleep(Duration::from_micros(100));
+        }
+
+        // Second submission must fail fast.
+        let r = transport.bulk_get(&req, second_src, second_dst).await;
+        assert!(matches!(r, Err(PoolError::Transport(_))));
+
+        // Release the gate so the first call completes; otherwise
+        // teardown waits forever for the in-flight RPC.
+        gate.store(true, Ordering::Release);
+        first.await.expect("first bulk_get completes once gated");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// 6. Teardown.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn server_run_exits_when_class_drops() {
+    let server = spawn_server(EchoSource {
+        pattern: 0xAA,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    // Tear down with no traffic: dropping the class closes the
+    // server queue, the server task observes `Ready(None)`, and the
+    // worker thread joins.
+    server.join_after_drop();
+}
+
+#[test]
+fn teardown_with_class_dropped_before_transport() {
+    let server = spawn_server(EchoSource {
+        pattern: 0xBE,
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let mut backing = vec![0u8; PAGE_SIZE];
+    let (client_class, transport) =
+        make_client_with_transport(&server, PeerId(1), &mut backing, PAGE_SIZE);
+    let req = TestReq { key: [0u8; 32] };
+    let src = BulkRef {
+        stripe: StripeKey([0u8; 32]),
+        offset: 0,
+        len: 8,
+    };
+    let dst = PageRef {
+        page_idx: 0,
+        offset: 0,
+        len: 8,
+    };
+    block_on(transport.bulk_get(&req, src, dst)).expect("bulk_get");
+
+    // Reverse order vs. the happy-path test: drop class first.
+    // Transport holds an Arc to ClassInner, so the FFI teardown
+    // defers until the transport drops too.
+    drop(client_class);
+    drop(transport);
+    server.join_after_drop();
+}
+
+// ---------------------------------------------------------------------------
+// 7. Construction-time guards (panics).
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "page_size")]
+fn transport_new_panics_on_zero_page_size() {
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: false,
+        peers: Vec::new(),
+        max_inflight: 1,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    let class = Class::new(cfg).expect("class");
+    let _t: MercuryTransport<TestReq, _> = MercuryTransport::new(&class, StaticPeer(PeerId(1)), 0);
+}
+
+#[test]
+#[should_panic(expected = "page_size")]
+fn transport_new_panics_on_non_power_of_two_page_size() {
+    let rt = DefaultRuntime::new(1);
+    let cfg = TransportConfig {
+        na_info: "na+sm://".into(),
+        listen: false,
+        peers: Vec::new(),
+        max_inflight: 1,
+        progress_poll_ms: 10,
+        runtime: rt,
+        worker_idx: WorkerIdx(0),
+    };
+    let class = Class::new(cfg).expect("class");
+    let _t: MercuryTransport<TestReq, _> =
+        MercuryTransport::new(&class, StaticPeer(PeerId(1)), 3000);
+}
+
+// ---------------------------------------------------------------------------
+// 8. Stress.
+// ---------------------------------------------------------------------------
+
+/// 5,000 back-to-back transfers through a single class pair. Run as
+/// part of the regular test suite to keep the round-trip path
+/// continuously exercised under load; the SM backend finishes this in
+/// well under a second on developer hardware.
+#[test]
+fn stress_round_trip_5k() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let server = spawn_server(EchoSource {
+        pattern: 0x99,
+        calls: calls.clone(),
+    });
+    let mut backing = vec![0u8; PAGE_SIZE];
+    let (client_class, transport) =
+        make_client_with_transport(&server, PeerId(1), &mut backing, PAGE_SIZE);
+
+    let req = TestReq { key: [0u8; 32] };
+    for _ in 0..5_000 {
+        let src = BulkRef {
+            stripe: StripeKey([0u8; 32]),
+            offset: 0,
+            len: 64,
+        };
+        let dst = PageRef {
+            page_idx: 0,
+            offset: 0,
+            len: 64,
+        };
+        block_on_within(transport.bulk_get(&req, src, dst), 1_000_000).expect("stress bulk_get");
+    }
+    assert_eq!(calls.load(Ordering::Relaxed), 5_000);
+    assert_eq!(&backing[..64], &[0x99; 64]);
+
+    drop(transport);
+    drop(client_class);
+    server.join_after_drop();
+}

--- a/cmd/unbounded-storage/src/mercury/transport.rs
+++ b/cmd/unbounded-storage/src/mercury/transport.rs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `bufferpool::Transport<R>` implementation over Mercury.
+//!
+//! Each `bulk_get` builds a `BulkGetIn`, creates a handle against the
+//! routed peer, and forwards. The forward callback fires on the
+//! Mercury progress thread and resolves the future via the
+//! completion bridge. The client never deserializes the response
+//! body; Mercury orders the bulk-push the server issued before the
+//! `HG_Respond`, so a successful callback means the destination page
+//! is fully populated.
+//!
+//! Construction binds the transport to a `Class` and a fixed
+//! `page_size`. The embedder is expected to have already registered
+//! the pool's backing with the class via `Class::register_backing`;
+//! the transport just flattens `PageRef { page_idx, offset }` into a
+//! byte offset using the page size baked in at `new()`.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::bufferpool::{BulkRef, Error as PoolError, PageRef, Req, Transport};
+use crate::mercury::class::{Class, ClassInner};
+use crate::mercury::error::{HgError, Result as HgResult};
+use crate::mercury::ffi;
+use crate::mercury::handle::Handle;
+use crate::mercury::progress::{CompletionFuture, CompletionSlot};
+use crate::mercury::router::PeerRouter;
+use crate::mercury::rpc::{BulkGetIn, BulkGetOut};
+
+/// Mercury-backed transport. One per NUMA shard. `R` is the
+/// bufferpool request type; `P` selects the peer per request.
+pub struct MercuryTransport<R, P>
+where
+    P: PeerRouter<R>,
+    R: Req + Serialize,
+{
+    class: Arc<ClassInner>,
+    router: P,
+    /// Bound at construction; used to flatten `PageRef` into a byte
+    /// offset for `bulk_get`. Must match the `page_size` the
+    /// embedder passed when allocating the backing it registered
+    /// with `class`.
+    page_size: usize,
+    _r: std::marker::PhantomData<fn() -> R>,
+}
+
+impl<R, P> MercuryTransport<R, P>
+where
+    P: PeerRouter<R>,
+    R: Req + Serialize,
+{
+    /// Build a transport bound to `class` and `page_size`. The
+    /// caller is responsible for having already registered the
+    /// pool's backing with `class` (via `Class::register_backing`).
+    /// `page_size` must equal the `Backing::page_size` of the pool
+    /// that will own this transport.
+    pub fn new(class: &Class, router: P, page_size: usize) -> Self {
+        assert!(
+            page_size > 0 && page_size.is_power_of_two(),
+            "MercuryTransport::new: page_size must be a positive power of two",
+        );
+        Self {
+            class: class.inner().clone(),
+            router,
+            page_size,
+            _r: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<R, P> Transport<R> for MercuryTransport<R, P>
+where
+    P: PeerRouter<R>,
+    R: Req + Serialize,
+{
+    async fn bulk_get(
+        &self,
+        req: &R,
+        src: BulkRef,
+        dst: PageRef,
+    ) -> std::result::Result<(), PoolError> {
+        let peer = self.router.route(req).map_err(PoolError::transport)?;
+        let page_size = self.page_size;
+        let dst_offset = (dst.page_idx as u64)
+            .checked_mul(page_size as u64)
+            .and_then(|p| p.checked_add(dst.offset as u64))
+            .ok_or(PoolError::OffsetOutOfRange)?;
+
+        let req_bytes = bincode::serialize(req).map_err(|_| {
+            // bufferpool::Error has no cause-chaining slot today; the
+            // static `ctx` on `HgError` is enough to identify the
+            // failure site. Extend `Error::transport` when we need
+            // the inner cause.
+            PoolError::transport(HgError::new(0, "bincode serialize failed"))
+        })?;
+        let local_bulk = self
+            .class
+            .local_bulk
+            .lock()
+            .expect("local_bulk mutex")
+            .as_ref()
+            .map(|b| b.handle())
+            .ok_or_else(|| PoolError::transport(HgError::new(0, "backing not registered")))?;
+
+        let addr = self.class.peer_addr(peer).map_err(PoolError::transport)?;
+
+        let slot = self
+            .class
+            .completions
+            .alloc()
+            .map_err(PoolError::transport)?;
+        let registry = self.class.completions.clone();
+
+        forward_one(
+            &self.class,
+            addr,
+            local_bulk,
+            dst_offset,
+            &src,
+            &req_bytes,
+            slot.clone(),
+        )
+        .map_err(PoolError::transport)?;
+
+        CompletionFuture { slot, registry }
+            .await
+            .map_err(PoolError::transport)
+    }
+}
+
+/// Internal helper: builds the input struct, creates the handle,
+/// and submits the forward. On any error the slot is released so
+/// the in-flight counter unblocks immediately.
+fn forward_one(
+    class: &Arc<ClassInner>,
+    addr: ffi::hg_addr_t,
+    local_bulk: ffi::hg_bulk_t,
+    dst_offset: u64,
+    src: &BulkRef,
+    req_bytes: &[u8],
+    slot: Arc<CompletionSlot>,
+) -> HgResult<()> {
+    let mut input = BulkGetIn {
+        stripe_key: src.stripe.0,
+        stripe_off: src.offset,
+        dst_offset,
+        len: src.len,
+        req_bytes_len: req_bytes.len() as u32,
+        req_bytes: req_bytes.as_ptr() as *mut u8,
+        dst_bulk: local_bulk,
+    };
+
+    let handle = Handle::create(class, addr)?;
+    // Hand the slot to C as a raw pointer. The forward callback reclaims
+    // the strong reference and lets it drop.
+    let arg = slot.into_callback_arg();
+    if let Err(e) = handle.forward(forward_cb, arg, &mut input) {
+        // The callback will not run; reclaim the leaked Arc reference.
+        // SAFETY: `arg` came from `CompletionSlot::into_callback_arg` above.
+        unsafe {
+            let _ = CompletionSlot::from_callback_arg(arg);
+        }
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Forward-callback. Runs on the progress thread inside
+/// `HG_Trigger`. Recovers the slot, reads the response status,
+/// and lets the handle drop to destroy it.
+unsafe extern "C" fn forward_cb(info: *const ffi::hg_cb_info) -> ffi::hg_return_t {
+    ffi::dispatch_forward_cb(info, |cb| {
+        // SAFETY: `cb.arg` came from `CompletionSlot::into_callback_arg`
+        // in `forward_one`; reclaim exactly once.
+        let slot = unsafe { CompletionSlot::from_callback_arg(cb.arg) };
+        // SAFETY: Mercury passes ownership of the handle to the forward
+        // callback; the wrapper destroys it when dropped.
+        let handle = unsafe { Handle::from_raw(cb.handle) };
+
+        let outcome: HgResult<()> = if cb.ret != ffi::HG_SUCCESS {
+            Err(HgError::new(cb.ret as i32, "forward returned error"))
+        } else {
+            match handle.get_output(BulkGetOut::zeroed()) {
+                Ok(out) => {
+                    let status = out.status;
+                    if status == 0 {
+                        Ok(())
+                    } else {
+                        Err(HgError::new(status, "server reported error"))
+                    }
+                }
+                Err(e) => Err(e),
+            }
+        };
+        slot.complete(outcome);
+        // `handle` drops here -> `HG_Destroy`.
+        ffi::HG_SUCCESS
+    })
+}

--- a/cmd/unbounded-storage/src/runtime/mod.rs
+++ b/cmd/unbounded-storage/src/runtime/mod.rs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::sync::Arc;
+
+#[cfg(target_os = "linux")]
+mod pinned;
+
+#[cfg(target_os = "linux")]
+pub use pinned::{PinnedRuntime, WorkerSpec};
+
+/// Universal identifier for a worker slot. The bufferpool runs one
+/// `Pool` per worker, Mercury constructs one `Class` per worker, and
+/// the future io_uring layer registers one submission ring per
+/// worker. All three pin against the same `WorkerIdx`.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct WorkerIdx(pub u16);
+
+/// Locality hint for the future io_uring submission API
+/// (PLAN.md Phase 3.2). Declared here, not yet consumed.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum NumaHint {
+    Any,
+    Worker(WorkerIdx),
+    Numa(u16),
+}
+
+/// Handle to an auxiliary thread spawned via [`Threading::spawn_aux`].
+/// A type alias because no runtime impl needs to hide the underlying
+/// thread; callers just want to join.
+pub type JoinHandle = std::thread::JoinHandle<()>;
+
+/// Worker-placement runtime trait. See PLAN.md Phase 3.1.
+pub trait Threading: Send + Sync + 'static {
+    /// Number of worker slots configured. `WorkerIdx(i)` is valid
+    /// for `i < worker_count()`.
+    fn worker_count(&self) -> usize;
+
+    /// NUMA node hosting `idx`, if the runtime is NUMA-aware.
+    fn numa_of(&self, idx: WorkerIdx) -> Option<u16>;
+
+    /// Pin the *current* thread to worker `idx` and run `f` to
+    /// completion. Blocks until `f` returns.
+    fn run_worker(&self, idx: WorkerIdx, f: Box<dyn FnOnce() + Send + 'static>);
+
+    /// Spawn an auxiliary OS thread pinned to the same NUMA node as
+    /// worker `idx`.
+    fn spawn_aux(
+        &self,
+        idx: WorkerIdx,
+        name: &str,
+        f: Box<dyn FnOnce() + Send + 'static>,
+    ) -> JoinHandle;
+}
+
+/// Non-pinning `Threading` impl. Used in tests and on non-Linux
+/// targets where the pinning syscalls don't exist.
+pub struct DefaultRuntime {
+    workers: usize,
+}
+
+impl DefaultRuntime {
+    pub fn new(workers: usize) -> Arc<Self> {
+        assert!(workers > 0, "DefaultRuntime requires at least one worker");
+        Arc::new(Self { workers })
+    }
+}
+
+impl Threading for DefaultRuntime {
+    fn worker_count(&self) -> usize {
+        self.workers
+    }
+
+    fn numa_of(&self, idx: WorkerIdx) -> Option<u16> {
+        debug_assert!((idx.0 as usize) < self.workers);
+        None
+    }
+
+    fn run_worker(&self, idx: WorkerIdx, f: Box<dyn FnOnce() + Send + 'static>) {
+        debug_assert!((idx.0 as usize) < self.workers);
+        f();
+    }
+
+    fn spawn_aux(
+        &self,
+        idx: WorkerIdx,
+        name: &str,
+        f: Box<dyn FnOnce() + Send + 'static>,
+    ) -> JoinHandle {
+        debug_assert!((idx.0 as usize) < self.workers);
+        std::thread::Builder::new()
+            .name(name.to_string())
+            .spawn(f)
+            .expect("DefaultRuntime::spawn_aux: thread spawn failed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[test]
+    fn default_runtime_runs_and_spawns() {
+        let rt = DefaultRuntime::new(2);
+        assert_eq!(rt.worker_count(), 2);
+        assert!(rt.numa_of(WorkerIdx(0)).is_none());
+
+        let observed = Arc::new(Mutex::new(0u32));
+        let o = observed.clone();
+        rt.run_worker(WorkerIdx(0), Box::new(move || *o.lock().unwrap() = 1));
+        assert_eq!(*observed.lock().unwrap(), 1);
+
+        let o = observed.clone();
+        let h = rt.spawn_aux(
+            WorkerIdx(1),
+            "default-aux",
+            Box::new(move || *o.lock().unwrap() = 2),
+        );
+        h.join().expect("aux thread");
+        assert_eq!(*observed.lock().unwrap(), 2);
+    }
+}

--- a/cmd/unbounded-storage/src/runtime/pinned.rs
+++ b/cmd/unbounded-storage/src/runtime/pinned.rs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::sync::Arc;
+
+use super::{JoinHandle, Threading, WorkerIdx};
+
+/// Pin spec for one worker slot. The embedder enumerates topology;
+/// `PinnedRuntime` only consumes the result.
+#[derive(Clone, Copy, Debug)]
+pub struct WorkerSpec {
+    /// Logical CPU id to pin the worker thread to.
+    pub cpu: u32,
+    /// NUMA node to bind memory allocations to. `None` leaves the
+    /// kernel default policy in place.
+    pub numa: Option<u16>,
+}
+
+impl WorkerSpec {
+    pub const fn new(cpu: u32, numa: Option<u16>) -> Self {
+        Self { cpu, numa }
+    }
+}
+
+/// Pinned, NUMA-aware `Threading` implementation.
+pub struct PinnedRuntime {
+    workers: Vec<WorkerSpec>,
+}
+
+impl PinnedRuntime {
+    pub fn new(workers: Vec<WorkerSpec>) -> Arc<Self> {
+        assert!(
+            !workers.is_empty(),
+            "PinnedRuntime requires at least one worker"
+        );
+        Arc::new(Self { workers })
+    }
+
+    /// Convenience: one worker per supplied CPU id, with each
+    /// worker's NUMA hint resolved from `/sys`.
+    pub fn one_per_cpu<I: IntoIterator<Item = u32>>(cpus: I) -> Arc<Self> {
+        let workers = cpus
+            .into_iter()
+            .map(|cpu| WorkerSpec {
+                cpu,
+                numa: numa_node_of_cpu(cpu),
+            })
+            .collect::<Vec<_>>();
+        Self::new(workers)
+    }
+
+    fn spec(&self, idx: WorkerIdx) -> WorkerSpec {
+        let i = idx.0 as usize;
+        assert!(i < self.workers.len(), "WorkerIdx out of range");
+        self.workers[i]
+    }
+}
+
+impl Threading for PinnedRuntime {
+    fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+
+    fn numa_of(&self, idx: WorkerIdx) -> Option<u16> {
+        self.spec(idx).numa
+    }
+
+    fn run_worker(&self, idx: WorkerIdx, f: Box<dyn FnOnce() + Send + 'static>) {
+        pin_current(self.spec(idx)).expect("PinnedRuntime::run_worker: pin failed");
+        f();
+    }
+
+    fn spawn_aux(
+        &self,
+        idx: WorkerIdx,
+        name: &str,
+        f: Box<dyn FnOnce() + Send + 'static>,
+    ) -> JoinHandle {
+        let spec = self.spec(idx);
+        std::thread::Builder::new()
+            .name(name.to_string())
+            .spawn(move || {
+                // A pin failure inside an aux thread shouldn't abort
+                // the host process; the work still has to run.
+                if let Err(e) = pin_current(spec) {
+                    eprintln!(
+                        "PinnedRuntime::spawn_aux: pin failed for cpu={} numa={:?}: {e}",
+                        spec.cpu, spec.numa
+                    );
+                }
+                f();
+            })
+            .expect("PinnedRuntime::spawn_aux: thread spawn failed")
+    }
+}
+
+fn pin_current(spec: WorkerSpec) -> std::io::Result<()> {
+    set_affinity(spec.cpu)?;
+    if let Some(node) = spec.numa {
+        set_preferred_node(node)?;
+    }
+    Ok(())
+}
+
+fn set_affinity(cpu: u32) -> std::io::Result<()> {
+    // SAFETY: cpu_set_t is a POD bitmap; we zero it and only call
+    // libc helpers that take a valid &mut.
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_ZERO(&mut set);
+        libc::CPU_SET(cpu as usize, &mut set);
+        let rc =
+            libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set as *const _);
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+fn set_preferred_node(node: u16) -> std::io::Result<()> {
+    // MPOL_PREFERRED: allocate from `node` if possible, fall back
+    // otherwise. Strict binding is too aggressive for a cache that
+    // can spill onto remote memory when local is full.
+    const MPOL_PREFERRED: libc::c_int = 1;
+    let bits_per_word = std::mem::size_of::<libc::c_ulong>() * 8;
+    let bit = node as usize;
+    let words = bit / bits_per_word + 1;
+    let mut mask = vec![0 as libc::c_ulong; words];
+    mask[bit / bits_per_word] |= (1 as libc::c_ulong) << (bit % bits_per_word);
+    let maxnode = (words * bits_per_word) as libc::c_ulong;
+    // SAFETY: mask is a valid, properly-sized bitmask for the syscall.
+    let rc = unsafe {
+        libc::syscall(
+            libc::SYS_set_mempolicy,
+            MPOL_PREFERRED as libc::c_long,
+            mask.as_ptr() as libc::c_long,
+            maxnode as libc::c_long,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn numa_node_of_cpu(cpu: u32) -> Option<u16> {
+    let dir = format!("/sys/devices/system/cpu/cpu{cpu}");
+    for entry in std::fs::read_dir(&dir).ok()?.flatten() {
+        let name = entry.file_name();
+        if let Some(rest) = name.to_string_lossy().strip_prefix("node") {
+            if let Ok(n) = rest.parse::<u16>() {
+                return Some(n);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // CPU 0 exists on every Linux host the test suite runs against.
+    const TEST_CPU: u32 = 0;
+
+    #[test]
+    fn run_worker_pins_to_target_cpu() {
+        let rt = PinnedRuntime::new(vec![WorkerSpec::new(TEST_CPU, None)]);
+        let pinned = Arc::new(Mutex::new(false));
+        let p = pinned.clone();
+        rt.run_worker(
+            WorkerIdx(0),
+            Box::new(move || {
+                let mut got: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                let rc = unsafe {
+                    libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut got)
+                };
+                assert_eq!(rc, 0);
+                let only_test = unsafe { libc::CPU_ISSET(TEST_CPU as usize, &got) }
+                    && (0..libc::CPU_SETSIZE as usize)
+                        .filter(|c| *c != TEST_CPU as usize)
+                        .all(|c| !unsafe { libc::CPU_ISSET(c, &got) });
+                *p.lock().unwrap() = only_test;
+            }),
+        );
+        assert!(*pinned.lock().unwrap());
+    }
+
+    #[test]
+    fn spawn_aux_runs_and_joins() {
+        let rt = PinnedRuntime::new(vec![WorkerSpec::new(TEST_CPU, Some(7))]);
+        assert_eq!(rt.worker_count(), 1);
+        assert_eq!(rt.numa_of(WorkerIdx(0)), Some(7));
+        let observed = Arc::new(Mutex::new(false));
+        let o = observed.clone();
+        // numa=Some(7) may fail on hosts without that node; pin
+        // with numa=None for the aux side to avoid that.
+        let rt2 = PinnedRuntime::new(vec![WorkerSpec::new(TEST_CPU, None)]);
+        let h = rt2.spawn_aux(
+            WorkerIdx(0),
+            "pinned-aux",
+            Box::new(move || *o.lock().unwrap() = true),
+        );
+        h.join().expect("aux thread");
+        assert!(*observed.lock().unwrap());
+    }
+}

--- a/cmd/unbounded-storage/src/topology.rs
+++ b/cmd/unbounded-storage/src/topology.rs
@@ -1,0 +1,982 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+/// One transport shard - the cores assigned to drive a single HCA.
+/// `dev_name == None` is the TCP fallback used when no RDMA NICs
+/// are discoverable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NicShard {
+    pub dev_name: Option<String>,
+    pub pci_bdf: Option<String>,
+    pub numa: Option<u16>,
+    pub cpus: Vec<u32>,
+}
+
+/// Per-thread placement record produced by [`flatten_shards`]. One
+/// `ProgressSlot` becomes one pinned OS thread and one Mercury Class.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProgressSlot {
+    pub shard: usize,
+    pub thread_in_shard: u16,
+    pub cpu: u32,
+    pub numa: Option<u16>,
+}
+
+/// Knobs that govern shard discovery. Defaults are picked for GB200
+/// + 4x 400G but are sensible on any datacenter host.
+#[derive(Clone, Debug)]
+pub struct TopologyConfig {
+    /// Upper bound on progress threads assigned to any single NIC.
+    /// The actual count may be lower if the NIC's local pool is
+    /// smaller. Default: 8.
+    pub threads_per_nic_cap: usize,
+    /// If true, use both SMT siblings of each physical core. The
+    /// default (false) keeps one logical CPU per physical core,
+    /// which is what RDMA progress workloads typically want.
+    pub use_smt_siblings: bool,
+    /// Honor `/sys/devices/system/cpu/isolated` when non-empty:
+    /// restrict per-NIC pools to its intersection.
+    pub respect_isolated: bool,
+    /// When `isolated` is empty (or `respect_isolated` is false),
+    /// drop CPU 0 of every NUMA node the pool spans. Cheap defense
+    /// against contending with kernel housekeeping.
+    pub exclude_node_cpu0: bool,
+    /// Require `/sys/class/infiniband/<dev>/node_type` to contain
+    /// `CA` (filters out soft-RoCE/iWARP shims and switch ports).
+    pub require_node_type_ca: bool,
+    /// Require at least one port whose `state` contains `ACTIVE`.
+    pub require_active_port: bool,
+}
+
+impl Default for TopologyConfig {
+    fn default() -> Self {
+        Self {
+            threads_per_nic_cap: 8,
+            use_smt_siblings: false,
+            respect_isolated: true,
+            exclude_node_cpu0: true,
+            require_node_type_ca: true,
+            require_active_port: true,
+        }
+    }
+}
+
+/// Discover one shard per usable RDMA HCA on the running host.
+///
+/// Returns an empty vec when sysfs lacks `class/infiniband/` (no
+/// kernel IB stack) or when every device fails the health/affinity
+/// filters. Callers that need a non-empty result should substitute
+/// [`fallback_shard`].
+pub fn discover_nic_shards() -> Vec<NicShard> {
+    discover_with(&TopologyConfig::default(), Path::new("/sys"))
+}
+
+/// Single TCP fallback shard for hosts without RDMA NICs. Not pinned
+/// to any specific NUMA node. `threads` controls how many progress
+/// threads the embedder will spawn for it.
+pub fn fallback_shard(threads: usize) -> NicShard {
+    let n = threads.max(1);
+    NicShard {
+        dev_name: None,
+        pci_bdf: None,
+        numa: None,
+        cpus: (0..n as u32).collect(),
+    }
+}
+
+/// Sysfs-root-parameterized variant of [`discover_nic_shards`].
+/// Production passes `/sys`; tests pass a staged temp dir.
+pub fn discover_with(cfg: &TopologyConfig, sys_root: &Path) -> Vec<NicShard> {
+    let mut candidates = enumerate_hcas(cfg, sys_root);
+    // Stable order across runs so log lines and worker indices line
+    // up with what an operator sees in /sys and `lspci`.
+    candidates.sort_by(|a, b| a.pci_bdf.cmp(&b.pci_bdf).then(a.dev_name.cmp(&b.dev_name)));
+
+    let isolated = if cfg.respect_isolated {
+        read_cpulist_file(&sys_root.join("devices/system/cpu/isolated")).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    // Build per-NIC pools.
+    let mut pools: Vec<Vec<u32>> = Vec::with_capacity(candidates.len());
+    for hca in &candidates {
+        let raw = nic_local_cpus(sys_root, hca);
+        let after_iso = if !isolated.is_empty() {
+            intersect(&raw, &isolated)
+        } else if cfg.exclude_node_cpu0 {
+            exclude_node_cpu0(sys_root, &raw)
+        } else {
+            raw
+        };
+        let collapsed = if cfg.use_smt_siblings {
+            after_iso
+        } else {
+            collapse_smt(sys_root, &after_iso)
+        };
+        pools.push(collapsed);
+    }
+
+    let assigned = allocate_disjoint(&pools, cfg.threads_per_nic_cap);
+
+    candidates
+        .into_iter()
+        .zip(assigned)
+        .filter_map(|(hca, cpus)| {
+            if cpus.is_empty() {
+                eprintln!(
+                    "topology: dropping HCA {} (numa={:?}): no usable CPUs after filtering",
+                    hca.dev_name.as_deref().unwrap_or("?"),
+                    hca.numa,
+                );
+                return None;
+            }
+            Some(NicShard {
+                dev_name: hca.dev_name,
+                pci_bdf: hca.pci_bdf,
+                numa: hca.numa,
+                cpus,
+            })
+        })
+        .collect()
+}
+
+/// Expand `shards` into one [`ProgressSlot`] per assigned CPU.
+/// Per-slot `numa` is derived from the CPU when sysfs is available,
+/// falling back to the shard's NIC-level hint.
+pub fn flatten_shards(shards: &[NicShard]) -> Vec<ProgressSlot> {
+    flatten_with(shards, Path::new("/sys"))
+}
+
+/// Sysfs-root-parameterized variant of [`flatten_shards`].
+pub fn flatten_with(shards: &[NicShard], sys_root: &Path) -> Vec<ProgressSlot> {
+    let mut slots = Vec::new();
+    for (idx, shard) in shards.iter().enumerate() {
+        for (t, &cpu) in shard.cpus.iter().enumerate() {
+            let numa = numa_of_cpu(sys_root, cpu).or(shard.numa);
+            slots.push(ProgressSlot {
+                shard: idx,
+                thread_in_shard: u16::try_from(t).expect("threads per shard fit in u16"),
+                cpu,
+                numa,
+            });
+        }
+    }
+    slots
+}
+
+// ---------------------------------------------------------------------------
+// HCA enumeration
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct Hca {
+    dev_name: Option<String>,
+    pci_bdf: Option<String>,
+    numa: Option<u16>,
+}
+
+fn enumerate_hcas(cfg: &TopologyConfig, sys_root: &Path) -> Vec<Hca> {
+    let ib_root = sys_root.join("class/infiniband");
+    let entries = match fs::read_dir(&ib_root) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let name_os = entry.file_name();
+        let dev = match name_os.to_str() {
+            Some(s) if !s.is_empty() => s.to_owned(),
+            _ => continue,
+        };
+        if cfg.require_node_type_ca && !node_type_is_ca(sys_root, &dev) {
+            eprintln!("topology: skipping {dev}: node_type is not CA");
+            continue;
+        }
+        if cfg.require_active_port && !has_active_port(sys_root, &dev) {
+            eprintln!("topology: skipping {dev}: no ACTIVE port");
+            continue;
+        }
+        let numa = read_nic_numa(sys_root, &dev);
+        let pci_bdf = read_pci_bdf(sys_root, &dev);
+        out.push(Hca {
+            dev_name: Some(dev),
+            pci_bdf,
+            numa,
+        });
+    }
+    out
+}
+
+fn node_type_is_ca(sys_root: &Path, dev: &str) -> bool {
+    let path = sys_root.join(format!("class/infiniband/{dev}/node_type"));
+    match fs::read_to_string(path) {
+        Ok(s) => s.contains("CA"),
+        // Older kernels may omit node_type; treat as CA so we
+        // don't regress on hosts the previous logic accepted.
+        Err(_) => true,
+    }
+}
+
+fn has_active_port(sys_root: &Path, dev: &str) -> bool {
+    let ports_dir = sys_root.join(format!("class/infiniband/{dev}/ports"));
+    let entries = match fs::read_dir(&ports_dir) {
+        Ok(e) => e,
+        // If `ports/` is absent (test fixture or odd driver), don't
+        // block discovery on it.
+        Err(_) => return true,
+    };
+    for entry in entries.flatten() {
+        let state_path = entry.path().join("state");
+        if let Ok(s) = fs::read_to_string(&state_path) {
+            if s.contains("ACTIVE") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn read_nic_numa(sys_root: &Path, dev: &str) -> Option<u16> {
+    let path = sys_root.join(format!("class/infiniband/{dev}/device/numa_node"));
+    let s = fs::read_to_string(path).ok()?;
+    match s.trim().parse::<i32>().ok()? {
+        n if n < 0 => None,
+        n => Some(n as u16),
+    }
+}
+
+fn read_pci_bdf(sys_root: &Path, dev: &str) -> Option<String> {
+    let path = sys_root.join(format!("class/infiniband/{dev}/device/uevent"));
+    let s = fs::read_to_string(path).ok()?;
+    for line in s.lines() {
+        if let Some(v) = line.strip_prefix("PCI_SLOT_NAME=") {
+            return Some(v.trim().to_string());
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// CPU set resolution
+// ---------------------------------------------------------------------------
+
+fn nic_local_cpus(sys_root: &Path, hca: &Hca) -> Vec<u32> {
+    let dev = match &hca.dev_name {
+        Some(d) => d,
+        None => return read_online_cpus(sys_root),
+    };
+    let local = sys_root.join(format!("class/infiniband/{dev}/device/local_cpulist"));
+    if let Some(cpus) = read_cpulist_file(&local) {
+        if !cpus.is_empty() {
+            return cpus;
+        }
+    }
+    if let Some(node) = hca.numa {
+        let node_path = sys_root.join(format!("devices/system/node/node{node}/cpulist"));
+        if let Some(cpus) = read_cpulist_file(&node_path) {
+            if !cpus.is_empty() {
+                return cpus;
+            }
+        }
+    }
+    read_online_cpus(sys_root)
+}
+
+fn read_online_cpus(sys_root: &Path) -> Vec<u32> {
+    read_cpulist_file(&sys_root.join("devices/system/cpu/online")).unwrap_or_default()
+}
+
+fn read_cpulist_file(path: &Path) -> Option<Vec<u32>> {
+    let raw = fs::read_to_string(path).ok()?;
+    Some(parse_cpulist(&raw))
+}
+
+/// Parse a Linux cpulist like `"0-71,144-215"` into a sorted, deduped
+/// Vec. Returns empty for empty input or unparseable fragments.
+fn parse_cpulist(s: &str) -> Vec<u32> {
+    let mut set = BTreeSet::new();
+    for group in s.trim().split(',') {
+        let group = group.trim();
+        if group.is_empty() {
+            continue;
+        }
+        let mut parts = group.splitn(2, '-');
+        let lo = match parts.next().and_then(|s| s.trim().parse::<u32>().ok()) {
+            Some(v) => v,
+            None => continue,
+        };
+        let hi = match parts.next() {
+            Some(s) => s.trim().parse::<u32>().ok().unwrap_or(lo),
+            None => lo,
+        };
+        for cpu in lo..=hi {
+            set.insert(cpu);
+        }
+    }
+    set.into_iter().collect()
+}
+
+// ---------------------------------------------------------------------------
+// Pool refinement
+// ---------------------------------------------------------------------------
+
+fn intersect(a: &[u32], b: &[u32]) -> Vec<u32> {
+    let set: BTreeSet<u32> = b.iter().copied().collect();
+    a.iter().copied().filter(|c| set.contains(c)).collect()
+}
+
+fn exclude_node_cpu0(sys_root: &Path, pool: &[u32]) -> Vec<u32> {
+    let mut node_to_first: std::collections::HashMap<u16, u32> = std::collections::HashMap::new();
+    for &cpu in pool {
+        if let Some(n) = numa_of_cpu(sys_root, cpu) {
+            node_to_first
+                .entry(n)
+                .and_modify(|c| {
+                    if cpu < *c {
+                        *c = cpu
+                    }
+                })
+                .or_insert(cpu);
+        }
+    }
+    if node_to_first.is_empty() {
+        // No node info -> conservatively drop CPU 0 if present.
+        return pool.iter().copied().filter(|c| *c != 0).collect();
+    }
+    let drop: BTreeSet<u32> = node_to_first.into_values().collect();
+    pool.iter().copied().filter(|c| !drop.contains(c)).collect()
+}
+
+fn collapse_smt(sys_root: &Path, pool: &[u32]) -> Vec<u32> {
+    let pool_set: BTreeSet<u32> = pool.iter().copied().collect();
+    let mut keep = BTreeSet::new();
+    let mut seen_core = BTreeSet::new();
+    for &cpu in pool {
+        let siblings = thread_siblings(sys_root, cpu);
+        let core_id = siblings.iter().copied().min().unwrap_or(cpu);
+        if seen_core.insert(core_id) && pool_set.contains(&core_id) {
+            keep.insert(core_id);
+        }
+    }
+    keep.into_iter().collect()
+}
+
+fn thread_siblings(sys_root: &Path, cpu: u32) -> Vec<u32> {
+    let path = sys_root.join(format!(
+        "devices/system/cpu/cpu{cpu}/topology/thread_siblings_list"
+    ));
+    match read_cpulist_file(&path) {
+        Some(v) if !v.is_empty() => v,
+        _ => vec![cpu],
+    }
+}
+
+fn numa_of_cpu(sys_root: &Path, cpu: u32) -> Option<u16> {
+    let dir = sys_root.join(format!("devices/system/cpu/cpu{cpu}"));
+    for entry in fs::read_dir(&dir).ok()?.flatten() {
+        let name = entry.file_name();
+        if let Some(rest) = name.to_string_lossy().strip_prefix("node") {
+            if let Ok(n) = rest.parse::<u16>() {
+                return Some(n);
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Global disjoint allocation
+// ---------------------------------------------------------------------------
+
+/// Given per-NIC candidate pools, assign each NIC up to `cap` CPUs
+/// such that assignments across NICs are disjoint when possible. If
+/// the union of pools is too small to satisfy every NIC, the over-
+/// flow NICs receive an oversubscribed (re-used) slice from their
+/// own pool; this is logged but never silently drops a NIC.
+///
+/// The allocator processes NICs in order of pool size ascending so
+/// the most constrained NICs get first pick.
+fn allocate_disjoint(pools: &[Vec<u32>], cap: usize) -> Vec<Vec<u32>> {
+    let n = pools.len();
+    let cap = cap.max(1);
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by_key(|&i| pools[i].len());
+
+    let mut claimed: BTreeSet<u32> = BTreeSet::new();
+    let mut out: Vec<Vec<u32>> = vec![Vec::new(); n];
+
+    for &i in &order {
+        let pool = &pools[i];
+        if pool.is_empty() {
+            continue;
+        }
+        let want = cap.min(pool.len()).max(1);
+        let mut picked: Vec<u32> = pool
+            .iter()
+            .copied()
+            .filter(|c| !claimed.contains(c))
+            .take(want)
+            .collect();
+
+        if picked.len() < want {
+            // Oversubscription: fall back to the NIC's full pool,
+            // round-robin from where we left off, allowing overlap.
+            let already: BTreeSet<u32> = picked.iter().copied().collect();
+            let leftover: Vec<u32> = pool
+                .iter()
+                .copied()
+                .filter(|c| !already.contains(c))
+                .collect();
+            let mut j = 0usize;
+            while picked.len() < want && !leftover.is_empty() {
+                picked.push(leftover[j % leftover.len()]);
+                j += 1;
+            }
+            if picked.len() < want {
+                eprintln!(
+                    "topology: NIC index {i} oversubscribed (pool={}, want={want}); duplicates allowed",
+                    pool.len()
+                );
+            }
+        }
+
+        for c in &picked {
+            claimed.insert(*c);
+        }
+        out[i] = picked;
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    struct FakeSys {
+        root: PathBuf,
+    }
+
+    impl FakeSys {
+        fn new() -> Self {
+            // Per-test unique dir under the workspace target/ so we
+            // don't touch /tmp (project rule) and avoid collisions
+            // across parallel tests.
+            let pid = std::process::id();
+            let counter = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let root = std::env::current_dir()
+                .unwrap()
+                .join("target")
+                .join("tmp-topology-tests")
+                .join(format!("{pid}-{counter}"));
+            let _ = fs::remove_dir_all(&root);
+            fs::create_dir_all(&root).unwrap();
+            Self { root }
+        }
+
+        fn write(&self, rel: &str, contents: &str) {
+            let p = self.root.join(rel);
+            fs::create_dir_all(p.parent().unwrap()).unwrap();
+            fs::write(p, contents).unwrap();
+        }
+
+        fn touch_dir(&self, rel: &str) {
+            fs::create_dir_all(self.root.join(rel)).unwrap();
+        }
+
+        /// Stage a complete-looking HCA. `local_cpulist` may be `None`
+        /// to force fallback to the NUMA-node cpulist.
+        fn add_hca(
+            &self,
+            dev: &str,
+            bdf: &str,
+            numa: i32,
+            local_cpulist: Option<&str>,
+            active: bool,
+        ) {
+            self.touch_dir(&format!("class/infiniband/{dev}/device"));
+            self.write(&format!("class/infiniband/{dev}/node_type"), "1: CA\n");
+            self.write(
+                &format!("class/infiniband/{dev}/device/numa_node"),
+                &format!("{numa}\n"),
+            );
+            self.write(
+                &format!("class/infiniband/{dev}/device/uevent"),
+                &format!("PCI_SLOT_NAME={bdf}\n"),
+            );
+            if let Some(list) = local_cpulist {
+                self.write(
+                    &format!("class/infiniband/{dev}/device/local_cpulist"),
+                    &format!("{list}\n"),
+                );
+            }
+            self.write(
+                &format!("class/infiniband/{dev}/ports/1/state"),
+                if active { "4: ACTIVE\n" } else { "1: DOWN\n" },
+            );
+        }
+
+        /// Register a CPU under its NUMA node and (optionally) its
+        /// SMT siblings list. Without siblings the CPU is treated as
+        /// single-threaded.
+        fn add_cpu(&self, cpu: u32, node: u16, siblings: Option<&str>) {
+            self.touch_dir(&format!("devices/system/cpu/cpu{cpu}/node{node}"));
+            self.touch_dir(&format!("devices/system/node/node{node}"));
+            if let Some(s) = siblings {
+                self.write(
+                    &format!("devices/system/cpu/cpu{cpu}/topology/thread_siblings_list"),
+                    &format!("{s}\n"),
+                );
+            }
+        }
+
+        fn add_node_cpulist(&self, node: u16, list: &str) {
+            self.write(
+                &format!("devices/system/node/node{node}/cpulist"),
+                &format!("{list}\n"),
+            );
+        }
+    }
+
+    impl Drop for FakeSys {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    fn dev_names(shards: &[NicShard]) -> Vec<String> {
+        shards
+            .iter()
+            .map(|s| s.dev_name.clone().unwrap_or_else(|| "tcp".into()))
+            .collect()
+    }
+
+    // -------- parse_cpulist --------
+
+    #[test]
+    fn parse_cpulist_basics() {
+        assert_eq!(parse_cpulist("0-3"), vec![0, 1, 2, 3]);
+        assert_eq!(parse_cpulist("0-1,4-5"), vec![0, 1, 4, 5]);
+        assert_eq!(parse_cpulist("  5  "), vec![5]);
+        assert_eq!(parse_cpulist(""), Vec::<u32>::new());
+        assert_eq!(parse_cpulist("\n"), Vec::<u32>::new());
+        // Out-of-order groups end up sorted and deduped.
+        assert_eq!(parse_cpulist("5,0-1,5"), vec![0, 1, 5]);
+    }
+
+    // -------- empty / fallback --------
+
+    #[test]
+    fn no_infiniband_dir_returns_empty() {
+        let s = FakeSys::new();
+        assert!(discover_with(&TopologyConfig::default(), &s.root).is_empty());
+    }
+
+    #[test]
+    fn fallback_shard_threads() {
+        let f = fallback_shard(4);
+        assert!(f.dev_name.is_none());
+        assert_eq!(f.cpus, vec![0, 1, 2, 3]);
+        // Always at least one progress thread.
+        assert_eq!(fallback_shard(0).cpus, vec![0]);
+    }
+
+    // -------- single NIC, local_cpulist drives affinity --------
+
+    #[test]
+    fn single_nic_uses_local_cpulist() {
+        let s = FakeSys::new();
+        s.add_hca("mlx5_0", "0000:af:00.0", 0, Some("4-11"), true);
+        // No SMT, simple node layout.
+        for cpu in 0u32..72 {
+            s.add_cpu(cpu, 0, None);
+        }
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 4,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].dev_name.as_deref(), Some("mlx5_0"));
+        assert_eq!(got[0].pci_bdf.as_deref(), Some("0000:af:00.0"));
+        assert_eq!(got[0].numa, Some(0));
+        // 4 cores drawn from the local_cpulist (4-11) in order.
+        assert_eq!(got[0].cpus, vec![4, 5, 6, 7]);
+    }
+
+    // -------- NUMA-only fallback when local_cpulist missing --------
+
+    #[test]
+    fn falls_back_to_node_cpulist_when_local_missing() {
+        let s = FakeSys::new();
+        s.add_hca("mlx5_0", "0000:af:00.0", 1, None, true);
+        for cpu in 72u32..80 {
+            s.add_cpu(cpu, 1, None);
+        }
+        s.add_node_cpulist(1, "72-79");
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 3,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].cpus, vec![72, 73, 74]);
+    }
+
+    // -------- NUMA -1 + global online fallback --------
+
+    #[test]
+    fn nic_numa_minus_one_uses_online_cpus() {
+        let s = FakeSys::new();
+        s.add_hca("mlx5_0", "0000:af:00.0", -1, None, true);
+        s.write("devices/system/cpu/online", "0-3\n");
+        for cpu in 0u32..4 {
+            s.add_cpu(cpu, 0, None);
+        }
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 2,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].numa, None);
+        assert_eq!(got[0].cpus, vec![0, 1]);
+    }
+
+    // -------- GB200-like: 4 NICs, 2 NUMA, disjoint assignment --------
+
+    #[test]
+    fn gb200_like_four_nic_two_numa_disjoint() {
+        let s = FakeSys::new();
+        // Two NICs per NUMA, each pair shares a local_cpulist.
+        s.add_hca("mlx5_0", "0000:01:00.0", 0, Some("0-35"), true);
+        s.add_hca("mlx5_1", "0000:02:00.0", 0, Some("0-35"), true);
+        s.add_hca("mlx5_2", "0000:81:00.0", 1, Some("36-71"), true);
+        s.add_hca("mlx5_3", "0000:82:00.0", 1, Some("36-71"), true);
+        for cpu in 0u32..36 {
+            s.add_cpu(cpu, 0, None);
+        }
+        for cpu in 36u32..72 {
+            s.add_cpu(cpu, 1, None);
+        }
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 8,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(
+            dev_names(&got),
+            vec!["mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3"]
+        );
+        // Each NIC has 8 cores.
+        for sh in &got {
+            assert_eq!(sh.cpus.len(), 8, "shard {sh:?}");
+        }
+        // Pair within NUMA 0 is disjoint and on the right side.
+        let n0: BTreeSet<u32> = got[0]
+            .cpus
+            .iter()
+            .chain(got[1].cpus.iter())
+            .copied()
+            .collect();
+        assert_eq!(n0.len(), 16);
+        assert!(n0.iter().all(|c| *c < 36));
+        // Pair within NUMA 1 is disjoint and on the right side.
+        let n1: BTreeSet<u32> = got[2]
+            .cpus
+            .iter()
+            .chain(got[3].cpus.iter())
+            .copied()
+            .collect();
+        assert_eq!(n1.len(), 16);
+        assert!(n1.iter().all(|c| (36..72).contains(c)));
+    }
+
+    // -------- EPYC-like: many CCDs, one NIC per CCD --------
+
+    #[test]
+    fn epyc_like_eight_nic_eight_ccd() {
+        let s = FakeSys::new();
+        for i in 0u32..8 {
+            let dev = format!("mlx5_{i}");
+            let bdf = format!("0000:{:02x}:00.0", 0x10 + i);
+            let lo = i * 8;
+            let hi = lo + 7;
+            s.add_hca(&dev, &bdf, i as i32, Some(&format!("{lo}-{hi}")), true);
+            for cpu in lo..=hi {
+                s.add_cpu(cpu, i as u16, None);
+            }
+        }
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 4,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(got.len(), 8);
+        for (i, sh) in got.iter().enumerate() {
+            let lo = (i as u32) * 8;
+            assert_eq!(sh.cpus, vec![lo, lo + 1, lo + 2, lo + 3]);
+            assert_eq!(sh.numa, Some(i as u16));
+        }
+    }
+
+    // -------- CPU-less NUMA node (GB200 HBM) handling --------
+
+    #[test]
+    fn cpuless_node_yields_empty_pool_and_dropped() {
+        let s = FakeSys::new();
+        // mlx5_0 valid; mlx5_1 reports NUMA=2 which has no CPUs.
+        s.add_hca("mlx5_0", "0000:01:00.0", 0, None, true);
+        s.add_hca("mlx5_1", "0000:02:00.0", 2, None, true);
+        for cpu in 0u32..8 {
+            s.add_cpu(cpu, 0, None);
+        }
+        s.add_node_cpulist(0, "0-7");
+        // node2 is CPU-less; no cpulist file, no online entries.
+        s.write("devices/system/cpu/online", "0-7\n");
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 2,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        // The CPU-less NIC falls back to the online list (0-7), so it
+        // is *not* dropped; it shares the online pool. This is the
+        // intentional, documented behavior: HBM-only nodes still need
+        // to participate, just not strictly NUMA-local.
+        assert_eq!(got.len(), 2);
+        // But assignments are disjoint across the two NICs.
+        let a: BTreeSet<u32> = got[0].cpus.iter().copied().collect();
+        let b: BTreeSet<u32> = got[1].cpus.iter().copied().collect();
+        assert!(a.is_disjoint(&b));
+    }
+
+    // -------- node_type filter --------
+
+    #[test]
+    fn rxe_filtered_out() {
+        let s = FakeSys::new();
+        s.touch_dir("class/infiniband/rxe0/device");
+        s.write("class/infiniband/rxe0/node_type", "2: SWITCH\n");
+        s.write("class/infiniband/rxe0/device/numa_node", "0\n");
+        s.write("class/infiniband/rxe0/ports/1/state", "4: ACTIVE\n");
+        let got = discover_with(&TopologyConfig::default(), &s.root);
+        assert!(got.is_empty());
+    }
+
+    // -------- port-state filter --------
+
+    #[test]
+    fn down_port_filtered_out() {
+        let s = FakeSys::new();
+        s.add_hca("mlx5_0", "0000:01:00.0", 0, Some("0-3"), false);
+        for cpu in 0u32..4 {
+            s.add_cpu(cpu, 0, None);
+        }
+        let got = discover_with(&TopologyConfig::default(), &s.root);
+        assert!(got.is_empty());
+    }
+
+    // -------- isolcpus respected --------
+
+    #[test]
+    fn isolated_intersected_into_pool() {
+        let s = FakeSys::new();
+        s.add_hca("mlx5_0", "0000:01:00.0", 0, Some("0-15"), true);
+        for cpu in 0u32..16 {
+            s.add_cpu(cpu, 0, None);
+        }
+        s.write("devices/system/cpu/isolated", "8-15\n");
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 4,
+            respect_isolated: true,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(got[0].cpus, vec![8, 9, 10, 11]);
+    }
+
+    // -------- housekeeping exclusion (no isolcpus) --------
+
+    #[test]
+    fn excludes_first_cpu_of_each_node() {
+        let s = FakeSys::new();
+        s.add_hca("mlx5_0", "0000:01:00.0", 0, Some("0-7"), true);
+        s.add_hca("mlx5_1", "0000:81:00.0", 1, Some("16-23"), true);
+        for cpu in 0u32..8 {
+            s.add_cpu(cpu, 0, None);
+        }
+        for cpu in 16u32..24 {
+            s.add_cpu(cpu, 1, None);
+        }
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 3,
+            respect_isolated: true,
+            exclude_node_cpu0: true,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        // First CPU of each node (0 and 16) dropped.
+        assert!(!got[0].cpus.contains(&0));
+        assert!(!got[1].cpus.contains(&16));
+        assert_eq!(got[0].cpus, vec![1, 2, 3]);
+        assert_eq!(got[1].cpus, vec![17, 18, 19]);
+    }
+
+    // -------- SMT collapse --------
+
+    #[test]
+    fn smt_siblings_collapsed_by_default() {
+        let s = FakeSys::new();
+        s.add_hca("mlx5_0", "0000:01:00.0", 0, Some("0-7"), true);
+        // 4 physical cores, pairs (0,4), (1,5), (2,6), (3,7).
+        for (cpu, sib) in [
+            (0, "0,4"),
+            (4, "0,4"),
+            (1, "1,5"),
+            (5, "1,5"),
+            (2, "2,6"),
+            (6, "2,6"),
+            (3, "3,7"),
+            (7, "3,7"),
+        ] {
+            s.add_cpu(cpu, 0, Some(sib));
+        }
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 8,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            use_smt_siblings: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(got[0].cpus, vec![0, 1, 2, 3]);
+
+        let cfg2 = TopologyConfig {
+            use_smt_siblings: true,
+            ..cfg
+        };
+        let got2 = discover_with(&cfg2, &s.root);
+        assert_eq!(got2[0].cpus, vec![0, 1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    // -------- oversubscription path --------
+
+    #[test]
+    fn oversubscribed_pool_assigns_with_duplicates() {
+        let s = FakeSys::new();
+        // Two NICs share a 4-cpu local pool; cap=4 -> total demand 8
+        // > pool size 4. First NIC gets disjoint 4, second NIC gets
+        // the same 4 reused.
+        s.add_hca("mlx5_0", "0000:01:00.0", 0, Some("0-3"), true);
+        s.add_hca("mlx5_1", "0000:02:00.0", 0, Some("0-3"), true);
+        for cpu in 0u32..4 {
+            s.add_cpu(cpu, 0, None);
+        }
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 4,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].cpus.len(), 4);
+        assert_eq!(got[1].cpus.len(), 4);
+        let a: BTreeSet<u32> = got[0].cpus.iter().copied().collect();
+        let b: BTreeSet<u32> = got[1].cpus.iter().copied().collect();
+        // No NIC is empty; second NIC overlaps with the first.
+        assert!(!a.is_disjoint(&b));
+    }
+
+    // -------- sort by PCI BDF, not lex dev_name --------
+
+    #[test]
+    fn sorts_by_pci_bdf() {
+        let s = FakeSys::new();
+        // Lex order would put mlx5_10 before mlx5_2; BDF order does
+        // not.
+        s.add_hca("mlx5_2", "0000:02:00.0", 0, Some("0-3"), true);
+        s.add_hca("mlx5_10", "0000:10:00.0", 0, Some("4-7"), true);
+        for cpu in 0u32..8 {
+            s.add_cpu(cpu, 0, None);
+        }
+        let cfg = TopologyConfig {
+            threads_per_nic_cap: 2,
+            respect_isolated: false,
+            exclude_node_cpu0: false,
+            ..TopologyConfig::default()
+        };
+        let got = discover_with(&cfg, &s.root);
+        assert_eq!(dev_names(&got), vec!["mlx5_2", "mlx5_10"]);
+    }
+
+    // -------- flatten --------
+
+    #[test]
+    fn flatten_emits_one_slot_per_cpu() {
+        let s = FakeSys::new();
+        for cpu in 0u32..4 {
+            s.add_cpu(cpu, 0, None);
+        }
+        for cpu in 8u32..12 {
+            s.add_cpu(cpu, 1, None);
+        }
+        let shards = vec![
+            NicShard {
+                dev_name: Some("mlx5_0".into()),
+                pci_bdf: Some("0000:01:00.0".into()),
+                numa: Some(0),
+                cpus: vec![1, 2],
+            },
+            NicShard {
+                dev_name: Some("mlx5_1".into()),
+                pci_bdf: Some("0000:81:00.0".into()),
+                numa: Some(1),
+                cpus: vec![9, 10],
+            },
+        ];
+        let slots = flatten_with(&shards, &s.root);
+        assert_eq!(slots.len(), 4);
+        assert_eq!(
+            slots[0],
+            ProgressSlot {
+                shard: 0,
+                thread_in_shard: 0,
+                cpu: 1,
+                numa: Some(0)
+            }
+        );
+        assert_eq!(
+            slots[3],
+            ProgressSlot {
+                shard: 1,
+                thread_in_shard: 1,
+                cpu: 10,
+                numa: Some(1)
+            }
+        );
+    }
+}

--- a/cmd/unbounded-storage/tests/bufferpool/mocks.rs
+++ b/cmd/unbounded-storage/tests/bufferpool/mocks.rs
@@ -98,34 +98,34 @@ pub struct DstTransport {
     stripes: Stripes,
     counts: Rc<CallCounts>,
     cfg: Rc<MockSimConfig>,
-    base: Cell<Option<*mut u8>>,
-    page_size: Cell<usize>,
+    /// Bound at construction. The `Transport` trait no longer
+    /// carries a `register_pages` hook: the embedder pre-registers
+    /// the backing out-of-band, so the mock learns the geometry the
+    /// same way a real transport does (constructor argument from
+    /// whoever owns the `Backing`).
+    base: *mut u8,
+    page_size: usize,
 }
 
 impl DstTransport {
-    pub fn new(stripes: Stripes, counts: Rc<CallCounts>, cfg: Rc<MockSimConfig>) -> Self {
+    pub fn new(
+        stripes: Stripes,
+        counts: Rc<CallCounts>,
+        cfg: Rc<MockSimConfig>,
+        base: *mut u8,
+        page_size: usize,
+    ) -> Self {
         Self {
             stripes,
             counts,
             cfg,
-            base: Cell::new(None),
-            page_size: Cell::new(0),
+            base,
+            page_size,
         }
     }
 }
 
 impl Transport<TestReq> for DstTransport {
-    fn register_pages(
-        &self,
-        base: *mut u8,
-        page_size: usize,
-        _page_count: usize,
-    ) -> Result<(), Error> {
-        self.base.set(Some(base));
-        self.page_size.set(page_size);
-        Ok(())
-    }
-
     async fn bulk_get(&self, _req: &TestReq, src: BulkRef, dst: PageRef) -> Result<(), Error> {
         // Pull delay and (optional) fault decision up front; this
         // keeps the PRNG draws deterministic across re-orderings of
@@ -133,7 +133,7 @@ impl Transport<TestReq> for DstTransport {
         let delay = draw_delay(&self.cfg);
         let fault = draw_fault(&self.cfg);
 
-        let page_size = self.page_size.get();
+        let page_size = self.page_size;
         let page_no = src.offset / page_size as u64;
         // Track concurrent in-flight for the single-flight invariant.
         {
@@ -165,12 +165,13 @@ impl Transport<TestReq> for DstTransport {
         let end = start + src.len as usize;
         assert!(end <= bytes.len(), "DstTransport: src out of range");
 
-        let base = self.base.get().expect("register_pages must run first");
         // SAFETY: dst is a pool-owned page within the registered
         // backing; src is a Vec<u8> owned by `stripes`. Both ranges
         // are valid for the duration of this call.
         unsafe {
-            let dst_ptr = base.add(dst.page_idx as usize * page_size + dst.offset as usize);
+            let dst_ptr = self
+                .base
+                .add(dst.page_idx as usize * page_size + dst.offset as usize);
             std::ptr::copy_nonoverlapping(bytes.as_ptr().add(start), dst_ptr, src.len as usize);
         }
 

--- a/cmd/unbounded-storage/tests/bufferpool/workload.rs
+++ b/cmd/unbounded-storage/tests/bufferpool/workload.rs
@@ -274,7 +274,13 @@ pub fn run_workload(seed: u64, w: Workload) -> Result<RunReport, RunError> {
     let mock_cfg = MockSimConfig::new();
     mock_cfg.max_io_delay.set(w.max_io_delay);
     mock_cfg.io_fault_rate.set(w.io_fault_rate);
-    let transport = DstTransport::new(stripes.clone(), counts.clone(), mock_cfg.clone());
+    let transport = DstTransport::new(
+        stripes.clone(),
+        counts.clone(),
+        mock_cfg.clone(),
+        backing.base,
+        backing.page_size,
+    );
     let blockstore = DstBlockStore::new(counts.clone(), stripes.clone(), mock_cfg.clone());
     blockstore.set_hit_rate(w.cache_hit_rate);
 
@@ -383,8 +389,11 @@ pub fn run_workload(seed: u64, w: Workload) -> Result<RunReport, RunError> {
     // recycles the slot and a new caller leads again.
     let max_pages_per_client = (stripe_len / w.page_size as u64) + 1;
     let fault_slack = 1 + w.io_fault_rate as u64 / 5;
-    let step_budget =
-        64 + (normalized.len() as u64) * max_pages_per_client * (w.max_io_delay as u64 + 4) * 16
+    let step_budget = 64
+        + (normalized.len() as u64)
+            * max_pages_per_client
+            * (w.max_io_delay as u64 + 4)
+            * 16
             * fault_slack;
 
     exec.run(step_budget)?;

--- a/cmd/unbounded-storage/tests/dst.rs
+++ b/cmd/unbounded-storage/tests/dst.rs
@@ -3,3 +3,4 @@
 
 mod bufferpool;
 mod framework;
+mod mercury;

--- a/cmd/unbounded-storage/tests/mercury/mocks.rs
+++ b/cmd/unbounded-storage/tests/mercury/mocks.rs
@@ -1,0 +1,250 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DST-aware fakes for the Mercury cross-thread bridge.
+//!
+//! The bridge under test is `mercury::progress`: an
+//! `Arc<CompletionSlot>` is handed to the FFI as a raw pointer, and a
+//! callback fires later from the progress thread. The single-threaded
+//! DST executor cannot run a second OS thread, so we model the
+//! progress thread as another async task. The "FFI" surface this
+//! suite cares about is just the raw-pointer round trip:
+//!
+//!   1. The client `into_callback_arg()`s its `Arc<CompletionSlot>`
+//!      and registers the resulting pointer with `FakeProgress`.
+//!   2. The progress task picks one pending entry per loop iteration
+//!      (uniformly via `with_sim`), `yield_n`s a random delay drawn
+//!      from `MercurySimCfg`, reclaims the slot via
+//!      `from_callback_arg`, and calls `slot.complete(outcome)`.
+//!   3. The shared `ServerJobQueue` is exercised the same way: a
+//!      producer task pushes jobs interleaved with yields and then
+//!      calls `close()`; consumer tasks pull via `next_job().await`.
+//!
+//! Per-area knobs (delay bound, error rate, out-of-order delivery)
+//! live on `MercurySimCfg` rather than the framework's `SimState`.
+
+use std::cell::{Cell, RefCell};
+use std::ffi::c_void;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use rand::Rng;
+use unbounded_storage::mercury::progress::{CompletionSlot, ServerJob, UnsafeSendPtr};
+
+use crate::framework::executor::{with_sim, yield_n};
+
+/// Per-run simulation knobs for the Mercury bridge mocks. Held
+/// behind an `Rc` so both the workload driver and the progress task
+/// can share a single configuration instance.
+pub struct MercurySimCfg {
+    /// Maximum number of `yield_once` pends the progress task emits
+    /// before delivering a single pending completion. Actual count
+    /// per delivery is drawn uniformly from `0..=max_delivery_delay`.
+    pub max_delivery_delay: Cell<u32>,
+    /// Probability in `[0, 100]` that a delivery resolves with a
+    /// synthetic error. `0` is the all-success regime.
+    pub error_rate: Cell<u32>,
+    /// If true, the progress task picks the pending entry to deliver
+    /// uniformly at random; if false it delivers FIFO. Out-of-order
+    /// delivery exercises the bridge's "callback for a future the
+    /// client has not yet polled" cases.
+    pub out_of_order: Cell<bool>,
+    /// Probability in `[0, 100]` that a `submit` call fails
+    /// synchronously, mirroring an `HG_Forward` rejection. The slot
+    /// is released by the client and no callback is ever scheduled,
+    /// so no entry is added to `pending` or the history.
+    pub submit_failure_rate: Cell<u32>,
+}
+
+impl MercurySimCfg {
+    pub fn new() -> Rc<Self> {
+        Rc::new(Self {
+            max_delivery_delay: Cell::new(0),
+            error_rate: Cell::new(0),
+            out_of_order: Cell::new(false),
+            submit_failure_rate: Cell::new(0),
+        })
+    }
+}
+
+/// Returns true with probability `MercurySimCfg::submit_failure_rate / 100`.
+/// All randomness flows through `with_sim` so the run is deterministic
+/// in `(seed, workload)`.
+pub fn draw_submit_failure(cfg: &MercurySimCfg) -> bool {
+    let rate = cfg.submit_failure_rate.get();
+    rate > 0 && with_sim(|s| s.rng.gen_ratio(rate.min(100), 100))
+}
+
+/// Identity tag a client stamps onto each submission so the oracle
+/// and history can correlate "submitted X" with "completed X".
+pub type SlotTag = u64;
+
+/// One outcome the progress task will deliver. `Ok(())` and `Err(code)`
+/// flatten down to the same `Result<(), HgError>` the production
+/// callback path would store on the slot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Outcome {
+    Ok,
+    Err(i32),
+}
+
+/// One in-flight submission held by the fake progress thread until
+/// it fires the callback.
+pub struct Pending {
+    pub tag: SlotTag,
+    /// Raw pointer produced by `CompletionSlot::into_callback_arg`.
+    /// `UnsafeSendPtr` is `Send + Sync` only to keep the type usable
+    /// across the bridge; the executor is single-threaded so no real
+    /// thread crossing happens here.
+    pub arg: UnsafeSendPtr,
+    pub outcome: Outcome,
+}
+
+/// Shared mock state. All mutators run on the single executor
+/// thread; `RefCell` is sufficient.
+pub struct FakeProgress {
+    pending: RefCell<Vec<Pending>>,
+    history: RefCell<Vec<(SlotTag, Outcome)>>,
+    /// Set by the workload driver after every client task has
+    /// finished spawning its submissions and any cancellations have
+    /// been initiated. The progress task exits its loop once this is
+    /// set and the pending queue is empty.
+    done: Cell<bool>,
+}
+
+impl FakeProgress {
+    pub fn new() -> Rc<Self> {
+        Rc::new(Self {
+            pending: RefCell::new(Vec::new()),
+            history: RefCell::new(Vec::new()),
+            done: Cell::new(false),
+        })
+    }
+
+    /// Called by a client task to enqueue a submission for later
+    /// delivery. Mirrors `HG_Forward`: the FFI now owns the slot
+    /// reference (`arg`) until the callback fires.
+    pub fn submit(&self, tag: SlotTag, slot: Arc<CompletionSlot>, outcome: Outcome) {
+        let arg = UnsafeSendPtr(slot.into_callback_arg());
+        self.pending
+            .borrow_mut()
+            .push(Pending { tag, arg, outcome });
+    }
+
+    /// Mark the workload as finished so the progress task can exit.
+    /// Any remaining pending entries are still delivered before exit
+    /// so cancelled futures observe their callback fire (modelling
+    /// Mercury's "exactly once" callback guarantee).
+    pub fn mark_done(&self) {
+        self.done.set(true);
+    }
+
+    /// History accessor used by invariants.
+    pub fn history(&self) -> std::cell::Ref<'_, Vec<(SlotTag, Outcome)>> {
+        self.history.borrow()
+    }
+
+    pub fn pending_len(&self) -> usize {
+        self.pending.borrow().len()
+    }
+
+    fn pop_next(&self, cfg: &MercurySimCfg) -> Option<Pending> {
+        let mut q = self.pending.borrow_mut();
+        if q.is_empty() {
+            return None;
+        }
+        let idx = if cfg.out_of_order.get() {
+            with_sim(|s| s.rng.gen_range(0..q.len()))
+        } else {
+            0
+        };
+        Some(q.swap_remove(idx))
+    }
+
+    fn record(&self, tag: SlotTag, outcome: Outcome) {
+        self.history.borrow_mut().push((tag, outcome));
+    }
+}
+
+/// Body of the simulated progress thread. Spawned as a task by the
+/// workload driver. Loops until `FakeProgress::done` is set *and*
+/// every pending submission has been delivered.
+pub async fn progress_task(progress: Rc<FakeProgress>, cfg: Rc<MercurySimCfg>) {
+    loop {
+        let delay = if cfg.max_delivery_delay.get() == 0 {
+            0
+        } else {
+            with_sim(|s| s.rng.gen_range(0..=cfg.max_delivery_delay.get()))
+        };
+        yield_n(delay).await;
+
+        let Some(p) = progress.pop_next(&cfg) else {
+            if progress.done.get() {
+                return;
+            }
+            // Nothing to do this tick; yield so other tasks can run.
+            yield_n(1).await;
+            continue;
+        };
+
+        // SAFETY: `p.arg` was produced by `CompletionSlot::into_callback_arg`
+        // in `FakeProgress::submit`; reclaim exactly once here, mirroring
+        // the production forward-callback path.
+        let slot: Arc<CompletionSlot> = unsafe { CompletionSlot::from_callback_arg(p.arg.0) };
+        let result = match p.outcome {
+            Outcome::Ok => Ok(()),
+            Outcome::Err(code) => Err(unbounded_storage::mercury::HgError::new(code, "dst-error")),
+        };
+        slot.complete(result);
+        progress.record(p.tag, p.outcome);
+        // Drop the reclaimed Arc here; the slot may still be alive
+        // via the registry plus the client's `CompletionFuture`.
+    }
+}
+
+/// Decide a per-submission outcome from `MercurySimCfg::error_rate`.
+pub fn draw_outcome(cfg: &MercurySimCfg) -> Outcome {
+    let rate = cfg.error_rate.get();
+    if rate > 0 && with_sim(|s| s.rng.gen_ratio(rate.min(100), 100)) {
+        Outcome::Err(-1)
+    } else {
+        Outcome::Ok
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server-job queue producer/consumer helpers.
+// ---------------------------------------------------------------------------
+
+/// One job the producer task will push onto a `ServerJobQueue`.
+/// The handle/input pointers are sentinel values: nothing in the
+/// bridge dereferences them, so we can stamp identity bits into
+/// `handle.0` and assert that consumers see exactly those bits.
+pub struct QueueJobSpec {
+    pub tag: SlotTag,
+    /// Number of yields the producer emits before pushing this job.
+    pub pre_push_delay: u32,
+}
+
+impl Clone for QueueJobSpec {
+    fn clone(&self) -> Self {
+        Self {
+            tag: self.tag,
+            pre_push_delay: self.pre_push_delay,
+        }
+    }
+}
+
+/// Construct a synthetic `ServerJob`. Pointers are tagged so the
+/// consumer can read them back without touching memory.
+pub fn make_synthetic_job(tag: SlotTag) -> ServerJob {
+    ServerJob {
+        handle: UnsafeSendPtr(tag as *mut c_void),
+        input_struct: UnsafeSendPtr((!tag) as *mut c_void),
+    }
+}
+
+/// Recover the tag from a `ServerJob` produced by `make_synthetic_job`.
+pub fn job_tag(job: &ServerJob) -> SlotTag {
+    job.handle.0 as usize as SlotTag
+}

--- a/cmd/unbounded-storage/tests/mercury/mod.rs
+++ b/cmd/unbounded-storage/tests/mercury/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(clippy::arc_with_non_send_sync)]
+#![allow(dead_code)]
+
+pub mod mocks;
+pub mod oracle;
+pub mod tests;
+pub mod workload;

--- a/cmd/unbounded-storage/tests/mercury/oracle.rs
+++ b/cmd/unbounded-storage/tests/mercury/oracle.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Per-submission and per-job expectations the test driver tracks
+//! alongside the system under test. Kept separate from `mocks.rs`
+//! so the invariant helpers in `tests.rs` read against an explicit
+//! model instead of inspecting mock internals directly.
+
+use std::collections::HashSet;
+
+use crate::mercury::mocks::{Outcome, SlotTag};
+
+/// Per-submission expectation: which outcome the progress task will
+/// deliver, and whether the client cancelled before observing it.
+#[derive(Clone, Copy, Debug)]
+pub struct SubmissionExpect {
+    pub tag: SlotTag,
+    pub outcome: Outcome,
+    pub cancelled: bool,
+}
+
+/// Per-submission observation reported by the client task.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SubmissionObserved {
+    /// The future resolved with the recorded outcome.
+    Resolved(Outcome),
+    /// The client dropped the future before observing the callback.
+    Cancelled,
+    /// Allocation failed (registry was at capacity).
+    AllocRejected,
+    /// `submit` failed synchronously after a successful alloc.
+    /// The client released the slot and no callback was scheduled.
+    SubmitRejected,
+}
+
+/// Expected and observed records for every server-job that the
+/// producer planned to push.
+#[derive(Clone, Copy, Debug)]
+pub struct JobExpect {
+    pub tag: SlotTag,
+    /// Whether the producer pushed this job before calling `close`.
+    /// Jobs pushed after close should be silently dropped by the
+    /// queue (current production behaviour).
+    pub before_close: bool,
+}
+
+/// Helper: build the set of tags pushed before close, for the
+/// `assert_queue_no_drop_before_close` invariant.
+pub fn pre_close_tags(jobs: &[JobExpect]) -> HashSet<SlotTag> {
+    jobs.iter()
+        .filter(|j| j.before_close)
+        .map(|j| j.tag)
+        .collect()
+}

--- a/cmd/unbounded-storage/tests/mercury/tests.proptest-regressions
+++ b/cmd/unbounded-storage/tests/mercury/tests.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 655efc9c652462f87a059a89342c621ed8b254ef441449c96c3807862b97f72d # shrinks to seed = 2797794359048203986, w = Workload { registry_cap: 1, max_delivery_delay: 0, error_rate: 0, out_of_order: false, clients: [ClientSpec { pre_submit_yields: 0, pre_poll_yields: 0, cancel: false }], queue_jobs: [], queue_consumers: 2, close_after: 0 }
+cc 982c8630d9d96c7ea8f8a186e62d56dd2caca6f69b52e226472bbc2cedaff5b2 # shrinks to seed = 9275027278974642556, w = Workload { registry_cap: 1, max_delivery_delay: 3, error_rate: 0, out_of_order: true, clients: [ClientSpec { pre_submit_yields: 4, pre_poll_yields: 6, cancel: Never, submissions: 4 }], queue_jobs: [JobSpec { pre_push_delay: 2 }], queue_consumers: 1, close_after: 1 }

--- a/cmd/unbounded-storage/tests/mercury/tests.rs
+++ b/cmd/unbounded-storage/tests/mercury/tests.rs
@@ -1,0 +1,293 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Proptest entrypoint and invariant helpers for the Mercury bridge
+//! DST area. One `proptest!` block per AGENTS.md convention; one
+//! `#[test]` that calls `run_workload` once and dispatches to small
+//! `assert_<invariant>` helpers returning `Result<(), TestCaseError>`.
+
+use std::collections::{HashMap, HashSet};
+
+use proptest::prelude::*;
+
+use crate::mercury::oracle::{SubmissionObserved, pre_close_tags};
+use crate::mercury::workload::{RunReport, run_workload, workload_strategy};
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn invariants(seed in any::<u64>(), w in workload_strategy()) {
+        let report = run_workload(seed, w).expect("run completed");
+        assert_no_completion_leak(&report)?;
+        assert_no_slot_arc_leak(&report)?;
+        assert_outcome_observed(&report)?;
+        assert_cancellation_safe(&report)?;
+        assert_max_inflight(&report)?;
+        assert_submit_rejected_releases_slot(&report)?;
+        assert_queue_no_drop_before_close(&report)?;
+        assert_queue_drained_after_close(&report)?;
+        assert_queue_post_close_pushes_dropped(&report)?;
+        assert_queue_fifo_before_close(&report)?;
+        assert_progress_history_complete(&report)?;
+    }
+}
+
+/// No leak: registry empties out and observed peak never exceeds cap.
+fn assert_no_completion_leak(r: &RunReport) -> Result<(), TestCaseError> {
+    prop_assert_eq!(
+        r.registry_live_at_end,
+        0,
+        "registry retained {} slots at end of run",
+        r.registry_live_at_end,
+    );
+    Ok(())
+}
+
+/// Stronger leak check: every `Arc<CompletionSlot>` allocated during
+/// the run is fully dropped by the time the executor returns. The
+/// registry's `live_count` only sees the registry-side `Arc`; this
+/// invariant proves the FFI-side reclaim path also drops its
+/// reference, by upgrading mock-held `Weak` snapshots.
+fn assert_no_slot_arc_leak(r: &RunReport) -> Result<(), TestCaseError> {
+    prop_assert_eq!(
+        r.slot_weak_upgrades_at_end,
+        0,
+        "{} CompletionSlot Arc(s) still upgradeable from Weak at end of run",
+        r.slot_weak_upgrades_at_end,
+    );
+    Ok(())
+}
+
+/// For every submission that was not cancelled and whose alloc
+/// succeeded, the client observes the exact outcome the mock chose.
+/// This also covers the lost-wakeup liveness invariant: a stuck
+/// `Pending` future would surface as `RunError::Deadlock` from
+/// `run_workload`, and a misrouted `Cancelled` observation against a
+/// non-cancelled client trips the `false` branch below.
+fn assert_outcome_observed(r: &RunReport) -> Result<(), TestCaseError> {
+    for (i, sub) in r.submissions.iter().enumerate() {
+        if sub.cancelled {
+            continue;
+        }
+        match r.observations[i] {
+            SubmissionObserved::Resolved(o) => {
+                prop_assert_eq!(
+                    o,
+                    sub.outcome,
+                    "client {} observed {:?}, expected {:?}",
+                    i,
+                    o,
+                    sub.outcome,
+                );
+            }
+            SubmissionObserved::Cancelled => {
+                prop_assert!(
+                    false,
+                    "client {} reported Cancelled but was not flagged cancelled",
+                    i
+                );
+            }
+            SubmissionObserved::AllocRejected | SubmissionObserved::SubmitRejected => {
+                // Pre-submit failures are legitimate: no callback was
+                // ever scheduled, so no outcome to compare against.
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Cancelled clients report `Cancelled`; the run must still finish
+/// (the `run_workload` Ok return covers liveness, this helper covers
+/// labelling).
+fn assert_cancellation_safe(r: &RunReport) -> Result<(), TestCaseError> {
+    for (i, sub) in r.submissions.iter().enumerate() {
+        if !sub.cancelled {
+            continue;
+        }
+        let o = r.observations[i];
+        prop_assert!(
+            matches!(
+                o,
+                SubmissionObserved::Cancelled
+                    | SubmissionObserved::AllocRejected
+                    | SubmissionObserved::SubmitRejected
+            ),
+            "client {} flagged cancel but observed {:?}",
+            i,
+            o,
+        );
+    }
+    Ok(())
+}
+
+/// `CompletionRegistry::alloc` honoured the configured cap.
+fn assert_max_inflight(r: &RunReport) -> Result<(), TestCaseError> {
+    prop_assert!(
+        r.registry_peak_inflight <= r.registry_capacity,
+        "peak {} exceeded cap {}",
+        r.registry_peak_inflight,
+        r.registry_capacity,
+    );
+    Ok(())
+}
+
+/// A synchronous `submit` failure must release the slot back to the
+/// registry (no leak) and must not produce a callback. The end-of-run
+/// `registry_live_at_end == 0` assertion plus the
+/// `assert_progress_history_complete` tag-multiset check between them
+/// catch double-counting; this helper names the invariant explicitly
+/// and checks that `SubmitRejected` only appears against submissions
+/// that the workload did not flag as cancelled (cancellation is
+/// applied post-submit).
+fn assert_submit_rejected_releases_slot(r: &RunReport) -> Result<(), TestCaseError> {
+    for (i, sub) in r.submissions.iter().enumerate() {
+        if r.observations[i] != SubmissionObserved::SubmitRejected {
+            continue;
+        }
+        prop_assert!(
+            !sub.cancelled,
+            "client {} reported SubmitRejected but was flagged cancelled",
+            i,
+        );
+    }
+    Ok(())
+}
+
+/// Every job pushed *before* `close` is observed by exactly one
+/// consumer.
+fn assert_queue_no_drop_before_close(r: &RunReport) -> Result<(), TestCaseError> {
+    let pre = pre_close_tags(&r.jobs);
+    let observed: HashSet<u64> = r.jobs_observed.iter().copied().collect();
+    // Multiplicity: tags are unique by construction; each pre-close
+    // tag must appear exactly once across consumers.
+    let mut counts: HashMap<u64, u32> = HashMap::new();
+    for tag in &r.jobs_observed {
+        *counts.entry(*tag).or_default() += 1;
+    }
+    for tag in &pre {
+        prop_assert!(
+            observed.contains(tag),
+            "pre-close job {} not observed by any consumer",
+            tag,
+        );
+        prop_assert_eq!(
+            counts.get(tag).copied().unwrap_or(0),
+            1,
+            "pre-close job {} observed {} times (expected 1)",
+            tag,
+            counts.get(tag).copied().unwrap_or(0),
+        );
+    }
+    Ok(())
+}
+
+/// Every consumer eventually observed `Ready(None)` after the queue
+/// closed.
+fn assert_queue_drained_after_close(r: &RunReport) -> Result<(), TestCaseError> {
+    prop_assert_eq!(
+        r.consumers_saw_none,
+        r.queue_consumers,
+        "{} of {} consumers exited via Ready(None)",
+        r.consumers_saw_none,
+        r.queue_consumers,
+    );
+    Ok(())
+}
+
+/// Jobs the producer pushed *after* calling `close` are silently
+/// dropped (current production behaviour). Verify they are not
+/// observed by any consumer.
+fn assert_queue_post_close_pushes_dropped(r: &RunReport) -> Result<(), TestCaseError> {
+    let post_close: HashSet<u64> = r
+        .jobs
+        .iter()
+        .filter(|j| !j.before_close)
+        .map(|j| j.tag)
+        .collect();
+    for tag in r.jobs_observed.iter() {
+        prop_assert!(
+            !post_close.contains(tag),
+            "post-close job {} was observed",
+            tag,
+        );
+    }
+    Ok(())
+}
+
+/// With a single consumer, pre-close jobs must be observed in
+/// producer (push) order. `ServerJobQueue` is a `Mutex<VecDeque>`
+/// drained from the front, so for a single drainer the observation
+/// order must equal the push order of pre-close tags. The producer
+/// pushes tags in the order they appear in `r.jobs`, so the
+/// pre-close subsequence of `r.jobs_observed` (filtering to tags
+/// that are in the pre-close set) must equal the pre-close
+/// subsequence of `r.jobs` in order.
+fn assert_queue_fifo_before_close(r: &RunReport) -> Result<(), TestCaseError> {
+    if r.queue_consumers != 1 {
+        return Ok(());
+    }
+    let pre: HashSet<u64> = pre_close_tags(&r.jobs);
+    let expected: Vec<u64> = r
+        .jobs
+        .iter()
+        .filter(|j| j.before_close)
+        .map(|j| j.tag)
+        .collect();
+    let observed: Vec<u64> = r
+        .jobs_observed
+        .iter()
+        .copied()
+        .filter(|t| pre.contains(t))
+        .collect();
+    prop_assert_eq!(
+        &observed,
+        &expected,
+        "queue did not deliver pre-close jobs FIFO",
+    );
+    Ok(())
+}
+
+/// The progress task delivers a callback for every submission that
+/// actually made it past `alloc`. The number of history entries
+/// must equal the number of non-`AllocRejected` submissions, and
+/// the tag multiset must match. Tags are unique per submission, so
+/// this also implies each tag is delivered at most once. Catches a
+/// class of bugs where the callback path silently drops a slot
+/// (e.g. losing the FFI-side `Arc` reclaim) without producing a
+/// `Deadlock`.
+fn assert_progress_history_complete(r: &RunReport) -> Result<(), TestCaseError> {
+    let submitted_tags: Vec<u64> = r
+        .submissions
+        .iter()
+        .zip(r.observations.iter())
+        .filter_map(|(s, o)| match o {
+            SubmissionObserved::AllocRejected | SubmissionObserved::SubmitRejected => None,
+            _ => Some(s.tag),
+        })
+        .collect();
+    prop_assert_eq!(
+        r.progress_history.len(),
+        submitted_tags.len(),
+        "progress_history.len() = {} vs submitted = {}",
+        r.progress_history.len(),
+        submitted_tags.len(),
+    );
+    let mut expected: HashMap<u64, u32> = HashMap::new();
+    for t in &submitted_tags {
+        *expected.entry(*t).or_default() += 1;
+    }
+    let mut got: HashMap<u64, u32> = HashMap::new();
+    for (t, _) in &r.progress_history {
+        *got.entry(*t).or_default() += 1;
+    }
+    prop_assert_eq!(
+        expected,
+        got,
+        "progress_history tag multiset mismatch",
+    );
+    Ok(())
+}

--- a/cmd/unbounded-storage/tests/mercury/workload.rs
+++ b/cmd/unbounded-storage/tests/mercury/workload.rs
@@ -1,0 +1,514 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::{Arc, Weak};
+use std::task::{Context, RawWaker, RawWakerVTable, Waker};
+
+use proptest::collection::vec;
+use proptest::prelude::*;
+use unbounded_storage::mercury::progress::{
+    CompletionFuture, CompletionRegistry, CompletionSlot, ServerJobQueue,
+};
+
+use crate::framework::executor::{Executor, RunError, yield_n};
+use crate::mercury::mocks::{
+    FakeProgress, MercurySimCfg, Outcome, QueueJobSpec, SlotTag, draw_outcome, draw_submit_failure,
+    job_tag, make_synthetic_job, progress_task,
+};
+use crate::mercury::oracle::{JobExpect, SubmissionExpect, SubmissionObserved};
+
+// ---------------------------------------------------------------------------
+// Workload model.
+// ---------------------------------------------------------------------------
+
+/// Max submissions per client. Tag namespace for client slots is
+/// `1 ..= clients.len() * MAX_SUBMISSIONS_PER_CLIENT`, kept well below
+/// the server-job tag base (`1_000`).
+const MAX_SUBMISSIONS_PER_CLIENT: u8 = 8;
+
+#[derive(Clone, Debug)]
+pub struct Workload {
+    pub registry_cap: u8,
+    pub max_delivery_delay: u32,
+    pub error_rate: u32,
+    /// Probability in `[0, 100]` that a `submit` rejects synchronously,
+    /// modelling an `HG_Forward` failure. The slot is released by the
+    /// client and no callback is ever scheduled.
+    pub submit_failure_rate: u32,
+    pub out_of_order: bool,
+    pub clients: Vec<ClientSpec>,
+    pub queue_jobs: Vec<JobSpec>,
+    /// Number of consumer tasks to spawn against the server queue.
+    /// Production assumes exactly one consumer: `ServerJobQueue`
+    /// uses a single `AtomicWaker`, so multiple awaiters racing on
+    /// `next_job` would drop wakeups. The workload pins this to 1
+    /// and the property suite encodes that invariant.
+    pub queue_consumers: u8,
+    /// Index into `queue_jobs` at or after which the producer calls
+    /// `close()` (i.e. jobs at indices `>= close_after` are pushed
+    /// after close and should be silently dropped). Clamped to
+    /// `queue_jobs.len()` so a workload with no late pushes is
+    /// representable.
+    pub close_after: u8,
+}
+
+#[derive(Clone, Debug)]
+pub struct ClientSpec {
+    /// Yields between alloc and submit; models a client that does
+    /// some prep work before handing the slot to "the FFI".
+    pub pre_submit_yields: u8,
+    /// Yields between submit and the first poll; lets the progress
+    /// task race ahead.
+    pub pre_poll_yields: u8,
+    /// Cancellation strategy for the completion future.
+    pub cancel: CancelMode,
+    /// Number of back-to-back submissions this client issues. Each
+    /// submission is a fresh `(alloc, submit, await)` round so the
+    /// registry sees alloc/release/alloc cycles. Bounded to
+    /// `MAX_SUBMISSIONS_PER_CLIENT` to keep the step budget sane and
+    /// the per-client tag namespace small.
+    pub submissions: u8,
+}
+
+/// When (if ever) the client drops its `CompletionFuture` instead of
+/// awaiting it to completion.
+#[derive(Clone, Copy, Debug)]
+pub enum CancelMode {
+    /// Await the future normally.
+    Never,
+    /// Drop the future before its first poll.
+    BeforePoll,
+    /// Poll the future once (which registers a waker), then drop it.
+    /// Exercises the path where the slot has a registered waker but
+    /// nobody is left to consume the wake.
+    AfterFirstPoll,
+}
+
+impl CancelMode {
+    fn cancels(self) -> bool {
+        !matches!(self, CancelMode::Never)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct JobSpec {
+    /// Yields the producer emits before pushing this job.
+    pub pre_push_delay: u8,
+}
+
+// ---------------------------------------------------------------------------
+// Proptest strategy.
+// ---------------------------------------------------------------------------
+
+pub fn workload_strategy() -> impl Strategy<Value = Workload> {
+    let registry_cap = 1u8..=16;
+    let max_delivery_delay = 0u32..=12;
+    let error_rate = prop_oneof![
+        7 => Just(0u32),
+        3 => 1u32..=80,
+    ];
+    let submit_failure_rate = prop_oneof![
+        7 => Just(0u32),
+        3 => 1u32..=80,
+    ];
+    let out_of_order = any::<bool>();
+    let clients = vec(client_strategy(), 1..=24);
+    let queue_jobs = vec(job_strategy(), 0..=24);
+    let queue_consumers = 1u8..=1;
+    let close_after = 0u8..=24;
+    (
+        registry_cap,
+        max_delivery_delay,
+        error_rate,
+        submit_failure_rate,
+        out_of_order,
+        clients,
+        queue_jobs,
+        queue_consumers,
+        close_after,
+    )
+        .prop_map(
+            |(
+                registry_cap,
+                max_delivery_delay,
+                error_rate,
+                submit_failure_rate,
+                out_of_order,
+                clients,
+                queue_jobs,
+                queue_consumers,
+                close_after,
+            )| Workload {
+                registry_cap,
+                max_delivery_delay,
+                error_rate,
+                submit_failure_rate,
+                out_of_order,
+                clients,
+                queue_jobs,
+                queue_consumers,
+                close_after,
+            },
+        )
+}
+
+fn client_strategy() -> impl Strategy<Value = ClientSpec> {
+    let cancel = prop_oneof![
+        7 => Just(CancelMode::Never),
+        2 => Just(CancelMode::BeforePoll),
+        1 => Just(CancelMode::AfterFirstPoll),
+    ];
+    let submissions = 1u8..=MAX_SUBMISSIONS_PER_CLIENT;
+    (0u8..=8, 0u8..=8, cancel, submissions).prop_map(
+        |(pre_submit_yields, pre_poll_yields, cancel, submissions)| ClientSpec {
+            pre_submit_yields,
+            pre_poll_yields,
+            cancel,
+            submissions,
+        },
+    )
+}
+
+fn job_strategy() -> impl Strategy<Value = JobSpec> {
+    (0u8..=8).prop_map(|pre_push_delay| JobSpec { pre_push_delay })
+}
+
+// ---------------------------------------------------------------------------
+// Report.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct RunReport {
+    /// Position-aligned with `observations`. One entry per
+    /// (client, submission) round actually issued, in the order each
+    /// round registered its expectation with the driver.
+    pub submissions: Vec<SubmissionExpect>,
+    pub observations: Vec<SubmissionObserved>,
+    pub progress_history: Vec<(SlotTag, Outcome)>,
+    pub registry_peak_inflight: usize,
+    pub registry_live_at_end: usize,
+    pub registry_capacity: usize,
+    /// Number of `CompletionSlot` `Arc`s that were allocated during
+    /// the run and could still be upgraded from a `Weak` snapshot at
+    /// the end. Computed from the mock-side weak-pointer tracker, not
+    /// from the registry's own bookkeeping, so it catches references
+    /// that leak through the FFI side as well as the registry side.
+    pub slot_weak_upgrades_at_end: usize,
+    pub jobs: Vec<JobExpect>,
+    /// Tags observed by consumers, in order. Multiple consumer tasks
+    /// each push to the same `Vec` (via `Rc<RefCell<_>>`); the order
+    /// reflects executor scheduling.
+    pub jobs_observed: Vec<SlotTag>,
+    pub consumers_saw_none: usize,
+    pub queue_consumers: usize,
+    pub steps: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Driver.
+// ---------------------------------------------------------------------------
+
+pub fn run_workload(seed: u64, w: Workload) -> Result<RunReport, RunError> {
+    let registry = CompletionRegistry::new(w.registry_cap.max(1) as usize);
+    let progress = FakeProgress::new();
+    let cfg = MercurySimCfg::new();
+    cfg.max_delivery_delay.set(w.max_delivery_delay);
+    cfg.error_rate.set(w.error_rate);
+    cfg.out_of_order.set(w.out_of_order);
+    cfg.submit_failure_rate.set(w.submit_failure_rate);
+
+    let mut exec = Executor::new(seed);
+
+    let submissions: Rc<RefCell<Vec<SubmissionExpect>>> = Rc::new(RefCell::new(Vec::new()));
+    let observations: Rc<RefCell<Vec<SubmissionObserved>>> = Rc::new(RefCell::new(Vec::new()));
+    // Tracks how many client tasks are still running. The last one
+    // to finish flips `FakeProgress::done` so the progress task can
+    // drain and exit. Timer-based mark_done was racy: a slow client
+    // could still be in `pre_submit_yields` when the timer fired,
+    // leaving its final submission with nobody to complete it.
+    let outstanding_clients: Rc<std::cell::Cell<usize>> =
+        Rc::new(std::cell::Cell::new(w.clients.len()));
+    // Weak snapshots of every successfully-allocated `CompletionSlot`.
+    // Mock-side bookkeeping: at end of run we assert none can still be
+    // upgraded, which proves both the registry-side `Arc` and the
+    // FFI-side reclaim have dropped their strong references.
+    let slot_weaks: Rc<RefCell<Vec<Weak<CompletionSlot>>>> = Rc::new(RefCell::new(Vec::new()));
+
+    // Spawn one task per client.
+    for (cid, spec) in w.clients.iter().enumerate() {
+        let registry = registry.clone();
+        let progress = progress.clone();
+        let cfg = cfg.clone();
+        let submissions = submissions.clone();
+        let observations = observations.clone();
+        let outstanding_clients = outstanding_clients.clone();
+        let slot_weaks = slot_weaks.clone();
+        let cancel = spec.cancel;
+        let pre_submit = spec.pre_submit_yields as u32;
+        let pre_poll = spec.pre_poll_yields as u32;
+        let rounds = spec.submissions.max(1);
+        // Each (client, submission) gets a unique tag. Layout
+        // packs them into a contiguous u64 range starting at 1;
+        // `cid * MAX_SUBMISSIONS_PER_CLIENT + sub_idx + 1` never
+        // collides with the server-job tag base (1_000).
+        let tag_base = (cid as SlotTag) * MAX_SUBMISSIONS_PER_CLIENT as SlotTag + 1;
+
+        exec.spawn(async move {
+            for sub_idx in 0..rounds {
+                let tag = tag_base + sub_idx as SlotTag;
+                yield_n(pre_submit).await;
+                let slot = match registry.alloc() {
+                    Ok(s) => s,
+                    Err(_) => {
+                        // Record the rejection and stop this client:
+                        // back-to-back retries would only churn the
+                        // registry without exercising new paths.
+                        let mut subs = submissions.borrow_mut();
+                        let mut obs = observations.borrow_mut();
+                        subs.push(SubmissionExpect {
+                            tag,
+                            outcome: Outcome::Ok,
+                            cancelled: false,
+                        });
+                        obs.push(SubmissionObserved::AllocRejected);
+                        break;
+                    }
+                };
+                slot_weaks.borrow_mut().push(Arc::downgrade(&slot));
+                // Model a synchronous `HG_Forward` failure: release the
+                // slot back to the registry and record the rejection.
+                // No callback will ever fire for this tag.
+                if draw_submit_failure(&cfg) {
+                    registry.release(&slot);
+                    drop(slot);
+                    let mut subs = submissions.borrow_mut();
+                    let mut obs = observations.borrow_mut();
+                    subs.push(SubmissionExpect {
+                        tag,
+                        outcome: Outcome::Ok,
+                        cancelled: false,
+                    });
+                    obs.push(SubmissionObserved::SubmitRejected);
+                    continue;
+                }
+                let outcome = draw_outcome(&cfg);
+                progress.submit(tag, slot.clone(), outcome);
+
+                // Reserve aligned slots in `submissions` /
+                // `observations` *before* yielding so the index is
+                // stable across await points.
+                let idx = {
+                    let mut subs = submissions.borrow_mut();
+                    let mut obs = observations.borrow_mut();
+                    subs.push(SubmissionExpect {
+                        tag,
+                        outcome,
+                        cancelled: cancel.cancels(),
+                    });
+                    obs.push(SubmissionObserved::Cancelled); // placeholder, overwritten below
+                    subs.len() - 1
+                };
+
+                yield_n(pre_poll).await;
+
+                let fut = CompletionFuture {
+                    slot,
+                    registry: registry.clone(),
+                };
+                let observed = match cancel {
+                    CancelMode::Never => {
+                        let result = fut.await;
+                        let o = match (result, outcome) {
+                            (Ok(()), _) => Outcome::Ok,
+                            (Err(e), Outcome::Err(c)) if e.code == c => Outcome::Err(c),
+                            (Err(e), _) => Outcome::Err(e.code),
+                        };
+                        SubmissionObserved::Resolved(o)
+                    }
+                    CancelMode::BeforePoll => {
+                        drop(fut);
+                        SubmissionObserved::Cancelled
+                    }
+                    CancelMode::AfterFirstPoll => {
+                        poll_once_then_drop(fut);
+                        SubmissionObserved::Cancelled
+                    }
+                };
+                observations.borrow_mut()[idx] = observed;
+            }
+            // Last client to finish flips the progress "done" flag
+            // so the progress task can drain pending entries and
+            // exit. Cancelled futures may have left no pending
+            // entries; either way, after every client has stopped
+            // submitting, no further `submit` calls can happen.
+            let remaining = outstanding_clients.get() - 1;
+            outstanding_clients.set(remaining);
+            if remaining == 0 {
+                progress.mark_done();
+            }
+        });
+    }
+
+    // Spawn the simulated progress task.
+    {
+        let progress = progress.clone();
+        let cfg = cfg.clone();
+        exec.spawn(async move {
+            progress_task(progress, cfg).await;
+        });
+    }
+
+    // Server-job queue producer/consumers.
+    let queue: Arc<ServerJobQueue> = ServerJobQueue::new();
+    let jobs_observed: Rc<RefCell<Vec<SlotTag>>> = Rc::new(RefCell::new(Vec::new()));
+    let consumers_saw_none: Rc<std::cell::Cell<usize>> = Rc::new(std::cell::Cell::new(0));
+    let queue_consumers = w.queue_consumers.max(1) as usize;
+
+    let job_specs: Vec<(SlotTag, QueueJobSpec, bool)> = w
+        .queue_jobs
+        .iter()
+        .enumerate()
+        .map(|(i, j)| {
+            let tag = (i as SlotTag) + 1_000;
+            let before_close = (i as u8) < w.close_after;
+            (
+                tag,
+                QueueJobSpec {
+                    tag,
+                    pre_push_delay: j.pre_push_delay as u32,
+                },
+                before_close,
+            )
+        })
+        .collect();
+
+    let jobs: Vec<JobExpect> = job_specs
+        .iter()
+        .map(|(tag, _, before_close)| JobExpect {
+            tag: *tag,
+            before_close: *before_close,
+        })
+        .collect();
+
+    // Producer task.
+    {
+        let queue = queue.clone();
+        let job_specs = job_specs.clone();
+        let close_after = w.close_after as usize;
+        exec.spawn(async move {
+            for (i, (_tag, spec, _before_close)) in job_specs.iter().enumerate() {
+                if i == close_after {
+                    queue.close();
+                }
+                yield_n(spec.pre_push_delay).await;
+                queue.push(make_synthetic_job(spec.tag));
+            }
+            // If close_after >= job_specs.len(), close still has to
+            // run so consumers terminate.
+            if close_after >= job_specs.len() {
+                queue.close();
+            }
+        });
+    }
+
+    // Consumer tasks.
+    for _ in 0..queue_consumers {
+        let queue = queue.clone();
+        let jobs_observed = jobs_observed.clone();
+        let consumers_saw_none = consumers_saw_none.clone();
+        exec.spawn(async move {
+            loop {
+                match queue.next_job().await {
+                    Some(job) => {
+                        jobs_observed.borrow_mut().push(job_tag(&job));
+                    }
+                    None => {
+                        consumers_saw_none.set(consumers_saw_none.get() + 1);
+                        return;
+                    }
+                }
+            }
+        });
+    }
+
+    // Total submissions actually requested across all clients; used
+    // to size the step budget.
+    let total_subs: u64 = w.clients.iter().map(|c| c.submissions.max(1) as u64).sum();
+
+    // If there are no clients at all (queue-only workloads), nothing
+    // will ever flip `progress.done`; do it up front so the progress
+    // task can exit immediately after draining its (empty) queue.
+    if w.clients.is_empty() {
+        progress.mark_done();
+    }
+
+    let step_budget: u64 = 256
+        + total_subs * (w.max_delivery_delay as u64 + 16) * 64
+        + (w.queue_jobs.len() as u64) * 64
+        + (queue_consumers as u64) * 32;
+    exec.run(step_budget)?;
+
+    let progress_history = progress.history().clone();
+
+    let submissions = Rc::try_unwrap(submissions)
+        .expect("submissions Rc unique at end of run")
+        .into_inner();
+    let observations = Rc::try_unwrap(observations)
+        .expect("observations Rc unique at end of run")
+        .into_inner();
+    let jobs_observed = Rc::try_unwrap(jobs_observed)
+        .expect("jobs_observed Rc unique at end of run")
+        .into_inner();
+    let consumers_saw_none = consumers_saw_none.get();
+
+    let slot_weaks = Rc::try_unwrap(slot_weaks)
+        .expect("slot_weaks Rc unique at end of run")
+        .into_inner();
+    let slot_weak_upgrades_at_end = slot_weaks.iter().filter(|w| w.upgrade().is_some()).count();
+
+    Ok(RunReport {
+        submissions,
+        observations,
+        progress_history,
+        registry_peak_inflight: registry.peak_inflight(),
+        registry_live_at_end: registry.live_count(),
+        registry_capacity: registry.capacity(),
+        slot_weak_upgrades_at_end,
+        jobs,
+        jobs_observed,
+        consumers_saw_none,
+        queue_consumers,
+        steps: exec.last_steps(),
+    })
+}
+
+/// Poll a future exactly once with a no-op waker, then drop it. Used
+/// by `CancelMode::AfterFirstPoll` to exercise the path where the
+/// slot has registered a waker that nobody will ever consume.
+fn poll_once_then_drop<F: Future>(fut: F) {
+    let mut fut = fut;
+    // SAFETY: `fut` lives on the local stack and is not moved after
+    // the pin is created; it is dropped at the end of this function
+    // while still pinned.
+    let pinned = unsafe { Pin::new_unchecked(&mut fut) };
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let _ = pinned.poll(&mut cx);
+}
+
+const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    |_| RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE),
+    |_| {},
+    |_| {},
+    |_| {},
+);
+
+fn noop_waker() -> Waker {
+    // SAFETY: the no-op vtable has 'static lifetime and all four
+    // functions are safe to call with a null data pointer.
+    unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE)) }
+}

--- a/hack/scripts/install-mercury.sh
+++ b/hack/scripts/install-mercury.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# install-mercury.sh - Idempotently build and install Mercury (mercury-hpc)
+# into a local prefix for use by the unbounded-storage Rust crate.
+#
+# The unbounded-storage crate links against Mercury via pkg-config. Rather
+# than depending on a system package (Mercury is not packaged on most
+# distros, and the version matters for ABI), we build a pinned release from
+# source and install it under a project-local prefix.
+#
+# Behaviour:
+#   - If $MERCURY_PREFIX/lib/pkgconfig/mercury.pc already advertises the
+#     requested $MERCURY_VERSION, exit 0 immediately. This makes the script
+#     safe to call from Make targets and CI caches.
+#   - Otherwise, clone Mercury at the pinned tag into a scratch source tree
+#     ($MERCURY_SRC), configure with CMake (libfabric NA + SM transport
+#     enabled), build, and install into $MERCURY_PREFIX.
+#
+# Required system packages (install separately, e.g. via apt):
+#   - cmake, build-essential (gcc/g++/make), pkg-config, git
+#   - libfabric-dev (provides the libfabric NA backend)
+#
+# Configuration (override via environment):
+#   MERCURY_VERSION  Mercury release tag to build. Default: v2.3.1.
+#   MERCURY_PREFIX   Install prefix. Default: $REPO_ROOT/tmp/mercury-prefix.
+#   MERCURY_SRC      Scratch source tree. Default: $REPO_ROOT/tmp/mercury-src.
+#   MERCURY_REPO     Upstream repo. Default: https://github.com/mercury-hpc/mercury.git
+#   JOBS             Parallel build jobs. Default: nproc.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+MERCURY_VERSION="${MERCURY_VERSION:-v2.3.1}"
+MERCURY_PREFIX="${MERCURY_PREFIX:-${REPO_ROOT}/tmp/mercury-prefix}"
+MERCURY_SRC="${MERCURY_SRC:-${REPO_ROOT}/tmp/mercury-src}"
+MERCURY_REPO="${MERCURY_REPO:-https://github.com/mercury-hpc/mercury.git}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+# Strip leading 'v' from tag for pkg-config comparison (Mercury's mercury.pc
+# advertises "2.3.1", the git tag is "v2.3.1").
+expected_pc_version="${MERCURY_VERSION#v}"
+
+pc_file="${MERCURY_PREFIX}/lib/pkgconfig/mercury.pc"
+if [[ -f "${pc_file}" ]]; then
+  installed_version="$(PKG_CONFIG_PATH="${MERCURY_PREFIX}/lib/pkgconfig" \
+    pkg-config --modversion mercury 2>/dev/null || true)"
+  if [[ "${installed_version}" == "${expected_pc_version}" ]]; then
+    echo "Mercury ${installed_version} already installed at ${MERCURY_PREFIX}; skipping build."
+    exit 0
+  fi
+  echo "Mercury at ${MERCURY_PREFIX} reports version '${installed_version}', need '${expected_pc_version}'; rebuilding."
+fi
+
+echo "Building Mercury ${MERCURY_VERSION} -> ${MERCURY_PREFIX}"
+
+# Verify required tools are present early with a clear message.
+for tool in git cmake make pkg-config; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "error: required tool '${tool}' not found in PATH" >&2
+    exit 1
+  fi
+done
+
+# Verify libfabric is available (needed for the OFI NA backend).
+if ! pkg-config --exists libfabric; then
+  echo "error: libfabric not found via pkg-config. Install libfabric-dev." >&2
+  exit 1
+fi
+
+# Fetch / refresh the source tree at the requested tag.
+if [[ ! -d "${MERCURY_SRC}/.git" ]]; then
+  echo "Cloning ${MERCURY_REPO} -> ${MERCURY_SRC}"
+  rm -rf "${MERCURY_SRC}"
+  mkdir -p "$(dirname "${MERCURY_SRC}")"
+  git clone --recurse-submodules --depth 1 --branch "${MERCURY_VERSION}" \
+    "${MERCURY_REPO}" "${MERCURY_SRC}"
+else
+  echo "Updating existing source tree ${MERCURY_SRC} to ${MERCURY_VERSION}"
+  git -C "${MERCURY_SRC}" fetch --depth 1 origin "refs/tags/${MERCURY_VERSION}:refs/tags/${MERCURY_VERSION}"
+  git -C "${MERCURY_SRC}" checkout --force "${MERCURY_VERSION}"
+  git -C "${MERCURY_SRC}" submodule update --init --recursive --depth 1
+fi
+
+build_dir="${MERCURY_SRC}/build"
+rm -rf "${build_dir}"
+mkdir -p "${build_dir}"
+
+cmake -S "${MERCURY_SRC}" -B "${build_dir}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${MERCURY_PREFIX}" \
+  -DBUILD_SHARED_LIBS=ON \
+  -DBUILD_TESTING=OFF \
+  -DBUILD_EXAMPLES=OFF \
+  -DMERCURY_USE_BOOST_PP=OFF \
+  -DMERCURY_USE_CHECKSUMS=OFF \
+  -DNA_USE_SM=ON \
+  -DNA_USE_OFI=ON
+
+cmake --build "${build_dir}" --parallel "${JOBS}"
+cmake --install "${build_dir}"
+
+# Sanity check: pkg-config should now agree.
+installed_version="$(PKG_CONFIG_PATH="${MERCURY_PREFIX}/lib/pkgconfig" \
+  pkg-config --modversion mercury)"
+if [[ "${installed_version}" != "${expected_pc_version}" ]]; then
+  echo "error: post-install mercury.pc reports '${installed_version}', expected '${expected_pc_version}'" >&2
+  exit 1
+fi
+
+echo "Mercury ${installed_version} installed at ${MERCURY_PREFIX}"


### PR DESCRIPTION
Uses Mercury and libfabric to support RPC semantics over IB, RoCE, and TCP.

Pins n Mercury worker threads to cores "near" the NIC they're bound to. Uses pre-allocated hugepages (managed by existing `bufferpool`) within the same NUMA node.