### PR TITLE
feat: daemon controller authn/z design doc and library

### DIFF
--- a/designs/daemon-controller-authnz.md
+++ b/designs/daemon-controller-authnz.md
@@ -1,0 +1,586 @@
+# Daemon Controller Authn/z
+
+The host-side `unbounded-agent` daemon controller needs a Kubernetes client
+credential for reconciling local Unbounded machine state. The credential must
+authenticate to kube-apiserver, keep the same baseline `Node` permissions as a
+kubelet, and carry an additional Unbounded group for Machina CR access.
+
+Today `cmd/agent/internal/daemon` builds that client from the applied agent
+config, which contains the API server URL, the cluster CA bundle, and the kubelet
+TLS bootstrap token. The daemon controller uses that bootstrap-token client to
+ensure the local `Machine` CR exists, publish `AgentUpgrade` startup status, run
+the shared daemon controller, watch local `Node` deletion events, and update
+local `Machine` status after repave-related reconciliation. This works today
+because the bootstrap token can authenticate with an extra authorization group
+that RBAC uses for Machina CR access. That extra group is part of the bootstrap
+token's authenticated user info, not a durable daemon identity.
+
+This is useful during early bootstrap, but it is not acceptable for a long-running
+daemon controller. The TLS bootstrap token is short-lived and is intended for
+joining, not ongoing reconciliation. The extra bootstrap-token group also will
+not be propagated into the built-in kubelet client certificate issued by Kubernetes;
+the built-in kubelet client signer accepts only the kubelet-shaped `system:nodes`
+organization. The daemon controller therefore needs a rotated client certificate
+whose authorization shape matches its two roles: kubelet-like own-node access and
+Unbounded CR access.
+
+## Goals
+
+- Give the daemon controller a client certificate for kube-apiserver
+  authentication and authorization.
+- Restrict daemon-controller `Node` permissions to the same baseline used by the
+  kubelet: own-Node read, own-Node main-resource create/update/patch subject to
+  NodeRestriction, and own-Node status update/patch.
+- Include an extra group in the certificate so RBAC can grant Machina CR access
+  to the daemon controller.
+- Keep lifecycle operations that require privileged `Node` mutation outside the
+  daemon controller, including updating node labels or taints and deleting the
+  `Node` object to trigger repave.
+- Keep daemon-controller behavior limited to local reconciliation and status
+  reporting.
+- Ensure the daemon implementation does not rely on own-Node main-resource
+  updates, even though the credential has kubelet-style own-Node update/patch
+  capability subject to NodeRestriction.
+
+## Non-goals
+
+- Define the separate lifecycle controller or operator workflow that performs
+  cordon, drain, privileged node changes, or Node deletion.
+- Change the kubelet client certificate signer or kubelet TLS bootstrap behavior.
+- Define a general-purpose node identity model for components other than the
+  `unbounded-agent` daemon controller.
+- Define revocation or CA rotation for daemon-controller certificates.
+
+## Proposed Certificate Identity
+
+A normal kubelet client certificate authenticates as a Kubernetes node identity:
+
+```text
+CN = system:node:<nodeName>
+O  = system:nodes
+```
+
+Kubernetes recognizes this shape as a node identity. The built-in
+[Node authorizer](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/node/node_authorizer.go)
+then limits node requests to kubelet-style node-scoped behavior. For `Node`
+objects, that includes own-Node reads, own-Node main-resource create/update/patch,
+and own-Node status update/patch. The
+[NodeRestriction admission plugin](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/noderestriction/admission.go)
+adds object-level restrictions for node requests, such as preventing a node from
+modifying another node or changing protected parts of its own `Node` object. This
+identity cannot delete Nodes through the Node authorizer path.
+
+The daemon controller should get the same baseline `Node` behavior, so its custom
+client certificate is intentionally kubelet-shaped and adds one configurable
+Unbounded group:
+
+```text
+CN = system:node:<nodeName>
+O  = system:nodes
+O  = <daemonGroup>
+```
+
+`<daemonGroup>` is the extra group used by RBAC for Machina CR access. The
+default value is `unbounded-agent-daemons`, but deployments may choose a different
+non-privileged group name. The daemon, CSR approver, signer configuration when a
+custom signer is used, and RBAC bindings must all use the same value.
+
+Including `system:nodes` causes the built-in Node authorizer and NodeRestriction
+admission plugin to apply the same own-node restrictions used for kubelets. This
+is how the daemon controller satisfies the baseline `Node` requirement. This is
+kubelet-style Node access, not a custom status-only permission model.
+
+Including `<daemonGroup>` allows RBAC to grant additional Unbounded CR
+permissions without granting those permissions to all kubelets.
+
+This certificate cannot use the built-in kubelet client signer. The built-in
+Kubernetes kubelet client signer validates kubelet client CSRs as exactly
+`O=system:nodes` in the
+[kubelet client CSR validation helper](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/certificates/helpers.go)
+and does not preserve bootstrap-token extra groups into the issued kubelet client
+certificate. By default, this design uses a strict custom CSR approver with the
+built-in `kubernetes.io/kube-apiserver-client` signer. The generic API client
+signer can issue kube-apiserver client certificates using the cluster's existing
+client certificate signing configuration, so using it avoids duplicating signing
+logic when the cluster supports that signer.
+
+## Authorization Model
+
+Authorization is split by resource family:
+
+- Built-in Node authorizer and NodeRestriction admission handle `Node` access for
+  the `system:node:<nodeName>` / `system:nodes` part of the identity.
+- Kubernetes RBAC grants Machina CR access through the configured daemon group.
+
+The Unbounded group must not grant additional `Node` mutation permissions. Node
+labels, taints, privileged annotations, and Node deletion remain outside the
+daemon controller.
+
+## Machina RBAC
+
+RBAC grants Machina-related permissions to the extra group, not directly to
+`system:nodes`. This example uses the default daemon group:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: unbounded-agent-daemon-controller
+rules:
+- apiGroups: ["unbounded-cloud.io"]
+  resources: ["machines"]
+  verbs: ["get", "create", "update", "patch"]
+- apiGroups: ["unbounded-cloud.io"]
+  resources: ["machines/status"]
+  verbs: ["get", "update", "patch"]
+- apiGroups: ["unbounded-cloud.io"]
+  resources: ["machineoperations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["unbounded-cloud.io"]
+  resources: ["machineoperations/status"]
+  verbs: ["get", "update", "patch"]
+- apiGroups: ["unbounded-cloud.io"]
+  resources: ["machineconfigurationversions"]
+  verbs: ["get", "list", "watch"]
+```
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: unbounded-agent-daemon-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: unbounded-agent-daemon-controller
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: unbounded-agent-daemons
+```
+
+If a deployment configures a different daemon group, replace
+`unbounded-agent-daemons` in the `ClusterRoleBinding` subject with that value.
+
+## CSR Approver And Signer Setup
+
+The default setup uses a custom approver and the built-in
+`kubernetes.io/kube-apiserver-client` signer.
+
+The approver is the security boundary. It is responsible for ensuring only the
+local daemon controller can receive the kubelet-shaped certificate with the extra
+group. It must be stricter than the signer: the signer proves the certificate is a
+valid client certificate, while the approver proves this requester may receive
+this specific daemon-controller identity.
+
+Using `kubernetes.io/kube-apiserver-client` means the signer enforces only generic
+API-client certificate constraints. All daemon-specific constraints are enforced
+by the custom approver before the CSR is approved.
+
+The approver validates:
+
+- `spec.signerName` is `kubernetes.io/kube-apiserver-client` by default, or the
+  configured daemon-controller signer for deployments that use a custom signer.
+- The requested common name is `system:node:<expected-node-name>`.
+- The requested organizations are exactly `system:nodes` and
+  the configured daemon group, for example `unbounded-agent-daemons` by default.
+- The requested usages are limited to client authentication.
+- The request has no subject alternative names unless a future design explicitly
+  allows them.
+- The PKCS#10 CSR in `spec.request` does not request CA privileges, unexpected
+  subject fields, unsupported key usages, or unexpected extensions.
+- For initial issuance, the bootstrap requester is allowed to claim the requested
+  node name.
+- Renewal requests cannot change the node name or group set.
+- A normal kubelet certificate that has `system:nodes` but does not have the
+  configured Unbounded daemon group cannot renew into a daemon-controller
+  certificate.
+
+For production use, the approver must validate the corresponding node and
+resource binding. In particular, initial issuance must prove that the bootstrap
+token submitting the CSR is allowed to claim the requested Node. In the
+Machina/Unbounded integration, the minimum early-bootstrap gate is a
+controller-owned site binding on the bootstrap token. If a matching `Machine`
+already exists, the approver also enforces the stronger token-to-Machine-to-Node
+binding. Renewal must prove that the existing certificate is already the same
+daemon-controller identity and still maps to the same node/resource binding.
+
+When the kube-controller-manager CSR signing controller is configured for
+`kubernetes.io/kube-apiserver-client`, approved CSRs are signed using the
+cluster's client certificate signing configuration, and the resulting
+certificates are intended to be honored as client certificates by kube-apiserver.
+This avoids implementing and operating a separate signer for the default
+deployment.
+
+The approver needs RBAC permission to approve CSRs for
+`kubernetes.io/kube-apiserver-client`. That signer can issue general API client
+certificates, not only daemon-controller certificates. For that reason, the
+approval permission should be granted only to the daemon-controller CSR approver
+service account. Other users or controllers should not receive this approval
+permission unless they have their own independent policy and validation path.
+
+Concretely, the approver service account needs permission to update CSR approval
+subresources and to approve only the signer it handles:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: daemon-controller-csr-approver
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/approval"]
+  verbs: ["update"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["signers"]
+  resourceNames: ["kubernetes.io/kube-apiserver-client"]
+  verbs: ["approve"]
+```
+
+Bind this role only to the service account that runs the daemon-controller CSR
+approver. In the Machina/Unbounded integration, this is the Machina controller
+service account because the approver runs inside the Machina controller. Do not
+bind it to broad groups such as `system:authenticated`, `system:masters`, or the
+daemon group itself.
+
+Deployments may provide their own approver and signer instead. A custom approver
+can enforce stricter node/resource validation, and a custom signer can use a
+different CA or signer name if the cluster policy requires it. In that case, the
+daemon, approver, signer, and RBAC configuration must agree on the signer name and
+daemon group. See [Appendix: Integration Examples](#appendix-integration-examples)
+for example wiring in Machina/Unbounded and AKS Flex Node environments.
+
+The reusable implementation in `pkg/agent/daemoncred` separates generic CSR
+validation from deployment-specific binding checks. It validates the signer,
+requested subject, requested organizations, usages, SANs, extensions, requester
+identity, and requester groups. The caller supplies callbacks for bootstrap and
+renewal authorization so each integration can enforce its own node/resource
+binding rules.
+
+Security-sensitive or multi-tenant deployments should prefer a custom signer name
+so approval and signing RBAC can be scoped to the daemon-controller certificate
+contract instead of the generic API client signer.
+
+### Built-in Signer Requirements
+
+The default model requires kube-controller-manager CSR signing to be enabled for
+`kubernetes.io/kube-apiserver-client` and configured with a client signing CA/key
+whose issued certificates are trusted by kube-apiserver client certificate
+authentication.
+
+If the cluster disables kube-controller-manager CSR signing, does not configure
+the client signing key, or does not trust the resulting CA for API client
+authentication, this default signer model cannot be used.
+
+## Certificate Issuing Process
+
+The daemon-controller certificate can be issued in two cases: initial issuance
+from a bootstrap token and renewal from an existing daemon-controller
+certificate. Both paths produce the same certificate shape:
+
+```text
+CN = system:node:<nodeName>
+O  = system:nodes
+O  = <daemonGroup>
+```
+
+### Initial Issuance From Bootstrap Token
+
+Initial issuance starts before the daemon has a durable client certificate. The
+daemon submits a CSR using the kubelet TLS bootstrap token from the applied agent
+config.
+
+The approval rule is: the bootstrap token submitting the CSR must be allowed to
+claim the requested node name. The CSR subject is not trusted by itself. Without
+this check, any valid bootstrap token could request a daemon-controller
+certificate for another node.
+
+The initial issuance flow is:
+
+1. The daemon builds a bootstrap REST client from the API server URL, cluster CA,
+   and kubelet TLS bootstrap token in the applied agent config.
+2. The daemon creates a private key and CSR for
+   `kubernetes.io/kube-apiserver-client` with `CN=system:node:<nodeName>`,
+   `O=system:nodes`, and the configured Unbounded daemon group.
+3. The custom approver validates the CSR shape, signer, usages, and requested
+   expiration.
+4. The custom approver resolves the bootstrap token identity and verifies that the
+   token is authorized to claim the requested Node. If a matching Machine already
+   exists, the approver also verifies the Machine and Node binding.
+5. The built-in API client signer signs the approved CSR with a CA trusted by the
+   kube-apiserver client certificate authenticator.
+6. The daemon stores the issued certificate and private key on the host with
+   permissions limited to the daemon user. The implementation uses the
+   `client-go` certificate file store under the daemon credential directory.
+7. The daemon uses the issued certificate for daemon-controller API requests.
+
+The token-to-node check should use controller-owned state, such as Machine data,
+provisioning state, or bootstrap-token metadata. The exact source can vary by
+provisioning path, but the security property is fixed: the approver must prove
+that this bootstrap token is allowed to request this node name.
+
+### Renewal From Existing Certificate
+
+Renewal starts after the daemon already has a valid daemon-controller
+certificate. Renewal uses `client-go`'s certificate manager and does not use the
+bootstrap token while the existing certificate remains valid.
+
+The renewal flow is:
+
+1. The `client-go` certificate manager monitors the stored certificate lifetime.
+2. When the certificate enters its renewal window, the manager creates a new
+   private key and CSR for the same signer, common name, organizations, and
+   usages.
+3. The daemon submits the CSR using the current daemon-controller certificate.
+4. The custom approver validates that the authenticated requester is the same
+   `system:node:<nodeName>` identity and still carries the configured Unbounded
+   daemon group.
+5. The custom approver rejects renewal if the requested node name, group set,
+   signer, or usages changed.
+6. The signer issues a replacement certificate.
+7. The certificate manager updates the file store and the daemon REST transport
+   closes existing connections so new API connections use the renewed certificate.
+
+If renewal fails while the current certificate remains valid, the certificate
+manager retries. The daemon still needs metrics for renewal failures and time to
+expiry. If the certificate expires and no valid bootstrap path exists, the daemon
+must fail closed and stop reconciling API-backed operations until a valid
+credential is available.
+
+## Request Flow
+
+Certificate issuance:
+
+```mermaid
+flowchart TD
+    BootstrapToken["Bootstrap token"]
+    InitialCSR["Initial CSR for system:node:<nodeName> plus daemon group"]
+    ExistingCert["Existing daemon-controller certificate"]
+    RenewalCSR["Renewal CSR for same identity and groups"]
+    Approver["Custom approver validates CSR shape and requester"]
+    ClaimCheck["Initial issuance: verify bootstrap token may claim node"]
+    RenewalCheck["Renewal: verify requester matches requested identity"]
+    Signer["Built-in API client signer issues daemon-controller certificate"]
+    StoredCert["Daemon stores cert and key on host"]
+
+    BootstrapToken --> InitialCSR
+    ExistingCert --> RenewalCSR
+    InitialCSR --> Approver
+    RenewalCSR --> Approver
+    Approver --> ClaimCheck
+    Approver --> RenewalCheck
+    ClaimCheck --> Signer
+    RenewalCheck --> Signer
+    Signer --> StoredCert
+```
+
+Authentication and authorization:
+
+```mermaid
+flowchart TD
+    Daemon["Daemon controller uses daemon-controller certificate"]
+    APIServer["kube-apiserver authenticates client certificate"]
+    Identity["username: system:node:<nodeName><br/>groups: system:nodes, <daemonGroup>"]
+    NodeRequest["Kubelet-style own-Node request"]
+    MachinaRequest["Machina CR request"]
+    NodeAuthz["Node authorizer and NodeRestriction enforce own-node access"]
+    RBAC["RBAC grants Machina CR access through daemon group"]
+
+    Daemon --> APIServer
+    APIServer --> Identity
+    Identity --> NodeRequest
+    Identity --> MachinaRequest
+    NodeRequest --> NodeAuthz
+    MachinaRequest --> RBAC
+```
+
+## Machina CR Scoping
+
+RBAC bound to the configured daemon group is group-wide. The built-in Node
+authorizer does not scope Unbounded CRDs to the local node or Machine. This
+design assumes daemon controllers are trusted to reconcile only their local
+`Machine` and `MachineOperation` objects by implementation logic and
+controller-owned conventions.
+
+If hard per-node or per-Machine enforcement is required later, it must be added
+separately. Options include deterministic `resourceNames`-based RBAC, admission
+checks for create/update/patch, or a custom authorizer.
+
+## Node Permissions
+
+The daemon controller receives kubelet-like baseline `Node` permissions from the
+`system:node:<nodeName>` and `system:nodes` parts of its certificate. It may rely
+on the built-in Kubernetes node path for own-Node reads and own-Node status
+updates. The same credential can also attempt kubelet-style own-Node
+main-resource create/update/patch, subject to NodeRestriction. The daemon
+implementation will not rely on main-resource `Node` updates.
+
+The configured daemon group must not grant any additional `Node`
+permissions.
+
+The daemon controller implementation must not perform lifecycle `Node` mutations
+such as:
+
+- Update `Node` labels.
+- Update `Node` taints.
+- Update privileged `Node` annotations.
+- Delete `Node` objects.
+
+Those operations must be performed by a separate controller, operator workflow,
+or future lifecycle identity that is explicitly authorized for that purpose.
+
+Today the daemon controller only watches the local `Node` for deletion and reacts
+by reconciling repave. It does not issue the `Node` deletion itself.
+
+The daemon should not assume that a normal shared informer list/watch over Nodes
+will work with this identity. The Node authorizer does not allow a node identity
+to read all Nodes. The implementation should use a single-object watch if the
+client path can express one, or fall back to periodic `GET` of its own `Node`.
+
+## Alternatives Considered
+
+One alternative is a completely separate daemon-controller identity, for example:
+
+```text
+CN = unbounded-agent:<nodeName>
+O  = unbounded-agent-daemons
+```
+
+The group shown here is only an example. If a deployment uses a different daemon
+group, the same concern applies to that configured group.
+
+That has cleaner audit separation from kubelet identities, but it no longer uses
+the built-in Node authorizer and NodeRestriction admission behavior. To preserve
+the same own-node safety guarantees, Unbounded would need to replicate that logic
+with a custom CSR approver, ValidatingAdmissionPolicy rules, and an authorization
+webhook for dynamic own-node checks. The authorization webhook is required to
+avoid creating one RBAC binding per node identity. That is more complicated than
+using a kubelet-shaped identity and letting Kubernetes enforce the baseline Node
+permissions.
+
+Another alternative is granting Machina CR permissions to `system:nodes`. That is
+not acceptable because it grants those permissions to all kubelets, not only
+Unbounded daemon controllers.
+
+## Implementation Requirements And Limitations
+
+The custom certificate includes `system:nodes`, so requests appear as
+`system:node:<nodeName>` in server-side audit logs. The extra group records that
+the request also belongs to the configured daemon group, but the username is still
+a node-shaped identity.
+
+The default signer is `kubernetes.io/kube-apiserver-client`, so this model depends
+on the cluster's kube-controller-manager CSR signing configuration. Deployments
+that choose a custom signer must ensure the custom signer issues certificates
+from a CA trusted by the kube-apiserver client certificate authenticator.
+
+The bootstrap-token-to-node claim check is the critical approval decision. The
+approver must have controller-owned state that maps the bootstrap token to the
+scope of nodes it may claim. In the Machina/Unbounded integration, this starts
+with a site binding on the bootstrap token and upgrades to a token/Machine/Node
+binding when a matching `Machine` exists.
+
+The daemon stores certificate material on the host, not inside the nspawn machine,
+because the host-side daemon is the certificate consumer. The implementation uses
+the `client-go` certificate file store in the daemon credential directory.
+
+Renewal metrics still need implementation-level definition. The daemon must expose
+enough state to detect renewal failures before the current certificate expires.
+
+There is no online revocation mechanism for these daemon-controller certificates
+in this design. If a certificate should stop working before expiry, enforcement
+depends on authorization or admission denying the identity, or on client CA
+rotation.
+
+Accepted risk: the daemon-controller certificate includes `system:nodes`, so it
+receives the same baseline Node authorizer behavior as a kubelet. This includes
+own-Node main-resource update/patch permissions subject to NodeRestriction, not
+only Node/status updates. The design accepts this because the daemon is node-local
+and the desired behavior is to inherit Kubernetes' existing kubelet node-scoping
+model rather than replicate it with a custom authorizer or ValidatingAdmissionPolicy.
+Compromise of this certificate should be treated similarly to compromise of a
+kubelet client credential for that node, plus the additional Machina CR
+permissions granted to the configured daemon group.
+
+## Appendix: Integration Examples
+
+### Machina / Unbounded
+
+In the default Machina/Unbounded deployment, the daemon group is
+`unbounded-agent-daemons` and the signer is
+`kubernetes.io/kube-apiserver-client`.
+
+The CSR approver is included as part of the Machina controller deployment. This
+keeps approval decisions close to the controller-owned Machine, bootstrap token,
+and site state used to validate daemon-controller certificate requests. The
+Machina controller uses the reusable `pkg/agent/daemoncred` approver and provides
+Machina-specific binding callbacks.
+
+The bootstrap token should authenticate with a bootstrap-scoped group that allows
+the approver to identify requests for daemon-controller certificates, for example:
+
+```text
+system:bootstrappers:unbounded-agent-daemons
+```
+
+Unbounded should issue bootstrap token Secrets with controller-owned binding data,
+including the site name the token is allowed to join. The token Secret can carry
+that binding through labels or annotations owned by Unbounded, for example the
+site label used by the bootstrap flow.
+
+The approver validates the bootstrap requester, the CSR shape, and the requested
+node identity. For initial issuance, the approver resolves the bootstrap token
+Secret from the authenticated `system:bootstrap:<tokenID>` requester and verifies
+that the token is bound to a valid Unbounded site. If the token is not bound to a
+valid site, the approver rejects the CSR.
+
+When a `Machine` exists and references that bootstrap token, the approver also
+verifies that the Machine has the same site binding and that the requested node
+matches the Machine's `spec.kubernetes.nodeRef.name` when set, otherwise the
+Machine name. If no Machine references the token yet, initial issuance may proceed
+from the site-bound bootstrap token so the daemon can create the Machine during
+bootstrap.
+
+Machina RBAC grants CR access to the configured daemon group. The group binding
+must include the same group that appears in the issued certificate:
+
+```yaml
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: unbounded-agent-daemons
+```
+
+This gives daemon controllers access to Machina resources without granting those
+permissions to all kubelets in `system:nodes`.
+
+### AKS Flex Node
+
+In an AKS Flex Node style environment, the same certificate shape can be used, but
+the deployment may choose a different daemon group and a different approver or
+signer implementation.
+
+The AKS resource provider should run a managed CSR approver for this flow. That
+approver validates that the bootstrap token and requested daemon-controller
+certificate come from an expected Flex agent node ARM resource before approving
+the CSR. In other words, the AKS RP owns the platform-specific ARM
+resource-to-node binding check instead of relying on Machina site or Machine
+state.
+
+The integration contract is:
+
+- The daemon requests `CN=system:node:<nodeName>`.
+- The certificate includes `O=system:nodes` so Kubernetes applies Node authorizer
+  and NodeRestriction behavior.
+- The certificate includes the configured daemon group so RBAC can grant the
+  platform-specific CR permissions required by the daemon controller.
+- The managed AKS RP approver verifies the platform's node/resource binding before
+  approving the CSR.
+
+The daemon group value should be treated as deployment configuration. For example,
+AKS Flex Node may use a platform-owned group name instead of
+`unbounded-agent-daemons`, as long as the daemon, approver, signer configuration,
+and RBAC bindings use the same value.

--- a/pkg/agent/daemoncred/approver.go
+++ b/pkg/agent/daemoncred/approver.go
@@ -1,0 +1,325 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package daemoncred
+
+import (
+	"context"
+	"crypto/subtle"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var privilegedRequesterGroups = map[string]struct{}{
+	"admin":          {},
+	"admins":         {},
+	"cluster-admin":  {},
+	"cluster-admins": {},
+	"master":         {},
+	"masters":        {},
+	"root":           {},
+	"system:masters": {},
+}
+
+const (
+	SystemNodesGroup     = "system:nodes"
+	SystemNodeUserPrefix = "system:node:"
+	BootstrapUserPrefix  = "system:bootstrap:"
+
+	defaultMaxExpirationSeconds = int32(365 * 24 * 60 * 60)
+)
+
+// RequestAuthorizationFunc authorizes a parsed daemon-controller CSR request for
+// the requested node name. Callers provide implementation-specific binding
+// checks, such as bootstrap token to Machine/Node validation.
+type RequestAuthorizationFunc func(context.Context, *certificatesv1.CertificateSigningRequest, string) (bool, error)
+
+// CSRApproverOptions configures daemon-controller CSR validation.
+type CSRApproverOptions struct {
+	// SignerName is the certificates.k8s.io signerName this approver handles.
+	// Defaults to kubernetes.io/kube-apiserver-client when empty.
+	SignerName string
+
+	// DaemonGroup is the non-privileged group requested in the issued certificate
+	// alongside system:nodes. It is required and must not use reserved names.
+	DaemonGroup string
+
+	// BootstrapGroup is the bootstrap-token requester group allowed to request
+	// initial daemon-controller certificates. It is required and intentionally not
+	// derived from DaemonGroup so integrations can choose their own bootstrap group.
+	BootstrapGroup string
+
+	// MaxExpirationSeconds is the maximum allowed spec.expirationSeconds value.
+	// Defaults to 365 days when unset.
+	MaxExpirationSeconds int32
+
+	// AuthorizeBootstrap validates implementation-specific bootstrap-token to node
+	// binding after the generic CSR shape and requester group checks pass.
+	AuthorizeBootstrap RequestAuthorizationFunc
+
+	// AuthorizeRenewal validates implementation-specific existing-cert to node
+	// binding after the generic CSR shape and requester identity checks pass.
+	AuthorizeRenewal RequestAuthorizationFunc
+}
+
+// CSRApprover validates daemon-controller CertificateSigningRequests and returns
+// approval decisions. It enforces generic certificate shape and requester checks;
+// callers provide resource-binding checks through callbacks.
+type CSRApprover struct {
+	opts CSRApproverOptions
+}
+
+// CSRDecision describes the outcome of evaluating one CertificateSigningRequest.
+type CSRDecision struct {
+	// Ignore is true when the CSR is for another signer and should not be touched.
+	Ignore bool
+
+	// AlreadyDecided is true when the CSR already has a terminal approval state or certificate.
+	AlreadyDecided bool
+
+	// Approve is true for approval decisions and false for denial decisions.
+	Approve bool
+
+	// Message is written to the CSR approval or denial condition.
+	Message string
+}
+
+func NewCSRApprover(opts CSRApproverOptions) (*CSRApprover, error) {
+	if opts.SignerName == "" {
+		opts.SignerName = DefaultControllerCertificateSignerName
+	}
+	if opts.DaemonGroup == "" {
+		return nil, fmt.Errorf("daemon group is required")
+	}
+	if isReservedDaemonGroup(opts.DaemonGroup) {
+		return nil, fmt.Errorf("daemon group must not use reserved or privileged group name: %s", opts.DaemonGroup)
+	}
+	if opts.MaxExpirationSeconds == 0 {
+		opts.MaxExpirationSeconds = defaultMaxExpirationSeconds
+	}
+	if opts.MaxExpirationSeconds < 0 {
+		return nil, fmt.Errorf("max expiration seconds must be non-negative")
+	}
+	if opts.BootstrapGroup == "" {
+		return nil, fmt.Errorf("bootstrap group is required")
+	}
+	if opts.AuthorizeBootstrap == nil {
+		return nil, fmt.Errorf("bootstrap authorization callback is required")
+	}
+	if opts.AuthorizeRenewal == nil {
+		return nil, fmt.Errorf("renewal authorization callback is required")
+	}
+
+	return &CSRApprover{opts: opts}, nil
+}
+
+func (a *CSRApprover) Evaluate(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) (CSRDecision, error) {
+	if csr.Spec.SignerName != a.opts.SignerName {
+		return CSRDecision{Ignore: true}, nil
+	}
+	if HasApprovalDecision(csr) || len(csr.Status.Certificate) > 0 {
+		return CSRDecision{AlreadyDecided: true}, nil
+	}
+
+	nodeName, decision, err := a.validateCSRShape(csr)
+	if err != nil || decision.Message != "" {
+		return decision, err
+	}
+
+	return a.evaluateRequester(ctx, csr, nodeName)
+}
+
+func (a *CSRApprover) validateCSRShape(csr *certificatesv1.CertificateSigningRequest) (string, CSRDecision, error) {
+	x509cr, err := parseCSR(csr.Spec.Request)
+	if err != nil {
+		return "", Deny("unable to parse CSR: %v", err), nil
+	}
+	if err := x509cr.CheckSignature(); err != nil {
+		return "", Deny("CSR signature is invalid: %v", err), nil
+	}
+
+	nodeName, ok := strings.CutPrefix(x509cr.Subject.CommonName, SystemNodeUserPrefix)
+	if !ok || nodeName == "" {
+		return "", Deny("common name must be %s<nodeName>", SystemNodeUserPrefix), nil
+	}
+	if hasUnexpectedSubjectFields(x509cr.Subject) {
+		return "", Deny("subject must contain only common name and organizations"), nil
+	}
+	if !equalStringSet(x509cr.Subject.Organization, []string{SystemNodesGroup, a.opts.DaemonGroup}) {
+		return "", Deny("organizations must be exactly %s and %s", SystemNodesGroup, a.opts.DaemonGroup), nil
+	}
+	if len(x509cr.DNSNames) > 0 || len(x509cr.EmailAddresses) > 0 || len(x509cr.IPAddresses) > 0 || len(x509cr.URIs) > 0 {
+		return "", Deny("subject alternative names are not allowed"), nil
+	}
+	if len(x509cr.Extensions) > 0 || len(x509cr.ExtraExtensions) > 0 {
+		return "", Deny("CSR extensions are not allowed"), nil
+	}
+	if err := validateClientAuthUsages(csr.Spec.Usages); err != nil {
+		return "", Deny("invalid usages: %v", err), nil
+	}
+	if csr.Spec.ExpirationSeconds != nil && *csr.Spec.ExpirationSeconds > a.opts.MaxExpirationSeconds {
+		return "", Deny("requested expiration %d exceeds maximum %d", *csr.Spec.ExpirationSeconds, a.opts.MaxExpirationSeconds), nil
+	}
+
+	return nodeName, CSRDecision{}, nil
+}
+
+func (a *CSRApprover) evaluateRequester(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, nodeName string) (CSRDecision, error) {
+	if strings.HasPrefix(csr.Spec.Username, BootstrapUserPrefix) {
+		return a.evaluateBootstrapRequester(ctx, csr, nodeName)
+	}
+	if constantTimeEqual(csr.Spec.Username, SystemNodeUserPrefix+nodeName) {
+		return a.evaluateRenewalRequester(ctx, csr, nodeName)
+	}
+
+	return Deny("requester is neither an authorized bootstrap token nor matching daemon-controller identity"), nil
+}
+
+func (a *CSRApprover) evaluateBootstrapRequester(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, nodeName string) (CSRDecision, error) {
+	// validateCSRShape checks groups requested in the certificate subject.
+	// csr.Spec.Groups is different: it is the authenticated requester groups
+	// on the CSR create request. Bootstrap requests must come through the
+	// configured bootstrap requester group before the binding callback is trusted.
+	for _, group := range csr.Spec.Groups {
+		if _, ok := privilegedRequesterGroups[strings.ToLower(strings.TrimSpace(group))]; ok {
+			return Deny("bootstrap token requester has forbidden group %q", group), nil
+		}
+	}
+	if !slices.Contains(csr.Spec.Groups, a.opts.BootstrapGroup) {
+		return Deny("bootstrap token requester is missing required group %q", a.opts.BootstrapGroup), nil
+	}
+	allowed, err := a.opts.AuthorizeBootstrap(ctx, csr, nodeName)
+	if err != nil {
+		return CSRDecision{}, err
+	}
+	if !allowed {
+		return Deny("bootstrap token is not allowed to claim node %q", nodeName), nil
+	}
+
+	return Approve("approved initial daemon-controller certificate for node %q", nodeName), nil
+}
+
+func (a *CSRApprover) evaluateRenewalRequester(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, nodeName string) (CSRDecision, error) {
+	// validateCSRShape checks the requested renewed certificate subject. For
+	// renewal, csr.Spec.Groups must also prove the requester already authenticated
+	// with the daemon-controller certificate identity. A stock kubelet cert has
+	// system:nodes but not the daemon group and must not be able to renew into one.
+	for _, group := range csr.Spec.Groups {
+		if _, ok := privilegedRequesterGroups[strings.ToLower(strings.TrimSpace(group))]; ok {
+			return Deny("renewal requester has forbidden group %q", group), nil
+		}
+	}
+	if !slices.Contains(csr.Spec.Groups, SystemNodesGroup) || !slices.Contains(csr.Spec.Groups, a.opts.DaemonGroup) {
+		return Deny("renewal requester is missing required node or daemon group"), nil
+	}
+	allowed, err := a.opts.AuthorizeRenewal(ctx, csr, nodeName)
+	if err != nil {
+		return CSRDecision{}, err
+	}
+	if !allowed {
+		return Deny("node %q is not bound to a Machine", nodeName), nil
+	}
+
+	return Approve("approved daemon-controller certificate renewal for node %q", nodeName), nil
+}
+
+func HasApprovalDecision(csr *certificatesv1.CertificateSigningRequest) bool {
+	for _, condition := range csr.Status.Conditions {
+		switch condition.Type {
+		case certificatesv1.CertificateApproved, certificatesv1.CertificateDenied, certificatesv1.CertificateFailed:
+			if condition.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func Approve(format string, args ...any) CSRDecision {
+	return CSRDecision{Approve: true, Message: fmt.Sprintf(format, args...)}
+}
+
+func Deny(format string, args ...any) CSRDecision {
+	return CSRDecision{Approve: false, Message: fmt.Sprintf(format, args...)}
+}
+
+func parseCSR(data []byte) (*x509.CertificateRequest, error) {
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, fmt.Errorf("PEM block type must be CERTIFICATE REQUEST")
+	}
+
+	request, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return request, nil
+}
+
+func validateClientAuthUsages(usages []certificatesv1.KeyUsage) error {
+	allowed := map[certificatesv1.KeyUsage]bool{
+		certificatesv1.UsageDigitalSignature: true,
+		certificatesv1.UsageKeyEncipherment:  true,
+		certificatesv1.UsageClientAuth:       true,
+	}
+	seenClientAuth := false
+	for _, usage := range usages {
+		if !allowed[usage] {
+			return fmt.Errorf("unsupported usage %q", usage)
+		}
+		if usage == certificatesv1.UsageClientAuth {
+			seenClientAuth = true
+		}
+	}
+	if !seenClientAuth {
+		return fmt.Errorf("missing %q", certificatesv1.UsageClientAuth)
+	}
+
+	return nil
+}
+
+func hasUnexpectedSubjectFields(subject pkix.Name) bool {
+	return len(subject.Country) > 0 ||
+		len(subject.OrganizationalUnit) > 0 ||
+		len(subject.Locality) > 0 ||
+		len(subject.Province) > 0 ||
+		len(subject.StreetAddress) > 0 ||
+		len(subject.PostalCode) > 0 ||
+		subject.SerialNumber != "" ||
+		len(subject.ExtraNames) > 0
+}
+
+func equalStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aa := append([]string(nil), a...)
+	bb := append([]string(nil), b...)
+	sort.Strings(aa)
+	sort.Strings(bb)
+	for i := range aa {
+		if aa[i] != bb[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func constantTimeEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}

--- a/pkg/agent/daemoncred/approver_test.go
+++ b/pkg/agent/daemoncred/approver_test.go
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package daemoncred
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCSRApproverBootstrapAllowed(t *testing.T) {
+	approver := testCSRApprover(t, true, true)
+	csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+		SignerName: DefaultControllerCertificateSignerName,
+		Username:   "system:bootstrap:abc123",
+		Groups:     []string{testBootstrapGroup},
+		Usages:     clientAuthUsages(),
+	}, csrSubject{
+		CommonName:   "system:node:node-a",
+		Organization: []string{SystemNodesGroup, testDaemonGroup},
+	})
+
+	decision, err := approver.Evaluate(context.Background(), csr)
+	require.NoError(t, err)
+	require.True(t, decision.Approve)
+}
+
+func TestCSRApproverRequiresDaemonGroup(t *testing.T) {
+	_, err := NewCSRApprover(CSRApproverOptions{
+		BootstrapGroup: testBootstrapGroup,
+		AuthorizeBootstrap: func(context.Context, *certificatesv1.CertificateSigningRequest, string) (bool, error) {
+			return true, nil
+		},
+		AuthorizeRenewal: func(context.Context, *certificatesv1.CertificateSigningRequest, string) (bool, error) {
+			return true, nil
+		},
+	})
+	require.ErrorContains(t, err, "daemon group is required")
+}
+
+func TestCSRApproverBootstrapRequiresGroup(t *testing.T) {
+	approver := testCSRApprover(t, true, true)
+	csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+		SignerName: DefaultControllerCertificateSignerName,
+		Username:   "system:bootstrap:abc123",
+		Usages:     clientAuthUsages(),
+	}, csrSubject{
+		CommonName:   "system:node:node-a",
+		Organization: []string{SystemNodesGroup, testDaemonGroup},
+	})
+
+	decision, err := approver.Evaluate(context.Background(), csr)
+	require.NoError(t, err)
+	require.False(t, decision.Approve)
+	require.Contains(t, decision.Message, "missing required group")
+}
+
+func TestCSRApproverBootstrapRejectsForbiddenRequesterGroup(t *testing.T) {
+	for _, group := range []string{"system:masters", "cluster-admin"} {
+		t.Run(group, func(t *testing.T) {
+			approver := testCSRApprover(t, true, true)
+			csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+				SignerName: DefaultControllerCertificateSignerName,
+				Username:   "system:bootstrap:abc123",
+				Groups:     []string{testBootstrapGroup, group},
+				Usages:     clientAuthUsages(),
+			}, csrSubject{
+				CommonName:   "system:node:node-a",
+				Organization: []string{SystemNodesGroup, testDaemonGroup},
+			})
+
+			decision, err := approver.Evaluate(context.Background(), csr)
+			require.NoError(t, err)
+			require.False(t, decision.Approve)
+			require.Contains(t, decision.Message, "forbidden group")
+			require.Contains(t, decision.Message, group)
+		})
+	}
+}
+
+func TestCSRApproverRenewalAllowed(t *testing.T) {
+	approver := testCSRApprover(t, true, true)
+	csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+		SignerName: DefaultControllerCertificateSignerName,
+		Username:   "system:node:node-a",
+		Groups:     []string{SystemNodesGroup, testDaemonGroup},
+		Usages:     clientAuthUsages(),
+	}, csrSubject{
+		CommonName:   "system:node:node-a",
+		Organization: []string{SystemNodesGroup, testDaemonGroup},
+	})
+
+	decision, err := approver.Evaluate(context.Background(), csr)
+	require.NoError(t, err)
+	require.True(t, decision.Approve)
+}
+
+func TestCSRApproverStockKubeletCertCannotRenew(t *testing.T) {
+	approver := testCSRApprover(t, true, true)
+	csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+		SignerName: DefaultControllerCertificateSignerName,
+		Username:   "system:node:node-a",
+		Groups:     []string{SystemNodesGroup},
+		Usages:     clientAuthUsages(),
+	}, csrSubject{
+		CommonName:   "system:node:node-a",
+		Organization: []string{SystemNodesGroup, testDaemonGroup},
+	})
+
+	decision, err := approver.Evaluate(context.Background(), csr)
+	require.NoError(t, err)
+	require.False(t, decision.Approve)
+	require.Contains(t, decision.Message, "missing required node or daemon group")
+}
+
+func TestCSRApproverRenewalRejectsForbiddenRequesterGroup(t *testing.T) {
+	for _, group := range []string{"system:masters", "cluster-admin"} {
+		t.Run(group, func(t *testing.T) {
+			approver := testCSRApprover(t, true, true)
+			csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+				SignerName: DefaultControllerCertificateSignerName,
+				Username:   "system:node:node-a",
+				Groups:     []string{SystemNodesGroup, testDaemonGroup, group},
+				Usages:     clientAuthUsages(),
+			}, csrSubject{
+				CommonName:   "system:node:node-a",
+				Organization: []string{SystemNodesGroup, testDaemonGroup},
+			})
+
+			decision, err := approver.Evaluate(context.Background(), csr)
+			require.NoError(t, err)
+			require.False(t, decision.Approve)
+			require.Contains(t, decision.Message, "forbidden group")
+			require.Contains(t, decision.Message, group)
+		})
+	}
+}
+
+func TestCSRApproverRejectsUnexpectedGroup(t *testing.T) {
+	approver := testCSRApprover(t, true, true)
+	csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+		SignerName: DefaultControllerCertificateSignerName,
+		Username:   "system:node:node-a",
+		Groups:     []string{SystemNodesGroup, testDaemonGroup},
+		Usages:     clientAuthUsages(),
+	}, csrSubject{
+		CommonName:   "system:node:node-a",
+		Organization: []string{SystemNodesGroup, testDaemonGroup, "system:masters"},
+	})
+
+	decision, err := approver.Evaluate(context.Background(), csr)
+	require.NoError(t, err)
+	require.False(t, decision.Approve)
+	require.Contains(t, decision.Message, "organizations")
+}
+
+func TestCSRApproverRejectsSANs(t *testing.T) {
+	approver := testCSRApprover(t, true, true)
+	csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+		SignerName: DefaultControllerCertificateSignerName,
+		Username:   "system:node:node-a",
+		Groups:     []string{SystemNodesGroup, testDaemonGroup},
+		Usages:     clientAuthUsages(),
+	}, csrSubject{
+		CommonName:   "system:node:node-a",
+		Organization: []string{SystemNodesGroup, testDaemonGroup},
+		DNSNames:     []string{"node-a.example.test"},
+	})
+
+	decision, err := approver.Evaluate(context.Background(), csr)
+	require.NoError(t, err)
+	require.False(t, decision.Approve)
+	require.Contains(t, decision.Message, "subject alternative names")
+}
+
+func TestCSRApproverRejectsUnexpectedSubjectFields(t *testing.T) {
+	approver := testCSRApprover(t, true, true)
+	csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+		SignerName: DefaultControllerCertificateSignerName,
+		Username:   "system:node:node-a",
+		Groups:     []string{SystemNodesGroup, testDaemonGroup},
+		Usages:     clientAuthUsages(),
+	}, csrSubject{
+		CommonName:         "system:node:node-a",
+		Organization:       []string{SystemNodesGroup, testDaemonGroup},
+		OrganizationalUnit: []string{"unexpected"},
+	})
+
+	decision, err := approver.Evaluate(context.Background(), csr)
+	require.NoError(t, err)
+	require.False(t, decision.Approve)
+	require.Contains(t, decision.Message, "subject")
+}
+
+func TestCSRApproverRejectsTooLongExpiration(t *testing.T) {
+	approver := testCSRApprover(t, true, true)
+	expiration := defaultMaxExpirationSeconds + 1
+	csr := csrFor(t, certificatesv1.CertificateSigningRequestSpec{
+		SignerName:        DefaultControllerCertificateSignerName,
+		Username:          "system:node:node-a",
+		Groups:            []string{SystemNodesGroup, testDaemonGroup},
+		Usages:            clientAuthUsages(),
+		ExpirationSeconds: &expiration,
+	}, csrSubject{
+		CommonName:   "system:node:node-a",
+		Organization: []string{SystemNodesGroup, testDaemonGroup},
+	})
+
+	decision, err := approver.Evaluate(context.Background(), csr)
+	require.NoError(t, err)
+	require.False(t, decision.Approve)
+	require.Contains(t, decision.Message, "exceeds maximum")
+}
+
+type csrSubject struct {
+	CommonName         string
+	Organization       []string
+	OrganizationalUnit []string
+	DNSNames           []string
+}
+
+func testCSRApprover(t *testing.T, bootstrapAllowed bool, renewalAllowed bool) *CSRApprover {
+	t.Helper()
+
+	approver, err := NewCSRApprover(CSRApproverOptions{
+		BootstrapGroup: testBootstrapGroup,
+		DaemonGroup:    testDaemonGroup,
+		AuthorizeBootstrap: func(context.Context, *certificatesv1.CertificateSigningRequest, string) (bool, error) {
+			return bootstrapAllowed, nil
+		},
+		AuthorizeRenewal: func(context.Context, *certificatesv1.CertificateSigningRequest, string) (bool, error) {
+			return renewalAllowed, nil
+		},
+	})
+	require.NoError(t, err)
+
+	return approver
+}
+
+const testBootstrapGroup = "system:bootstrappers:unbounded-agent-daemons"
+
+func clientAuthUsages() []certificatesv1.KeyUsage {
+	return []certificatesv1.KeyUsage{
+		certificatesv1.UsageDigitalSignature,
+		certificatesv1.UsageClientAuth,
+	}
+}
+
+func csrFor(t *testing.T, spec certificatesv1.CertificateSigningRequestSpec, subject csrSubject) *certificatesv1.CertificateSigningRequest {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	requestDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:         subject.CommonName,
+			Organization:       subject.Organization,
+			OrganizationalUnit: subject.OrganizationalUnit,
+		},
+		DNSNames: subject.DNSNames,
+	}, key)
+	require.NoError(t, err)
+
+	spec.Request = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: requestDER})
+
+	return &certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-csr"},
+		Spec:       spec,
+	}
+}

--- a/pkg/agent/daemoncred/approver_test.go
+++ b/pkg/agent/daemoncred/approver_test.go
@@ -229,7 +229,7 @@ type csrSubject struct {
 	DNSNames           []string
 }
 
-func testCSRApprover(t *testing.T, bootstrapAllowed bool, renewalAllowed bool) *CSRApprover {
+func testCSRApprover(t *testing.T, bootstrapAllowed, renewalAllowed bool) *CSRApprover {
 	t.Helper()
 
 	approver, err := NewCSRApprover(CSRApproverOptions{

--- a/pkg/agent/daemoncred/credentials.go
+++ b/pkg/agent/daemoncred/credentials.go
@@ -1,0 +1,352 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package daemoncred
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/certificate"
+	"k8s.io/client-go/util/connrotation"
+)
+
+const (
+	DefaultControllerCertificateSignerName = "kubernetes.io/kube-apiserver-client"
+
+	controllerCertificateStorePrefix               = "daemon-controller"
+	defaultControllerCertificateWaitTimeout        = 10 * time.Second
+	defaultControllerCertificateWaitPoll           = 500 * time.Millisecond
+	defaultControllerCertificateExpirationDuration = 365 * 24 * time.Hour
+	defaultControllerCertificateReloadPeriod       = 10 * time.Second
+)
+
+// ControllerCertificateOptions configures daemon-controller client certificate
+// issuance, storage, and REST client rotation.
+type ControllerCertificateOptions struct {
+	// Name identifies this certificate manager in logs.
+	Name string
+
+	// SignerName is the certificates.k8s.io signerName used for daemon-controller CSRs.
+	// Defaults to kubernetes.io/kube-apiserver-client when empty.
+	SignerName string
+
+	// DaemonGroup is the additional group requested alongside system:nodes.
+	// It is required and must not use reserved or privileged group names.
+	DaemonGroup string
+
+	// CredentialDir stores the daemon-controller certificate material.
+	// It is required.
+	CredentialDir string
+
+	// WaitTimeout is how long initial certificate issuance waits before failing.
+	// Defaults to 10 seconds when unset.
+	WaitTimeout time.Duration
+
+	// WaitPoll is the polling interval used while waiting for initial issuance.
+	// Defaults to 500 milliseconds when unset.
+	WaitPoll time.Duration
+
+	// ExpirationDuration is the requested lifetime for issued certificates.
+	// Defaults to 365 days when unset.
+	ExpirationDuration time.Duration
+
+	// ReloadPeriod is how often the REST config provider checks for rotation.
+	// Defaults to 10 seconds when unset.
+	ReloadPeriod time.Duration
+}
+
+func (o *ControllerCertificateOptions) validate() error {
+	if o == nil {
+		return fmt.Errorf("controller certificate options are required")
+	}
+	if o.SignerName == "" {
+		o.SignerName = DefaultControllerCertificateSignerName
+	}
+	if o.Name == "" {
+		return fmt.Errorf("certificate manager name is required")
+	}
+	if o.DaemonGroup == "" {
+		return fmt.Errorf("daemon group is required")
+	}
+	if isReservedDaemonGroup(o.DaemonGroup) {
+		return fmt.Errorf("daemon group must not use reserved or privileged group name: %s", o.DaemonGroup)
+	}
+	if o.WaitTimeout == 0 {
+		o.WaitTimeout = defaultControllerCertificateWaitTimeout
+	}
+	if o.WaitPoll == 0 {
+		o.WaitPoll = defaultControllerCertificateWaitPoll
+	}
+	if o.ExpirationDuration == 0 {
+		o.ExpirationDuration = defaultControllerCertificateExpirationDuration
+	}
+	if o.ReloadPeriod == 0 {
+		o.ReloadPeriod = defaultControllerCertificateReloadPeriod
+	}
+	if o.CredentialDir == "" {
+		return fmt.Errorf("credential directory is required")
+	}
+	if o.WaitTimeout < 0 {
+		return fmt.Errorf("wait timeout must be non-negative")
+	}
+	if o.WaitPoll <= 0 {
+		return fmt.Errorf("wait poll must be positive")
+	}
+	if o.ExpirationDuration <= 0 {
+		return fmt.Errorf("expiration duration must be positive")
+	}
+	if o.ReloadPeriod <= 0 {
+		return fmt.Errorf("reload period must be positive")
+	}
+
+	return nil
+}
+
+func isReservedDaemonGroup(group string) bool {
+	group = strings.ToLower(strings.TrimSpace(group))
+	if strings.HasPrefix(group, "system:") {
+		return true
+	}
+
+	switch group {
+	case "admin", "admins", "cluster-admin", "cluster-admins", "master", "masters", "root":
+		return true
+	default:
+		return false
+	}
+}
+
+type RESTConfigProvider struct {
+	config       *rest.Config
+	manager      certificate.Manager
+	closeAll     func()
+	reloadPeriod time.Duration
+	startOnce    sync.Once
+}
+
+func NewRESTConfigProvider(
+	ctx context.Context,
+	base *rest.Config,
+	nodeName string,
+	opts ControllerCertificateOptions,
+) (*RESTConfigProvider, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	provider, err := newRESTConfigProvider(base, nodeName, opts)
+	if err != nil {
+		return nil, err
+	}
+	if provider.manager.Current() == nil {
+		provider.start()
+		if err := wait.PollUntilContextTimeout(ctx, opts.WaitPoll, opts.WaitTimeout, true, func(context.Context) (bool, error) {
+			return provider.manager.Current() != nil, nil
+		}); err != nil {
+			provider.manager.Stop()
+			return nil, fmt.Errorf("wait for daemon controller certificate: %w", err)
+		}
+	}
+
+	return provider, nil
+}
+
+func (p *RESTConfigProvider) RESTConfig() *rest.Config {
+	return p.config
+}
+
+func (p *RESTConfigProvider) Run(ctx context.Context) {
+	p.start()
+	defer p.manager.Stop()
+
+	var last *tls.Certificate
+	wait.UntilWithContext(ctx, func(context.Context) {
+		current := p.manager.Current()
+		if current == nil || current == last {
+			return
+		}
+		last = current
+		p.closeAll()
+	}, p.reloadPeriod)
+}
+
+func (p *RESTConfigProvider) start() {
+	p.startOnce.Do(func() {
+		p.manager.Start()
+	})
+}
+
+func newRESTConfigProvider(base *rest.Config, nodeName string, opts ControllerCertificateOptions) (*RESTConfigProvider, error) {
+	if nodeName == "" {
+		return nil, fmt.Errorf("node name is required")
+	}
+
+	store, err := newCertificateStore(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	lifetime := opts.ExpirationDuration
+	manager, err := certificate.NewManager(&certificate.Config{
+		ClientsetFn: func(current *tls.Certificate) (kubernetes.Interface, error) {
+			return clientsetForCertificate(base, current)
+		},
+		Template: &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName:   "system:node:" + nodeName,
+				Organization: []string{"system:nodes", opts.DaemonGroup},
+			},
+		},
+		SignerName:                   opts.SignerName,
+		RequestedCertificateLifetime: &lifetime,
+		Usages: []certificatesv1.KeyUsage{
+			certificatesv1.UsageDigitalSignature,
+			certificatesv1.UsageClientAuth,
+		},
+		CertificateStore: store,
+		Name:             opts.Name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create daemon controller certificate manager: %w", err)
+	}
+
+	config, closeAll, err := restConfigWithManager(base, manager)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RESTConfigProvider{
+		config:       config,
+		manager:      manager,
+		closeAll:     closeAll,
+		reloadPeriod: opts.ReloadPeriod,
+	}, nil
+}
+
+func newCertificateStore(opts ControllerCertificateOptions) (certificate.FileStore, error) {
+	certPath, keyPath, err := credentialPaths(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := certificate.NewFileStore(
+		controllerCertificateStorePrefix,
+		opts.CredentialDir,
+		opts.CredentialDir,
+		certPath,
+		keyPath,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create daemon controller certificate store: %w", err)
+	}
+
+	return store, nil
+}
+
+func restConfigWithManager(base *rest.Config, manager certificate.Manager) (*rest.Config, func(), error) {
+	cfg := rest.CopyConfig(base)
+	cfg.BearerToken = ""
+	cfg.BearerTokenFile = ""
+
+	tlsConfig, err := rest.TLSConfigFor(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("configure TLS: %w", err)
+	}
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+	tlsConfig.Certificates = nil
+	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		cert := manager.Current()
+		if cert == nil {
+			return &tls.Certificate{Certificate: nil}, nil
+		}
+		return cert, nil
+	}
+
+	dialer := connrotation.NewDialer((&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext)
+	cfg.Transport = utilnet.SetTransportDefaults(&http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+		MaxIdleConnsPerHost: 25,
+		DialContext:         dialer.DialContext,
+	})
+
+	cfg.CertData = nil
+	cfg.KeyData = nil
+	cfg.CertFile = ""
+	cfg.KeyFile = ""
+	cfg.CAData = nil
+	cfg.CAFile = ""
+	cfg.Insecure = false
+	cfg.NextProtos = nil
+
+	return cfg, dialer.CloseAll, nil
+}
+
+func clientsetForCertificate(base *rest.Config, current *tls.Certificate) (kubernetes.Interface, error) {
+	cfg := rest.CopyConfig(base)
+	if current == nil {
+		return kubernetes.NewForConfig(cfg)
+	}
+
+	certPEM, err := encodeCertificateChain(current.Certificate)
+	if err != nil {
+		return nil, err
+	}
+	keyPEM, err := encodePrivateKey(current.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.BearerToken = ""
+	cfg.BearerTokenFile = ""
+	cfg.CertFile = ""
+	cfg.KeyFile = ""
+	cfg.CertData = certPEM
+	cfg.KeyData = keyPEM
+
+	return kubernetes.NewForConfig(cfg)
+}
+
+func encodeCertificateChain(chain [][]byte) ([]byte, error) {
+	if len(chain) == 0 {
+		return nil, fmt.Errorf("certificate chain is empty")
+	}
+
+	out := make([]byte, 0)
+	for _, der := range chain {
+		out = append(out, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})...)
+	}
+
+	return out, nil
+}
+
+func encodePrivateKey(key any) ([]byte, error) {
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("marshal private key: %w", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), nil
+}
+
+func credentialPaths(opts ControllerCertificateOptions) (string, string, error) {
+	return filepath.Join(opts.CredentialDir, "client.crt"), filepath.Join(opts.CredentialDir, "client.key"), nil
+}

--- a/pkg/agent/daemoncred/credentials_test.go
+++ b/pkg/agent/daemoncred/credentials_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package daemoncred
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestNewRESTConfigProviderUsesStoredCertificate(t *testing.T) {
+	opts := testControllerCertificateOptions(t)
+	certPEM, keyPEM := testCertificate(t, "first")
+	storeControllerCertificateForTest(t, opts, certPEM, keyPEM)
+
+	base := &rest.Config{
+		Host:        "https://example.test",
+		BearerToken: "bootstrap-token",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: certPEM,
+		},
+	}
+
+	provider, err := NewRESTConfigProvider(context.Background(), base, "node-a", opts)
+	require.NoError(t, err)
+	cfg := provider.RESTConfig()
+	assert.Equal(t, base.Host, cfg.Host)
+	assert.Empty(t, cfg.BearerToken)
+	assert.NotNil(t, cfg.Transport)
+	assert.Empty(t, cfg.CertFile)
+	assert.Empty(t, cfg.KeyFile)
+	assert.Empty(t, cfg.CAData)
+}
+
+func TestCertificateStore(t *testing.T) {
+	opts := testControllerCertificateOptions(t)
+	certPEM, keyPEM := testCertificate(t, "first")
+	storeControllerCertificateForTest(t, opts, certPEM, keyPEM)
+
+	store, err := newCertificateStore(opts)
+	require.NoError(t, err)
+	cert, err := store.Current()
+	require.NoError(t, err)
+	assert.Equal(t, "first", cert.Leaf.Subject.CommonName)
+	assert.FileExists(t, store.CurrentPath())
+}
+
+func TestValidateRejectsReservedDaemonGroup(t *testing.T) {
+	for _, group := range []string{"system:masters", "masters", "cluster-admin"} {
+		t.Run(group, func(t *testing.T) {
+			opts := testControllerCertificateOptions(t)
+			opts.DaemonGroup = group
+
+			err := opts.validate()
+			require.ErrorContains(t, err, "reserved or privileged")
+		})
+	}
+}
+
+func storeControllerCertificateForTest(
+	t *testing.T,
+	opts ControllerCertificateOptions,
+	certPEM []byte,
+	keyPEM []byte,
+) {
+	t.Helper()
+
+	store, err := newCertificateStore(opts)
+	require.NoError(t, err)
+	_, err = store.Update(certPEM, keyPEM)
+	require.NoError(t, err)
+}
+
+func testControllerCertificateOptions(t *testing.T) ControllerCertificateOptions {
+	t.Helper()
+
+	return ControllerCertificateOptions{
+		Name:          "test-daemon-controller",
+		SignerName:    DefaultControllerCertificateSignerName,
+		DaemonGroup:   testDaemonGroup,
+		CredentialDir: t.TempDir(),
+	}
+}
+
+const testDaemonGroup = "test-daemon-group"
+
+func testCertificate(t *testing.T, commonName string) ([]byte, []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore: time.Now().Add(-time.Minute),
+		NotAfter:  time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}

--- a/pkg/agent/daemoncred/reconciler.go
+++ b/pkg/agent/daemoncred/reconciler.go
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package daemoncred
+
+import (
+	"context"
+	"fmt"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	approvalReasonApproved = "Approved"
+	approvalReasonDenied   = "Denied"
+)
+
+// CSRApproverReconciler watches CertificateSigningRequest objects and writes
+// approval or denial conditions for requests evaluated by CSRApprover.
+type CSRApproverReconciler struct {
+	// Client reads CertificateSigningRequest objects from the controller cache.
+	client.Client
+
+	// KubeClient updates the CSR approval subresource.
+	KubeClient kubernetes.Interface
+
+	// Approver evaluates daemon-controller CSR requests.
+	Approver *CSRApprover
+
+	// EventFilter optionally customizes which CSR events enqueue reconcile work.
+	// When nil, create, update, and generic events are processed and deletes are ignored.
+	EventFilter predicate.Predicate
+}
+
+func NewCSRApproverReconciler(
+	c client.Client,
+	kubeClient kubernetes.Interface,
+	approver *CSRApprover,
+) (*CSRApproverReconciler, error) {
+	if c == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	if kubeClient == nil {
+		return nil, fmt.Errorf("kubernetes client is required")
+	}
+	if approver == nil {
+		return nil, fmt.Errorf("approver is required")
+	}
+
+	return &CSRApproverReconciler{
+		Client:     c,
+		KubeClient: kubeClient,
+		Approver:   approver,
+	}, nil
+}
+
+func (r *CSRApproverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var csr certificatesv1.CertificateSigningRequest
+	if err := r.Get(ctx, req.NamespacedName, &csr); apierrors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		return ctrl.Result{}, fmt.Errorf("get CSR %s: %w", req.Name, err)
+	}
+
+	decision, err := r.Approver.Evaluate(ctx, &csr)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("evaluate CSR %s: %w", csr.Name, err)
+	}
+	if decision.Ignore || decision.AlreadyDecided {
+		return ctrl.Result{}, nil
+	}
+
+	conditionType := certificatesv1.CertificateApproved
+	reason := approvalReasonApproved
+	if !decision.Approve {
+		conditionType = certificatesv1.CertificateDenied
+		reason = approvalReasonDenied
+	}
+
+	updated := csr.DeepCopy()
+	updated.Status.Conditions = append(updated.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+		Type:           conditionType,
+		Status:         corev1.ConditionTrue,
+		Reason:         reason,
+		Message:        decision.Message,
+		LastUpdateTime: metav1.Now(),
+	})
+
+	if _, err := r.KubeClient.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, updated.Name, updated, metav1.UpdateOptions{}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("update CSR approval %s: %w", updated.Name, err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *CSRApproverReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	filter := r.EventFilter
+	if filter == nil {
+		filter = defaultCSRApproverEventFilter()
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&certificatesv1.CertificateSigningRequest{}).
+		WithEventFilter(filter).
+		Complete(r)
+}
+
+func defaultCSRApproverEventFilter() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return true },
+		UpdateFunc:  func(event.UpdateEvent) bool { return true },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return true },
+	}
+}


### PR DESCRIPTION
## Summary
- Add daemon controller authn/z design covering kubelet-shaped certificates, CSR approval, RBAC, and integration examples.
- Add reusable `pkg/agent/daemoncred` helpers for daemon-controller certificate issuance, rotation-ready REST configs, and CSR approval validation.
- Keep platform-specific CSR binding checks injectable through callbacks so Machina/AKS integrations can supply their own policy.

## Testing
- `go test ./pkg/agent/daemoncred`