### PR TITLE
fix: bump Mercury to v2.4.1 for libfabric 2.x compatibility

### DIFF
--- a/.github/workflows/unbounded-storage-sim.yaml
+++ b/.github/workflows/unbounded-storage-sim.yaml
@@ -27,7 +27,7 @@ permissions:
 env:
   # Keep in sync with the default in the Makefile / install-mercury.sh and
   # the unbounded-storage.yaml workflow.
-  MERCURY_VERSION: v2.3.1
+  MERCURY_VERSION: v2.4.1
 
 jobs:
   sim:

--- a/.github/workflows/unbounded-storage.yaml
+++ b/.github/workflows/unbounded-storage.yaml
@@ -28,7 +28,7 @@ permissions:
 
 env:
   # Keep in sync with the default in the Makefile / install-mercury.sh.
-  MERCURY_VERSION: v2.3.1
+  MERCURY_VERSION: v2.4.1
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ CARGO ?= cargo
 # We build a pinned version from source into a project-local prefix; the
 # unbounded-storage build.rs honours $MERCURY_PKG_CONFIG_PATH so it picks up
 # our local install ahead of any system copy.
-MERCURY_VERSION ?= v2.3.1
+MERCURY_VERSION ?= v2.4.1
 MERCURY_PREFIX  ?= $(CURDIR)/tmp/mercury-prefix
 MERCURY_SRC     ?= $(CURDIR)/tmp/mercury-src
 MERCURY_PC_FILE := $(MERCURY_PREFIX)/lib/pkgconfig/mercury.pc

--- a/hack/scripts/install-mercury.sh
+++ b/hack/scripts/install-mercury.sh
@@ -23,7 +23,7 @@
 #   - libfabric-dev (provides the libfabric NA backend)
 #
 # Configuration (override via environment):
-#   MERCURY_VERSION  Mercury release tag to build. Default: v2.3.1.
+#   MERCURY_VERSION  Mercury release tag to build. Default: v2.4.1.
 #   MERCURY_PREFIX   Install prefix. Default: $REPO_ROOT/tmp/mercury-prefix.
 #   MERCURY_SRC      Scratch source tree. Default: $REPO_ROOT/tmp/mercury-src.
 #   MERCURY_REPO     Upstream repo. Default: https://github.com/mercury-hpc/mercury.git
@@ -34,14 +34,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-MERCURY_VERSION="${MERCURY_VERSION:-v2.3.1}"
+MERCURY_VERSION="${MERCURY_VERSION:-v2.4.1}"
 MERCURY_PREFIX="${MERCURY_PREFIX:-${REPO_ROOT}/tmp/mercury-prefix}"
 MERCURY_SRC="${MERCURY_SRC:-${REPO_ROOT}/tmp/mercury-src}"
 MERCURY_REPO="${MERCURY_REPO:-https://github.com/mercury-hpc/mercury.git}"
 JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
 
 # Strip leading 'v' from tag for pkg-config comparison (Mercury's mercury.pc
-# advertises "2.3.1", the git tag is "v2.3.1").
+# advertises "2.4.1", the git tag is "v2.4.1").
 expected_pc_version="${MERCURY_VERSION#v}"
 
 pc_file="${MERCURY_PREFIX}/lib/pkgconfig/mercury.pc"


### PR DESCRIPTION
## Summary

- `make mercury` fails to build against libfabric 2.x because Mercury v2.3.1's `src/na/na_ofi.c` references `FI_LOG_SUBSYS_MAX` and `FI_LOG_MAX`, which were removed in libfabric 2.0.
- Fedora 43 (and other recent distros) ship libfabric 2.2.0, so developers on those machines cannot build `unbounded-storage`.
- Bump the pinned Mercury version from `v2.3.1` to `v2.4.1`, whose release notes explicitly call out "Fix compatibility with libfabric 2.0" under NA OFI.

## Files changed

- `Makefile` - `MERCURY_VERSION` default.
- `hack/scripts/install-mercury.sh` - default value, header comment, and the pkg-config comparison comment.
- `.github/workflows/unbounded-storage.yaml` - `MERCURY_VERSION` env.
- `.github/workflows/unbounded-storage-sim.yaml` - `MERCURY_VERSION` env.

The CI cache keys already incorporate `MERCURY_VERSION`, so the existing `mercury-*` and `cargo-unbounded-storage-*` caches will miss on first run after merge and rebuild cleanly.

## Verification

Locally on Fedora 43 / libfabric 2.2.0:

```
make mercury-clean
make mercury   # builds successfully; pkg-config --modversion mercury reports 2.4.1
```

Deprecation warnings for `fi_wait_open` / `fi_wait` remain (still present in v2.4.1) but are warnings only, not errors.

## Out of scope

- `make unbounded-storage-test` was not run as part of this fix. The HG public-header surface used by `cmd/unbounded-storage/src/mercury/shim.c` is unchanged in v2.4.1 release notes, but a follow-up test run is recommended before relying on the new Mercury for Rust-side work.