### PR TITLE
build(lint): enforce wsl_v5 in CI and stop formatting drift

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ run:
 linters:
   enable:
     - goheader
+    - wsl_v5
   disable:
     # Unlikely to ever Enable
     # =======================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,9 @@ unbounded-kube is organized into several directories:
 - `make generate` runs `go generate ./...` to regenerate deepcopy, CRDs, and protobuf for all packages.
 - `make build` compiles all Go packages (`go build ./...`).
 - `make vulncheck` runs `govulncheck` for known vulnerabilities.
-- `make fmt` formats with gofumpt; `make lint` runs golangci-lint; `make test` runs all tests.
-- Locally these chain: `test` -> `lint` -> `fmt`. In CI (`CI=1`), each runs independently.
+- `make fmt` formats Go source (gofumpt + wsl_v5 blank-line rules); `make lint` runs golangci-lint; `make test` runs all tests.
+- `make lint` runs the same checks locally and in CI and does NOT auto-fix. Always run `make fmt` before committing to satisfy the linter (gofumpt and wsl_v5 are enforced by `make lint`/CI); do not hand-format.
+- Locally `test` implies `lint`. In CI (`CI=1`), each runs independently.
 
 ## Coding Standards
 

--- a/Makefile
+++ b/Makefile
@@ -350,20 +350,19 @@ fmt: check-deps ## Format all Go source files (gofumpt + wsl_v5 whitespace)
 	$(GOFMT) -w .
 	$(GOLINT) --fix -E wsl_v5 ./...
 
+# lint runs the same checks locally and in CI and does NOT auto-fix. Run
+# `make fmt` to apply fixes. wsl_v5 is enforced via .golangci.yaml.
+lint: ## Run golangci-lint (matches CI; run `make fmt` to auto-fix)
+	$(GOLINT) ./...
+
 ifdef CI
 # In CI each job is independent; skip chained prerequisites.
-
-lint: ## Run golangci-lint
-	$(GOLINT) ./...
 
 test: machina-manifests net-manifests ## Run all tests with race detector
 	$(GOTEST) -race ./...
 
 else
-# Locally, chain targets for convenience: test -> lint -> fmt -> check-deps.
-
-lint: fmt ## Run golangci-lint (implies fmt)
-	$(GOLINT) ./...
+# Locally, chain test -> lint for convenience.
 
 test: lint machina-manifests net-manifests ## Run all tests (implies lint)
 	$(GOTEST) ./...

--- a/cmd/agent/internal/daemon/daemon.go
+++ b/cmd/agent/internal/daemon/daemon.go
@@ -52,12 +52,15 @@ func (o *runOptions) validate() error {
 	if o == nil {
 		return fmt.Errorf("run options are required")
 	}
+
 	if o.NewClient == nil {
 		o.NewClient = client.NewWithWatch
 	}
+
 	if o.NodeOperator == nil {
 		o.NodeOperator = nspawnNodeOperator{}
 	}
+
 	if o.DaemonCredentialDir == "" {
 		o.DaemonCredentialDir = filepath.Join(goalstates.AgentConfigDir, "daemon-controller")
 	}
@@ -147,6 +150,7 @@ func daemonControllerCredentials(
 	}
 
 	log.Info("daemon controller certificate ready", "credentialDir", runOpts.DaemonCredentialDir)
+
 	providerCtx, stopProvider := context.WithCancel(ctx)
 	go provider.Run(providerCtx)
 

--- a/cmd/machina/machina/controller/daemon_csr_approver.go
+++ b/cmd/machina/machina/controller/daemon_csr_approver.go
@@ -36,6 +36,7 @@ func NewDaemonCSRApprover(
 	kubeClient kubernetes.Interface,
 ) (*daemoncred.CSRApproverReconciler, error) {
 	claims := &daemonCSRClaimChecker{Client: c}
+
 	approver, err := daemoncred.NewCSRApprover(daemoncred.CSRApproverOptions{
 		BootstrapGroup:     bootstrapGroup,
 		DaemonGroup:        daemonGroup,
@@ -60,15 +61,18 @@ func (c *daemonCSRClaimChecker) bootstrapTokenMayClaimNode(
 	}
 
 	secretName := bootstrapSecretPref + tokenID
+
 	var token corev1.Secret
 	if err := c.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: secretName}, &token); err != nil {
 		return false, client.IgnoreNotFound(err)
 	}
+
 	if token.Type != corev1.SecretTypeBootstrapToken {
 		return false, nil
 	}
 
 	siteName := strings.TrimSpace(token.Labels[unboundedv1alpha3.MachineSiteLabelKey])
+
 	isDefaultToken := strings.EqualFold(strings.TrimSpace(token.Labels[defaultBootstrapTokenLabel]), "true")
 	if siteName == "" && !isDefaultToken {
 		return false, nil

--- a/cmd/machina/machina/controller/manager.go
+++ b/cmd/machina/machina/controller/manager.go
@@ -101,6 +101,7 @@ func RunManager(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("create daemon CSR approver controller: %w", err)
 	}
+
 	if err := daemonCSRApprover.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup daemon CSR approver controller: %w", err)
 	}

--- a/cmd/machine-ops-controller/main.go
+++ b/cmd/machine-ops-controller/main.go
@@ -186,6 +186,7 @@ func leaderElectionID(cfg config) string {
 
 func safeNamePart(value string) string {
 	var b strings.Builder
+
 	for _, r := range strings.ToLower(value) {
 		switch {
 		case r >= 'a' && r <= 'z':
@@ -203,11 +204,13 @@ func safeNamePart(value string) string {
 	if prefix == "" {
 		prefix = scopeFallbackName
 	}
+
 	if len(prefix) > 40 {
 		prefix = strings.TrimRight(prefix[:40], "-")
 	}
 
 	sum := sha256.Sum256([]byte(value))
+
 	return fmt.Sprintf("%s-%s", prefix, hex.EncodeToString(sum[:])[:10])
 }
 

--- a/cmd/unbounded-net-node/status_server_test.go
+++ b/cmd/unbounded-net-node/status_server_test.go
@@ -689,6 +689,7 @@ func TestCollectRoutingTableFromKernelManagedInterfaces(t *testing.T) {
 	}
 
 	devices := make(map[string]bool)
+
 	for _, r := range info.Routes {
 		for _, hop := range r.NextHops {
 			devices[hop.Device] = true

--- a/hack/cmd/orcadev/orcadev/bench.go
+++ b/hack/cmd/orcadev/orcadev/bench.go
@@ -216,6 +216,7 @@ func runBench(ctx context.Context, g *globalFlags, o *benchOpts) error {
 	}
 
 	rangeSize := info.Size
+
 	if !o.full {
 		rs, err := parseSize(o.rangeSizeStr)
 		if err != nil {
@@ -244,6 +245,7 @@ func runBench(ctx context.Context, g *globalFlags, o *benchOpts) error {
 		if err != nil {
 			return fmt.Errorf("warmup: %w", err)
 		}
+
 		_ = resp //nolint:wsl // warmup output is intentionally discarded
 	}
 
@@ -253,6 +255,7 @@ func runBench(ctx context.Context, g *globalFlags, o *benchOpts) error {
 
 	finishedAt := time.Now()
 	elapsed := finishedAt.Sub(startedAt)
+
 	gateDuration := gateClosedAt.Sub(startedAt)
 	if gateDuration < 0 {
 		gateDuration = 0
@@ -373,6 +376,7 @@ func (a *benchAcc) record(elapsed time.Duration, n int64, err error, code string
 	}
 
 	a.mu.Lock()
+
 	a.latencies = append(a.latencies, elapsed)
 	if code != "" {
 		if a.errorsByCode == nil {
@@ -543,6 +547,7 @@ func runBenchLoop(
 
 	for i := 0; i < o.concurrency; i++ {
 		wg.Add(1)
+
 		go worker(i)
 	}
 

--- a/hack/cmd/orcadev/orcadev/cache.go
+++ b/hack/cmd/orcadev/orcadev/cache.go
@@ -113,6 +113,7 @@ func runCacheList(ctx context.Context, g *globalFlags, o *cacheListOpts) error {
 	fmt.Printf("%-80s\t%-12s\t%s\n", "PATH", "SIZE", "LAST_MODIFIED")
 
 	var total int64
+
 	for _, ob := range objs {
 		fmt.Printf("%-80s\t%-12s\t%s\n", ob.Path, formatSize(ob.Size), ob.LastModified.UTC().Format("2006-01-02T15:04:05Z"))
 		total += ob.Size
@@ -253,7 +254,9 @@ func runCacheInspect(ctx context.Context, g *globalFlags, o *cacheInspectOpts) e
 	}
 
 	etag := o.etag
+
 	var size int64
+
 	if etag == "" {
 		info, err := oc.Head(ctx, o.key)
 		if err != nil {
@@ -307,6 +310,7 @@ func runCacheInspect(ctx context.Context, g *globalFlags, o *cacheInspectOpts) e
 			fmt.Printf("%-6d\t%-80s\t%-8s\t%s\n", i, path, "ERR", err.Error())
 		default:
 			fmt.Printf("%-6d\t%-80s\t%-8s\t%s\n", i, path, "yes", formatSize(info.Size))
+
 			present++
 			bytes += info.Size
 		}
@@ -515,6 +519,7 @@ const defaultMaxClearChunks = 1024
 // caller can still bound the walk.
 func resolveObjectMetadata(ctx context.Context, oc originClient, key, etag string, chunkSize int64) (string, int64, error) {
 	size := int64(0)
+
 	if etag == "" {
 		info, err := oc.Head(ctx, key)
 		if err != nil {

--- a/hack/cmd/orcadev/orcadev/list.go
+++ b/hack/cmd/orcadev/orcadev/list.go
@@ -56,6 +56,7 @@ func runList(ctx context.Context, g *globalFlags, o *listOpts) error {
 	}
 
 	var total int64
+
 	for _, obj := range objs {
 		fmt.Printf("%-12s\t%s\n", formatSize(obj.Size), obj.Name)
 

--- a/hack/cmd/orcadev/orcadev/port_forward_coverage_test.go
+++ b/hack/cmd/orcadev/orcadev/port_forward_coverage_test.go
@@ -90,7 +90,6 @@ func TestEverySubcommandOpensPortForwards(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Not t.Parallel: swaps package-level seams.
-
 			var called bool
 
 			switch tt.firstBackend {

--- a/hack/cmd/orcadev/orcadev/portforward.go
+++ b/hack/cmd/orcadev/orcadev/portforward.go
@@ -114,6 +114,7 @@ func derivePortForwardSpecs(g *globalFlags) []portForwardSpec {
 		}
 
 		seen[key] = struct{}{}
+
 		specs = append(specs, s)
 	}
 

--- a/hack/cmd/orcadev/orcadev/roundtrip.go
+++ b/hack/cmd/orcadev/orcadev/roundtrip.go
@@ -317,6 +317,7 @@ func fetchOriginAndHash(ctx context.Context, oc originClient, key, rangeSpec str
 	h := hasher()
 
 	var n int64
+
 	if rangeSpec != "" {
 		start, end, err := parseByteRange(rangeSpec, info.Size)
 		if err != nil {
@@ -430,6 +431,7 @@ func fetchAndHash(ctx context.Context, edge *edgeClient, bucket, key, rangeSpec 
 	defer resp.Body.Close() //nolint:errcheck
 
 	h := hasher()
+
 	n, err := io.Copy(h, resp.Body)
 	if err != nil {
 		return "", resp.Status, 0, resp.ETag, fmt.Errorf("read body: %w", err)
@@ -504,6 +506,7 @@ func emitHexDiff(ctx context.Context, oc originClient, edge *edgeClient, key, ra
 	}
 
 	var rcvResp edgeResponse
+
 	if rangeSpec != "" {
 		hd, err := edge.Head(ctx, oc.Bucket(), key)
 		if err != nil {
@@ -607,6 +610,7 @@ func parseByteRange(spec string, size int64) (int64, int64, error) {
 	}
 
 	end := size - 1
+
 	if rightStr != "" {
 		e, err := strconv.ParseInt(rightStr, 10, 64)
 		if err != nil || e < start {
@@ -629,6 +633,7 @@ func formatRate(bytes int64, elapsed time.Duration) string {
 	}
 
 	perSec := float64(bytes) / elapsed.Seconds()
+
 	const (
 		kib = 1024.0
 		mib = 1024 * kib

--- a/hack/cmd/orcadev/orcadev/roundtrip_expect_etag_test.go
+++ b/hack/cmd/orcadev/orcadev/roundtrip_expect_etag_test.go
@@ -67,6 +67,7 @@ func TestFetchAndHashReturnsETag(t *testing.T) {
 	defer server.Close()
 
 	edge := newEdgeClient(server.URL, time.Second)
+
 	hash, status, size, etag, err := fetchAndHash(context.Background(), edge, "bucket", "key", "")
 	if err != nil {
 		t.Fatalf("fetchAndHash() error = %v", err)

--- a/hack/cmd/orcadev/orcadev/roundtrip_output_test.go
+++ b/hack/cmd/orcadev/orcadev/roundtrip_output_test.go
@@ -32,7 +32,6 @@ import (
 // contract in tests rather than only documenting it in comments.
 func TestRunRoundtripWith_OutputFormat(t *testing.T) {
 	// Not t.Parallel: swaps os.Stderr.
-
 	const (
 		bucket = "test-bucket"
 		key    = "test-key"
@@ -107,7 +106,6 @@ func TestRunRoundtripWith_OutputFormat(t *testing.T) {
 // block still prints below it.
 func TestRunRoundtripWith_MismatchMarker(t *testing.T) {
 	// Not t.Parallel: swaps os.Stderr.
-
 	const (
 		bucket   = "test-bucket"
 		key      = "test-key"
@@ -293,6 +291,7 @@ func captureStderr(t *testing.T, fn func()) string {
 
 	go func() {
 		var buf bytes.Buffer
+
 		_, _ = io.Copy(&buf, r)
 		done <- buf.Bytes()
 	}()

--- a/hack/cmd/orcadev/orcadev/scenario.go
+++ b/hack/cmd/orcadev/orcadev/scenario.go
@@ -321,6 +321,7 @@ func runScenarioColdWarmWith(
 
 	// Step 2: ensure cold cache by clearing any chunks for this key.
 	t0 = time.Now()
+
 	clearErr := clearScenarioObject(ctx, g, cs, oc, key, "", o.chunkSize)
 	if err := recordDropCacheStep(res, t0, clearErr); err != nil {
 		return err
@@ -384,6 +385,7 @@ func runScenarioRangeStress(ctx context.Context, g *globalFlags, o *scenarioOpts
 
 	// Step 1: upload with known bytes and a known checksum.
 	t0 := time.Now()
+
 	source, sourceHash, sourceErr := scenarioSourceBuffer(size)
 	if sourceErr != nil {
 		recordStep(res, "upload", t0, sourceErr, map[string]any{"bytes": size})
@@ -431,8 +433,10 @@ func runScenarioRangeStress(ctx context.Context, g *globalFlags, o *scenarioOpts
 
 	step := size / int64(ranges)
 
-	var mismatch bool
-	var rangeErr error
+	var (
+		mismatch bool
+		rangeErr error
+	)
 
 	for i := int64(0); i < int64(ranges); i++ {
 		start := i * step
@@ -446,6 +450,7 @@ func runScenarioRangeStress(ctx context.Context, g *globalFlags, o *scenarioOpts
 		if rerr != nil {
 			mismatch = true
 			rangeErr = rerr
+
 			break
 		}
 

--- a/internal/kube/bootstrap_token.go
+++ b/internal/kube/bootstrap_token.go
@@ -113,6 +113,7 @@ func GetBootstrapTokenForSite(ctx context.Context, kubeCli kubernetes.Interface,
 		if _, ok := secret.Data["token-secret"]; !ok {
 			continue
 		}
+
 		if isExpiredBootstrapToken(secret, time.Now()) {
 			continue
 		}
@@ -145,6 +146,7 @@ func bootstrapTokenExpiration(secret *corev1.Secret) time.Time {
 	if raw == "" {
 		return time.Time{}
 	}
+
 	expiresAt, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
 		return time.Time{}

--- a/internal/machineops/auth.go
+++ b/internal/machineops/auth.go
@@ -46,6 +46,7 @@ func (r *MachineOperationReconciler) resolveOperationAuth(ctx context.Context, m
 	if failure != nil || err != nil {
 		return nil, failure, err
 	}
+
 	if credential == nil {
 		return nil, &authResolutionFailure{
 			Reason:  authReasonNotFound,
@@ -74,6 +75,7 @@ func operationAuthTargetFor(machine *unboundedv1alpha3.Machine) (operationAuthTa
 			Message: fmt.Sprintf("Machine %s is missing site label %q", machine.Name, unboundedv1alpha3.MachineSiteLabelKey),
 		}
 	}
+
 	if target.Provider == "" {
 		return operationAuthTarget{}, &authResolutionFailure{
 			Reason:  authReasonInvalid,
@@ -94,6 +96,7 @@ func (r *MachineOperationReconciler) machineOperationCredentialFor(
 	}
 
 	var match *unboundedv1alpha3.MachineOperationCredential
+
 	for i := range credentials.Items {
 		credential := &credentials.Items[i]
 		if credential.Spec.SiteName != target.SiteName || credential.Spec.Provider != target.Provider {
@@ -186,6 +189,7 @@ func (r *MachineOperationReconciler) credentialSecret(
 	}
 
 	var secret corev1.Secret
+
 	secretKey := client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
 	if err := r.Get(ctx, secretKey, &secret); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/internal/machineops/controller.go
+++ b/internal/machineops/controller.go
@@ -149,6 +149,7 @@ func (r *MachineOperationReconciler) reconcileSupportedOperation(
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
 	if authFailure != nil {
 		return r.failOperation(ctx, op, authFailure.Reason, authFailure.Message)
 	}

--- a/internal/machineops/controller_test.go
+++ b/internal/machineops/controller_test.go
@@ -790,6 +790,7 @@ func (p *recordingProvider) Execute(_ context.Context, request OperationRequest)
 	if request.ReplaceUserData != "" {
 		p.replaceUserData = append(p.replaceUserData, request.ReplaceUserData)
 	}
+
 	if request.Auth != nil {
 		p.authModes = append(p.authModes, request.Auth.Mode)
 		p.authData = append(p.authData, request.Auth.SecretData)

--- a/internal/machineops/providers/azurevm/provider.go
+++ b/internal/machineops/providers/azurevm/provider.go
@@ -170,10 +170,12 @@ func newAzureVMClient(subscriptionID string, auth *machineops.OperationAuth) (az
 		if err != nil {
 			return nil, fmt.Errorf("read Azure external plugin tenantID: %w", err)
 		}
+
 		clientID, err := auth.RequiredSecretValue("clientID")
 		if err != nil {
 			return nil, fmt.Errorf("read Azure external plugin clientID: %w", err)
 		}
+
 		clientSecret, err := auth.RequiredSecretValue("clientSecret")
 		if err != nil {
 			return nil, fmt.Errorf("read Azure external plugin clientSecret: %w", err)

--- a/internal/machineops/providers/azurevm/provider_test.go
+++ b/internal/machineops/providers/azurevm/provider_test.go
@@ -123,6 +123,7 @@ func TestProviderExecutePassesAuthToClientFactory(t *testing.T) {
 		NewClientWithAuth: func(subscriptionID string, gotAuth *machineops.OperationAuth) (azureVMClient, error) {
 			require.Equal(t, "sub", subscriptionID)
 			require.Equal(t, auth, gotAuth)
+
 			return client, nil
 		},
 	}

--- a/internal/machineops/providers/ociinstance/oci_client.go
+++ b/internal/machineops/providers/ociinstance/oci_client.go
@@ -26,18 +26,22 @@ func (p *Provider) newComputeClientForAuth(auth *machineops.OperationAuth) (comp
 		if err != nil {
 			return nil, fmt.Errorf("read OCI external plugin tenancyOCID: %w", err)
 		}
+
 		userOCID, err := auth.RequiredSecretValue("userOCID")
 		if err != nil {
 			return nil, fmt.Errorf("read OCI external plugin userOCID: %w", err)
 		}
+
 		region, err := auth.RequiredSecretValue("region")
 		if err != nil {
 			return nil, fmt.Errorf("read OCI external plugin region: %w", err)
 		}
+
 		fingerprint, err := auth.RequiredSecretValue("fingerprint")
 		if err != nil {
 			return nil, fmt.Errorf("read OCI external plugin fingerprint: %w", err)
 		}
+
 		privateKey, err := auth.RequiredSecretValue("privateKey")
 		if err != nil {
 			return nil, fmt.Errorf("read OCI external plugin privateKey: %w", err)

--- a/internal/metalman/machineops/controller.go
+++ b/internal/metalman/machineops/controller.go
@@ -123,6 +123,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	} else if older != "" {
 		message := fmt.Sprintf("waiting for older host operation %s", older)
+
 		return ctrl.Result{RequeueAfter: r.pollInterval()}, r.updateOperationStatus(ctx, op.Name, func(latest *v1alpha3.MachineOperation) {
 			latest.Status.Phase = v1alpha3.OperationPhasePending
 			latest.Status.Message = message
@@ -134,6 +135,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+
 		if !owned {
 			return ctrl.Result{}, nil
 		}
@@ -177,6 +179,7 @@ func (r *Reconciler) snapshotTargets(ctx context.Context, op *v1alpha3.MachineOp
 	}
 
 	now := r.now()
+
 	targetStatuses := make([]v1alpha3.MachineOperationTargetStatus, 0, len(targets))
 	for _, machine := range targets {
 		targetStatuses = append(targetStatuses, v1alpha3.MachineOperationTargetStatus{
@@ -215,6 +218,7 @@ func (r *Reconciler) resolveTargets(ctx context.Context, op *v1alpha3.MachineOpe
 		if !r.ownsMachine(&machine) {
 			return nil, nil
 		}
+
 		if machine.Spec.Provider != "" || machine.Spec.ProviderID != "" {
 			return nil, nil
 		}
@@ -284,6 +288,7 @@ func (r *Reconciler) advanceTargets(ctx context.Context, op *v1alpha3.MachineOpe
 	for _, target := range op.Status.Targets {
 		if target.Phase == v1alpha3.OperationPhaseInProgress {
 			active++
+
 			selected = append(selected, target)
 		}
 	}
@@ -293,6 +298,7 @@ func (r *Reconciler) advanceTargets(ctx context.Context, op *v1alpha3.MachineOpe
 			if target.Phase != "" && target.Phase != v1alpha3.OperationPhasePending {
 				continue
 			}
+
 			if active >= maxConcurrent {
 				break
 			}
@@ -308,17 +314,22 @@ func (r *Reconciler) advanceTargets(ctx context.Context, op *v1alpha3.MachineOpe
 	}
 
 	changes := make([]targetChange, len(selected))
+
 	var wg sync.WaitGroup
 	for i, target := range selected {
 		wg.Add(1)
+
 		go func(i int, target v1alpha3.MachineOperationTargetStatus) {
 			defer wg.Done()
+
 			changes[i] = r.advanceTarget(ctx, op, target)
 		}(i, target)
 	}
+
 	wg.Wait()
 
 	requeue := r.pollInterval()
+
 	return changes, requeue
 }
 
@@ -493,10 +504,12 @@ func (r *Reconciler) waitForPowerAction(target v1alpha3.MachineOperationTargetSt
 	if target.Stage != stage || target.LastAttemptAt == nil {
 		return targetChange{}, false
 	}
+
 	if now.Sub(target.LastAttemptAt.Time) < r.powerActionTimeout() {
 		target.Message = waitingMessage
 		return targetChange{target: target}, true
 	}
+
 	if target.Attempts >= r.maxAttempts() {
 		return failTarget(target, reasonExecutionFailed, fmt.Sprintf("%s after %d attempts", timeoutMessage, target.Attempts), now), true
 	}
@@ -545,6 +558,7 @@ func computeReplaceTargets(machine *v1alpha3.Machine) *v1alpha3.OperationsStatus
 		specReboot = machine.Spec.Operations.RebootCounter
 		specRepave = machine.Spec.Operations.RepaveCounter
 	}
+
 	if machine.Status.Operations != nil {
 		statusReboot = machine.Status.Operations.RebootCounter
 		statusRepave = machine.Status.Operations.RepaveCounter
@@ -583,10 +597,12 @@ func (r *Reconciler) applyTargetChanges(ctx context.Context, opName string, chan
 
 	return r.updateOperationStatus(ctx, opName, func(latest *v1alpha3.MachineOperation) {
 		byName := map[string]v1alpha3.MachineOperationTargetStatus{}
+
 		for _, change := range changes {
 			if change.aggregateOnly || change.target.MachineRef == "" {
 				continue
 			}
+
 			byName[change.target.MachineRef] = change.target
 		}
 
@@ -606,6 +622,7 @@ func (r *Reconciler) aggregateStatus(op *v1alpha3.MachineOperation) {
 	}
 
 	var complete, failed, inProgress, pending int
+
 	for _, target := range op.Status.Targets {
 		switch target.Phase {
 		case v1alpha3.OperationPhaseComplete:
@@ -624,15 +641,18 @@ func (r *Reconciler) aggregateStatus(op *v1alpha3.MachineOperation) {
 
 	if complete+failed == len(op.Status.Targets) {
 		now := r.now()
+
 		op.Status.CompletedAt = &now
 		if failed > 0 {
 			op.Status.Phase = v1alpha3.OperationPhaseFailed
 			setCompletedCondition(op, metav1.ConditionFalse, "TargetFailed", message)
+
 			return
 		}
 
 		op.Status.Phase = v1alpha3.OperationPhaseComplete
 		setCompletedCondition(op, metav1.ConditionTrue, reasonSucceeded, message)
+
 		return
 	}
 
@@ -650,9 +670,11 @@ func (r *Reconciler) olderActiveOperation(ctx context.Context, op *v1alpha3.Mach
 		if candidate.Name == op.Name || candidate.Status.IsTerminal() || !isHostOperation(candidate.Spec.OperationKind) {
 			continue
 		}
+
 		if !r.operationBelongsToSite(ctx, &candidate) {
 			continue
 		}
+
 		if operationBefore(&candidate, op) {
 			return candidate.Name, nil
 		}
@@ -703,6 +725,7 @@ func (r *Reconciler) reconcileTerminal(ctx context.Context, op *v1alpha3.Machine
 	}
 
 	deadline := op.Status.CompletedAt.Add(time.Duration(*op.Spec.TTLSecondsAfterFinished) * time.Second)
+
 	now := r.now().Time
 	if now.Before(deadline) {
 		return ctrl.Result{RequeueAfter: deadline.Sub(now)}, nil
@@ -730,17 +753,21 @@ func (r *Reconciler) updateOperationStatus(ctx context.Context, name string, mut
 
 func (r *Reconciler) finishOperation(ctx context.Context, name string, phase v1alpha3.OperationPhase, reason, message string) error {
 	now := r.now()
+
 	return r.updateOperationStatus(ctx, name, func(latest *v1alpha3.MachineOperation) {
 		if latest.Status.StartedAt == nil {
 			latest.Status.StartedAt = &now
 		}
+
 		latest.Status.Phase = phase
 		latest.Status.Message = message
 		latest.Status.CompletedAt = &now
+
 		conditionStatus := metav1.ConditionTrue
 		if phase == v1alpha3.OperationPhaseFailed {
 			conditionStatus = metav1.ConditionFalse
 		}
+
 		setCompletedCondition(latest, conditionStatus, reason, message)
 	})
 }

--- a/internal/metalman/machineops/controller_test.go
+++ b/internal/metalman/machineops/controller_test.go
@@ -315,6 +315,7 @@ func (r *recordingPowerClient) ForMachine(_ context.Context, machine *v1alpha3.M
 	if r.states == nil {
 		r.states = map[string]redfish.PowerState{}
 	}
+
 	if _, ok := r.states[machine.Name]; !ok {
 		r.states[machine.Name] = redfish.PowerOn
 	}

--- a/internal/metalman/machineops/redfish_factory.go
+++ b/internal/metalman/machineops/redfish_factory.go
@@ -27,10 +27,12 @@ func (f *RedfishPowerClientFactory) ForMachine(ctx context.Context, machine *v1a
 	}
 
 	rf := machine.Spec.PXE.Redfish
+
 	fingerprint := ""
 	if machine.Status.Redfish != nil {
 		fingerprint = machine.Status.Redfish.CertFingerprint
 	}
+
 	if fingerprint == "" {
 		return nil, fmt.Errorf("machine %s has no Redfish certificate fingerprint", machine.Name)
 	}
@@ -44,6 +46,7 @@ func (f *RedfishPowerClientFactory) ForMachine(ctx context.Context, machine *v1a
 	if !ok {
 		return nil, fmt.Errorf("redfish password secret %s/%s missing key %q", rf.PasswordRef.Namespace, rf.PasswordRef.Name, rf.PasswordRef.Key)
 	}
+
 	password := string(passwordBytes)
 
 	c, err := f.Pool.Get(ctx, rf.URL, fingerprint, rf.Username, password, rf.DeviceID)

--- a/internal/net/healthcheck/session_test.go
+++ b/internal/net/healthcheck/session_test.go
@@ -254,6 +254,7 @@ func TestSessionSendsProbes(t *testing.T) {
 			t.Error("expected at least one packet sent")
 			break
 		}
+
 		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/orca/inttest/s3sdk_test.go
+++ b/internal/orca/inttest/s3sdk_test.go
@@ -224,6 +224,7 @@ func TestS3SDK(t *testing.T) {
 		t.Parallel()
 
 		const n = 100
+
 		out, err := client.GetObject(ctx, &s3.GetObjectInput{
 			Bucket: aws.String(bucket),
 			Key:    aws.String(blob.Key),

--- a/internal/orca/server/server.go
+++ b/internal/orca/server/server.go
@@ -150,6 +150,7 @@ func (h *EdgeHandler) handleGet(w http.ResponseWriter, r *http.Request, bucket, 
 			writeS3Error(w, r, http.StatusRequestedRangeNotSatisfiable, s3ErrInvalidRange,
 				"The requested range is not satisfiable.",
 				withBucketKey(bucket, key))
+
 			return
 		}
 
@@ -178,6 +179,7 @@ func (h *EdgeHandler) handleGet(w http.ResponseWriter, r *http.Request, bucket, 
 			writeS3Error(w, r, http.StatusRequestedRangeNotSatisfiable, s3ErrInvalidRange,
 				"The requested range is not valid for the resource.",
 				withBucketKey(bucket, key))
+
 			return
 		}
 
@@ -190,6 +192,7 @@ func (h *EdgeHandler) handleGet(w http.ResponseWriter, r *http.Request, bucket, 
 		writeS3Error(w, r, http.StatusRequestedRangeNotSatisfiable, s3ErrInvalidRange,
 			"The requested range is not satisfiable.",
 			withBucketKey(bucket, key))
+
 		return
 	}
 

--- a/pkg/agent/daemoncred/approver.go
+++ b/pkg/agent/daemoncred/approver.go
@@ -96,24 +96,31 @@ func NewCSRApprover(opts CSRApproverOptions) (*CSRApprover, error) {
 	if opts.SignerName == "" {
 		opts.SignerName = DefaultControllerCertificateSignerName
 	}
+
 	if opts.DaemonGroup == "" {
 		return nil, fmt.Errorf("daemon group is required")
 	}
+
 	if isReservedDaemonGroup(opts.DaemonGroup) {
 		return nil, fmt.Errorf("daemon group must not use reserved or privileged group name: %s", opts.DaemonGroup)
 	}
+
 	if opts.MaxExpirationSeconds == 0 {
 		opts.MaxExpirationSeconds = defaultMaxExpirationSeconds
 	}
+
 	if opts.MaxExpirationSeconds < 0 {
 		return nil, fmt.Errorf("max expiration seconds must be non-negative")
 	}
+
 	if opts.BootstrapGroup == "" {
 		return nil, fmt.Errorf("bootstrap group is required")
 	}
+
 	if opts.AuthorizeBootstrap == nil {
 		return nil, fmt.Errorf("bootstrap authorization callback is required")
 	}
+
 	if opts.AuthorizeRenewal == nil {
 		return nil, fmt.Errorf("renewal authorization callback is required")
 	}
@@ -125,6 +132,7 @@ func (a *CSRApprover) Evaluate(ctx context.Context, csr *certificatesv1.Certific
 	if csr.Spec.SignerName != a.opts.SignerName {
 		return CSRDecision{Ignore: true}, nil
 	}
+
 	if HasApprovalDecision(csr) || len(csr.Status.Certificate) > 0 {
 		return CSRDecision{AlreadyDecided: true}, nil
 	}
@@ -137,6 +145,7 @@ func (a *CSRApprover) Evaluate(ctx context.Context, csr *certificatesv1.Certific
 
 		return CSRDecision{Ignore: true}, nil
 	}
+
 	if !a.handlesCSR(csr, x509cr) {
 		return CSRDecision{Ignore: true}, nil
 	}
@@ -161,21 +170,27 @@ func (a *CSRApprover) validateCSRShape(
 	if !ok || nodeName == "" {
 		return "", Deny("common name must be %s<nodeName>", SystemNodeUserPrefix), nil
 	}
+
 	if hasUnexpectedSubjectFields(x509cr.Subject) {
 		return "", Deny("subject must contain only common name and organizations"), nil
 	}
+
 	if !equalStringSet(x509cr.Subject.Organization, []string{SystemNodesGroup, a.opts.DaemonGroup}) {
 		return "", Deny("organizations must be exactly %s and %s", SystemNodesGroup, a.opts.DaemonGroup), nil
 	}
+
 	if len(x509cr.DNSNames) > 0 || len(x509cr.EmailAddresses) > 0 || len(x509cr.IPAddresses) > 0 || len(x509cr.URIs) > 0 {
 		return "", Deny("subject alternative names are not allowed"), nil
 	}
+
 	if len(x509cr.Extensions) > 0 || len(x509cr.ExtraExtensions) > 0 {
 		return "", Deny("CSR extensions are not allowed"), nil
 	}
+
 	if err := validateClientAuthUsages(csr.Spec.Usages); err != nil {
 		return "", Deny("invalid usages: %v", err), nil
 	}
+
 	if csr.Spec.ExpirationSeconds != nil && *csr.Spec.ExpirationSeconds > a.opts.MaxExpirationSeconds {
 		return "", Deny("requested expiration %d exceeds maximum %d", *csr.Spec.ExpirationSeconds, a.opts.MaxExpirationSeconds), nil
 	}
@@ -199,6 +214,7 @@ func (a *CSRApprover) evaluateRequester(ctx context.Context, csr *certificatesv1
 	if strings.HasPrefix(csr.Spec.Username, BootstrapUserPrefix) {
 		return a.evaluateBootstrapRequester(ctx, csr, nodeName)
 	}
+
 	if constantTimeEqual(csr.Spec.Username, SystemNodeUserPrefix+nodeName) {
 		return a.evaluateRenewalRequester(ctx, csr, nodeName)
 	}
@@ -216,13 +232,16 @@ func (a *CSRApprover) evaluateBootstrapRequester(ctx context.Context, csr *certi
 			return Deny("bootstrap token requester has forbidden group %q", group), nil
 		}
 	}
+
 	if !slices.Contains(csr.Spec.Groups, a.opts.BootstrapGroup) {
 		return Deny("bootstrap token requester is missing required group %q", a.opts.BootstrapGroup), nil
 	}
+
 	allowed, err := a.opts.AuthorizeBootstrap(ctx, csr, nodeName)
 	if err != nil {
 		return CSRDecision{}, err
 	}
+
 	if !allowed {
 		return Deny("bootstrap token is not allowed to claim node %q", nodeName), nil
 	}
@@ -240,13 +259,16 @@ func (a *CSRApprover) evaluateRenewalRequester(ctx context.Context, csr *certifi
 			return Deny("renewal requester has forbidden group %q", group), nil
 		}
 	}
+
 	if !slices.Contains(csr.Spec.Groups, SystemNodesGroup) || !slices.Contains(csr.Spec.Groups, a.opts.DaemonGroup) {
 		return Deny("renewal requester is missing required node or daemon group"), nil
 	}
+
 	allowed, err := a.opts.AuthorizeRenewal(ctx, csr, nodeName)
 	if err != nil {
 		return CSRDecision{}, err
 	}
+
 	if !allowed {
 		return Deny("node %q is not bound to a Machine", nodeName), nil
 	}
@@ -296,14 +318,17 @@ func validateClientAuthUsages(usages []certificatesv1.KeyUsage) error {
 		certificatesv1.UsageClientAuth:       true,
 	}
 	seenClientAuth := false
+
 	for _, usage := range usages {
 		if !allowed[usage] {
 			return fmt.Errorf("unsupported usage %q", usage)
 		}
+
 		if usage == certificatesv1.UsageClientAuth {
 			seenClientAuth = true
 		}
 	}
+
 	if !seenClientAuth {
 		return fmt.Errorf("missing %q", certificatesv1.UsageClientAuth)
 	}
@@ -326,10 +351,13 @@ func equalStringSet(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
+
 	aa := append([]string(nil), a...)
 	bb := append([]string(nil), b...)
+
 	sort.Strings(aa)
 	sort.Strings(bb)
+
 	for i := range aa {
 		if aa[i] != bb[i] {
 			return false

--- a/pkg/agent/daemoncred/credentials.go
+++ b/pkg/agent/daemoncred/credentials.go
@@ -75,42 +75,55 @@ func (o *ControllerCertificateOptions) validate() error {
 	if o == nil {
 		return fmt.Errorf("controller certificate options are required")
 	}
+
 	if o.SignerName == "" {
 		o.SignerName = DefaultControllerCertificateSignerName
 	}
+
 	if o.Name == "" {
 		return fmt.Errorf("certificate manager name is required")
 	}
+
 	if o.DaemonGroup == "" {
 		return fmt.Errorf("daemon group is required")
 	}
+
 	if isReservedDaemonGroup(o.DaemonGroup) {
 		return fmt.Errorf("daemon group must not use reserved or privileged group name: %s", o.DaemonGroup)
 	}
+
 	if o.WaitTimeout == 0 {
 		o.WaitTimeout = defaultControllerCertificateWaitTimeout
 	}
+
 	if o.WaitPoll == 0 {
 		o.WaitPoll = defaultControllerCertificateWaitPoll
 	}
+
 	if o.ExpirationDuration == 0 {
 		o.ExpirationDuration = defaultControllerCertificateExpirationDuration
 	}
+
 	if o.ReloadPeriod == 0 {
 		o.ReloadPeriod = defaultControllerCertificateReloadPeriod
 	}
+
 	if o.CredentialDir == "" {
 		return fmt.Errorf("credential directory is required")
 	}
+
 	if o.WaitTimeout < 0 {
 		return fmt.Errorf("wait timeout must be non-negative")
 	}
+
 	if o.WaitPoll <= 0 {
 		return fmt.Errorf("wait poll must be positive")
 	}
+
 	if o.ExpirationDuration <= 0 {
 		return fmt.Errorf("expiration duration must be positive")
 	}
+
 	if o.ReloadPeriod <= 0 {
 		return fmt.Errorf("reload period must be positive")
 	}
@@ -149,12 +162,15 @@ func NewRESTConfigProvider(
 	if err := opts.validate(); err != nil {
 		return nil, err
 	}
+
 	provider, err := newRESTConfigProvider(base, nodeName, opts)
 	if err != nil {
 		return nil, err
 	}
+
 	if provider.manager.Current() == nil {
 		provider.start()
+
 		if err := wait.PollUntilContextTimeout(ctx, opts.WaitPoll, opts.WaitTimeout, true, func(context.Context) (bool, error) {
 			return provider.manager.Current() != nil, nil
 		}); err != nil {
@@ -175,12 +191,15 @@ func (p *RESTConfigProvider) Run(ctx context.Context) {
 	defer p.manager.Stop()
 
 	var last *tls.Certificate
+
 	wait.UntilWithContext(ctx, func(context.Context) {
 		current := p.manager.Current()
 		if current == nil || current == last {
 			return
 		}
+
 		last = current
+
 		p.closeAll()
 	}, p.reloadPeriod)
 }
@@ -202,6 +221,7 @@ func newRESTConfigProvider(base *rest.Config, nodeName string, opts ControllerCe
 	}
 
 	lifetime := opts.ExpirationDuration
+
 	manager, err := certificate.NewManager(&certificate.Config{
 		ClientsetFn: func(current *tls.Certificate) (kubernetes.Interface, error) {
 			return clientsetForCertificate(base, current)
@@ -267,15 +287,18 @@ func restConfigWithManager(base *rest.Config, manager certificate.Manager) (*res
 	if err != nil {
 		return nil, nil, fmt.Errorf("configure TLS: %w", err)
 	}
+
 	if tlsConfig == nil {
 		tlsConfig = &tls.Config{}
 	}
+
 	tlsConfig.Certificates = nil
 	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 		cert := manager.Current()
 		if cert == nil {
 			return &tls.Certificate{Certificate: nil}, nil
 		}
+
 		return cert, nil
 	}
 
@@ -310,6 +333,7 @@ func clientsetForCertificate(base *rest.Config, current *tls.Certificate) (kuber
 	if err != nil {
 		return nil, err
 	}
+
 	keyPEM, err := encodePrivateKey(current.PrivateKey)
 	if err != nil {
 		return nil, err

--- a/pkg/agent/daemoncred/credentials_test.go
+++ b/pkg/agent/daemoncred/credentials_test.go
@@ -35,6 +35,7 @@ func TestNewRESTConfigProviderUsesStoredCertificate(t *testing.T) {
 
 	provider, err := NewRESTConfigProvider(context.Background(), base, "node-a", opts)
 	require.NoError(t, err)
+
 	cfg := provider.RESTConfig()
 	assert.Equal(t, base.Host, cfg.Host)
 	assert.Empty(t, cfg.BearerToken)

--- a/pkg/agent/daemoncred/reconciler.go
+++ b/pkg/agent/daemoncred/reconciler.go
@@ -48,9 +48,11 @@ func NewCSRApproverReconciler(
 	if c == nil {
 		return nil, fmt.Errorf("client is required")
 	}
+
 	if kubeClient == nil {
 		return nil, fmt.Errorf("kubernetes client is required")
 	}
+
 	if approver == nil {
 		return nil, fmt.Errorf("approver is required")
 	}
@@ -74,12 +76,14 @@ func (r *CSRApproverReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("evaluate CSR %s: %w", csr.Name, err)
 	}
+
 	if decision.Ignore || decision.AlreadyDecided {
 		return ctrl.Result{}, nil
 	}
 
 	conditionType := certificatesv1.CertificateApproved
 	reason := approvalReasonApproved
+
 	if !decision.Approve {
 		conditionType = certificatesv1.CertificateDenied
 		reason = approvalReasonDenied


### PR DESCRIPTION
Fixes #159.

## Problem

`wsl_v5` had a `settings` block in `.golangci.yaml` but was never listed in `linters.enable`. In golangci-lint v2 that means it is **not** run by `golangci-lint run` (the CI gate), so CI never enforced it. The linter was only ever applied by the `fmt` target via `--fix -E wsl_v5`.

Result: formatting drift. PRs that skipped `make fmt` (e.g. agent-authored ones) merged with un-wsl'd code and CI passed; later a `make fmt` produced a large surprise diff. A second, aggravating factor: local `make lint` *depended on* `fmt`, so it silently auto-fixed instead of failing, hiding the drift from developers too.

## Fix

- **`.golangci.yaml`**: add `wsl_v5` to `linters.enable` so CI `golangci-lint run` enforces it and fails PRs with violations.
- **`Makefile`**: `lint` no longer depends on `fmt`. `make lint` now runs the same `golangci-lint run` locally and in CI (reports, does not auto-fix); run `make fmt` to apply fixes. Both `ifdef CI` branches of `lint` were identical, so `lint` is lifted out of the split.
- **`AGENTS.md`**: document that `make lint` matches CI and that `make fmt` (gofumpt + wsl_v5) must be run before committing.
- **Repo-wide reformat**: `make fmt` applied across the tree (commit 1, pure formatting, no logic changes).

## Validation

- `make fmt` is idempotent (second run = no diff): no gofumpt/wsl_v5 oscillation.
- `CI=1 make lint` -> `0 issues` on the reformatted tree (gofumpt and wsl_v5 pass simultaneously; wsl_v5 confirmed in the enabled-linters set).
- `go build ./...` green.

## Commits

1. `style: apply gofumpt + wsl_v5 formatting repo-wide` - pure formatting.
2. `build(lint): enforce wsl_v5 in CI; decouple local lint from fmt` - config + Makefile + AGENTS.md.

## Note

The reformat touches many files and will conflict with open PRs; they should rebase and re-run `make fmt`. Scope is intentionally limited to `wsl_v5` per discussion on #159 (other configured-but-disabled linters left as-is).