### PR TITLE
ci: publish orca image on release and on merge to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -397,3 +397,55 @@ jobs:
           cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
           push: false
           provenance: false
+
+  # ---------- Publish Orca image (main only) ----------
+  # Publishes a dev Orca image to ghcr on every merge to main so the
+  # long-lived AKS integration cluster has something to pull. Gated on
+  # the core quality jobs so a broken main is never published. Release
+  # builds (signed + SBOM) are handled separately by release.yaml.
+  # Tags: `:main` (moving) and `:main-<sha>` (immutable, for pinning).
+  publish-orca:
+    name: Publish Orca Image (main)
+    needs: [lint, test, orca-inttest, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Normalize container registry
+        run: echo "REGISTRY=${REGISTRY,,}" >> "$GITHUB_ENV"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: images/orca/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=main-${{ github.sha }}
+            GIT_COMMIT=${{ github.sha }}
+          tags: |
+            ${{ env.REGISTRY }}/orca:main
+            ${{ env.REGISTRY }}/orca:main-${{ github.sha }}
+          cache-from: type=gha,scope=orca
+          cache-to: type=gha,mode=max,scope=orca

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -516,6 +516,10 @@ jobs:
             file: images/metalman/Containerfile
             platforms: linux/amd64,linux/arm64
             trivy: true
+          - name: orca
+            file: images/orca/Containerfile
+            platforms: linux/amd64,linux/arm64
+            trivy: true
           - name: host-ubuntu2404
             file: images/host-ubuntu2404/Containerfile
             platforms: linux/amd64


### PR DESCRIPTION
## Problem

Orca has no published container image. CI never builds/pushes it (the only tags are local build artifacts), so a cluster - notably the planned long-lived AKS integration environment - has nothing to pull (`ghcr.io/azure/orca:*` does not exist). This is the first blocker for running Orca on a integration cluster.

## Change

Two publish paths, both reusing the repo's existing image-publishing conventions:

### Release (`release.yaml`)
Add `orca` to the existing `component-images` matrix. On release it is now built, **trivy-scanned**, pushed as `ghcr.io/<owner>/orca:<version>` + `:latest`, **cosign-signed**, and **SBOM-attested** - identical treatment to machina/metalman.

### Merge to main (`ci.yaml`)
New `publish-orca` job:
- Runs **only** on `push` to `main` (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`) - never on PRs/forks.
- **Gated** on `needs: [lint, test, orca-inttest, build]` so a broken main is never published.
- Job-level `packages: write`.
- Builds **multi-arch** (amd64+arm64) and pushes:
  - `ghcr.io/<owner>/orca:main` (moving, "current main")
  - `ghcr.io/<owner>/orca:main-<sha>` (immutable, for deterministic AKS pin/rollback)
- **Lean**: no cosign/SBOM (reserved for releases), consistent with the fact that no component publishes dev images on main today.

All action versions are copied from the existing pinned SHAs in these workflows; `actionlint` passes.

## Operational follow-up (not in this PR)

The first push **creates** the ghcr `orca` package as **private**. Before an AKS cluster can pull `ghcr.io/azure/orca:main-<sha>` without a pull secret, an org admin must set the package visibility to **public** (one-time), or the deploy must use a ghcr image pull secret. This feeds the registry/visibility step of the broader AKS-integration plan.

## Validation

- `actionlint` clean on both workflows (`needs` targets resolve, expressions valid).
- YAML parses; diffs limited to the matrix entry + the new gated job.