### PR TITLE
unbounded-storage housekeeping

### DIFF
--- a/cmd/unbounded-storage/AGENTS.md
+++ b/cmd/unbounded-storage/AGENTS.md
@@ -5,6 +5,12 @@ the project is Go, so the conventions below intentionally diverge from
 the top-level `AGENTS.md` where they need to. Read this file before
 touching anything under `cmd/unbounded-storage/`.
 
+For the crate's design - what the daemon does, how it is structured into
+subsystems, and how data flows through it - read
+[`ARCHITECTURE.md`](ARCHITECTURE.md). This file covers the conventions
+(layout, build, test); `ARCHITECTURE.md` covers the system itself. Read
+both before making non-trivial changes.
+
 ## Crate layout
 
 - Each subsystem is a directory module:

--- a/cmd/unbounded-storage/ARCHITECTURE.md
+++ b/cmd/unbounded-storage/ARCHITECTURE.md
@@ -1,0 +1,574 @@
+# unbounded-storage Architecture
+
+`unbounded-storage` is the per-host storage daemon for Project Unbounded. It is
+the only Rust crate in the repository (Rust edition 2024) and has its own
+conventions for layout, build, and testing. Agents working under
+`cmd/unbounded-storage/` must read `cmd/unbounded-storage/AGENTS.md` first; the
+repository-wide Go conventions do not apply here.
+
+## 1. Purpose and Place in the System
+
+Project Unbounded serves immutable, content-addressed data to workloads through
+a tiered cache that sits in front of a slow origin. The design (see
+`designs/storage-high-level.md`) has three tiers:
+
+1. **P2P cache** - runs on every node. Content-addressed by checksum, strictly
+   immutable, and shares hot data between peers over RDMA. **This daemon is a
+   P2P cache node.**
+2. **Regional cache** - a pull-through tier with bounded mutability (etag
+   validated) that absorbs misses from the P2P tier.
+3. **Origin** - the authoritative store (S3, Azure Blob, or POSIX).
+
+The read path is:
+
+```
+workload -> local client -> P2P cache (local NVMe / peer pull / regional pull-through)
+                                 -> regional cache -> origin
+```
+
+A single daemon instance owns one host's NVMe drives and RDMA HCAs, exposes an
+HTTP frontend to local clients, fetches misses from an origin over HTTP, and
+serves/relays stripes to and from peer nodes over a libfabric RDMA fabric.
+
+## 2. Core Design Principles
+
+- **Runtime-agnostic, no async runtime.** The crate uses `async fn` extensively
+  but ships **no** tokio/async-std. Futures are driven by hand-rolled
+  noop-waker executors: a cooperative tick loop on shard threads
+  (`ShardLoop`), and dedicated per-request OS threads inside the fabric RPC
+  server. This keeps the daemon in full control of CPU pinning and polling.
+- **Thread-per-core with hard pinning.** Work is partitioned into shards, each
+  pinned to a dedicated CPU with NUMA-local memory. Most hot-path types are
+  `!Send`/`!Sync` (`Rc`, `RefCell`, `Cell`, raw pointers) and never cross a
+  thread boundary. Cross-core communication is explicit and channel-based.
+- **Topology-driven.** At startup the daemon discovers host hardware (CPUs,
+  NUMA nodes, HCAs, NVMe drives) from sysfs and computes a `Plan` that assigns
+  disjoint CPUs to roles. Everything downstream is sized from that plan.
+- **NUMA locality everywhere.** Memory backings, fabric memory regions, and disk
+  engines are all allocated on, and pinned to, the NUMA node of the CPU that
+  uses them.
+- **Hot-reloadable configuration.** Peers and disks reconcile into the running
+  process when `config.toml` changes; only the backing memory, fabric, and
+  topology plan are fixed at startup.
+- **Content addressing.** Stripes are keyed by a 32-byte `StripeKey` derived
+  from a checksum, so data is immutable and freely cacheable/relayable.
+
+## 3. Build and Toolchain
+
+Build only through the top-level `Makefile`, never raw `cargo`:
+
+- `make unbounded-storage` - fmt + lint + test + release build; copies the
+  binary to `bin/unbounded-storage`.
+- `make unbounded-storage-build` - release build only (used in Containerfiles).
+- `make unbounded-storage-test` - `cargo test --locked --all-targets`.
+
+All cargo invocations use `--locked`.
+
+The crate produces two binaries:
+
+- `unbounded-storage` (`src/main.rs`) - the daemon.
+- `bench` (`src/bin/bench.rs`) - a benchmarking harness.
+
+### libfabric
+
+The fabric layer links the native libfabric `tcp` RDM provider (requires
+libfabric 2.0+; the experimental `net` provider has been merged into `tcp`).
+`make libfabric` installs the pinned `LIBFABRIC_VERSION` under
+`tmp/libfabric/<version>/`, and the Makefile exports
+`LIBFABRIC_PKG_CONFIG_PATH` and `LD_LIBRARY_PATH`. The build compiles a small C
+shim (`shim.c`) against the libfabric headers via the `cc`/`pkg-config` build
+dependencies.
+
+## 4. Process Lifecycle (`src/main.rs`)
+
+The daemon's `main` wires every subsystem together. The default config path is
+`/etc/unbounded-storage/config.toml`.
+
+### CLI (clap derive)
+
+- `--config <PATH>` - optional. A missing **default** path is non-fatal (falls
+  back to a built-in `Config::default()`); a missing **explicit** path is fatal.
+- `--no-hugepages` - overrides `[storage] backing_kind` to `Heap`.
+- `--bytes-per-shard <BYTES>` - bare integer = bytes; `K`/`M`/`G` suffixes are
+  powers of 1024; zero is rejected. CLI overrides config.
+
+### Startup sequence
+
+1. Load and validate config; apply CLI overrides.
+2. `Host::discover()` reads hardware from sysfs.
+3. `Plan::for_host(&host, topology_cfg_to_plan_config(...))` computes the CPU/
+   role assignment. `RoleCounts::from_plan` tallies roles (RDMA progress and
+   RDMA handler roles are counted; `NvmeIoUring`/`NetworkShard` are currently
+   vestigial).
+4. `progress: Vec<Worker>` is filtered to `Role::RdmaProgress` workers. **One
+   shard thread is spawned per RDMA-progress worker.** If empty, the daemon
+   exits with failure.
+5. A `PinnedRuntime::from_plan` is built over the retained workers;
+   `WorkerIdx(i)` indexes the i-th retained worker (the filter and the index
+   must stay in sync).
+6. A `DiskChannelDirectory` (Arc) is created before shards as the hot-swap
+   publication surface for disk channels.
+7. Read-only shared state (`Arc<FabricCfg>`, `Arc<Vec<FrontendSpec>>`,
+   `Arc<Vec<BackendSpec>>`) and routing (`build_routing` -> `Arc<FingerTable>`
+   plus `Arc<HashMap<NodeId, PeerId>>`) are constructed once and shared across
+   shards.
+8. Each shard is spawned with `rt.spawn_pinned(widx, name, Box<FnOnce>)`. The
+   `!Send` shard objects are constructed **inside** `run_shard`, after pinning.
+9. After every shard reports `Up`, peers are reconciled per shard, the disk
+   supervisor opens disks and publishes channels, and the config watcher takes
+   over for the lifetime of the process.
+
+### Shard readiness and panic safety
+
+Each shard reports exactly one `ShardReady` message: `Up { descriptor, fabric }`
+(after which it parks while holding its `Sender`), or `Failed(String)`.
+`report_on_panic` wraps shard bring-up in `catch_unwind`/`AssertUnwindSafe` so a
+panicking shard still emits one `Failed` via a dedicated panic channel;
+otherwise main's bounded receive would hang. Main performs a bounded `recv()`
+exactly `joins.len()` times (it does **not** drain to disconnect, because `Up`
+shards never drop their sender).
+
+### Shutdown
+
+A process-wide `static SHUTDOWN: AtomicBool` is set by an async-signal-safe
+SIGINT/SIGTERM handler (installed via `libc::sigaction`, relaxed atomic store).
+Every thread polls this flag.
+
+Teardown order is deliberate: join shard threads in reverse (releasing
+`Arc<engine>` references) **first**, then drop the disk channel directory, then
+`disk_registry.drain()`.
+
+## 5. Shard Bring-up (`run_shard`)
+
+`run_shard` runs on an already-pinned thread and constructs the entire
+per-shard `!Send` object graph:
+
+1. **Fabric.** Pick a provider (`Provider::from_device_name` for the HCA, or
+   `Provider::Tcp` fallback on `lo`); build a `FabricConfig` via
+   `fabric::defaults_for(device_name, runtime, widx)`; `Fabric::new` and resolve
+   `self_address()`.
+2. **Memory.** Allocate a NUMA-local `Backing` via `memory::allocate` **on the
+   pinned thread** (mempolicy keeps pages local; the hugepage variant `mbind`s).
+   Register it with the fabric as a memory region (MR), and register it with the
+   socket ring as a fixed buffer for zero-copy send/recv.
+3. **Origin backend.** Resolve the origin endpoint and build an `HttpBackend`
+   over the shard socket, carving origin-fetch pages from the backing.
+4. **Transport + blockstore + pool.** Build a `RoutedTransport` (Chord routing +
+   fabric transport + origin backend), a `LiveShardLocalStore` over the disk
+   channel directory as the `BlockStore`, then `Pool::new`.
+5. **RPC server.** Allocate a **separate** scratch backing
+   (`RPC_SCRATCH_PAGES = 8`, one scratch page per in-flight serve/forward),
+   register it as its own fabric MR and its own `LiveShardLocalStore` (a
+   `PageRef` resolves through exactly one backing's geometry, so scratch needs a
+   distinct store). Build a `RecursiveHandler` and start the fabric RPC server.
+6. **Frontend.** In v1 a shard hosts at most one frontend (the first spec;
+   extras are logged and skipped). Bind the listener with `SO_REUSEPORT` and
+   build an `HttpDriver`.
+7. **Tick loop.** Register tick hooks (socket-ring `progress()`, and the
+   frontend driver's `progress()`), report `Up`, and run
+   `shard_loop.run_until_with(|| SHUTDOWN.load(Acquire), 100us)` - busy-poll
+   when active, sleep 100us when idle. The fabric and pool self-drive on their
+   own threads.
+
+Drop order at shard exit is critical: `shard_loop -> pool -> socket ->
+rpc_server -> fabric` (fabric last; it joins progress threads, closes the
+scratch MR, and tears libfabric down).
+
+## 6. Module Map (`src/lib.rs`)
+
+All subsystems are `pub mod`: `backend`, `bufferpool`, `config`, `fabric`,
+`frontend`, `http`, `memory`, `p2p`, `ring`, `runtime`, `storage`, `topology`.
+
+Each subsystem follows the same layout convention: `src/<area>/mod.rs` declares
+private submodules and re-exports a curated public surface via `pub use`. Files
+are kept under ~1500 lines and split on concept boundaries.
+
+```
+                         +------------------+
+   local client  ---->   |  frontend (HTTP) |
+                         +---------+--------+
+                                   |
+                                   v
+                         +------------------+        +-----------------+
+                         |    bufferpool    |  <---->|     backend     |---> origin (HTTP)
+                         |    (Pool/shard)  |        |    (HttpBackend)|
+                         +----+--------+----+        +-----------------+
+                              |        |
+              transport (peer)|        | blockstore (local)
+                              v        v
+                    +-----------+   +---------------------+
+                    |    p2p    |   |       storage       |
+                    | (Chord +  |   | (engine/btree/disk) |
+                    | Routed/   |   +----------+----------+
+                    | Recursive)|              |
+                    +-----+-----+              | page_channel (cross-core)
+                          |                    v
+                          v             +-------------+
+                    +-----------+       |    ring     |
+                    |  fabric   |       | (io_uring)  |
+                    | (libfabric|       +-------------+
+                    |   RDMA)   |
+                    +-----------+
+```
+
+Foundational layers shared by everyone: `memory` (NUMA backings), `ring`
+(io_uring), `runtime` (pinning + tick loop), `topology` (planning), `config`,
+and `http` (wire codec).
+
+## 7. Subsystems
+
+### 7.1 `runtime/` - pinning and the cooperative loop
+
+This layer owns two things: putting each shard thread on a fixed CPU, and giving
+it a simple loop to drive work without an async runtime.
+
+- `WorkerIdx(u16)` is the universal worker-slot id; the pool, fabric, and
+  io_uring layers all pin against the same index.
+- `trait Threading: Send + Sync + 'static` exposes `worker_count`,
+  `numa_of(WorkerIdx)`, and `spawn_pinned(idx, name, Box<FnOnce + Send>)`.
+  `spawn_pinned` pins CPU affinity and NUMA mempolicy **first**, then runs the
+  closure. `DefaultRuntime` is the non-pinning fallback (tests/non-Linux);
+  `PinnedRuntime` is the Linux implementation.
+- `ShardLoop` is the cooperative driver: `add_tick_hook(FnMut() -> bool)` and
+  `run_until_with(stop, idle_sleep)`. Tick hooks return `true` to stay hot.
+- `NumaHint { Any, Worker, Numa }` is declared for future use.
+
+### 7.2 `topology/` - hardware discovery and planning
+
+- `Host::discover()` reads CPUs, NUMA nodes, HCAs (`Hca`), NICs (`Nic`), and
+  NVMe drives (`Nvme`) from sysfs.
+- `Plan::for_host(&host, &PlanConfig)` allocates disjoint, NUMA-local CPUs to
+  roles, scheduling the most constrained roles first (NVMe io_uring), then RDMA
+  progress, then RDMA handlers; an exhausted pool spills into a per-node
+  oversubscription pool.
+- `Role` variants: `RdmaProgress{hca}`, `RdmaHandler{hca}`, `NvmeIoUring{nvme}`,
+  `NetworkShard{nic}`. A `Worker` carries `{ cpu, numa, role }`.
+- `PlanConfig` knobs (defaults): `rdma_progress_per_hca` (1),
+  `rdma_handlers_per_hca` (4), `nvme_threads_per_drive` (2),
+  `network_shards_per_nic` (0), `use_smt_siblings` (false),
+  `respect_isolated` (true), `exclude_node_cpu0` (true),
+  `require_node_type_ca` (true, currently a no-op), `require_active_port`
+  (true), `tcp_fallback_threads` (1), and `disable_rdma` (force TCP even when
+  HCAs exist - an escape hatch for unusable verbs).
+- Key accessors consumed by main: `plan.rdma_progress()` and
+  `plan.disk_cpu_slots()`.
+
+### 7.3 `memory/` - NUMA-local backings
+
+- `Backing` is a pinned, NUMA-local memory region carved into fixed-size pages
+  (`base`, `page_size`, `page_count`).
+- `memory::allocate(BackingRequest { kind, bytes, numa })` must run on the
+  pinned thread so mempolicy applies; the hugepage variant (`HUGEPAGE_2MB`)
+  `mbind`s to the NUMA node.
+- This single backing is shared by reference across the bufferpool (data pages),
+  the fabric MR, and the socket-ring fixed buffer.
+
+### 7.4 `ring/` - the io_uring engine
+
+This is the crate's only path to the kernel for disk and socket I/O. One engine
+per thread submits and reaps io_uring operations; everything above it talks to
+that engine through two thin facades.
+
+- `RingCore` is the single low-level engine: one io_uring ring, a slot map keyed
+  by monotonic `user_data`, a sparse registered-buffer table, a registered file
+  table, and a FIFO back-pressure queue bounded by `queue_depth`. It is
+  `!Send + !Sync` (pinned to its building thread).
+- `progress()` pushes queued SQEs, drains CQEs, fills slots, and wakes futures
+  plus one parked back-pressure waiter. It implements `SEND_ZC` two-CQE
+  semantics (the `F_MORE` byte-count completion, then the notification that
+  releases the source buffer).
+- Two facades sit on top: `StorageRing`/`StorageRingConfig` for block read/write
+  (IOPOLL-capable), and `NetHandle`/`NetworkRing`/`SockAddr` for sockets (no
+  IOPOLL). A thread-local registry exposes the current `StorageRing`
+  (`set`/`clear`/`current`/`with_current_storage_ring`), which is how
+  `CoreLocalDevice` finds its ring.
+
+### 7.5 `bufferpool/` - the per-shard page pool
+
+The buffer pool is the heart of the read path. It hands out fixed-size pages
+from the shard's backing memory, coalesces concurrent readers of the same
+stripe, and knows how to fill a miss from either a peer or the local disk.
+
+- One `Pool` per shard; single-threaded and `!Send`. `Pool<T: Transport<R>,
+  S: BlockStore, R: Req>` is an `Rc<PoolInner>`.
+- `Pool::new` carves the backing into pages, calls `blockstore.register_pages`
+  once, and validates invariants (page size power-of-two; non-zero page count
+  `<= u32::MAX`; non-null base). It performs no async I/O - RDMA `ibv_reg_mr` is
+  done out-of-band by the embedder before `Pool::new`, and the embedder
+  constructs the pool off the pinned thread.
+- `PoolInner` tracks a `FreeList`, an `inflight` map
+  (`StripeKey -> Rc<RefCell<StripeFetch>>`) so concurrent readers of the same
+  stripe coalesce, and `inflight_prefetch_pages`, a global speculative-prefetch
+  budget capped by `cfg.max_inflight_pages` (the head page never counts against
+  it).
+- Core traits (`traits.rs`): `Req { key() -> StripeKey }`; `PageStream` (a
+  local, futures-core-free `Stream` of `Result<PageRef, Error>`); and
+  `Transport<R> { bulk_get(&req, src: BulkRef, dsts: &[PageRef]) -> Stream }`,
+  which fetches from a **peer**. Blanket impls cover `Arc<T>`.
+- Public surface also includes `PoolGroup`/`ShardDescriptor`/`ShardRouter`
+  (sharding helpers), `PageGuard`/`ReadStream`/`WindowedRead` (read API), and
+  `NullBlockStore`.
+
+A shard's data path therefore has two miss sources: the `Transport` (peer pull
+over fabric) and the `BlockStore` (local NVMe). The `RoutedTransport` decides
+between them, and the origin `Backend` is the final fallback.
+
+### 7.6 `p2p/` - the Chord stripe DHT
+
+- Routing topology only. Each node deterministically computes a k-arc finger
+  table from the sorted node list, and routing is recursive Chord
+  closest-preceding-finger. Caching, admission, and eviction belong to the
+  storage layer, not here.
+- `FingerTable` is fully deterministic in `(local, peers, k)`, so there is **no
+  stabilization phase**. `FingerTableConfig { k }` defaults to 100 (targeting
+  100-150 fingers against a ~200 RDMA QP budget per node). It holds a local
+  `PeerEntry`, `fingers: Vec<PeerEntry>` of length `k` (arc `i` is the half-open
+  arc at `local.ring + i*arc_span`; an empty arc stores a clone of `local` and
+  `next_hop` filters it out), plus successor/predecessor.
+- `RoutedTransport<R, B: Backend<Req = R>>` (the client side) makes the
+  first-hop decision via a single Chord `next_hop(stripe_to_ring(key))`:
+  - `None` -> this node owns the stripe; serve from the local origin `Backend`.
+  - `Some(peer)` -> hand off to a wrapped `FabricTransport<R, FingerRouter>`
+    with a `MAX_HOPS` TTL; recursion happens server-side.
+- `RecursiveHandler` (the server side) **resolves** every request (in contrast
+  to `fabric::PoolHandler`, which only serves locally resident pages). It
+  computes `stripe_to_ring(key)` and consults `next_hop`:
+  - `None` -> own stripe: read the local `BlockStore`, and on a miss fetch from
+    the origin `Backend`.
+  - `Some` with hops remaining -> forward to the next hop with a decremented
+    TTL; the downstream node RDMA-writes the page into **this** node's scratch,
+    the handler yields it, and the RPC server relays it upstream.
+  - `Some` with no hops remaining -> `HopLimitExceeded`.
+  It owns a dedicated scratch `Backing` (its own fabric MR and an extra
+  `BlockStore` buffer); a `Mutex` free list hands out one scratch page per
+  in-flight request, reclaimed when the response stream drops.
+- Ring math lives in `ring.rs`: `node_to_ring`, `stripe_to_ring`, `splitmix64`.
+
+### 7.7 `fabric/` - the libfabric RDMA transport
+
+This is how nodes move pages between each other. It binds directly to libfabric
+and exposes a small RPC server: a peer asks for a stripe, and this node
+RDMA-writes the requested pages straight into the asker's memory.
+
+A thin, direct binding over libfabric (no high-level wrapper crate). It is built
+in phases: types/error/FFI, class lifecycle with one pinned progress thread per
+completion queue, connection CRUD + MR registration + tagged ping/pong, and the
+streaming RPC server plus client `Transport`.
+
+- `Fabric` owns the libfabric objects and progress threads. `MrHandle` is a
+  `Copy` value handle; the underlying `fid_mr` is owned by `Fabric`.
+- `Provider` selects the libfabric provider (`from_device_name` or `Tcp`);
+  `defaults_for` builds a `FabricConfig`.
+- The completion machinery (`CompletionFuture`, `CompletionInfo`,
+  `CompletionRegistry`, `CompletionSlot`) bridges libfabric CQ entries to
+  futures.
+- **RPC server model** (`rpc.rs`): per in-flight request a **dedicated OS
+  thread** drives the `Handler` stream synchronously with a noop waker, submits
+  libfabric ops, and spin-polls `CompletionFuture`s. Wire framing uses reserved
+  tag bases (`REQUEST_TAG_BASE = 0xFFFF_FFFC_0000_0000`, `PAGE_ACK_TAG_BASE`,
+  `RESPONSE_END_TAG_BASE`, `ERROR_ACK_TAG_BASE`); the low 32 bits carry the
+  request id. The client `fi_tsend`s a bincode `RequestHeader` plus the bincode
+  request body; the server `fi_write`s each page into the client's destination
+  MR and `fi_tsend`s one `PageAck` per page, then a `RESPONSE_END` (success) or
+  `ERROR_ACK`. `RpcServerHandle::drop` sets a shutdown flag the workers poll
+  between handler-stream polls.
+- `Handler`/`HandlerStream` is the server-side resolution trait;
+  `PoolHandler`/`PoolHandlerStream` serve locally-resident pages.
+- The client side (`transport`) provides `FabricTransport`, the `PeerRouter`
+  trait, `StaticPeer`, and capacity helpers
+  (`ensure_launch_fits_registry`, `required_completion_slots`).
+
+### 7.8 `backend/` and `frontend/` - the HTTP edges
+
+These are symmetric twins around the buffer pool.
+
+- `Backend` (origin side): `bulk_get(&req, src: BulkRef, dsts: &[PageRef]) ->
+  Stream` resolves a `BulkRef` from the authoritative **origin** into
+  destination pages, one page at a time (contrast `Transport`, which pulls from
+  a peer). `HttpBackend` (Linux) memcpys origin bytes into pages carved from the
+  backing and holds an `Rc<socket>`. `NullBackend` is the no-op.
+- `Frontend` (client side): a factory (`start_on_shard`) that binds a listener
+  once per shard with `SO_REUSEPORT` and returns a `Driver`. `Driver::progress`
+  is a tick hook (returning `true` to stay hot); the socket ring's `progress()`
+  is a **separate** tick hook. `HttpDriver`/`HttpFrontend` (Linux) multiplex
+  many connection futures. `range.rs` handles HTTP byte ranges and maps them to
+  stripe sets (`ByteRange`, `ResolvedRange`, `StripeSlice`, `full_object`,
+  `stripe_set`).
+- `FrontendRegistry`/`DiskRegistry` share a string-keyed registry pattern that
+  rejects duplicate ids.
+
+### 7.9 `http/` - the wire codec
+
+A transport-agnostic, opinion-free HTTP/1.1 parser/serializer shared by both
+edges. Parsing uses `httparse` with zero-copy borrowed header views; typed
+`Method`/`StatusCode` come from the external `http` crate (referred to as
+`::http` to disambiguate from `crate::http`). It carries no storage policy
+(ranges, stripes, status codes live in `frontend`/`backend`), so it can back
+both the current plaintext pair and a future S3-compatible pair. Public surface:
+`Header`/`ParseError`, `HttpRequest`/`serialize_request`,
+`ResponseHead`/`serialize_response_head`, and re-exported `Method`/`StatusCode`.
+
+### 7.10 `storage/` - the per-disk engine
+
+The local NVMe cache, composed bottom-up: `blockdev` (the only layer that
+touches the kernel device) -> `alloc` + `refcount` (pure LBA tables) -> `btree`
+(a copy-on-write B+tree over a `BlockDevice`) -> `singleflight`/`lru`/
+`admission` (concurrency and policy) -> `engine` (wires the whole thing into
+`bufferpool::BlockStore`).
+
+**`StorageEngine`** composes:
+
+- a `BlockDevice` for NVMe I/O,
+- an `Allocator` over LBA space (meta slots reserved at open),
+- a `RefcountTable` for pin tracking and the SIEVE referenced bit,
+- a `BTreeIndex` mapping `(value_hash, page_index) -> (lba, checksum,
+  byte_len)`,
+- a `SieveLru` for eviction,
+- an `AdmissionFilter` (one-hit-wonder rejection), and
+- a `Singleflight` for per-key write dedup.
+
+`EngineConfig` defaults: `page_size_bytes` 2 MiB (a multiple of
+`btree_page_bytes`), `btree_page_bytes` 4096 (the device atomic write unit),
+`commit_batch_max` 1024, `commit_batch_deadline_us` 200,
+`eviction_watermark` 0.9, `probationary_fraction` 0.1,
+`admission_sketch_multiplier` 2, `singleflight_shards` 64,
+`restart_scan_queue_depth` 256, `bypass_admission` false (bench/tooling only),
+and `skip_recovery_scan_if_no_meta` false (production keeps it false so partial
+recovery runs).
+
+**CoW B+tree** (`btree/`): not `Sync`. Commits flow through a single mutator
+task holding only a `RefCell` borrow on `MutatorState`; lookups are wait-free
+through `arc_swap::ArcSwap<RootSnapshot>`. Each `apply_batch` coalesces sorted
+`(key, op)` pairs and updates a mirror, rewrites only the spine pages on touched
+paths (sharing untouched subtrees) reporting allocated and retired pages, writes
+the new meta page into the **inactive** slot (a dual meta-page commit that
+survives torn writes), records retired pages and the alive txn, then
+`ArcSwap::store`s the new snapshot. When the previous snapshot's last `Guard`
+drops it recomputes the minimum-alive txn and frees retired bundles. A failure
+mid-commit unwinds the new pages and leaves the old snapshot intact.
+
+**`BlockDevice` trait** (`blockdev/`): deliberately narrow (read page, write
+page, geometry); higher layers own checksums, retries, and eviction. It is
+generic over the runtime and not boxed (no `dyn BlockDevice`), so the engine is
+generic over the device. Implementations: `CoreLocalDevice` (resolves its
+`StorageRing` from the thread-local registry and returns `ENXIO` if driven off
+its storage core), `MockDevice` (with `MockFaultMode` for fault injection),
+`ScratchPool`/`ScratchPage`, and the Linux `UringBlockDevice`/`UringDevice`
+(`OpenDisk`, `provision_file`).
+
+**Cross-core bridge** (`page_channel.rs`): a `StorageEngine<CoreLocalDevice>` is
+pinned to one storage core and can only be driven from that core. Shard cores
+ship each page op (read/write/buffer-registration) over an mpsc `PageChannel` to
+a `PageService` running on the storage core, which executes it against the
+engine and completes the caller's `ReplySlot`. The handle is `Send + Sync` and
+clonable; when the last handle drops, the service drains and exits. **Buffer
+lifetime contract:** dropping a read/write future does **not** cancel the
+in-flight op (the kernel may still touch the buffer), so the caller must keep the
+buffer alive until the `ReplySlot` is set - the same lifetime rule as the
+bufferpool `Backing`.
+
+**Disk lifecycle** (`disks/`): `trait DiskTarget { open(spec, pin) ->
+(Handle, PageChannel) }`, with `UringDiskTarget` in production (runs the disk on
+a pinned storage core) and a mock for tests. `DiskRegistry<T>` is seeded with the
+plan's disjoint NVMe `DiskCpuSlot`s and `reconcile(desired)` closes missing
+paths, opens new ones, and treats any spec drift (kind/numa/size/queue_depth/
+page_size/bypass_admission/skip_recovery_scan) as a remove + add.
+`assign_disk_cpus` keeps survivors on their physical pin (preserving the
+disjoint-CPU invariant and idempotence under churn) and assigns new disks
+NUMA-local-first, then any free slot, then unpinned. `channels_snapshot()` is
+path-sorted for stable hashing; `drain()` clears channels before handles.
+`DiskChannelDirectory` is the Arc'd hot-swap publication surface, and
+`LiveShardLocalStore` is a per-shard view over the live directory that
+re-registers buffers when it observes a swap (`current_or_replay`).
+
+**Stripe keys**: `stripe_key` derives the 32-byte content-addressed key;
+`LENGTH_STRIPE_IDX` and `OriginRef`/`StripeReq` describe the request shape.
+
+### 7.11 `config/` - typed, validated, hot-reloadable TOML
+
+Every level uses `deny_unknown_fields`. On a successful reparse the peer set and
+disk set are swapped in place **without a restart**; backing memory, fabric, and
+the topology plan are only built at startup.
+
+TOML sections (all optional, each falling back to defaults):
+
+- `[fabric]` - `listen_addr` (`"0.0.0.0:0"`), `max_inflight` (1024),
+  `progress_threads` (2), `progress_poll_us` (10).
+- `[storage]` - `bytes_per_shard` (`"128M"`), `backing_kind`
+  (`"hugepage_2mb"` | `"heap"`).
+- `[topology]` - mirrors the `PlanConfig` knobs.
+- `[[peers]]` - `id` (unique `u64`, doubles as both `NodeId` and `PeerId`),
+  `transport` (`"tcp"` | `"rdma"`), `address` (a `host:port` `SocketAddr` for
+  tcp, or a lowercase even-length hex raw libfabric address for rdma),
+  `hca_numa` (optional), and `labels`.
+- `[[disks]]` - `path` (unique), `kind` (`"nvme"` default | `"block"` |
+  `"file"`), `numa` (optional), `queue_depth` (optional), plus `size`,
+  `page_size_bytes`, `bypass_admission`, and `skip_recovery_scan_if_no_meta`
+  (the same four extra fields that disk reconcile treats as drift, see 7.10).
+- frontends/backends specs, plus `p2p` (`local_node_id`, `local_labels`,
+  `fingers_per_node`).
+
+The watcher (`notify`-based) emits `ConfigUpdate`s; main's
+`wait_for_shutdown_with_updates` reconciles peers (remove + add on address/numa
+drift, via a `last_applied` cache) and disks, republishes the channel snapshot
+each update, logs `config gen=N ...`, and sets `SHUTDOWN` if the watcher
+disconnects. Note that frontends are **not** currently hot-reapplied.
+
+## 8. Concurrency Model Summary
+
+| Layer | Threading | Notes |
+|-------|-----------|-------|
+| Shard | One pinned OS thread per `RdmaProgress` worker | Owns `!Send` pool, transport, frontend, RPC handler |
+| Shard loop | Cooperative tick hooks, noop waker | Busy-poll active, sleep 100us idle |
+| Fabric progress | One pinned thread per CQ | Self-driving |
+| Fabric RPC serve | One dedicated OS thread per in-flight request | Synchronous noop-waker drive |
+| Storage engine | One pinned storage core per disk | Reached only via `PageChannel` mpsc |
+| Config watcher | `notify` thread + main loop | Reconciles peers/disks live |
+
+Cross-thread hand-offs are explicit: shard-to-disk via `PageChannel`, peer pulls
+via fabric RPC, and shard readiness/shutdown via channels and the `SHUTDOWN`
+atomic.
+
+## 9. Conventions
+
+- Every `.rs` file (source and test) begins with exactly:
+  ```rust
+  // Copyright (c) Microsoft Corporation.
+  // Licensed under the MIT License.
+  ```
+- No em-dashes anywhere (use an ASCII hyphen or rephrase).
+- Default `rustfmt`/`clippy` (no `clippy.toml`/`rustfmt.toml`).
+- Subsystem layout: private submodules behind a `mod.rs` that re-exports a
+  curated public surface.
+
+## 10. Testing
+
+Four complementary layers:
+
+1. **Inline unit tests** - `#[cfg(test)] mod tests {}` at the bottom of the file
+   that defines the construct.
+2. **Module integration tests** - `src/<area>/tests.rs`, gated behind
+   `#[cfg(test)] mod tests;`, driven by a hand-rolled noop-waker `block_on`
+   (spin bound `< 1_000_000`; no async runtime, because the crate is
+   runtime-agnostic).
+3. **Deterministic Simulation Testing (DST)** - under `tests/`, driven by
+   `proptest`. The framework (`tests/framework/executor.rs`) uses a seeded
+   `ChaCha8Rng`, a thread-local `SimState`, a random ready-queue pick per step,
+   a step budget for liveness, and a `Deadlock` error. Public surface:
+   `Executor`, `SimState`, `RunError`, `with_sim`, `yield_once`, `yield_n`. Each
+   area gets a plugin directory `tests/<area>/` with `mod.rs`, `mocks.rs` (all
+   randomness via `with_sim`, I/O latency via `yield_n`, a per-area `*SimCfg`
+   behind an `Rc`), `workload.rs` (`Workload`, `workload_strategy()`,
+   `run_workload`), an optional `oracle.rs`, and `tests.rs` (a single
+   `proptest!` with `ProptestConfig { cases: 256 }` and many small
+   `assert_<invariant>` functions). `tests.proptest-regressions` files are
+   committed. `tests/dst.rs` declares the area modules. Current DST areas:
+   `bufferpool`, `fabric`, `p2p`, `page_channel`, and `storage` (the last with
+   `oracle.rs` and `recovery.rs`).
+4. **End-to-end smoke test** - `hack/smoke-storage.py` runs two real binaries on
+   loopback over real libfabric tcp, with file-backed disks, HTTP frontends, and
+   a stub origin, exercising a cross-node fabric RPC fetch. It needs `sudo` (to
+   pin io_uring buffers and raise `RLIMIT_MEMLOCK`) and runs in CI
+   (`.github/workflows/smoke-storage.yaml`). Run it after any change to the
+   fabric layer, `shim.c`, the FFI, the `main.rs` wiring, or the libfabric
+   version.

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -53,6 +53,24 @@ type ShardPool = Pool<RoutedTransport<StripeReq, HttpBackend>, Arc<LiveShardLoca
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+
+    // Enable the libfabric tcp provider's kernel zero-copy send path
+    // (send(MSG_ZEROCOPY)) so the non-RDMA fallback preserves the same
+    // zero-copy semantics as the verbs RMA path. libfabric reads this
+    // fi_param lazily at provider init (first fi_getinfo), which happens
+    // per-shard on the spawned shard threads, so it must be set here while
+    // the process is still single-threaded. 16 KiB sits just above the tcp
+    // message-buffer size and well below the 2 MiB page transfers, so every
+    // bulk fi_write qualifies. Ignored by the verbs provider, and the
+    // provider falls back to a copying send on kernels without TCP
+    // MSG_ZEROCOPY support, so setting it unconditionally is safe.
+    //
+    // SAFETY: no other threads have been spawned yet in `main`, so this
+    // set_var cannot race a concurrent getenv/setenv.
+    unsafe {
+        std::env::set_var("FI_TCP_ZEROCOPY_SIZE", "16384");
+    }
+
     let (config_path, config_explicit) = match cli.config.as_ref() {
         Some(p) => (p.clone(), true),
         None => (PathBuf::from(DEFAULT_CONFIG_PATH), false),

--- a/cmd/unbounded-storage/src/ring/core.rs
+++ b/cmd/unbounded-storage/src/ring/core.rs
@@ -73,6 +73,13 @@ pub(crate) struct RingCore {
     /// Number of live (submitted, not yet reaped) ops. Bounded by
     /// `queue_depth` via the `submit_waiters` back-pressure queue.
     submitted: Cell<u32>,
+    /// High-water mark of `submitted` since the core was created,
+    /// recorded at increment time in [`Self::submit`]. Lets tests
+    /// observe that ops actually went in-flight even when each op
+    /// completes within its own poll - the transient peak is invisible
+    /// to an external sample of `submitted`, which can return to zero
+    /// before it is read.
+    peak_submitted: Cell<u32>,
     /// FIFO of wakers parked because `submitted == queue_depth` at
     /// submit time. Drained one-per-completion in [`Self::progress`].
     submit_waiters: RefCell<Vec<Waker>>,
@@ -200,6 +207,7 @@ impl RingCore {
             slots: RefCell::new(HashMap::new()),
             registered: RefCell::new(Vec::new()),
             submitted: Cell::new(0),
+            peak_submitted: Cell::new(0),
             submit_waiters: RefCell::new(Vec::new()),
             next_user_data: Cell::new(1),
             more_completions: Cell::new(0),
@@ -321,6 +329,9 @@ impl RingCore {
         let slot = Rc::new(Slot::new(expects_more, resource));
         self.slots.borrow_mut().insert(ud, Rc::clone(&slot));
         self.submitted.set(self.submitted.get() + 1);
+        if self.submitted.get() > self.peak_submitted.get() {
+            self.peak_submitted.set(self.submitted.get());
+        }
         // SAFETY: see the contract on the public submit methods.
         let push_res = unsafe {
             let mut ring = self.ring.borrow_mut();
@@ -465,6 +476,14 @@ impl RingCore {
     /// assert the back-pressure bound.
     pub(crate) fn in_flight(&self) -> u32 {
         self.submitted.get()
+    }
+
+    /// High-water mark of in-flight ops since creation. Used by the
+    /// back-pressure tests to confirm ops actually went in-flight
+    /// without racing the per-poll completion that returns `in_flight`
+    /// to zero before an external sample can read it.
+    pub(crate) fn peak_in_flight(&self) -> u32 {
+        self.peak_submitted.get()
     }
 
     /// Configured submission/completion depth.

--- a/cmd/unbounded-storage/src/ring/storage.rs
+++ b/cmd/unbounded-storage/src/ring/storage.rs
@@ -197,6 +197,13 @@ impl StorageRing {
     pub(crate) fn in_flight(&self) -> u32 {
         self.core.in_flight()
     }
+
+    /// High-water mark of in-flight ops since this ring was created.
+    /// Used by the back-pressure tests to confirm ops actually went
+    /// in-flight without racing the per-poll completion path.
+    pub(crate) fn peak_in_flight(&self) -> u32 {
+        self.core.peak_in_flight()
+    }
 }
 
 /// Validate a fixed-I/O CQE `res` against the expected byte count.
@@ -411,7 +418,6 @@ mod tests {
         let mut cx = Context::from_waker(&waker);
         let mut out: Vec<Option<Result<(), Error>>> = (0..futs.len()).map(|_| None).collect();
         let mut spins = 0u32;
-        let mut max_in_flight: u32 = 0;
         loop {
             let mut made_progress = false;
             for (i, fut) in futs.iter_mut().enumerate() {
@@ -422,7 +428,6 @@ mod tests {
                     out[i] = Some(v);
                     made_progress = true;
                 }
-                max_in_flight = max_in_flight.max(ring.in_flight());
                 assert!(
                     ring.in_flight() <= QD,
                     "in_flight={} exceeds queue_depth={QD}",
@@ -430,7 +435,6 @@ mod tests {
                 );
             }
             ring.progress().expect("progress");
-            max_in_flight = max_in_flight.max(ring.in_flight());
             assert!(ring.in_flight() <= QD);
             if out.iter().all(|o| o.is_some()) {
                 break;
@@ -445,7 +449,14 @@ mod tests {
         for r in &out {
             r.as_ref().unwrap().as_ref().expect("write ok");
         }
-        assert!(max_in_flight > 0, "should have had in-flight ops");
-        assert!(max_in_flight <= QD);
+        // The per-poll assertions above prove the ceiling held. The
+        // peak high-water mark is read from the ring rather than sampled
+        // externally: with buffered I/O each write can complete within
+        // its own poll, returning `in_flight` to zero before this loop
+        // ever samples it, so an external sample can legitimately never
+        // observe a non-zero in-flight count.
+        let peak = ring.peak_in_flight();
+        assert!(peak > 0, "should have had in-flight ops");
+        assert!(peak <= QD);
     }
 }

--- a/cmd/unbounded-storage/src/storage/blockdev/uring.rs
+++ b/cmd/unbounded-storage/src/storage/blockdev/uring.rs
@@ -134,6 +134,13 @@ pub struct UringBlockDevice {
     /// against the kernel. Bounded by `queue_depth` via the
     /// `submit_waiters` back-pressure queue.
     submitted: Cell<u32>,
+    /// High-water mark of `submitted` since the device was opened,
+    /// recorded at increment time in [`Self::submit_fixed_io`]. Lets
+    /// callers (and tests) observe that ops actually went in-flight
+    /// even when each op completes within its own poll - the
+    /// transient peak is invisible to an external sample of
+    /// `submitted`, which can return to zero before it is read.
+    peak_submitted: Cell<u32>,
     /// FIFO of wakers parked because `submitted == queue_depth`
     /// at submit time. Drained one-per-completion in `progress`.
     submit_waiters: RefCell<Vec<Waker>>,
@@ -211,6 +218,7 @@ impl UringBlockDevice {
             slot_capacity: MAX_REGISTERED_SLOTS,
             slots: RefCell::new(HashMap::new()),
             submitted: Cell::new(0),
+            peak_submitted: Cell::new(0),
             submit_waiters: RefCell::new(Vec::new()),
             next_user_data: Cell::new(1),
             page_size: cfg.page_size,
@@ -308,6 +316,9 @@ impl UringBlockDevice {
         let slot = Rc::new(IoSlot::new());
         self.slots.borrow_mut().insert(user_data, Rc::clone(&slot));
         self.submitted.set(self.submitted.get() + 1);
+        if self.submitted.get() > self.peak_submitted.get() {
+            self.peak_submitted.set(self.submitted.get());
+        }
 
         // SAFETY: SQE references caller-owned buffers within the
         // registered region; the caller keeps them alive until this
@@ -939,7 +950,6 @@ mod tests {
         let mut cx = Context::from_waker(&waker);
         let mut out: Vec<Option<Result<(), Error>>> = (0..futs.len()).map(|_| None).collect();
         let mut spins = 0u32;
-        let mut max_submitted: u32 = 0;
         loop {
             let mut made_progress = false;
             for (i, fut) in futs.iter_mut().enumerate() {
@@ -950,7 +960,6 @@ mod tests {
                     out[i] = Some(v);
                     made_progress = true;
                 }
-                max_submitted = max_submitted.max(dev.submitted.get());
                 assert!(
                     dev.submitted.get() <= QD,
                     "submitted={} exceeds queue_depth={}",
@@ -959,7 +968,6 @@ mod tests {
                 );
             }
             dev.progress().expect("progress");
-            max_submitted = max_submitted.max(dev.submitted.get());
             assert!(dev.submitted.get() <= QD);
             if out.iter().all(|o| o.is_some()) {
                 break;
@@ -974,8 +982,16 @@ mod tests {
         for r in &out {
             r.as_ref().unwrap().as_ref().expect("write ok");
         }
-        assert!(max_submitted > 0, "should have had in-flight ops");
-        assert!(max_submitted <= QD);
+        // The per-poll assertions above prove the ceiling held. The
+        // peak high-water mark is read from the device rather than
+        // sampled externally: with buffered I/O each write can complete
+        // within its own poll (the opportunistic `progress` in
+        // `IoFut::poll` reaps the CQE and decrements `submitted` back to
+        // zero before this loop ever samples it), so an external sample
+        // can legitimately never observe a non-zero in-flight count.
+        let peak = dev.peak_submitted.get();
+        assert!(peak > 0, "should have had in-flight ops");
+        assert!(peak <= QD);
     }
 
     fn unique_path(name: &str) -> PathBuf {


### PR DESCRIPTION
Fixes a test flake, adds ARCHITECTURE.md, and enables zero copy for libfabric's tcp transport.