### PR TITLE
[wip] Refactor MachineOperation controllers

### DIFF
--- a/cmd/agent/internal/daemon/controller_machineoperation.go
+++ b/cmd/agent/internal/daemon/controller_machineoperation.go
@@ -22,7 +22,7 @@ type machineOperationTarget struct {
 	nodeOperator nodeOperator
 }
 
-func (t *machineOperationTarget) reconcileNodeReboot(ctx context.Context, store daemon.MachineOperationStore[int64], op daemon.MachineOperation) (ctrl.Result, error) {
+func (t *machineOperationTarget) reconcileNodeReboot(ctx context.Context, store daemon.MachineOperationStore, op daemon.MachineOperation) (ctrl.Result, error) {
 	if err := store.MarkInProgress(ctx, op, "restarting active nspawn node"); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -41,7 +41,7 @@ func (t *machineOperationTarget) reconcileNodeReboot(ctx context.Context, store 
 		return finishFailedMachineOperation(ctx, store, op, err)
 	}
 
-	return ctrl.Result{}, store.Finish(ctx, op, daemon.MachineOperationResult[int64]{
+	return ctrl.Result{}, store.Finish(ctx, op, daemon.MachineOperationResult{
 		Phase:                     v1alpha3.OperationPhaseComplete,
 		Reason:                    "Succeeded",
 		Message:                   "NodeReboot completed",
@@ -49,7 +49,7 @@ func (t *machineOperationTarget) reconcileNodeReboot(ctx context.Context, store 
 	})
 }
 
-func (t *machineOperationTarget) reconcileAgentUpgrade(ctx context.Context, store daemon.MachineOperationStore[int64], op daemon.MachineOperation) (ctrl.Result, error) {
+func (t *machineOperationTarget) reconcileAgentUpgrade(ctx context.Context, store daemon.MachineOperationStore, op daemon.MachineOperation) (ctrl.Result, error) {
 	if err := store.MarkInProgress(ctx, op, "staging upgraded host agent binary"); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -61,7 +61,7 @@ func (t *machineOperationTarget) reconcileAgentUpgrade(ctx context.Context, stor
 
 	downloadURL, err := agentUpgradeDownloadURL(op.Parameters)
 	if err != nil {
-		return ctrl.Result{}, store.Finish(ctx, op, daemon.MachineOperationResult[int64]{Phase: v1alpha3.OperationPhaseFailed, Reason: "InvalidParameters", Message: err.Error()})
+		return ctrl.Result{}, store.Finish(ctx, op, daemon.MachineOperationResult{Phase: v1alpha3.OperationPhaseFailed, Reason: "InvalidParameters", Message: err.Error()})
 	}
 	t.log.Info("staging AgentUpgrade binary", "operation", op.Name, "url", downloadURL)
 
@@ -87,7 +87,7 @@ func (t *machineOperationTarget) reconcileAgentUpgrade(ctx context.Context, stor
 	return ctrl.Result{}, nil
 }
 
-func (t *machineOperationTarget) reconcileAgentReset(ctx context.Context, store daemon.MachineOperationStore[int64], op daemon.MachineOperation) (ctrl.Result, error) {
+func (t *machineOperationTarget) reconcileAgentReset(ctx context.Context, store daemon.MachineOperationStore, op daemon.MachineOperation) (ctrl.Result, error) {
 	if err := store.MarkInProgress(ctx, op, "resetting unbounded agent"); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -101,7 +101,7 @@ func (t *machineOperationTarget) reconcileAgentReset(ctx context.Context, store 
 		return finishFailedMachineOperation(ctx, store, op, err)
 	}
 
-	if err := store.Finish(ctx, op, daemon.MachineOperationResult[int64]{
+	if err := store.Finish(ctx, op, daemon.MachineOperationResult{
 		Phase:                     v1alpha3.OperationPhaseComplete,
 		Reason:                    "Succeeded",
 		Message:                   "AgentReset completed",
@@ -114,8 +114,8 @@ func (t *machineOperationTarget) reconcileAgentReset(ctx context.Context, store 
 	return ctrl.Result{}, t.nodeOperator.StopDaemon(ctx, t.log)
 }
 
-func finishFailedMachineOperation(ctx context.Context, store daemon.MachineOperationStore[int64], op daemon.MachineOperation, executionErr error) (ctrl.Result, error) {
-	err := store.Finish(ctx, op, daemon.MachineOperationResult[int64]{
+func finishFailedMachineOperation(ctx context.Context, store daemon.MachineOperationStore, op daemon.MachineOperation, executionErr error) (ctrl.Result, error) {
+	err := store.Finish(ctx, op, daemon.MachineOperationResult{
 		Phase:   v1alpha3.OperationPhaseFailed,
 		Reason:  "ExecutionFailed",
 		Message: executionErr.Error(),
@@ -138,7 +138,7 @@ func publishAndClearAgentUpgradeSignals(ctx context.Context, log *slog.Logger, c
 		return nil
 	case signal.FailureMessage != "":
 		op := daemon.MachineOperation{Name: signal.OperationName}
-		result := daemon.MachineOperationResult[int64]{
+		result := daemon.MachineOperationResult{
 			Phase:   v1alpha3.OperationPhaseFailed,
 			Reason:  "DaemonFailed",
 			Message: signal.FailureMessage,
@@ -155,7 +155,7 @@ func publishAndClearAgentUpgradeSignals(ctx context.Context, log *slog.Logger, c
 			ctx,
 			c,
 			daemon.MachineOperation{Name: signal.OperationName},
-			daemon.MachineOperationResult[int64]{
+			daemon.MachineOperationResult{
 				Phase:                     v1alpha3.OperationPhaseComplete,
 				Reason:                    "Succeeded",
 				Message:                   "AgentUpgrade completed",

--- a/internal/machineops/controller.go
+++ b/internal/machineops/controller.go
@@ -7,26 +7,22 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	machineopscontroller "github.com/Azure/unbounded/pkg/machineops/controller"
 )
 
 const (
-	OperationConditionCompleted = "Completed"
+	OperationConditionCompleted = machineopscontroller.OperationConditionCompleted
 )
 
 // OperationRequest is the generic provider-facing view of a MachineOperation.
@@ -65,6 +61,7 @@ type MachineOperationReconciler struct {
 	ClusterInfo             *ClusterInfo
 	KubeClient              kubernetes.Interface
 	APIServerEndpoint       string
+	operationController     *machineopscontroller.Reconciler
 }
 
 // +kubebuilder:rbac:groups=unbounded-cloud.io,resources=machineoperations,verbs=get;list;watch;delete
@@ -76,40 +73,51 @@ type MachineOperationReconciler struct {
 // +kubebuilder:rbac:nonResourceURLs=/version,verbs=get
 
 func (r *MachineOperationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	controller, err := r.controller()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return controller.Reconcile(ctx, req)
+}
+
+func (r *MachineOperationReconciler) resolveOperationTarget(ctx context.Context, op *unboundedv1alpha3.MachineOperation) (machineopscontroller.TargetResult, error) {
 	logger := log.FromContext(ctx)
-	opKey := client.ObjectKey{Name: req.Name}
-
-	var op unboundedv1alpha3.MachineOperation
-	if err := r.Get(ctx, opKey, &op); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	if op.Status.IsTerminal() {
-		return r.reconcileTerminal(ctx, &op)
-	}
 
 	if op.Spec.MachineRef == "" {
 		if op.Spec.MachineSelector != nil {
 			logger.V(1).Info("selector-based operation not handled by external power controller", "operation", op.Name)
-			return ctrl.Result{}, nil
+			return machineopscontroller.TargetResult{Decision: machineopscontroller.TargetIgnore}, nil
 		}
 
-		return r.failOperation(ctx, &op, "InvalidSpec", "spec.machineRef is required")
+		return machineopscontroller.TargetResult{
+			Decision: machineopscontroller.TargetFail,
+			Reason:   "InvalidSpec",
+			Message:  "spec.machineRef is required",
+		}, nil
 	}
 
 	var machine unboundedv1alpha3.Machine
 	if err := r.Get(ctx, client.ObjectKey{Name: op.Spec.MachineRef}, &machine); err != nil {
 		if apierrors.IsNotFound(err) {
-			return r.failOperation(ctx, &op, "MachineNotFound", fmt.Sprintf("Machine %s not found", op.Spec.MachineRef))
+			return machineopscontroller.TargetResult{
+				Decision: machineopscontroller.TargetFail,
+				Reason:   "MachineNotFound",
+				Message:  fmt.Sprintf("Machine %s not found", op.Spec.MachineRef),
+			}, nil
 		}
 
-		return ctrl.Result{}, fmt.Errorf("get Machine %s: %w", op.Spec.MachineRef, err)
+		return machineopscontroller.TargetResult{}, fmt.Errorf("get Machine %s: %w", op.Spec.MachineRef, err)
 	}
 
 	providerMatch := r.providerFor(&machine, op.Spec.OperationKind)
 	if providerMatch.provider == nil {
 		if providerMatch.providerExists && isHostOperation(op.Spec.OperationKind) {
-			return r.failOperation(ctx, &op, "UnsupportedOperation", fmt.Sprintf("%s is not supported for %s", op.Spec.OperationKind, machine.Spec.Provider))
+			return machineopscontroller.TargetResult{
+				Decision: machineopscontroller.TargetFail,
+				Reason:   "UnsupportedOperation",
+				Message:  fmt.Sprintf("%s is not supported for %s", op.Spec.OperationKind, machine.Spec.Provider),
+			}, nil
 		}
 
 		logger.V(1).Info("operation not handled by external power controller",
@@ -117,33 +125,31 @@ func (r *MachineOperationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			"operationKind", op.Spec.OperationKind,
 			"machine", machine.Name)
 
-		return ctrl.Result{}, nil
+		return machineopscontroller.TargetResult{Decision: machineopscontroller.TargetIgnore}, nil
 	}
 
-	shouldExecute := shouldExecuteOperation(&op)
-	if shouldExecute {
-		if op.Status.Phase != unboundedv1alpha3.OperationPhaseInProgress {
-			if err := r.markInProgress(ctx, &op, fmt.Sprintf("executing %s via %s", op.Spec.OperationKind, providerMatch.provider.Name())); err != nil {
-				return ctrl.Result{}, err
-			}
+	return machineopscontroller.TargetResult{Decision: machineopscontroller.TargetClaim, Machine: &machine}, nil
+}
 
-			if err := r.Get(ctx, opKey, &op); err != nil {
-				return ctrl.Result{}, client.IgnoreNotFound(err)
-			}
+func (r *MachineOperationReconciler) handleOperation(ctx context.Context, store machineopscontroller.Store, request machineopscontroller.OperationRequest) (ctrl.Result, error) {
+	op := request.Object
+	machine := request.Machine
+	if machine == nil {
+		return ctrl.Result{}, fmt.Errorf("resolved Machine is required")
+	}
+
+	providerMatch := r.providerFor(machine, op.Spec.OperationKind)
+	if providerMatch.provider == nil {
+		return ctrl.Result{}, fmt.Errorf("provider for %s on Machine %s is no longer available", op.Spec.OperationKind, machine.Name)
+	}
+	if op.Status.Phase != unboundedv1alpha3.OperationPhaseInProgress {
+		if err := store.MarkInProgress(ctx, request, fmt.Sprintf("executing %s via %s", op.Spec.OperationKind, providerMatch.provider.Name())); err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 
-	if !shouldExecute {
-		logger.V(1).Info("operation already in progress, not re-executing external power action",
-			"operation", op.Name,
-			"operationKind", op.Spec.OperationKind,
-			"machine", machine.Name)
-
-		return ctrl.Result{}, nil
-	}
-
 	operationRequest := OperationRequest{
-		Machine:       &machine,
+		Machine:       machine,
 		OperationName: op.Name,
 		OperationUID:  op.UID,
 		ProviderID:    providerMatch.providerID,
@@ -151,9 +157,13 @@ func (r *MachineOperationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Parameters:    op.Spec.Parameters,
 	}
 	if op.Spec.OperationKind == unboundedv1alpha3.OperationHostReplace {
-		userData, err := r.buildReplaceUserData(ctx, &machine)
+		userData, err := r.buildReplaceUserData(ctx, machine)
 		if err != nil {
-			return r.failOperation(ctx, &op, "BootstrapDataFailed", err.Error())
+			return ctrl.Result{}, store.Finish(ctx, request, machineopscontroller.OperationResult{
+				Phase:   unboundedv1alpha3.OperationPhaseFailed,
+				Reason:  "BootstrapDataFailed",
+				Message: err.Error(),
+			})
 		}
 
 		operationRequest.ReplaceUserData = userData
@@ -161,11 +171,15 @@ func (r *MachineOperationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	operationResult, err := providerMatch.provider.Execute(ctx, operationRequest)
 	if err != nil {
-		return r.failOperation(ctx, &op, "ExecutionFailed", err.Error())
+		return ctrl.Result{}, store.Finish(ctx, request, machineopscontroller.OperationResult{
+			Phase:   unboundedv1alpha3.OperationPhaseFailed,
+			Reason:  "ExecutionFailed",
+			Message: err.Error(),
+		})
 	}
 
 	if operationResult.ProviderID != "" && operationResult.ProviderID != machine.Spec.ProviderID {
-		updatedGeneration, err := r.updateMachineProviderID(ctx, &machine, operationResult.ProviderID)
+		updatedGeneration, err := r.updateMachineProviderID(ctx, machine, operationResult.ProviderID)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -178,7 +192,12 @@ func (r *MachineOperationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, fmt.Errorf("cleanup %s via %s: %w", op.Spec.OperationKind, providerMatch.provider.Name(), err)
 	}
 
-	return r.completeOperation(ctx, &op, machine.Generation, fmt.Sprintf("%s completed via %s", op.Spec.OperationKind, providerMatch.provider.Name()))
+	return ctrl.Result{}, store.Finish(ctx, request, machineopscontroller.OperationResult{
+		Phase:                     unboundedv1alpha3.OperationPhaseComplete,
+		Reason:                    "Succeeded",
+		Message:                   fmt.Sprintf("%s completed via %s", op.Spec.OperationKind, providerMatch.provider.Name()),
+		ObservedMachineGeneration: machine.Generation,
+	})
 }
 
 func (r *MachineOperationReconciler) updateMachineProviderID(ctx context.Context, machine *unboundedv1alpha3.Machine, providerID string) (int64, error) {
@@ -224,39 +243,16 @@ type providerMatch struct {
 }
 
 func (r *MachineOperationReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	maxConcurrent := r.MaxConcurrentReconciles
-	if maxConcurrent <= 0 {
-		maxConcurrent = 1
+	controller, err := r.controller()
+	if err != nil {
+		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
-		Named("machineoperation-external-power").
-		For(&unboundedv1alpha3.MachineOperation{}).
-		WithEventFilter(predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool {
-				op, ok := e.Object.(*unboundedv1alpha3.MachineOperation)
-				return ok && shouldReconcileOperation(op)
-			},
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				op, ok := e.ObjectNew.(*unboundedv1alpha3.MachineOperation)
-				return ok && shouldReconcileOperation(op)
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool { return false },
-			GenericFunc: func(e event.GenericEvent) bool {
-				op, ok := e.Object.(*unboundedv1alpha3.MachineOperation)
-				return ok && shouldReconcileOperation(op)
-			},
-		}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrent}).
-		Complete(r)
+	return controller.SetupWithManager(mgr, "machineoperation-external-power", r.MaxConcurrentReconciles)
 }
 
 func shouldReconcileOperation(op *unboundedv1alpha3.MachineOperation) bool {
-	if !op.Status.IsTerminal() {
-		return true
-	}
-
-	return op.Spec.TTLSecondsAfterFinished != nil && op.Status.CompletedAt != nil
+	return machineopscontroller.ShouldReconcileOperation(op)
 }
 
 func (r *MachineOperationReconciler) providerFor(machine *unboundedv1alpha3.Machine, operation unboundedv1alpha3.OperationKind) providerMatch {
@@ -283,126 +279,35 @@ func (r *MachineOperationReconciler) providerFor(machine *unboundedv1alpha3.Mach
 	return matched
 }
 
-func (r *MachineOperationReconciler) reconcileTerminal(ctx context.Context, op *unboundedv1alpha3.MachineOperation) (ctrl.Result, error) {
-	if op.Spec.TTLSecondsAfterFinished == nil || op.Status.CompletedAt == nil {
-		return ctrl.Result{}, nil
-	}
-
-	deadline := op.Status.CompletedAt.Add(time.Duration(*op.Spec.TTLSecondsAfterFinished) * time.Second)
-
-	now := r.now().Time
-	if now.Before(deadline) {
-		return ctrl.Result{RequeueAfter: deadline.Sub(now)}, nil
-	}
-
-	if err := r.Delete(ctx, op); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	return ctrl.Result{}, nil
-}
-
-func (r *MachineOperationReconciler) markInProgress(ctx context.Context, op *unboundedv1alpha3.MachineOperation, message string) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		var latest unboundedv1alpha3.MachineOperation
-		if err := r.Get(ctx, client.ObjectKeyFromObject(op), &latest); err != nil {
-			return err
-		}
-
-		now := r.now()
-		latest.Status.Phase = unboundedv1alpha3.OperationPhaseInProgress
-
-		latest.Status.Message = message
-		if latest.Status.StartedAt == nil {
-			latest.Status.StartedAt = &now
-		}
-
-		apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
-			Type:               OperationConditionCompleted,
-			Status:             metav1.ConditionFalse,
-			Reason:             "InProgress",
-			Message:            message,
-			ObservedGeneration: latest.Generation,
-		})
-
-		if err := r.Status().Update(ctx, &latest); err != nil {
-			return fmt.Errorf("mark MachineOperation InProgress: %w", err)
-		}
-
-		return nil
-	})
-}
-
-func (r *MachineOperationReconciler) completeOperation(ctx context.Context, op *unboundedv1alpha3.MachineOperation, observedMachineGeneration int64, message string) (ctrl.Result, error) {
-	return r.finishOperation(ctx, op, unboundedv1alpha3.OperationPhaseComplete, "Succeeded", message, observedMachineGeneration, nil)
-}
-
-func (r *MachineOperationReconciler) failOperation(ctx context.Context, op *unboundedv1alpha3.MachineOperation, reason, message string) (ctrl.Result, error) {
-	return r.finishOperation(ctx, op, unboundedv1alpha3.OperationPhaseFailed, reason, message, 0, nil)
-}
-
-func (r *MachineOperationReconciler) finishOperation(
-	ctx context.Context,
-	op *unboundedv1alpha3.MachineOperation,
-	phase unboundedv1alpha3.OperationPhase,
-	reason string,
-	message string,
-	observedMachineGeneration int64,
-	execErr error,
-) (ctrl.Result, error) {
-	var updated unboundedv1alpha3.MachineOperation
-
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, client.ObjectKeyFromObject(op), &updated); err != nil {
-			return err
-		}
-
-		now := r.now()
-		if updated.Status.StartedAt == nil {
-			updated.Status.StartedAt = &now
-		}
-
-		updated.Status.Phase = phase
-		updated.Status.Message = message
-
-		updated.Status.CompletedAt = &now
-		if observedMachineGeneration > 0 {
-			updated.Status.ObservedMachineGeneration = observedMachineGeneration
-		}
-
-		conditionStatus := metav1.ConditionTrue
-		if phase == unboundedv1alpha3.OperationPhaseFailed {
-			conditionStatus = metav1.ConditionFalse
-		}
-
-		apimeta.SetStatusCondition(&updated.Status.Conditions, metav1.Condition{
-			Type:               OperationConditionCompleted,
-			Status:             conditionStatus,
-			Reason:             reason,
-			Message:            message,
-			ObservedGeneration: updated.Generation,
-		})
-
-		return r.Status().Update(ctx, &updated)
-	}); err != nil {
-		if execErr != nil {
-			return ctrl.Result{}, execErr
-		}
-
-		return ctrl.Result{}, fmt.Errorf("finish MachineOperation: %w", err)
-	}
-
-	if updated.Spec.TTLSecondsAfterFinished != nil {
-		return r.reconcileTerminal(ctx, &updated)
-	}
-
-	return ctrl.Result{}, execErr
-}
-
 func (r *MachineOperationReconciler) now() metav1.Time {
 	if r.Now != nil {
 		return r.Now()
 	}
 
 	return metav1.Now()
+}
+
+func (r *MachineOperationReconciler) controller() (*machineopscontroller.Reconciler, error) {
+	if r.operationController != nil {
+		return r.operationController, nil
+	}
+
+	controller, err := machineopscontroller.NewReconciler(machineopscontroller.Config{
+		Client: r.Client,
+		Operations: []machineopscontroller.Operation{
+			{Kind: unboundedv1alpha3.OperationHostReboot, Handler: r.handleOperation},
+			{Kind: unboundedv1alpha3.OperationHostPowerOff, Handler: r.handleOperation},
+			{Kind: unboundedv1alpha3.OperationHostPowerOn, Handler: r.handleOperation},
+			{Kind: unboundedv1alpha3.OperationHostReplace, Handler: r.handleOperation, ReexecuteInProgress: true},
+		},
+		TargetResolver:             machineopscontroller.TargetResolverFunc(r.resolveOperationTarget),
+		UnsupportedOperationPolicy: machineopscontroller.UnsupportedOperationFail,
+		Now:                        r.now,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r.operationController = controller
+	return controller, nil
 }

--- a/pkg/agent/daemon/machineoperation.go
+++ b/pkg/agent/daemon/machineoperation.go
@@ -9,26 +9,20 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	machinav1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	machineopscontroller "github.com/Azure/unbounded/pkg/machineops/controller"
 )
 
-// MachineOperationHandlers maps operation kinds to host-local MachineOperation handlers.
-type MachineOperationHandlers map[machinav1alpha3.OperationKind]MachineOperationHandler[int64]
-
-// MachinaMachineOperationReconciler fetches MachineOperation objects, skips terminal
-// operations, and dispatches non-terminal operations to kind-specific targets.
+// MachinaMachineOperationReconciler claims local MachineOperations and
+// dispatches them to kind-specific targets.
 type MachinaMachineOperationReconciler struct {
 	client      client.Client
+	controller  *machineopscontroller.Reconciler
 	machineName string
 	nodeName    string
 	handlers    MachineOperationHandlers
@@ -60,15 +54,36 @@ func NewMachinaMachineOperationReconciler(
 		}
 	}
 
-	return &MachinaMachineOperationReconciler{client: c, machineName: machineName, nodeName: nodeName, handlers: handlers}, nil
+	reconciler := &MachinaMachineOperationReconciler{client: c, machineName: machineName, nodeName: nodeName, handlers: handlers}
+	operations := make([]machineopscontroller.Operation, 0, len(handlers))
+	for kind, handler := range handlers {
+		operations = append(operations, machineopscontroller.Operation{Kind: kind, Handler: handler})
+	}
+	operationController, err := machineopscontroller.NewReconciler(machineopscontroller.Config{
+		Client:                     c,
+		Operations:                 operations,
+		TargetResolver:             machineopscontroller.TargetResolverFunc(reconciler.resolveMachineOperationTarget),
+		UnsupportedOperationPolicy: machineopscontroller.UnsupportedOperationIgnore,
+	})
+	if err != nil {
+		return nil, err
+	}
+	reconciler.controller = operationController
+
+	return reconciler, nil
 }
 
 // SetupController registers the MachineOperation watch for this reconciler.
 func (r *MachinaMachineOperationReconciler) SetupController(b *builder.TypedBuilder[Request]) *builder.TypedBuilder[Request] {
 	return b.Watches(
 		&machinav1alpha3.MachineOperation{},
-		handler.TypedEnqueueRequestsFromMapFunc(r.mapMachineOperation),
+		handler.TypedEnqueueRequestsFromMapFunc(machineopscontroller.NewTypedMapper(r.controller, NewMachineOperationRequest)),
 	)
+}
+
+func (r *MachinaMachineOperationReconciler) mapMachineOperation(ctx context.Context, obj client.Object) []Request {
+	mapper := machineopscontroller.NewTypedMapper(r.controller, NewMachineOperationRequest)
+	return mapper(ctx, obj)
 }
 
 // ReconcileMachineOperation handles a queued MachineOperation request.
@@ -76,56 +91,19 @@ func (r *MachinaMachineOperationReconciler) ReconcileMachineOperation(
 	ctx context.Context,
 	name string,
 ) (ctrl.Result, error) {
-	var op machinav1alpha3.MachineOperation
-	if err := r.client.Get(ctx, client.ObjectKey{Name: name}, &op); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	if op.Status.IsTerminal() {
-		return ctrl.Result{}, nil
-	}
-
-	operation := MachineOperation{
-		Name: op.Name,
-		Kind: op.Spec.OperationKind,
-	}
-	handler, ok := r.handlers[op.Spec.OperationKind]
-	if !ok {
-		log.FromContext(ctx).Info("failing MachineOperation with no handler", "operation", op.Name, "operationKind", op.Spec.OperationKind)
-
-		return ctrl.Result{}, r.Finish(ctx, operation, MachineOperationResult[int64]{
-			Phase:   machinav1alpha3.OperationPhaseFailed,
-			Reason:  "UnsupportedOperation",
-			Message: fmt.Sprintf("no handler registered for operation kind %s", op.Spec.OperationKind),
-		})
-	}
-
-	operation.Parameters = op.Spec.Parameters
-
-	return handler(ctx, r, operation)
+	return r.controller.ReconcileName(ctx, name)
 }
 
-func (r *MachinaMachineOperationReconciler) mapMachineOperation(ctx context.Context, obj client.Object) []Request {
-	op, ok := obj.(*machinav1alpha3.MachineOperation)
-	if !ok || !r.shouldEnqueue(ctx, op) {
-		return nil
-	}
-
-	return []Request{NewMachineOperationRequest(op.Name)}
-}
-
-func (r *MachinaMachineOperationReconciler) shouldEnqueue(ctx context.Context, op *machinav1alpha3.MachineOperation) bool {
-	if op.Status.Phase != "" && op.Status.Phase != machinav1alpha3.OperationPhasePending {
-		return false
-	}
-
+func (r *MachinaMachineOperationReconciler) resolveMachineOperationTarget(ctx context.Context, op *machinav1alpha3.MachineOperation) (machineopscontroller.TargetResult, error) {
 	matches, err := r.matchesMachine(ctx, op)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "invalid MachineOperation target selector", "operation", op.Name)
-		return false
+		return machineopscontroller.TargetResult{}, err
+	}
+	if !matches {
+		return machineopscontroller.TargetResult{Decision: machineopscontroller.TargetIgnore}, nil
 	}
 
-	return matches
+	return machineopscontroller.TargetResult{Decision: machineopscontroller.TargetClaim}, nil
 }
 
 func (r *MachinaMachineOperationReconciler) matchesMachine(ctx context.Context, op *machinav1alpha3.MachineOperation) (bool, error) {
@@ -139,7 +117,7 @@ func (r *MachinaMachineOperationReconciler) matchesMachine(ctx context.Context, 
 
 	var node corev1.Node
 	if err := r.client.Get(ctx, client.ObjectKey{Name: r.nodeName}, &node); err == nil {
-		return selectorMatches(op.Spec.MachineSelector, node.Labels)
+		return machineopscontroller.SelectorMatches(op.Spec.MachineSelector, node.Labels)
 	} else if !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("get Node %s for selector match: %w", r.nodeName, err)
 	}
@@ -153,90 +131,23 @@ func (r *MachinaMachineOperationReconciler) matchesMachine(ctx context.Context, 
 		return false, fmt.Errorf("get Machine %s for selector match: %w", r.machineName, err)
 	}
 
-	return selectorMatches(op.Spec.MachineSelector, machine.Labels)
+	return machineopscontroller.SelectorMatches(op.Spec.MachineSelector, machine.Labels)
 }
 
 func (r *MachinaMachineOperationReconciler) MarkInProgress(ctx context.Context, op MachineOperation, message string) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		var latest machinav1alpha3.MachineOperation
-		if err := r.client.Get(ctx, client.ObjectKey{Name: op.Name}, &latest); err != nil {
-			return err
-		}
-
-		if latest.Status.IsTerminal() {
-			return nil
-		}
-
-		now := metav1.Now()
-		latest.Status.Phase = machinav1alpha3.OperationPhaseInProgress
-		latest.Status.Message = message
-		if latest.Status.StartedAt == nil {
-			latest.Status.StartedAt = &now
-		}
-
-		apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
-			Type:               "Completed",
-			Status:             metav1.ConditionFalse,
-			Reason:             "InProgress",
-			Message:            message,
-			ObservedGeneration: latest.Generation,
-		})
-
-		return r.client.Status().Update(ctx, &latest)
-	})
+	return r.controller.MarkInProgress(ctx, op, message)
 }
 
 // Finish records the final status for a MachineOperation.
-func (r *MachinaMachineOperationReconciler) Finish(ctx context.Context, op MachineOperation, result MachineOperationResult[int64]) error {
-	return FinishMachineOperation(ctx, r.client, op, result)
+func (r *MachinaMachineOperationReconciler) Finish(ctx context.Context, op MachineOperation, result MachineOperationResult) error {
+	return r.controller.Finish(ctx, op, result)
 }
 
 // FinishMachineOperation records the final status for a MachineOperation.
-func FinishMachineOperation(ctx context.Context, c client.Client, op MachineOperation, result MachineOperationResult[int64]) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		var latest machinav1alpha3.MachineOperation
-		if err := c.Get(ctx, client.ObjectKey{Name: op.Name}, &latest); err != nil {
-			return client.IgnoreNotFound(err)
-		}
-
-		now := metav1.Now()
-		if latest.Status.StartedAt == nil {
-			latest.Status.StartedAt = &now
-		}
-
-		latest.Status.Phase = result.Phase
-		latest.Status.Message = result.Message
-		latest.Status.CompletedAt = &now
-		if result.ObservedMachineGeneration > 0 {
-			latest.Status.ObservedMachineGeneration = result.ObservedMachineGeneration
-		}
-
-		conditionStatus := metav1.ConditionTrue
-		if result.Phase == machinav1alpha3.OperationPhaseFailed {
-			conditionStatus = metav1.ConditionFalse
-		}
-
-		apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
-			Type:               "Completed",
-			Status:             conditionStatus,
-			Reason:             result.Reason,
-			Message:            result.Message,
-			ObservedGeneration: latest.Generation,
-		})
-
-		return c.Status().Update(ctx, &latest)
-	})
+func FinishMachineOperation(ctx context.Context, c client.Client, op MachineOperation, result MachineOperationResult) error {
+	return machineopscontroller.NewStatusStore(c, nil).Finish(ctx, op, result)
 }
 
-var _ MachineOperationStore[int64] = (*MachinaMachineOperationReconciler)(nil)
-
-func selectorMatches(selector *metav1.LabelSelector, targetLabels map[string]string) (bool, error) {
-	compiled, err := metav1.LabelSelectorAsSelector(selector)
-	if err != nil {
-		return false, err
-	}
-
-	return compiled.Matches(labels.Set(targetLabels)), nil
-}
+var _ MachineOperationStore = (*MachinaMachineOperationReconciler)(nil)
 
 var _ MachineOperationRequestReconciler = (*MachinaMachineOperationReconciler)(nil)

--- a/pkg/agent/daemon/machineoperation_test.go
+++ b/pkg/agent/daemon/machineoperation_test.go
@@ -47,6 +47,7 @@ func TestMachinaMachineOperationReconcilerDispatchesTarget(t *testing.T) {
 	op := &machinav1alpha3.MachineOperation{
 		ObjectMeta: metav1.ObjectMeta{Name: "op-1"},
 		Spec: machinav1alpha3.MachineOperationSpec{
+			MachineRef:    "machine-1",
 			OperationKind: machinav1alpha3.OperationNodeReboot,
 		},
 	}
@@ -77,7 +78,7 @@ func TestMachinaMachineOperationReconcilerDispatchesTarget(t *testing.T) {
 	}
 }
 
-func TestMachinaMachineOperationReconcilerSkipsTerminalAndFailsUnsupported(t *testing.T) {
+func TestMachinaMachineOperationReconcilerSkipsTerminalAndIgnoresUnsupported(t *testing.T) {
 	t.Parallel()
 
 	terminal := &machinav1alpha3.MachineOperation{
@@ -87,7 +88,10 @@ func TestMachinaMachineOperationReconcilerSkipsTerminalAndFailsUnsupported(t *te
 	}
 	unsupported := &machinav1alpha3.MachineOperation{
 		ObjectMeta: metav1.ObjectMeta{Name: "unsupported"},
-		Spec:       machinav1alpha3.MachineOperationSpec{OperationKind: machinav1alpha3.OperationHostReboot},
+		Spec: machinav1alpha3.MachineOperationSpec{
+			MachineRef:    "machine-1",
+			OperationKind: machinav1alpha3.OperationHostReboot,
+		},
 	}
 	target := &recordingMachineOperationTargetState{}
 	reconciler, err := NewMachinaMachineOperationReconciler(
@@ -114,11 +118,8 @@ func TestMachinaMachineOperationReconcilerSkipsTerminalAndFailsUnsupported(t *te
 	if err := reconciler.client.Get(context.Background(), client.ObjectKey{Name: "unsupported"}, &updated); err != nil {
 		t.Fatalf("get unsupported MachineOperation: %v", err)
 	}
-	if updated.Status.Phase != machinav1alpha3.OperationPhaseFailed {
-		t.Fatalf("unsupported phase = %s, want %s", updated.Status.Phase, machinav1alpha3.OperationPhaseFailed)
-	}
-	if updated.Status.Conditions[0].Reason != "UnsupportedOperation" {
-		t.Fatalf("unsupported reason = %s, want UnsupportedOperation", updated.Status.Conditions[0].Reason)
+	if updated.Status.Phase != "" {
+		t.Fatalf("unsupported phase = %s, want empty", updated.Status.Phase)
 	}
 }
 
@@ -129,7 +130,10 @@ func TestMachinaMachineOperationReconcilerReturnsTargetError(t *testing.T) {
 	machine := &machinav1alpha3.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-1", Generation: 7}}
 	op := &machinav1alpha3.MachineOperation{
 		ObjectMeta: metav1.ObjectMeta{Name: "op-1"},
-		Spec:       machinav1alpha3.MachineOperationSpec{OperationKind: machinav1alpha3.OperationNodeReboot},
+		Spec: machinav1alpha3.MachineOperationSpec{
+			MachineRef:    "machine-1",
+			OperationKind: machinav1alpha3.OperationNodeReboot,
+		},
 	}
 	reconciler, err := NewMachinaMachineOperationReconciler(
 		fakeMachineOperationClient(machine, op),
@@ -240,6 +244,31 @@ func TestMachinaMachineOperationReconcilerSkipsNonMatchingWatchObjects(t *testin
 	}
 }
 
+func TestMachinaMachineOperationReconcilerDoesNotMapUnownedTerminalOperation(t *testing.T) {
+	t.Parallel()
+
+	completedAt := metav1.Now()
+	ttl := int32(30)
+	reconciler := newTestMachinaMachineOperationReconciler(t, fakeMachineOperationClient())
+	op := &machinav1alpha3.MachineOperation{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloud-operation"},
+		Spec: machinav1alpha3.MachineOperationSpec{
+			MachineRef:              "machine-1",
+			OperationKind:           machinav1alpha3.OperationHostReboot,
+			TTLSecondsAfterFinished: &ttl,
+		},
+		Status: machinav1alpha3.MachineOperationStatus{
+			Phase:       machinav1alpha3.OperationPhaseComplete,
+			CompletedAt: &completedAt,
+		},
+	}
+
+	requests := reconciler.mapMachineOperation(context.Background(), op)
+	if len(requests) != 0 {
+		t.Fatalf("requests = %#v, want none", requests)
+	}
+}
+
 func TestMachinaMachineOperationReconcilerMapsUnsupportedMatchingOperation(t *testing.T) {
 	t.Parallel()
 
@@ -253,13 +282,8 @@ func TestMachinaMachineOperationReconcilerMapsUnsupportedMatchingOperation(t *te
 	}
 
 	requests := reconciler.mapMachineOperation(context.Background(), op)
-	if len(requests) != 1 {
-		t.Fatalf("requests = %#v, want one", requests)
-	}
-
-	req, ok := requests[0].machineOperationRequest()
-	if !ok || req.Name != "unsupported" {
-		t.Fatalf("request = %#v", requests[0])
+	if len(requests) != 0 {
+		t.Fatalf("requests = %#v, want none", requests)
 	}
 }
 
@@ -279,13 +303,13 @@ func newTestMachinaMachineOperationReconciler(t *testing.T, c client.Client) *Ma
 	return reconciler
 }
 
-func noopMachineOperationTarget(context.Context, MachineOperationStore[int64], MachineOperation) (ctrl.Result, error) {
+func noopMachineOperationTarget(context.Context, MachineOperationStore, MachineOperation) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
 type recordingMachineOperationTargetState struct {
 	operation MachineOperation
-	store     MachineOperationStore[int64]
+	store     MachineOperationStore
 	called    bool
 	result    ctrl.Result
 	err       error
@@ -293,7 +317,7 @@ type recordingMachineOperationTargetState struct {
 
 func (t *recordingMachineOperationTargetState) reconcile(
 	_ context.Context,
-	store MachineOperationStore[int64],
+	store MachineOperationStore,
 	op MachineOperation,
 ) (ctrl.Result, error) {
 	t.called = true

--- a/pkg/agent/daemon/types.go
+++ b/pkg/agent/daemon/types.go
@@ -11,49 +11,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	machinav1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	machineopscontroller "github.com/Azure/unbounded/pkg/machineops/controller"
 )
 
 // MachineOperation is a typed host-local daemon operation request.
-type MachineOperation struct {
-	// Name is the operation name in its source system.
-	Name string
-
-	// Kind is the requested host-local operation kind.
-	Kind machinav1alpha3.OperationKind
-
-	// Parameters contains operation-specific inputs, such as an AgentUpgrade download URL.
-	Parameters map[string]string
-}
+type MachineOperation = machineopscontroller.OperationRequest
 
 // MachineOperationResult describes the outcome of a host-local daemon operation.
-type MachineOperationResult[TGeneration comparable] struct {
-	// Phase is the resulting operation phase.
-	Phase machinav1alpha3.OperationPhase
-
-	// Reason is a stable, machine-readable reason for the result.
-	Reason string
-
-	// Message is a human-readable result description.
-	Message string
-
-	// ObservedMachineGeneration records the machine generation acted on by the operation.
-	ObservedMachineGeneration TGeneration
-}
+type MachineOperationResult = machineopscontroller.OperationResult
 
 // MachineOperationHandler executes a host-local daemon operation.
-type MachineOperationHandler[TGeneration comparable] func(context.Context, MachineOperationStore[TGeneration], MachineOperation) (ctrl.Result, error)
+type MachineOperationHandler = machineopscontroller.OperationHandler
+
+// MachineOperationHandlers maps operation kinds to host-local MachineOperation handlers.
+type MachineOperationHandlers map[machinav1alpha3.OperationKind]MachineOperationHandler
 
 // MachineOperationStore records operation lifecycle state.
-type MachineOperationStore[TGeneration comparable] interface {
-	// MarkInProgress records that op has started execution with message as the
-	// human-readable in-progress status.
-	MarkInProgress(context.Context, MachineOperation, string) error
-
-	// Finish records the terminal or non-terminal result for op. The result
-	// carries the desired phase, reason, message, observed generation, and any
-	// controller-runtime requeue request.
-	Finish(context.Context, MachineOperation, MachineOperationResult[TGeneration]) error
-}
+type MachineOperationStore = machineopscontroller.Store
 
 // machineOperationRequest identifies a MachineOperation reconcile request.
 type machineOperationRequest struct {

--- a/pkg/machineops/controller/doc.go
+++ b/pkg/machineops/controller/doc.go
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package controller provides a configurable MachineOperation controller pattern.
+//
+// A controller declares the operation kinds it handles, supplies a target
+// resolver that decides whether the controller owns each operation, and receives
+// a Store for lifecycle status updates.
+package controller

--- a/pkg/machineops/controller/mapper.go
+++ b/pkg/machineops/controller/mapper.go
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package controller
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	machinav1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+// NewTypedMapper maps MachineOperation events to caller-specific typed requests.
+func NewTypedMapper[T comparable](
+	r *Reconciler,
+	newRequest func(string) T,
+) handler.TypedMapFunc[client.Object, T] {
+	return func(ctx context.Context, obj client.Object) []T {
+		op, ok := obj.(*machinav1alpha3.MachineOperation)
+		if !ok || !r.ShouldEnqueue(ctx, op) {
+			return nil
+		}
+
+		return []T{newRequest(op.Name)}
+	}
+}

--- a/pkg/machineops/controller/reconciler.go
+++ b/pkg/machineops/controller/reconciler.go
@@ -1,0 +1,300 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	machinav1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+const (
+	// OperationConditionCompleted is the MachineOperation completion condition type.
+	OperationConditionCompleted = "Completed"
+)
+
+// Config configures a Reconciler.
+type Config struct {
+	Client                     client.Client
+	Operations                 []Operation
+	TargetResolver             TargetResolver
+	UnsupportedOperationPolicy UnsupportedOperationPolicy
+	Now                        func() metav1.Time
+}
+
+// Reconciler fetches, claims, dispatches, and records MachineOperation state.
+type Reconciler struct {
+	client                     client.Client
+	operations                 operationRegistry
+	targetResolver             TargetResolver
+	unsupportedOperationPolicy UnsupportedOperationPolicy
+	store                      *StatusStore
+	now                        func() metav1.Time
+}
+
+// NewReconciler returns a reusable MachineOperation reconciler.
+func NewReconciler(cfg Config) (*Reconciler, error) {
+	if cfg.Client == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	operations, err := newOperationRegistry(cfg.Operations)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.TargetResolver == nil {
+		return nil, fmt.Errorf("target resolver is required")
+	}
+
+	now := cfg.Now
+	if now == nil {
+		now = metav1.Now
+	}
+
+	return &Reconciler{
+		client:                     cfg.Client,
+		operations:                 operations,
+		targetResolver:             cfg.TargetResolver,
+		unsupportedOperationPolicy: cfg.UnsupportedOperationPolicy,
+		store:                      NewStatusStore(cfg.Client, now),
+		now:                        now,
+	}, nil
+}
+
+// Reconcile handles a controller-runtime request.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return r.ReconcileName(ctx, req.Name)
+}
+
+// ReconcileName handles a MachineOperation by name.
+func (r *Reconciler) ReconcileName(ctx context.Context, name string) (ctrl.Result, error) {
+	opKey := client.ObjectKey{Name: name}
+
+	var op machinav1alpha3.MachineOperation
+	if err := r.client.Get(ctx, opKey, &op); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if op.Status.IsTerminal() {
+		if !ShouldReconcileOperation(&op) {
+			return ctrl.Result{}, nil
+		}
+		if _, ok := r.operations[op.Spec.OperationKind]; !ok && r.unsupportedOperationPolicy != UnsupportedOperationFail {
+			return ctrl.Result{}, nil
+		}
+		target, err := r.targetResolver.ResolveTarget(ctx, &op)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if target.Decision == TargetIgnore {
+			return ctrl.Result{}, nil
+		}
+
+		return r.reconcileTerminal(ctx, &op)
+	}
+
+	target, err := r.targetResolver.ResolveTarget(ctx, &op)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	switch target.Decision {
+	case TargetIgnore:
+		return ctrl.Result{}, nil
+	case TargetFail:
+		return r.finishAndReconcileTerminal(ctx, requestFromOperation(&op, target.Machine), OperationResult{
+			Phase:   machinav1alpha3.OperationPhaseFailed,
+			Reason:  target.Reason,
+			Message: target.Message,
+		})
+	case TargetClaim:
+	default:
+		return ctrl.Result{}, fmt.Errorf("unknown MachineOperation target decision %q", target.Decision)
+	}
+
+	operation, ok := r.operations[op.Spec.OperationKind]
+	if !ok {
+		if r.unsupportedOperationPolicy != UnsupportedOperationFail {
+			return ctrl.Result{}, nil
+		}
+
+		return r.finishAndReconcileTerminal(ctx, requestFromOperation(&op, target.Machine), OperationResult{
+			Phase:   machinav1alpha3.OperationPhaseFailed,
+			Reason:  "UnsupportedOperation",
+			Message: fmt.Sprintf("no handler registered for operation kind %s", op.Spec.OperationKind),
+		})
+	}
+
+	if !operationShouldExecute(&op, operation) {
+		log.FromContext(ctx).V(1).Info("operation already in progress, not re-executing",
+			"operation", op.Name,
+			"operationKind", op.Spec.OperationKind)
+
+		return ctrl.Result{}, nil
+	}
+
+	handlerResult, err := operation.Handler(ctx, r, requestFromOperation(&op, target.Machine))
+	if err != nil {
+		return handlerResult, err
+	}
+
+	terminalResult, err := r.reconcileTerminalByName(ctx, op.Name)
+	if err != nil {
+		return terminalResult, err
+	}
+	if handlerResult != (ctrl.Result{}) {
+		return handlerResult, nil
+	}
+
+	return terminalResult, nil
+}
+
+// ShouldEnqueue returns true when obj is a MachineOperation this reconciler
+// should queue.
+func (r *Reconciler) ShouldEnqueue(ctx context.Context, obj client.Object) bool {
+	op, ok := obj.(*machinav1alpha3.MachineOperation)
+	if !ok {
+		return false
+	}
+	if !ShouldReconcileOperation(op) {
+		return false
+	}
+
+	target, err := r.targetResolver.ResolveTarget(ctx, op)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "resolve MachineOperation target for enqueue", "operation", op.Name)
+		return false
+	}
+
+	if target.Decision == TargetIgnore {
+		return false
+	}
+	if _, ok := r.operations[op.Spec.OperationKind]; !ok && r.unsupportedOperationPolicy != UnsupportedOperationFail {
+		return false
+	}
+
+	return true
+}
+
+// EventFilter returns a controller-runtime predicate for MachineOperation events.
+func (r *Reconciler) EventFilter() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			op, ok := e.Object.(*machinav1alpha3.MachineOperation)
+			return ok && ShouldReconcileOperation(op)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			op, ok := e.ObjectNew.(*machinav1alpha3.MachineOperation)
+			return ok && ShouldReconcileOperation(op)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool {
+			op, ok := e.Object.(*machinav1alpha3.MachineOperation)
+			return ok && ShouldReconcileOperation(op)
+		},
+	}
+}
+
+// SetupWithManager registers a plain MachineOperation controller with mgr.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, name string, maxConcurrentReconciles int) error {
+	if name == "" {
+		return fmt.Errorf("controller name is required")
+	}
+	if maxConcurrentReconciles <= 0 {
+		maxConcurrentReconciles = 1
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		For(&machinav1alpha3.MachineOperation{}).
+		WithEventFilter(r.EventFilter()).
+		WithOptions(crcontroller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		Complete(r)
+}
+
+// MarkInProgress records that op has started execution.
+func (r *Reconciler) MarkInProgress(ctx context.Context, op OperationRequest, message string) error {
+	return r.store.MarkInProgress(ctx, op, message)
+}
+
+// Finish records the final status for a MachineOperation.
+func (r *Reconciler) Finish(ctx context.Context, op OperationRequest, result OperationResult) error {
+	return r.store.Finish(ctx, op, result)
+}
+
+func (r *Reconciler) reconcileTerminalByName(ctx context.Context, name string) (ctrl.Result, error) {
+	var latest machinav1alpha3.MachineOperation
+	if err := r.client.Get(ctx, client.ObjectKey{Name: name}, &latest); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if !latest.Status.IsTerminal() {
+		return ctrl.Result{}, nil
+	}
+
+	return r.reconcileTerminal(ctx, &latest)
+}
+
+func (r *Reconciler) finishAndReconcileTerminal(ctx context.Context, op OperationRequest, result OperationResult) (ctrl.Result, error) {
+	if err := r.Finish(ctx, op, result); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return r.reconcileTerminalByName(ctx, op.Name)
+}
+
+func (r *Reconciler) reconcileTerminal(ctx context.Context, op *machinav1alpha3.MachineOperation) (ctrl.Result, error) {
+	if op.Spec.TTLSecondsAfterFinished == nil || op.Status.CompletedAt == nil {
+		return ctrl.Result{}, nil
+	}
+
+	deadline := op.Status.CompletedAt.Add(time.Duration(*op.Spec.TTLSecondsAfterFinished) * time.Second)
+	now := r.now().Time
+	if now.Before(deadline) {
+		return ctrl.Result{RequeueAfter: deadline.Sub(now)}, nil
+	}
+
+	if err := r.client.Delete(ctx, op); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func requestFromOperation(op *machinav1alpha3.MachineOperation, machine *machinav1alpha3.Machine) OperationRequest {
+	return OperationRequest{
+		Object:     op,
+		Machine:    machine,
+		Name:       op.Name,
+		UID:        op.UID,
+		Kind:       op.Spec.OperationKind,
+		Parameters: op.Spec.Parameters,
+	}
+}
+
+// ShouldReconcileOperation returns true when a MachineOperation event should be
+// queued by a generic controller.
+func ShouldReconcileOperation(op *machinav1alpha3.MachineOperation) bool {
+	if !op.Status.IsTerminal() {
+		return true
+	}
+
+	return op.Spec.TTLSecondsAfterFinished != nil && op.Status.CompletedAt != nil
+}
+
+func operationShouldExecute(op *machinav1alpha3.MachineOperation, operation Operation) bool {
+	if op.Status.Phase == "" || op.Status.Phase == machinav1alpha3.OperationPhasePending {
+		return true
+	}
+
+	return op.Status.Phase == machinav1alpha3.OperationPhaseInProgress && operation.ReexecuteInProgress
+}

--- a/pkg/machineops/controller/reconciler_test.go
+++ b/pkg/machineops/controller/reconciler_test.go
@@ -1,0 +1,356 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	machinav1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+func TestReconcilerDispatchesClaimedOperation(t *testing.T) {
+	t.Parallel()
+
+	machine := &machinav1alpha3.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-1", Generation: 7}}
+	op := newTestOperation("op-1", machinav1alpha3.OperationNodeReboot)
+	handler := &recordingHandler{result: ctrl.Result{RequeueAfter: time.Second}}
+	c := newTestClient(machine, op)
+	reconciler := newTestReconciler(t, c, []Operation{{Kind: machinav1alpha3.OperationNodeReboot, Handler: handler.handle}}, func(context.Context, *machinav1alpha3.MachineOperation) (TargetResult, error) {
+		return TargetResult{Decision: TargetClaim, Machine: machine}, nil
+	})
+
+	result, err := reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+	require.Equal(t, time.Second, result.RequeueAfter)
+	require.True(t, handler.called)
+	require.Equal(t, "op-1", handler.request.Name)
+	require.Equal(t, machinav1alpha3.OperationNodeReboot, handler.request.Kind)
+	require.Equal(t, machine, handler.request.Machine)
+}
+
+func TestReconcilerTargetFailMarksOperationFailed(t *testing.T) {
+	t.Parallel()
+
+	op := newTestOperation("op-1", machinav1alpha3.OperationHostReboot)
+	c := newTestClient(op)
+	reconciler := newTestReconciler(t, c, []Operation{{Kind: machinav1alpha3.OperationHostReboot, Handler: (&recordingHandler{}).handle}}, func(context.Context, *machinav1alpha3.MachineOperation) (TargetResult, error) {
+		return TargetResult{Decision: TargetFail, Reason: "InvalidSpec", Message: "spec.machineRef is required"}, nil
+	})
+
+	result, err := reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	var updated machinav1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "op-1"}, &updated))
+	require.Equal(t, machinav1alpha3.OperationPhaseFailed, updated.Status.Phase)
+	require.Equal(t, "spec.machineRef is required", updated.Status.Message)
+
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, OperationConditionCompleted)
+	require.NotNil(t, cond)
+	require.Equal(t, metav1.ConditionFalse, cond.Status)
+	require.Equal(t, "InvalidSpec", cond.Reason)
+}
+
+func TestReconcilerTargetFailRequeuesTerminalCleanup(t *testing.T) {
+	t.Parallel()
+
+	ttl := int32(30)
+	op := newTestOperation("op-1", machinav1alpha3.OperationHostReboot)
+	op.Spec.TTLSecondsAfterFinished = &ttl
+	reconciler := newTestReconciler(t, newTestClient(op), []Operation{{Kind: machinav1alpha3.OperationHostReboot, Handler: (&recordingHandler{}).handle}}, func(context.Context, *machinav1alpha3.MachineOperation) (TargetResult, error) {
+		return TargetResult{Decision: TargetFail, Reason: "InvalidSpec", Message: "spec.machineRef is required"}, nil
+	})
+
+	result, err := reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Second, result.RequeueAfter)
+}
+
+func TestReconcilerSkipsInProgressByDefault(t *testing.T) {
+	t.Parallel()
+
+	op := newTestOperation("op-1", machinav1alpha3.OperationHostReboot)
+	op.Status.Phase = machinav1alpha3.OperationPhaseInProgress
+	handler := &recordingHandler{}
+	reconciler := newTestReconciler(t, newTestClient(op), []Operation{{Kind: machinav1alpha3.OperationHostReboot, Handler: handler.handle}}, handleAll)
+
+	result, err := reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	require.False(t, handler.called)
+}
+
+func TestReconcilerReexecutesConfiguredInProgressOperation(t *testing.T) {
+	t.Parallel()
+
+	op := newTestOperation("op-1", machinav1alpha3.OperationHostReplace)
+	op.Status.Phase = machinav1alpha3.OperationPhaseInProgress
+	handler := &recordingHandler{}
+	c := newTestClient(op)
+	reconciler, err := NewReconciler(Config{
+		Client:         c,
+		Operations:     []Operation{{Kind: machinav1alpha3.OperationHostReplace, Handler: handler.handle, ReexecuteInProgress: true}},
+		TargetResolver: TargetResolverFunc(handleAll),
+		Now:            fixedNow,
+	})
+	require.NoError(t, err)
+
+	_, err = reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+	require.True(t, handler.called)
+}
+
+func TestStoreMarkInProgressAndFinish(t *testing.T) {
+	t.Parallel()
+
+	op := newTestOperation("op-1", machinav1alpha3.OperationNodeReboot)
+	c := newTestClient(op)
+	reconciler := newTestReconciler(t, c, []Operation{{
+		Kind: machinav1alpha3.OperationNodeReboot,
+		Handler: func(ctx context.Context, store Store, request OperationRequest) (ctrl.Result, error) {
+			require.NoError(t, store.MarkInProgress(ctx, request, "restarting node"))
+			return ctrl.Result{}, store.Finish(ctx, request, OperationResult{
+				Phase:                     machinav1alpha3.OperationPhaseComplete,
+				Reason:                    "Succeeded",
+				Message:                   "NodeReboot completed",
+				ObservedMachineGeneration: 12,
+			})
+		},
+	}}, handleAll)
+
+	_, err := reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+
+	var updated machinav1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "op-1"}, &updated))
+	require.Equal(t, machinav1alpha3.OperationPhaseComplete, updated.Status.Phase)
+	require.Equal(t, int64(12), updated.Status.ObservedMachineGeneration)
+	require.True(t, updated.Status.StartedAt.Time.Equal(fixedNow().Time))
+	require.True(t, updated.Status.CompletedAt.Time.Equal(fixedNow().Time))
+
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, OperationConditionCompleted)
+	require.NotNil(t, cond)
+	require.Equal(t, metav1.ConditionTrue, cond.Status)
+	require.Equal(t, "Succeeded", cond.Reason)
+}
+
+func TestReconcilerDeletesExpiredTerminalOperation(t *testing.T) {
+	t.Parallel()
+
+	completedAt := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	ttl := int32(30)
+	op := newTestOperation("op-1", machinav1alpha3.OperationHostReboot)
+	op.Spec.TTLSecondsAfterFinished = &ttl
+	op.Status.Phase = machinav1alpha3.OperationPhaseComplete
+	op.Status.CompletedAt = &completedAt
+	c := newTestClient(op)
+	reconciler := newTestReconcilerWithNow(t, c, []Operation{{Kind: machinav1alpha3.OperationHostReboot, Handler: (&recordingHandler{}).handle}}, handleAll, func() metav1.Time {
+		return metav1.NewTime(completedAt.Add(31 * time.Second))
+	})
+
+	result, err := reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	var updated machinav1alpha3.MachineOperation
+	require.Error(t, c.Get(context.Background(), client.ObjectKey{Name: "op-1"}, &updated))
+}
+
+func TestReconcilerIgnoresUnclaimedTerminalOperation(t *testing.T) {
+	t.Parallel()
+
+	completedAt := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	ttl := int32(30)
+	op := newTestOperation("op-1", machinav1alpha3.OperationHostReboot)
+	op.Spec.TTLSecondsAfterFinished = &ttl
+	op.Status.Phase = machinav1alpha3.OperationPhaseComplete
+	op.Status.CompletedAt = &completedAt
+	c := newTestClient(op)
+	reconciler := newTestReconcilerWithNow(t, c, []Operation{{Kind: machinav1alpha3.OperationHostReboot, Handler: (&recordingHandler{}).handle}}, func(context.Context, *machinav1alpha3.MachineOperation) (TargetResult, error) {
+		return TargetResult{Decision: TargetIgnore}, nil
+	}, func() metav1.Time {
+		return metav1.NewTime(completedAt.Add(31 * time.Second))
+	})
+
+	result, err := reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	var updated machinav1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "op-1"}, &updated))
+	require.Equal(t, machinav1alpha3.OperationPhaseComplete, updated.Status.Phase)
+}
+
+func TestReconcilerRequeuesUnexpiredTerminalOperation(t *testing.T) {
+	t.Parallel()
+
+	completedAt := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	ttl := int32(30)
+	op := newTestOperation("op-1", machinav1alpha3.OperationHostReboot)
+	op.Spec.TTLSecondsAfterFinished = &ttl
+	op.Status.Phase = machinav1alpha3.OperationPhaseComplete
+	op.Status.CompletedAt = &completedAt
+	reconciler := newTestReconcilerWithNow(t, newTestClient(op), []Operation{{Kind: machinav1alpha3.OperationHostReboot, Handler: (&recordingHandler{}).handle}}, handleAll, func() metav1.Time {
+		return metav1.NewTime(completedAt.Add(10 * time.Second))
+	})
+
+	result, err := reconciler.ReconcileName(context.Background(), "op-1")
+	require.NoError(t, err)
+	require.Equal(t, 20*time.Second, result.RequeueAfter)
+}
+
+func TestShouldReconcileOperation(t *testing.T) {
+	t.Parallel()
+
+	completedAt := metav1.Now()
+	ttl := int32(30)
+
+	tests := []struct {
+		name string
+		op   *machinav1alpha3.MachineOperation
+		want bool
+	}{
+		{
+			name: "non terminal",
+			op:   newTestOperation("op-1", machinav1alpha3.OperationHostReboot),
+			want: true,
+		},
+		{
+			name: "terminal without ttl",
+			op: &machinav1alpha3.MachineOperation{
+				Status: machinav1alpha3.MachineOperationStatus{Phase: machinav1alpha3.OperationPhaseComplete},
+			},
+			want: false,
+		},
+		{
+			name: "terminal with ttl and completion time",
+			op: &machinav1alpha3.MachineOperation{
+				Spec: machinav1alpha3.MachineOperationSpec{TTLSecondsAfterFinished: &ttl},
+				Status: machinav1alpha3.MachineOperationStatus{
+					Phase:       machinav1alpha3.OperationPhaseComplete,
+					CompletedAt: &completedAt,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "terminal with ttl but no completion time",
+			op: &machinav1alpha3.MachineOperation{
+				Spec:   machinav1alpha3.MachineOperationSpec{TTLSecondsAfterFinished: &ttl},
+				Status: machinav1alpha3.MachineOperationStatus{Phase: machinav1alpha3.OperationPhaseComplete},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, ShouldReconcileOperation(tt.op))
+		})
+	}
+}
+
+func TestSelectorMatches(t *testing.T) {
+	t.Parallel()
+
+	matches, err := SelectorMatches(
+		&metav1.LabelSelector{MatchLabels: map[string]string{"pool": "edge"}},
+		map[string]string{"pool": "edge", "zone": "a"},
+	)
+	require.NoError(t, err)
+	require.True(t, matches)
+
+	matches, err = SelectorMatches(
+		&metav1.LabelSelector{MatchLabels: map[string]string{"pool": "cloud"}},
+		map[string]string{"pool": "edge"},
+	)
+	require.NoError(t, err)
+	require.False(t, matches)
+}
+
+func handleAll(context.Context, *machinav1alpha3.MachineOperation) (TargetResult, error) {
+	return TargetResult{Decision: TargetClaim}, nil
+}
+
+type recordingHandler struct {
+	called  bool
+	request OperationRequest
+	result  ctrl.Result
+	err     error
+}
+
+func (h *recordingHandler) handle(_ context.Context, _ Store, request OperationRequest) (ctrl.Result, error) {
+	h.called = true
+	h.request = request
+	return h.result, h.err
+}
+
+func newTestReconciler(
+	t *testing.T,
+	c client.Client,
+	operations []Operation,
+	resolver TargetResolverFunc,
+) *Reconciler {
+	t.Helper()
+
+	return newTestReconcilerWithNow(t, c, operations, resolver, fixedNow)
+}
+
+func newTestReconcilerWithNow(
+	t *testing.T,
+	c client.Client,
+	operations []Operation,
+	resolver TargetResolverFunc,
+	now func() metav1.Time,
+) *Reconciler {
+	t.Helper()
+
+	reconciler, err := NewReconciler(Config{
+		Client:         c,
+		Operations:     operations,
+		TargetResolver: resolver,
+		Now:            now,
+	})
+	require.NoError(t, err)
+
+	return reconciler
+}
+
+func newTestOperation(name string, operation machinav1alpha3.OperationKind) *machinav1alpha3.MachineOperation {
+	return &machinav1alpha3.MachineOperation{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name + "-uid")},
+		Spec: machinav1alpha3.MachineOperationSpec{
+			OperationKind: operation,
+		},
+	}
+}
+
+func newTestClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = machinav1alpha3.AddToScheme(scheme)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&machinav1alpha3.MachineOperation{}).
+		WithObjects(objs...).
+		Build()
+}
+
+func fixedNow() metav1.Time {
+	return metav1.NewTime(time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC))
+}

--- a/pkg/machineops/controller/selector.go
+++ b/pkg/machineops/controller/selector.go
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// SelectorMatches returns true when selector matches targetLabels.
+func SelectorMatches(selector *metav1.LabelSelector, targetLabels map[string]string) (bool, error) {
+	compiled, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return false, err
+	}
+
+	return compiled.Matches(labels.Set(targetLabels)), nil
+}

--- a/pkg/machineops/controller/store.go
+++ b/pkg/machineops/controller/store.go
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package controller
+
+import (
+	"context"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	machinav1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+// StatusStore updates MachineOperation lifecycle status.
+type StatusStore struct {
+	client client.Client
+	now    func() metav1.Time
+}
+
+// NewStatusStore returns a MachineOperation status store.
+func NewStatusStore(c client.Client, now func() metav1.Time) *StatusStore {
+	if now == nil {
+		now = metav1.Now
+	}
+
+	return &StatusStore{client: c, now: now}
+}
+
+// MarkInProgress records that op has started execution.
+func (s *StatusStore) MarkInProgress(ctx context.Context, op OperationRequest, message string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latest machinav1alpha3.MachineOperation
+		if err := s.client.Get(ctx, client.ObjectKey{Name: op.Name}, &latest); err != nil {
+			return err
+		}
+		if latest.Status.IsTerminal() {
+			return nil
+		}
+
+		currentTime := s.now()
+		latest.Status.Phase = machinav1alpha3.OperationPhaseInProgress
+		latest.Status.Message = message
+		if latest.Status.StartedAt == nil {
+			latest.Status.StartedAt = &currentTime
+		}
+
+		apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+			Type:               OperationConditionCompleted,
+			Status:             metav1.ConditionFalse,
+			Reason:             "InProgress",
+			Message:            message,
+			ObservedGeneration: latest.Generation,
+		})
+
+		return s.client.Status().Update(ctx, &latest)
+	})
+}
+
+// Finish records a result for op.
+func (s *StatusStore) Finish(ctx context.Context, op OperationRequest, result OperationResult) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latest machinav1alpha3.MachineOperation
+		if err := s.client.Get(ctx, client.ObjectKey{Name: op.Name}, &latest); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+
+		currentTime := s.now()
+		if latest.Status.StartedAt == nil {
+			latest.Status.StartedAt = &currentTime
+		}
+
+		latest.Status.Phase = result.Phase
+		latest.Status.Message = result.Message
+		latest.Status.CompletedAt = &currentTime
+		if result.ObservedMachineGeneration > 0 {
+			latest.Status.ObservedMachineGeneration = result.ObservedMachineGeneration
+		}
+
+		conditionStatus := metav1.ConditionTrue
+		if result.Phase == machinav1alpha3.OperationPhaseFailed {
+			conditionStatus = metav1.ConditionFalse
+		}
+
+		apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+			Type:               OperationConditionCompleted,
+			Status:             conditionStatus,
+			Reason:             result.Reason,
+			Message:            result.Message,
+			ObservedGeneration: latest.Generation,
+		})
+
+		return s.client.Status().Update(ctx, &latest)
+	})
+}
+
+var _ Store = (*StatusStore)(nil)

--- a/pkg/machineops/controller/types.go
+++ b/pkg/machineops/controller/types.go
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	machinav1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+// Operation declares one operation kind handled by a MachineOperation controller.
+type Operation struct {
+	// Kind is the MachineOperation kind handled by Handler.
+	Kind machinav1alpha3.OperationKind
+
+	// Handler executes Kind.
+	Handler OperationHandler
+
+	// ReexecuteInProgress allows Handler to run when the operation is already
+	// InProgress. The default is to execute only empty or Pending operations.
+	ReexecuteInProgress bool
+}
+
+// OperationRequest is the generic controller-facing view of a MachineOperation.
+// Object and Machine are read-only context for handlers; status writes should
+// go through Store.
+type OperationRequest struct {
+	// Object is the raw MachineOperation object fetched for this reconcile.
+	Object *machinav1alpha3.MachineOperation
+
+	// Machine is the resolved target Machine when the controller's target
+	// resolver resolved one.
+	Machine *machinav1alpha3.Machine
+
+	// Name is the MachineOperation object name.
+	Name string
+
+	// UID is the MachineOperation object UID.
+	UID types.UID
+
+	// Kind is the requested operation kind.
+	Kind machinav1alpha3.OperationKind
+
+	// Parameters contains operation-specific inputs.
+	Parameters map[string]string
+}
+
+// OperationResult describes the MachineOperation status to record.
+type OperationResult struct {
+	// Phase is the resulting operation phase.
+	Phase machinav1alpha3.OperationPhase
+
+	// Reason is a stable, machine-readable reason for the result.
+	Reason string
+
+	// Message is a human-readable result description.
+	Message string
+
+	// ObservedMachineGeneration records the Machine generation acted on by the operation.
+	ObservedMachineGeneration int64
+}
+
+// OperationHandler executes a MachineOperation.
+type OperationHandler func(context.Context, Store, OperationRequest) (ctrl.Result, error)
+
+// Store records operation lifecycle state.
+type Store interface {
+	// MarkInProgress records that op has started execution with message as the
+	// human-readable in-progress status.
+	MarkInProgress(context.Context, OperationRequest, string) error
+
+	// Finish records the terminal or non-terminal result for op.
+	Finish(context.Context, OperationRequest, OperationResult) error
+}
+
+// TargetDecision describes whether a controller owns a MachineOperation target.
+type TargetDecision string
+
+const (
+	// TargetIgnore leaves the operation untouched so another controller can own it.
+	TargetIgnore TargetDecision = "Ignore"
+
+	// TargetClaim means this controller owns the target and should dispatch to
+	// a registered operation handler.
+	TargetClaim TargetDecision = "Claim"
+
+	// TargetFail marks the operation Failed with TargetResult's reason and message.
+	TargetFail TargetDecision = "Fail"
+)
+
+// TargetResult is returned by a TargetResolver.
+type TargetResult struct {
+	Decision TargetDecision
+	Machine  *machinav1alpha3.Machine
+	Reason   string
+	Message  string
+}
+
+// TargetResolver decides whether this controller owns an operation's target. It
+// may resolve and return a Machine for handlers that need one.
+type TargetResolver interface {
+	ResolveTarget(context.Context, *machinav1alpha3.MachineOperation) (TargetResult, error)
+}
+
+// TargetResolverFunc adapts a function into a TargetResolver.
+type TargetResolverFunc func(context.Context, *machinav1alpha3.MachineOperation) (TargetResult, error)
+
+// ResolveTarget calls f.
+func (f TargetResolverFunc) ResolveTarget(ctx context.Context, op *machinav1alpha3.MachineOperation) (TargetResult, error) {
+	return f(ctx, op)
+}
+
+// UnsupportedOperationPolicy controls what happens when this controller owns a
+// target but has no handler for the requested operation kind.
+type UnsupportedOperationPolicy string
+
+const (
+	// UnsupportedOperationIgnore leaves unsupported claimed operations untouched.
+	UnsupportedOperationIgnore UnsupportedOperationPolicy = "Ignore"
+
+	// UnsupportedOperationFail marks unsupported claimed operations Failed.
+	UnsupportedOperationFail UnsupportedOperationPolicy = "Fail"
+)
+
+type operationRegistry map[machinav1alpha3.OperationKind]Operation
+
+func newOperationRegistry(operations []Operation) (operationRegistry, error) {
+	if len(operations) == 0 {
+		return nil, fmt.Errorf("machine operations are required")
+	}
+	registry := make(operationRegistry, len(operations))
+	for _, operation := range operations {
+		if operation.Kind == "" {
+			return nil, fmt.Errorf("machine operation kind is required")
+		}
+		if operation.Handler == nil {
+			return nil, fmt.Errorf("machine operation handler %s is required", operation.Kind)
+		}
+		if _, exists := registry[operation.Kind]; exists {
+			return nil, fmt.Errorf("duplicate machine operation %s", operation.Kind)
+		}
+		registry[operation.Kind] = operation
+	}
+
+	return registry, nil
+}


### PR DESCRIPTION
## Summary
- add shared MachineOperation controller pattern with target resolution, operation registry, lifecycle store, and TTL cleanup
- refactor agent and cloud controllers onto it
- keep cloud provider logic internal

## Tests
- go test ./pkg/machineops/controller ./pkg/agent/daemon ./internal/machineops ./internal/machineops/providers/azurevm ./internal/machineops/providers/ociinstance ./cmd/agent/internal/daemon ./cmd/machine-ops-controller