### PR TITLE
unbounded-storage: async runtime improvements

### DIFF
--- a/cmd/unbounded-storage/ARCHITECTURE.md
+++ b/cmd/unbounded-storage/ARCHITECTURE.md
@@ -453,7 +453,7 @@ generic over the runtime and not boxed (no `dyn BlockDevice`), so the engine is
 generic over the device. Implementations: `CoreLocalDevice` (resolves its
 `StorageRing` from the thread-local registry and returns `ENXIO` if driven off
 its storage core), `MockDevice` (with `MockFaultMode` for fault injection),
-`ScratchPool`/`ScratchPage`, and the Linux `UringBlockDevice`/`UringDevice`
+`ScratchPool`/`ScratchPage`, and the Linux `UringDevice` open path
 (`OpenDisk`, `provision_file`).
 
 **Cross-core bridge** (`page_channel.rs`): a `StorageEngine<CoreLocalDevice>` is

--- a/cmd/unbounded-storage/src/backend/http.rs
+++ b/cmd/unbounded-storage/src/backend/http.rs
@@ -1166,7 +1166,10 @@ mod tests {
         write_slice_into_pages(&[10u8, 20, 30], &dsts, 0, base, page_size).unwrap();
         write_slice_into_pages(&[40u8, 50, 60, 70], &dsts, 3, base, page_size).unwrap();
         assert_eq!(&backing[page_size..page_size + 4], &[10, 20, 30, 40]);
-        assert_eq!(&backing[2 * page_size + 8..2 * page_size + 11], &[50, 60, 70]);
+        assert_eq!(
+            &backing[2 * page_size + 8..2 * page_size + 11],
+            &[50, 60, 70]
+        );
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/backend/mod.rs
+++ b/cmd/unbounded-storage/src/backend/mod.rs
@@ -82,23 +82,47 @@ impl<T: Backend + ?Sized> Backend for Arc<T> {
     }
 }
 
+/// Bridge a pool's [`RecvQuarantineHandle`] onto a shard's
+/// [`NetworkRing`], so a cancelled fixed-buffer RECV withholds its
+/// destination bufferpool page from reuse until the kernel is done with
+/// it (its RECV CQE is reaped). Install once per shard, before serving
+/// begins, on the ring whose `recv_fixed` destinations are pool pages
+/// (the shard socket ring). Rings writing into non-pool memory (e.g. a
+/// worker-local scratch backing) are left without a sink and fall back
+/// to the blocking-but-sound drain on drop.
+pub fn install_recv_quarantine(
+    ring: &crate::ring::NetworkRing,
+    handle: crate::bufferpool::RecvQuarantineHandle,
+) {
+    use std::rc::Rc;
+
+    /// Adapter implementing the ring's `RecvQuarantine` in terms of the
+    /// bufferpool free-list handle. Both are keyed by byte offset into
+    /// the registered backing, so this is a thin forward.
+    struct PoolRecvQuarantine(crate::bufferpool::RecvQuarantineHandle);
+
+    impl crate::ring::RecvQuarantine for PoolRecvQuarantine {
+        fn quarantine(&self, page_byte_offset: usize) {
+            self.0.quarantine(page_byte_offset);
+        }
+
+        fn reclaim(&self, page_byte_offset: usize) {
+            self.0.reclaim(page_byte_offset);
+        }
+    }
+
+    ring.set_recv_quarantine(Rc::new(PoolRecvQuarantine(handle)));
+}
+
 #[cfg(test)]
 mod tests {
     use std::pin::Pin;
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{Context, Poll};
 
     use crate::bufferpool::{BulkRef, Error, PageRef, PageStream, Req, StripeKey};
+    use crate::runtime::noop_waker;
 
     use super::Backend;
-
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        // SAFETY: VTABLE clone/wake/drop are all no-ops on static data.
-        unsafe { Waker::from_raw(raw()) }
-    }
 
     /// Drive a future to completion on a single thread using a noop
     /// waker, with a generous spin bound that fails loudly rather

--- a/cmd/unbounded-storage/src/backend/null.rs
+++ b/cmd/unbounded-storage/src/backend/null.rs
@@ -75,9 +75,8 @@ impl PageStream for NullStream {
 
 #[cfg(test)]
 mod tests {
-    use std::task::{RawWaker, RawWakerVTable, Waker};
-
     use crate::bufferpool::{BulkRef, StripeKey};
+    use crate::runtime::noop_waker;
 
     use super::*;
 
@@ -87,15 +86,6 @@ mod tests {
         fn key(&self) -> StripeKey {
             self.0
         }
-    }
-
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        // SAFETY: VTABLE clone/wake/drop are all no-ops on static data.
-        unsafe { Waker::from_raw(raw()) }
     }
 
     fn block_on<F: std::future::Future>(fut: F) -> F::Output {

--- a/cmd/unbounded-storage/src/backend/origin_ring.rs
+++ b/cmd/unbounded-storage/src/backend/origin_ring.rs
@@ -93,10 +93,7 @@ thread_local! {
     static WORKER_RING: RefCell<Option<Rc<RefCell<NetworkRing>>>> = const { RefCell::new(None) };
 }
 
-fn worker_local_handle(
-    queue_depth: u32,
-    region: Option<FixedRegion>,
-) -> io::Result<NetHandle> {
+fn worker_local_handle(queue_depth: u32, region: Option<FixedRegion>) -> io::Result<NetHandle> {
     WORKER_RING.with(|cell| {
         if let Some(ring) = cell.borrow().as_ref() {
             return Ok(NetHandle::new(Rc::clone(ring)));

--- a/cmd/unbounded-storage/src/backend/s3.rs
+++ b/cmd/unbounded-storage/src/backend/s3.rs
@@ -784,7 +784,10 @@ mod tests {
     fn absolute_range_offsets_into_stripe() {
         assert_eq!(absolute_range(0, 4 * 1024 * 1024, 0, 4096), (0, 4096));
         let stripe = 4 * 1024 * 1024u64;
-        assert_eq!(absolute_range(3, stripe, 8192, 4096), (3 * stripe + 8192, 4096));
+        assert_eq!(
+            absolute_range(3, stripe, 8192, 4096),
+            (3 * stripe + 8192, 4096)
+        );
     }
 
     #[test]
@@ -966,7 +969,10 @@ mod tests {
         write_slice_into_pages(&[10u8, 20, 30], &dsts, 0, base, page_size).unwrap();
         write_slice_into_pages(&[40u8, 50, 60, 70], &dsts, 3, base, page_size).unwrap();
         assert_eq!(&backing[page_size..page_size + 4], &[10, 20, 30, 40]);
-        assert_eq!(&backing[2 * page_size + 8..2 * page_size + 11], &[50, 60, 70]);
+        assert_eq!(
+            &backing[2 * page_size + 8..2 * page_size + 11],
+            &[50, 60, 70]
+        );
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/bin/bench.rs
+++ b/cmd/unbounded-storage/src/bin/bench.rs
@@ -34,18 +34,20 @@
 //!   to reconfirm closed-loop correctness before trusting any
 //!   throughput numbers.
 //!
-//! Threading model: `UringBlockDevice` is `!Send + !Sync` because the
-//! ring is pinned to the thread that opened it. The design
-//! (`docs design "io_uring"`) calls for N pinned threads per NVMe
-//! drive, where each thread owns its own ring, on a CPU in that
+//! Threading model: the `StorageRing` built by `UringDevice::open` is
+//! `!Send + !Sync` because it is pinned to the thread that opened it.
+//! The design (`docs design "io_uring"`) calls for N pinned threads per
+//! NVMe drive, where each thread owns its own ring, on a CPU in that
 //! drive's NUMA domain. We satisfy that by spawning one OS shard
 //! thread per (device, thread-slot) pair via the crate's
 //! `runtime::PinnedRuntime`, with placement derived from
-//! `topology::Plan`. Each shard owns its own `UringBlockDevice`,
-//! `StorageEngine`, hugepage `Backing`, and a single-engine
-//! `LocalStorage` so the registration and routing paths are exercised;
-//! cross-shard routing is partitioned at the workload generator (each
-//! shard only writes / reads keys hashed to its own global shard idx).
+//! `topology::Plan`. Each storage-core thread installs its own
+//! `StorageRing` into the thread-local registry, then builds a
+//! `CoreLocalDevice` (which resolves that ring), a `StorageEngine`,
+//! hugepage `Backing`, and a single-engine `LocalStorage` so the
+//! registration and routing paths are exercised; cross-shard routing is
+//! partitioned at the workload generator (each shard only writes /
+//! reads keys hashed to its own global shard idx).
 //!
 //! When the host's sysfs topology cannot be discovered or a `--device`
 //! path cannot be mapped onto a topology NVMe controller, the bench
@@ -55,6 +57,7 @@
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::ExitCode;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
@@ -65,8 +68,13 @@ use rand_chacha::ChaCha20Rng;
 
 use unbounded_storage::bufferpool::{BlockStore, PageRef, StripeKey};
 use unbounded_storage::memory::{BackingKind, BackingRequest, HUGEPAGE_2MB, allocate};
-use unbounded_storage::runtime::{DefaultRuntime, PinnedRuntime, Threading, WorkerIdx, WorkerSpec};
-use unbounded_storage::storage::blockdev::{BlockDevice, UringBlockDevice, UringConfig};
+use unbounded_storage::ring::{
+    StorageRing, StorageRingConfig, clear_current_storage_ring, set_current_storage_ring,
+};
+use unbounded_storage::runtime::{
+    DefaultRuntime, PinnedRuntime, Threading, WorkerIdx, WorkerSpec, noop_waker,
+};
+use unbounded_storage::storage::blockdev::{BlockDevice, CoreLocalDevice, OpenDisk, UringDevice};
 use unbounded_storage::storage::{EngineConfig, LocalStorage, StorageEngine};
 use unbounded_storage::topology::{Host, Nvme, Plan, PlanConfig, Role};
 
@@ -609,28 +617,39 @@ fn run_device_inner(cfgs: &[ShardConfig]) -> Result<(Vec<ShardReport>, Vec<Shard
         );
     }
 
-    let mut uring_cfg = UringConfig {
-        // Device page size is the atomic write unit (4 KiB on
-        // commodity SCSI/NVMe). Cache pages are PAGE_BYTES and
-        // each cache-page write spans `PAGE_BYTES / 4096`
-        // consecutive LBAs.
-        page_size: 4096,
-        ..UringConfig::default()
+    let mut ring_cfg = StorageRingConfig {
+        iopoll: head.iopoll,
+        single_issuer: head.single_issuer,
+        defer_taskrun: head.defer_taskrun,
+        ..StorageRingConfig::default()
     };
-    uring_cfg.iopoll = head.iopoll;
-    uring_cfg.single_issuer = head.single_issuer;
-    uring_cfg.defer_taskrun = head.defer_taskrun;
-    uring_cfg.o_direct = head.o_direct;
     if let Some(qd) = head.queue_depth {
         if qd == 0 {
             return Err("--queue-depth must be >= 1".into());
         }
-        uring_cfg.queue_depth = qd;
+        ring_cfg.queue_depth = qd;
     }
-    let device = Arc::new(
-        UringBlockDevice::open(&head.device_path, uring_cfg)
-            .map_err(|e| format!("UringBlockDevice::open: {e:?}"))?,
-    );
+    // Device page size is the atomic write unit (4 KiB on commodity
+    // SCSI/NVMe). Cache pages are PAGE_BYTES and each cache-page write
+    // spans `PAGE_BYTES / 4096` consecutive LBAs. `o_direct` is passed
+    // independently of `iopoll` (production NVMe sets both).
+    let OpenDisk {
+        device,
+        ring,
+        // Held for this storage core's lifetime: the ring addresses
+        // this fd by its registered Fixed index, so it must outlive the
+        // ring. Dropped last (after the ring) at end of scope.
+        file: _disk_file,
+    } = UringDevice::open(&head.device_path, ring_cfg, head.o_direct, 4096)
+        .map_err(|e| format!("UringDevice::open: {e}"))?;
+    let ring = Rc::new(ring);
+    let device = Arc::new(device);
+
+    // Install the ring so this thread's `CoreLocalDevice`, engine, and
+    // engine-open I/O resolve it from the thread-local registry. MUST
+    // run before `register_buffers` and `StorageEngine::open`, both of
+    // which issue ring ops on this thread.
+    set_current_storage_ring(ring.clone());
 
     // One PAGE_BYTES slot per worker across every shard on this
     // device, packed into a single page-aligned region. All shards
@@ -656,11 +675,13 @@ fn run_device_inner(cfgs: &[ShardConfig]) -> Result<(Vec<ShardReport>, Vec<Shard
     );
 
     // Register the backing region with the io_uring ring before
-    // opening the engine: `BTreeIndex::open` issues meta writes
-    // through the device, and `READ_FIXED` / `WRITE_FIXED` need a
-    // registered buffer. The later `local.register_pages` call is
-    // tolerant of a duplicate `register_buffers` (it ignores the
-    // -EBUSY) and still installs the bufferpool binding.
+    // opening the engine. `BTreeIndex::open` issues meta writes through
+    // the engine's own scratch pool (registered during open), but
+    // registering the backing up front means the bufferpool's pages are
+    // ready for `READ_FIXED` / `WRITE_FIXED` the moment the phases run.
+    // `local.register_pages` later re-registers this same region; the
+    // ring's buffer table accumulates entries and `resolve_buf_index`
+    // matches the first containing region, so the duplicate is harmless.
     device
         .register_buffers(backing_base, backing_bytes)
         .map_err(|e| format!("device.register_buffers: {e:?}"))?;
@@ -677,17 +698,17 @@ fn run_device_inner(cfgs: &[ShardConfig]) -> Result<(Vec<ShardReport>, Vec<Shard
         skip_recovery_scan_if_no_meta: head.skip_recovery_scan_if_no_meta,
         ..Default::default()
     };
-    let engine = Arc::new(
-        block_on(StorageEngine::open(device.clone(), engine_cfg))
-            .map_err(|e| format!("StorageEngine::open: {e:?}"))?,
-    );
+    let engine = Arc::new(open_engine_on_ring(
+        &ring,
+        StorageEngine::open(device.clone(), engine_cfg),
+    )?);
 
     // Build a single-engine LocalStorage that every shard on this
-    // device shares. Engines owning a `UringBlockDevice` are
-    // `!Send`, which forces one OS thread per device; sharing the
-    // engine across the `threads_per_device` logical shards on
-    // that thread is what makes the multi-shard configuration
-    // correct (single allocator + btree per LBA space).
+    // device shares. The `CoreLocalDevice` is `Send`, but the ring it
+    // resolves is pinned to this thread, which forces one OS thread per
+    // device; sharing the engine across the `threads_per_device`
+    // logical shards on that thread is what makes the multi-shard
+    // configuration correct (single allocator + btree per LBA space).
     let local = Arc::new(LocalStorage::new(vec![engine.clone()]));
     local
         .register_pages(&backing)
@@ -712,6 +733,10 @@ fn run_device_inner(cfgs: &[ShardConfig]) -> Result<(Vec<ShardReport>, Vec<Shard
         drop(engine);
         drop(device);
         drop(backing);
+        // Release the thread-local ring before `ring` (and then
+        // `_disk_file`) drop at scope end: the ring unregisters the file
+        // fd, so it must drop before the `File` closes it.
+        clear_current_storage_ring();
         return Ok((report, Vec::new()));
     }
 
@@ -798,6 +823,10 @@ fn run_device_inner(cfgs: &[ShardConfig]) -> Result<(Vec<ShardReport>, Vec<Shard
     drop(engine);
     drop(device);
     drop(backing);
+    // Release the thread-local ring before `ring` (and then
+    // `_disk_file`) drop at scope end: the ring unregisters the file fd,
+    // so it must drop before the `File` closes it.
+    clear_current_storage_ring();
 
     Ok((write_reports, read_reports))
 }
@@ -810,9 +839,9 @@ fn run_device_inner(cfgs: &[ShardConfig]) -> Result<(Vec<ShardReport>, Vec<Shard
 /// existing report-printing code does not have to special-case
 /// verify.
 fn run_verify_device(
-    engine: &Arc<StorageEngine<UringBlockDevice>>,
-    local: &Arc<LocalStorage<UringBlockDevice>>,
-    device: &Arc<UringBlockDevice>,
+    engine: &Arc<StorageEngine<CoreLocalDevice>>,
+    local: &Arc<LocalStorage<CoreLocalDevice>>,
+    device: &Arc<CoreLocalDevice>,
     backing_base: *mut u8,
     cfgs: &[ShardConfig],
     page_offsets: &[usize],
@@ -934,8 +963,8 @@ fn run_verify_device(
 
 #[allow(clippy::too_many_arguments)]
 async fn verify_round_trip(
-    local: Arc<LocalStorage<UringBlockDevice>>,
-    engine: Arc<StorageEngine<UringBlockDevice>>,
+    local: Arc<LocalStorage<CoreLocalDevice>>,
+    engine: Arc<StorageEngine<CoreLocalDevice>>,
     backing_base: *mut u8,
     src_idx: u32,
     dst_idx: u32,
@@ -1080,9 +1109,9 @@ fn run_phase_device(
     phase: Phase,
     cfgs: &[ShardConfig],
     page_offsets: &[usize],
-    engine: Arc<StorageEngine<UringBlockDevice>>,
-    local: Arc<LocalStorage<UringBlockDevice>>,
-    device: Arc<UringBlockDevice>,
+    engine: Arc<StorageEngine<CoreLocalDevice>>,
+    local: Arc<LocalStorage<CoreLocalDevice>>,
+    device: Arc<CoreLocalDevice>,
     page_size: usize,
     seed_keys: Option<Vec<Vec<Vec<StripeKey>>>>,
     backing_base: *mut u8,
@@ -1274,7 +1303,7 @@ impl WorkerState {
 #[allow(clippy::too_many_arguments)]
 async fn write_worker(
     state: Arc<Mutex<WorkerState>>,
-    local: Arc<LocalStorage<UringBlockDevice>>,
+    local: Arc<LocalStorage<CoreLocalDevice>>,
     phase_done: Arc<AtomicBool>,
     total_ops: Arc<AtomicU64>,
     phase_start: Instant,
@@ -1383,7 +1412,7 @@ async fn write_worker(
 
 async fn read_worker(
     state: Arc<Mutex<WorkerState>>,
-    local: Arc<LocalStorage<UringBlockDevice>>,
+    local: Arc<LocalStorage<CoreLocalDevice>>,
     phase_done: Arc<AtomicBool>,
     total_ops: Arc<AtomicU64>,
     phase_start: Instant,
@@ -1648,20 +1677,17 @@ fn install_signal_handler() {
     }
 }
 
-fn noop_waker() -> std::task::Waker {
-    use std::task::{RawWaker, RawWakerVTable, Waker};
-    fn raw() -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VTABLE)
-    }
-    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-    // SAFETY: VTABLE clone/wake/drop are all no-ops referencing static data.
-    unsafe { Waker::from_raw(raw()) }
-}
-
-/// Drive a future to completion on a single thread using a noop
-/// waker. Used for one-shot `StorageEngine::open` futures during
-/// shard bring-up.
-fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+/// Drive a one-shot `StorageEngine::open` future to completion on this
+/// storage core, pumping `ring.progress()` between polls so the btree's
+/// open-time meta I/O (issued through the installed thread-local ring)
+/// actually reaps. Mirrors the production bring-up loop in
+/// `disks::uring::run_storage_core`. The ring must already be installed
+/// via `set_current_storage_ring` so the engine's `CoreLocalDevice`
+/// resolves it.
+fn open_engine_on_ring<E: std::fmt::Debug>(
+    ring: &StorageRing,
+    fut: impl std::future::Future<Output = Result<StorageEngine<CoreLocalDevice>, E>>,
+) -> Result<StorageEngine<CoreLocalDevice>, String> {
     use std::pin::pin;
     use std::task::{Context, Poll};
     let w = noop_waker();
@@ -1670,11 +1696,13 @@ fn block_on<F: std::future::Future>(fut: F) -> F::Output {
     let mut spins: u64 = 0;
     loop {
         match fut.as_mut().poll(&mut cx) {
-            Poll::Ready(v) => return v,
+            Poll::Ready(r) => return r.map_err(|e| format!("StorageEngine::open: {e:?}")),
             Poll::Pending => {
+                ring.progress()
+                    .map_err(|e| format!("ring progress during open: {e:?}"))?;
                 spins += 1;
                 if spins > 100_000_000 {
-                    panic!("block_on stuck");
+                    panic!("open_engine_on_ring stuck");
                 }
             }
         }

--- a/cmd/unbounded-storage/src/bufferpool/free_list.rs
+++ b/cmd/unbounded-storage/src/bufferpool/free_list.rs
@@ -19,9 +19,10 @@
 //! underlying [`RefCell`] is sufficient; no atomics are required.
 
 use std::cell::RefCell;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
 
 pub(super) struct FreeList {
@@ -35,7 +36,23 @@ struct Inner {
     /// Pages handed off to a specific waiter, awaiting its next poll.
     /// Reserved here so speculation cannot reclaim them.
     granted: Vec<(u64, u32)>,
+    /// Pages withheld from reuse because a fixed-buffer RECV writing
+    /// into them was cancelled while still in flight. A quarantined
+    /// page returns to circulation only once BOTH the kernel has
+    /// finished with it (`kernel_done`, set when its RECV CQE is reaped)
+    /// AND the owner has handed it back (`owner_released`, set by the
+    /// normal [`FreeList::release`]). Until then it appears neither in
+    /// `free` nor `granted`, so no allocation can hand the page out
+    /// while the kernel may still write into it. This makes cancelling
+    /// a fixed RECV sound without blocking the dropping task.
+    quarantined: HashMap<u32, QState>,
     next_id: u64,
+}
+
+#[derive(Default)]
+struct QState {
+    kernel_done: bool,
+    owner_released: bool,
 }
 
 struct Waiter {
@@ -72,6 +89,7 @@ impl FreeList {
                 free,
                 waiters: VecDeque::new(),
                 granted: Vec::new(),
+                quarantined: HashMap::new(),
                 next_id: 0,
             }),
         }
@@ -126,8 +144,78 @@ impl FreeList {
 
     /// Return `page_idx` to the pool, handing it directly to the
     /// oldest waiter if one is parked.
+    ///
+    /// If the page is in recv-quarantine (its destination was withheld
+    /// by [`FreeList::quarantine_recv`] because an in-flight RECV into
+    /// it was cancelled), this only marks the owner side done. The page
+    /// is handed back to circulation here only if the kernel has also
+    /// already finished with it; otherwise it stays withheld until
+    /// [`FreeList::reclaim_recv`] observes the RECV CQE.
     pub fn release(&self, page_idx: u32) {
-        let waker = self.inner.borrow_mut().hand_off(page_idx);
+        let waker = {
+            let mut g = self.inner.borrow_mut();
+            // `Some(kernel_done)` if quarantined, `None` if not.
+            let quarantined = match g.quarantined.get_mut(&page_idx) {
+                Some(st) => {
+                    st.owner_released = true;
+                    Some(st.kernel_done)
+                }
+                None => None,
+            };
+            match quarantined {
+                None => g.hand_off(page_idx),
+                Some(false) => None,
+                Some(true) => {
+                    g.quarantined.remove(&page_idx);
+                    g.hand_off(page_idx)
+                }
+            }
+        };
+        if let Some(w) = waker {
+            w.wake();
+        }
+    }
+
+    /// Withhold `page_idx` from reuse until its in-flight fixed-buffer
+    /// RECV CQE is reaped. Called when such a RECV is cancelled on early
+    /// drop while still owning `page_idx`: the kernel may still complete
+    /// the RECV into the page after the dropping task returns, so the
+    /// page must not be reused yet. Pairs with [`FreeList::reclaim_recv`]
+    /// (kernel side) and the owner's [`FreeList::release`]; the page
+    /// returns to circulation only once both have fired.
+    pub fn quarantine_recv(&self, page_idx: u32) {
+        let mut g = self.inner.borrow_mut();
+        let st = g.quarantined.entry(page_idx).or_default();
+        debug_assert!(
+            !st.kernel_done && !st.owner_released,
+            "page {page_idx} quarantined while already in quarantine",
+        );
+    }
+
+    /// Mark the kernel finished with a quarantined `page_idx` (its RECV
+    /// CQE has been reaped). If the owner has already released the page
+    /// it returns to circulation now (handed to the oldest waiter if one
+    /// is parked); otherwise it waits for the owner's
+    /// [`FreeList::release`]. A no-op if the page is not quarantined.
+    pub fn reclaim_recv(&self, page_idx: u32) {
+        let waker = {
+            let mut g = self.inner.borrow_mut();
+            // `Some(owner_released)` if quarantined, `None` if not.
+            let owner_released = match g.quarantined.get_mut(&page_idx) {
+                Some(st) => {
+                    st.kernel_done = true;
+                    Some(st.owner_released)
+                }
+                None => None,
+            };
+            match owner_released {
+                Some(true) => {
+                    g.quarantined.remove(&page_idx);
+                    g.hand_off(page_idx)
+                }
+                _ => None,
+            }
+        };
         if let Some(w) = waker {
             w.wake();
         }
@@ -136,6 +224,40 @@ impl FreeList {
     #[allow(dead_code)]
     pub fn available(&self) -> usize {
         self.inner.borrow().free.len()
+    }
+}
+
+/// Public, non-generic handle to a shard pool's free list, exposing
+/// only the recv-quarantine operations keyed by byte offset into the
+/// registered backing.
+///
+/// It is handed to the ring layer (via a backend adapter implementing
+/// `ring::RecvQuarantine`) so a cancelled fixed-buffer RECV can withhold
+/// its destination page until the kernel is done with it, without the
+/// ring needing to know the pool's generic parameters or page geometry.
+#[derive(Clone)]
+pub struct RecvQuarantineHandle {
+    free: Rc<FreeList>,
+    page_size: usize,
+}
+
+impl RecvQuarantineHandle {
+    pub(super) fn new(free: Rc<FreeList>, page_size: usize) -> Self {
+        Self { free, page_size }
+    }
+
+    /// Withhold the page containing `page_byte_offset` from reuse until
+    /// its RECV CQE is reaped. See [`FreeList::quarantine_recv`].
+    pub fn quarantine(&self, page_byte_offset: usize) {
+        self.free
+            .quarantine_recv((page_byte_offset / self.page_size) as u32);
+    }
+
+    /// Mark the kernel finished with the page containing
+    /// `page_byte_offset`. See [`FreeList::reclaim_recv`].
+    pub fn reclaim(&self, page_byte_offset: usize) {
+        self.free
+            .reclaim_recv((page_byte_offset / self.page_size) as u32);
     }
 }
 

--- a/cmd/unbounded-storage/src/bufferpool/mod.rs
+++ b/cmd/unbounded-storage/src/bufferpool/mod.rs
@@ -14,6 +14,7 @@ mod window;
 #[cfg(test)]
 mod tests;
 
+pub use free_list::RecvQuarantineHandle;
 pub use group::{PoolGroup, ShardDescriptor, ShardRouter};
 pub use null::NullBlockStore;
 pub use pool::Pool;

--- a/cmd/unbounded-storage/src/bufferpool/null.rs
+++ b/cmd/unbounded-storage/src/bufferpool/null.rs
@@ -53,18 +53,10 @@ impl BlockStore for NullBlockStore {
 mod tests {
     use std::future::Future;
     use std::pin::pin;
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{Context, Poll};
 
     use super::*;
-
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        // SAFETY: vtable never dereferences the data pointer.
-        unsafe { Waker::from_raw(raw()) }
-    }
+    use crate::runtime::noop_waker;
 
     fn block_on<F: Future>(f: F) -> F::Output {
         let waker = noop_waker();

--- a/cmd/unbounded-storage/src/bufferpool/pool.rs
+++ b/cmd/unbounded-storage/src/bufferpool/pool.rs
@@ -9,10 +9,10 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use crate::bufferpool::free_list::FreeList;
+use crate::bufferpool::free_list::{FreeList, RecvQuarantineHandle};
 use crate::bufferpool::inflight::{PageSlot, SlotState, StripeFetch};
 use crate::bufferpool::stream::{LocalBoxFuture, ReadStream, StaticBoxFuture, StreamSrc};
-use crate::bufferpool::traits::{BlockStore, BufferPool, PageStream, Req, Transport};
+use crate::bufferpool::traits::{BlockStore, BufferPool, Req, Transport};
 use crate::bufferpool::types::{BulkRef, Error, PageRef, PoolConfig, StripeKey};
 use crate::bufferpool::window::WindowedRead;
 use crate::memory::Backing;
@@ -39,7 +39,7 @@ where
     pub(super) cfg: PoolConfig,
     pub(super) backing: Backing,
     pub(super) page_size: usize,
-    pub(super) free: FreeList,
+    pub(super) free: Rc<FreeList>,
     pub(super) inflight: RefCell<HashMap<StripeKey, Rc<RefCell<StripeFetch>>>>,
     pub(super) stream_count: Cell<usize>,
     /// Global speculative-prefetch budget shared by every
@@ -96,7 +96,7 @@ where
             cfg,
             backing,
             page_size,
-            free: FreeList::new(page_count_u32),
+            free: Rc::new(FreeList::new(page_count_u32)),
             inflight: RefCell::new(HashMap::new()),
             stream_count: Cell::new(0),
             inflight_prefetch_pages: Cell::new(0),
@@ -111,6 +111,16 @@ where
     /// out-of-tree DST harness under `tests/`.
     pub fn free_pages(&self) -> usize {
         self.inner.free.available()
+    }
+
+    /// Build a [`RecvQuarantineHandle`] over this pool's free list, for
+    /// installing on the shard's `NetworkRing` (see
+    /// `backend::install_recv_quarantine`). It lets a cancelled
+    /// fixed-buffer RECV withhold its destination page from reuse until
+    /// the kernel is done writing into it, keeping cancellation sound
+    /// without blocking the dropping task.
+    pub fn recv_quarantine_handle(&self) -> RecvQuarantineHandle {
+        RecvQuarantineHandle::new(self.inner.free.clone(), self.inner.page_size)
     }
 
     /// Test-only accessor for the inflight map size. Also used by
@@ -650,7 +660,6 @@ where
                     free: &inner.free,
                     completed: false,
                 };
-
                 if slot.page_idx.get().is_none() {
                     // Allocate the backing page lazily, here on the
                     // leader's first poll, so a fetch future that is
@@ -706,9 +715,7 @@ where
                             offset: stripe_off,
                             len: inner.page_size as u32,
                         };
-                        let dsts: [PageRef; 1] = [dst];
-                        let stream = inner.transport.bulk_get(req.as_ref(), bulk, &dsts);
-                        drive_single_page(stream).await?;
+                        inner.transport.fetch_one(req.as_ref(), bulk, dst).await?;
                     }
                     Ok(hit)
                 }
@@ -970,38 +977,4 @@ enum Outcome {
     Ready,
     Error(Error),
     Retry,
-}
-
-// ---------------------------------------------------------------------------
-// PageStream -> single-page adapter.
-// ---------------------------------------------------------------------------
-
-/// Drive a transport stream that the pool issued for a single
-/// `dsts: &[PageRef]` of length 1. Resolves `Ok(())` on the first
-/// `Some(Ok(_))`, propagates `Some(Err(_))`, and surfaces a
-/// premature `None` as `Error::Transport`.
-fn drive_single_page<S: PageStream>(stream: S) -> DriveSinglePage<S> {
-    DriveSinglePage { stream }
-}
-
-struct DriveSinglePage<S: PageStream> {
-    stream: S,
-}
-
-impl<S: PageStream> Future for DriveSinglePage<S> {
-    type Output = Result<(), Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // SAFETY: standard structural pin projection through the
-        // single `stream` field; we never move out of `self`.
-        let stream = unsafe { self.map_unchecked_mut(|s| &mut s.stream) };
-        match stream.poll_next(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Some(Ok(_page))) => Poll::Ready(Ok(())),
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Err(e)),
-            Poll::Ready(None) => Poll::Ready(Err(Error::from(
-                "transport stream ended without delivering page",
-            ))),
-        }
-    }
 }

--- a/cmd/unbounded-storage/src/bufferpool/tests.rs
+++ b/cmd/unbounded-storage/src/bufferpool/tests.rs
@@ -11,26 +11,18 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::{Pin, pin};
 use std::rc::Rc;
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll};
 
 use crate::bufferpool::{
     BlockStore, BufferPool, BulkRef, Error, PageRef, PageStream, Pool, PoolConfig, Req, StripeKey,
     Transport,
 };
 use crate::memory::Backing;
+use crate::runtime::noop_waker;
 
 // ---------------------------------------------------------------------------
 // Tiny single-thread executor.
 // ---------------------------------------------------------------------------
-
-fn noop_waker() -> Waker {
-    fn raw() -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VTABLE)
-    }
-    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-    // SAFETY: the vtable functions never dereference the data pointer.
-    unsafe { Waker::from_raw(raw()) }
-}
 
 fn block_on<F: Future>(future: F) -> F::Output {
     let waker = noop_waker();

--- a/cmd/unbounded-storage/src/bufferpool/traits.rs
+++ b/cmd/unbounded-storage/src/bufferpool/traits.rs
@@ -3,6 +3,7 @@
 
 #![allow(async_fn_in_trait)]
 
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -50,6 +51,52 @@ pub trait Transport<R: Req> {
     /// transport to `Pool::new`). The `Pool` calls only this
     /// method at runtime.
     fn bulk_get<'a>(&'a self, req: &'a R, src: BulkRef, dsts: &'a [PageRef]) -> Self::Stream<'a>;
+
+    /// Fetch exactly one page from a peer into `dst`, collapsing the
+    /// single-page `bulk_get` stream into a flat async completion.
+    ///
+    /// This is the single-page consumer surface that is symmetric
+    /// with [`BlockStore::read_page`]: both deliver one page into a
+    /// `PageRef` via a flat `async fn`, so the buffer pool can drive
+    /// a local-disk read and a remote fetch through identical shapes
+    /// with no stream adapter at the call site. Multi-page consumers
+    /// (server handlers, object-range backends) keep using
+    /// [`Transport::bulk_get`] directly.
+    ///
+    /// Resolves `Ok(())` on the first delivered page, propagates a
+    /// stream error, and surfaces a premature end-of-stream as an
+    /// `Error`.
+    async fn fetch_one(&self, req: &R, src: BulkRef, dst: PageRef) -> Result<(), Error> {
+        let dsts = [dst];
+        DriveSinglePage {
+            stream: self.bulk_get(req, src, &dsts),
+        }
+        .await
+    }
+}
+
+/// Adapter that drives a single-page `bulk_get` stream to its first
+/// delivered page. Used by [`Transport::fetch_one`].
+struct DriveSinglePage<S: PageStream> {
+    stream: S,
+}
+
+impl<S: PageStream> Future for DriveSinglePage<S> {
+    type Output = Result<(), Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: standard structural pin projection through the
+        // single `stream` field; we never move out of `self`.
+        let stream = unsafe { self.map_unchecked_mut(|s| &mut s.stream) };
+        match stream.poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(Ok(_page))) => Poll::Ready(Ok(())),
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Err(e)),
+            Poll::Ready(None) => Poll::Ready(Err(Error::from(
+                "transport stream ended without delivering page",
+            ))),
+        }
+    }
 }
 
 impl<R: Req, T: Transport<R> + ?Sized> Transport<R> for Arc<T> {

--- a/cmd/unbounded-storage/src/config/load.rs
+++ b/cmd/unbounded-storage/src/config/load.rs
@@ -337,8 +337,8 @@ fn is_valid_even_hex(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::schema::BackendKind;
+    use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
 

--- a/cmd/unbounded-storage/src/config/schema.rs
+++ b/cmd/unbounded-storage/src/config/schema.rs
@@ -40,7 +40,13 @@ impl Default for Config {
 pub struct FabricCfg {
     pub listen_addr: String,
     pub max_inflight: usize,
+    /// Size of the RPC server's persistent worker-thread pool. This
+    /// bounds concurrent server-side request handling regardless of
+    /// arrival rate; see `fabric::FabricConfig::rpc_worker_threads`.
+    pub rpc_worker_threads: usize,
     pub progress_threads: u8,
+    /// Microseconds the progress thread sleeps when the CQ is empty,
+    /// to bound idle CPU. Default is 10.
     pub progress_poll_us: u32,
 }
 
@@ -49,6 +55,7 @@ impl Default for FabricCfg {
         Self {
             listen_addr: "0.0.0.0:0".to_string(),
             max_inflight: 1024,
+            rpc_worker_threads: 4,
             progress_threads: 2,
             progress_poll_us: 10,
         }
@@ -363,6 +370,7 @@ mod tests {
         let c: Config = toml::from_str("").unwrap();
         assert_eq!(c.fabric.listen_addr, "0.0.0.0:0");
         assert_eq!(c.fabric.max_inflight, 1024);
+        assert_eq!(c.fabric.rpc_worker_threads, 4);
         assert_eq!(c.fabric.progress_threads, 2);
         assert_eq!(c.fabric.progress_poll_us, 10);
         assert_eq!(c.storage.bytes_per_shard.bytes(), 128 * 1024 * 1024);

--- a/cmd/unbounded-storage/src/fabric/completion.rs
+++ b/cmd/unbounded-storage/src/fabric/completion.rs
@@ -280,21 +280,50 @@ impl CompletionRegistry {
     }
 }
 
+/// Collapse a libfabric completion outcome to the shared boundary
+/// type. `Cq` errors keep their numeric detail; the remaining
+/// `FabricError` variants have no numeric boundary form and render to
+/// [`crate::io::IoError::Other`]. Backend-specific detail (the full
+/// `CompletionInfo` with tag/src_addr) stays available to callers that
+/// take the `Result<CompletionInfo>` directly instead of going through
+/// this collapse.
+impl crate::io::CompletionOutcome for Result<CompletionInfo> {
+    fn into_io_result(self) -> crate::io::IoResult {
+        match self {
+            Ok(info) => Ok(crate::io::Completed { bytes: info.bytes }),
+            Err(FabricError::Cq { prov_errno, err }) => {
+                Err(crate::io::IoError::Provider { prov_errno, err })
+            }
+            Err(other) => Err(crate::io::IoError::Other(other.to_string())),
+        }
+    }
+}
+
+/// libfabric admits via the registry's capacity check: [`allocate`]
+/// fails once `live == cap`, so the policy is
+/// [`crate::io::BackPressurePolicy::Capacity`]. This impl is the shared
+/// introspection surface; the actual capacity check stays in
+/// [`CompletionRegistry::allocate`].
+///
+/// [`allocate`]: CompletionRegistry::allocate
+impl crate::io::BackPressure for CompletionRegistry {
+    fn capacity(&self) -> usize {
+        self.shared.cap
+    }
+
+    fn in_flight(&self) -> usize {
+        self.live_count()
+    }
+
+    fn policy(&self) -> crate::io::BackPressurePolicy {
+        crate::io::BackPressurePolicy::Capacity
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::task::{RawWaker, RawWakerVTable, Waker};
-
-    fn noop_waker() -> Waker {
-        fn no(_: *const ()) {}
-        fn clone(_: *const ()) -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VT)
-        }
-        static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-        // SAFETY: the vtable's functions never dereference the data
-        // pointer, so a null data pointer is sound.
-        unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VT)) }
-    }
+    use crate::runtime::noop_waker;
 
     #[test]
     fn slot_round_trips_through_raw_context_and_resolves_future() {
@@ -409,5 +438,58 @@ mod tests {
             Poll::Ready(Ok(_)) => {}
             _ => panic!("expected Ready(Ok)"),
         }
+    }
+
+    #[test]
+    fn completion_info_collapses_to_unified_result() {
+        use crate::io::{CompletionOutcome, IoError};
+
+        let ok: Result<CompletionInfo> = Ok(CompletionInfo {
+            flags: 0,
+            bytes: 4096,
+            tag: 7,
+            src_addr: 9,
+            op_context: 0,
+        });
+        match ok.into_io_result() {
+            Ok(c) => assert_eq!(c.bytes, 4096),
+            Err(e) => panic!("expected Ok, got {e}"),
+        }
+
+        let cq: Result<CompletionInfo> = Err(FabricError::Cq {
+            prov_errno: -3,
+            err: -5,
+        });
+        match cq.into_io_result() {
+            Err(IoError::Provider { prov_errno, err }) => {
+                assert_eq!(prov_errno, -3);
+                assert_eq!(err, -5);
+            }
+            other => panic!("expected Provider, got {other:?}"),
+        }
+
+        let other: Result<CompletionInfo> = Err(FabricError::BadConfig("nope"));
+        match other.into_io_result() {
+            Err(IoError::Other(msg)) => assert!(msg.contains("nope")),
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn registry_reports_capacity_backpressure_policy() {
+        use crate::io::{BackPressure, BackPressurePolicy};
+
+        let reg = CompletionRegistry::new(2);
+        assert_eq!(reg.capacity(), 2);
+        assert_eq!(BackPressure::in_flight(&*reg), 0);
+        assert_eq!(reg.available(), 2);
+        assert!(reg.admits());
+        assert_eq!(reg.policy(), BackPressurePolicy::Capacity);
+
+        let (_s0, _f0) = reg.allocate().unwrap();
+        let (_s1, _f1) = reg.allocate().unwrap();
+        assert_eq!(BackPressure::in_flight(&*reg), 2);
+        assert_eq!(reg.available(), 0);
+        assert!(!reg.admits());
     }
 }

--- a/cmd/unbounded-storage/src/fabric/config.rs
+++ b/cmd/unbounded-storage/src/fabric/config.rs
@@ -46,7 +46,15 @@ pub struct FabricConfig {
     /// `max_inflight` so write and ack completions always have registry
     /// slots.
     pub rpc_posted_recvs: usize,
+    /// Number of long-lived worker threads the RPC server spawns to
+    /// serve inbound requests. Each request is enqueued by the progress
+    /// thread and picked up by one of these workers; the pool size
+    /// bounds concurrent server-side request handling (and thus the
+    /// thread count) regardless of arrival rate. Must be `>= 1`.
+    pub rpc_worker_threads: usize,
     pub progress_threads: u8,
+    /// Microseconds the progress thread sleeps when the CQ is empty,
+    /// to bound idle CPU. Default is 10.
     pub progress_poll_us: u32,
     pub runtime: Arc<dyn Threading>,
     pub worker_idx: WorkerIdx,
@@ -63,6 +71,9 @@ impl FabricConfig {
         }
         if self.rpc_posted_recvs == 0 {
             return Err(FabricError::BadConfig("rpc_posted_recvs must be >= 1"));
+        }
+        if self.rpc_worker_threads == 0 {
+            return Err(FabricError::BadConfig("rpc_worker_threads must be >= 1"));
         }
         if self.listen && self.listen_addr.is_none() {
             return Err(FabricError::BadConfig(
@@ -87,6 +98,7 @@ pub fn defaults_for(
         listen_addr: None,
         max_inflight: 4096,
         rpc_posted_recvs: 256,
+        rpc_worker_threads: 4,
         progress_threads: 2,
         progress_poll_us: 10,
         runtime,
@@ -159,6 +171,16 @@ mod tests {
     fn validate_rejects_zero_rpc_posted_recvs() {
         let mut c = defaults_for("eth0", rt(), WorkerIdx(0));
         c.rpc_posted_recvs = 0;
+        match c.validate() {
+            Err(FabricError::BadConfig(_)) => {}
+            other => panic!("expected BadConfig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_zero_rpc_worker_threads() {
+        let mut c = defaults_for("eth0", rt(), WorkerIdx(0));
+        c.rpc_worker_threads = 0;
         match c.validate() {
             Err(FabricError::BadConfig(_)) => {}
             other => panic!("expected BadConfig, got {other:?}"),

--- a/cmd/unbounded-storage/src/fabric/mod.rs
+++ b/cmd/unbounded-storage/src/fabric/mod.rs
@@ -20,6 +20,7 @@ mod ping;
 mod pool_handler;
 mod progress;
 mod rpc;
+mod rpc_queue;
 mod transport;
 mod types;
 

--- a/cmd/unbounded-storage/src/fabric/ping.rs
+++ b/cmd/unbounded-storage/src/fabric/ping.rs
@@ -259,15 +259,9 @@ where
     F: std::future::Future<Output = Result<CompletionInfo>>,
 {
     use std::pin::Pin;
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{Context, Poll};
 
-    fn raw() -> RawWaker {
-        static VT: RawWakerVTable =
-            RawWakerVTable::new(|_| RawWaker::new(ptr::null(), &VT), |_| {}, |_| {}, |_| {});
-        RawWaker::new(ptr::null(), &VT)
-    }
-    // SAFETY: vtable never dereferences the data pointer.
-    let waker = unsafe { Waker::from_raw(raw()) };
+    let waker = crate::runtime::noop_waker();
     let mut cx = Context::from_waker(&waker);
     // SAFETY: we own `fut` by value on the stack.
     let mut fut = unsafe { Pin::new_unchecked(&mut fut) };

--- a/cmd/unbounded-storage/src/fabric/pool_handler.rs
+++ b/cmd/unbounded-storage/src/fabric/pool_handler.rs
@@ -40,7 +40,7 @@
 
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll};
 
 use crate::bufferpool::{BlockStore, BulkRef, PageRef, Req, StripeKey};
 use crate::memory::Backing;
@@ -259,27 +259,16 @@ impl<S: BlockStore + Send + Sync + 'static> Drop for PoolHandlerStream<S> {
 /// [`crate::fabric::rpc`]; the underlying disk I/O makes progress on
 /// its own io_uring threads while this spins.
 fn block_on_local<F: std::future::Future>(fut: F) -> F::Output {
-    fn no(_: *const ()) {}
-    fn clone(_: *const ()) -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VT)
-    }
-    static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-    // SAFETY: the vtable never dereferences the data pointer.
-    let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VT)) };
-    let mut cx = Context::from_waker(&waker);
-    let mut fut = Box::pin(fut);
-    loop {
-        match fut.as_mut().poll(&mut cx) {
-            Poll::Ready(v) => return v,
-            Poll::Pending => std::thread::sleep(std::time::Duration::from_micros(50)),
-        }
-    }
+    crate::runtime::block_on_cooperative(fut, || {
+        std::thread::sleep(std::time::Duration::from_micros(50))
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::bufferpool::Error;
+    use crate::runtime::noop_waker;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// In-memory `BlockStore` mock: holds page bytes keyed by stripe.
@@ -388,13 +377,7 @@ mod tests {
         let mut stream = handler.handle(&req, src, crate::fabric::MAX_HOPS);
         // SAFETY: stream is pinned to this stack frame and not moved.
         let mut stream = unsafe { Pin::new_unchecked(&mut stream) };
-        fn no(_: *const ()) {}
-        fn clone(_: *const ()) -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VT)
-        }
-        static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-        // SAFETY: vtable never dereferences the data pointer.
-        let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VT)) };
+        let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
         let mut out = Vec::new();
         let mut spins = 0u64;
@@ -506,13 +489,7 @@ mod tests {
         let mut held = handler.handle(&req, src, crate::fabric::MAX_HOPS);
         // SAFETY: pinned on stack, not moved.
         let mut held_pin = unsafe { Pin::new_unchecked(&mut held) };
-        fn no(_: *const ()) {}
-        fn clone(_: *const ()) -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VT)
-        }
-        static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-        // SAFETY: vtable never dereferences the data pointer.
-        let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VT)) };
+        let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
         let first = held_pin.as_mut().poll_next(&mut cx);
         assert!(matches!(first, Poll::Ready(Some(Ok(_)))));

--- a/cmd/unbounded-storage/src/fabric/progress.rs
+++ b/cmd/unbounded-storage/src/fabric/progress.rs
@@ -6,6 +6,9 @@
 //! resolves the `CompletionSlot` Box that libfabric handed back as
 //! the op_context. Shutdown is cooperative: the owning [`ProgressThread`]
 //! holds an `AtomicBool` flag that the loop checks each iteration.
+//!
+//! When the CQ is empty the thread sleeps for
+//! `FabricConfig::progress_poll_us` microseconds to bound idle CPU.
 
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
@@ -113,6 +116,7 @@ fn progress_loop(cq: CqPtr, shutdown: Arc<AtomicBool>, errors: Arc<AtomicU64>, p
     let mut srcs: [ffi::fi_addr_t; CQ_BATCH] = [ffi::FI_ADDR_UNSPEC; CQ_BATCH];
     let eagain = unsafe { ffi::ub_fi_eagain() } as isize;
     let eavail = unsafe { ffi::ub_fi_eavail() } as isize;
+    let idle = Duration::from_micros(poll_us as u64);
 
     while !shutdown.load(Ordering::Acquire) {
         // SAFETY: cq is valid for the lifetime of this thread;
@@ -142,13 +146,13 @@ fn progress_loop(cq: CqPtr, shutdown: Arc<AtomicBool>, errors: Arc<AtomicU64>, p
 
         if n == 0 {
             // No completions; brief sleep to bound CPU.
-            std::thread::sleep(Duration::from_micros(poll_us as u64));
+            std::thread::sleep(idle);
             continue;
         }
 
         // n < 0
         if n == -eagain {
-            std::thread::sleep(Duration::from_micros(poll_us as u64));
+            std::thread::sleep(idle);
             continue;
         }
 
@@ -157,11 +161,11 @@ fn progress_loop(cq: CqPtr, shutdown: Arc<AtomicBool>, errors: Arc<AtomicU64>, p
             continue;
         }
 
-        // Unexpected negative return: bump the counter, sleep
-        // briefly, keep going. Tearing the thread down on transient
-        // errors would silently strand all in-flight ops.
+        // Unexpected negative return: bump the counter, sleep briefly,
+        // keep going. Tearing the thread down on transient errors
+        // would silently strand all in-flight ops.
         errors.fetch_add(1, Ordering::Relaxed);
-        std::thread::sleep(Duration::from_micros(poll_us as u64));
+        std::thread::sleep(idle);
     }
 }
 

--- a/cmd/unbounded-storage/src/fabric/rpc.rs
+++ b/cmd/unbounded-storage/src/fabric/rpc.rs
@@ -17,14 +17,19 @@
 //!   `fi_tsend(RESPONSE_END_TAG_BASE | rid)` (success, zero payload)
 //!   or `fi_tsend(ERROR_ACK_TAG_BASE | rid, bincode(ErrorAck))`.
 //!
-//! **Worker model**: each in-flight request is processed by a
-//! dedicated OS thread spawned via the fabric's runtime. The thread
-//! drives the handler stream synchronously, polling it with a
-//! noop-waker; it then submits libfabric ops and blocks on their
-//! `CompletionFuture`s via a spin-poller (mirroring `ping.rs`).
-//! `RpcServerHandle::drop` sets a shutdown flag that workers check
-//! between handler-stream polls; this is the mechanism that drops
-//! mid-stream handlers when the embedder tears the server down.
+//! **Worker model**: a fixed pool of `rpc_worker_threads` long-lived
+//! OS threads is spawned at `start_rpc_server`, each pinned to the
+//! shard's `worker_idx`. The recv-completion handler runs on the
+//! progress thread; it re-posts a fresh recv and enqueues the decoded
+//! request onto a bounded [`JobQueue`](super::rpc_queue::JobQueue)
+//! rather than spawning a thread per request. A pool worker pulls the
+//! job, drives the handler stream to completion, RMA-writes pages, and
+//! blocks on each libfabric completion with a *real* waker that unparks
+//! the worker (see [`park`](super::park)); the progress-thread
+//! completion path resolves the wait immediately. Queue depth is capped
+//! at `max_inflight` (back-pressure); excess requests get a fast
+//! "server overloaded" `ERROR_ACK`. `RpcServerHandle::drop` sets a
+//! shutdown flag, closes the queue, and joins every worker.
 //!
 //! **MR strategy** (per Phase 5a spec, option (a)): we allocate
 //! request-recv buffers per outstanding recv and free them in the
@@ -41,7 +46,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::bufferpool::{BulkRef, Req, StripeKey};
-use crate::runtime::WorkerIdx;
+use crate::runtime::{JoinHandle, park_block_on_until, thread_waker};
 
 use super::backing::MrHandle;
 use super::completion::{CompletionFuture, CompletionInfo, CompletionSlot};
@@ -49,6 +54,7 @@ use super::error::{FabricError, Result as FabResult};
 use super::fabric::{Fabric, FabricInner};
 use super::ffi;
 use super::handler::{Handler, HandlerStream};
+use super::rpc_queue::{Job, JobQueue};
 
 // Reserved tag bases for the RPC protocol. The low 32 bits carry the
 // request id; the high 32 bits select the message class.
@@ -59,6 +65,14 @@ pub const ERROR_ACK_TAG_BASE: u64 = 0xFFFF_FFF6_0000_0000;
 
 const REQ_TAG_IGNORE: u64 = 0x0000_0000_FFFF_FFFF;
 const REQUEST_RECV_BUF_LEN: usize = 64 * 1024;
+
+/// How long a worker parks in a single slice while blocked on a
+/// libfabric completion before re-checking the server shutdown flag.
+/// The completion path still unparks the worker immediately on success;
+/// this only bounds how long a worker waiting on a completion that may
+/// never arrive (peer gone mid-write) lingers after shutdown is
+/// signaled, keeping `RpcServerHandle::drop` responsive.
+const SHUTDOWN_POLL_SLICE: Duration = Duration::from_millis(25);
 
 /// Loop-protection safety net for recursive Chord-finger routing.
 ///
@@ -162,25 +176,47 @@ struct ServerShared {
     /// [`Fabric::start_rpc_server`] to match the bufferpool's actual
     /// page size.
     page_size: usize,
+    /// Bounded queue feeding the persistent worker pool. The recv
+    /// handler (progress thread) pushes decoded requests; workers pop
+    /// and serve them. Closed on shutdown so workers drain and exit.
+    queue: Arc<JobQueue>,
+    /// Set on shutdown. Workers check it between handler-stream polls
+    /// to abandon an in-flight stream with a fast `ERROR_ACK`.
     shutdown: AtomicBool,
+    /// Number of requests currently queued or being served. Bounded by
+    /// `max_inflight` as the server-side back-pressure limit: a recv
+    /// that would exceed it is rejected with a "server overloaded"
+    /// `ERROR_ACK` instead of being enqueued.
     inflight: AtomicU64,
 }
 
 /// Handle returned from `Fabric::start_rpc_server`. Drop signals
-/// shutdown to outstanding workers and waits briefly for them to
-/// observe the flag.
+/// shutdown to the worker pool, closes the job queue, and joins every
+/// worker thread before returning, so no worker outlives the handle.
 pub struct RpcServerHandle {
     shared: Arc<ServerShared>,
+    /// Join handles for the persistent worker pool. Owned here (not in
+    /// `ServerShared`) because joining consumes them.
+    workers: Vec<JoinHandle>,
 }
 
 impl Drop for RpcServerHandle {
     fn drop(&mut self) {
+        // Signal in-flight handlers to bail out, then close the queue so
+        // idle workers wake and any still-queued jobs drain (each sees
+        // the shutdown flag and finishes fast). Unpark every worker so
+        // one blocked inside a completion wait (a fixed `fi_write`/ack to
+        // a slow or dead peer) re-polls, observes the shutdown flag, and
+        // abandons the wait instead of parking out its 10s deadline.
+        // Joining then guarantees every worker has stopped touching the
+        // fabric before it is torn down.
         self.shared.shutdown.store(true, Ordering::Release);
-        let started = std::time::Instant::now();
-        while self.shared.inflight.load(Ordering::Acquire) > 0
-            && started.elapsed() < Duration::from_secs(2)
-        {
-            std::thread::sleep(Duration::from_millis(5));
+        self.shared.queue.close();
+        for worker in &self.workers {
+            worker.thread().unpark();
+        }
+        for worker in self.workers.drain(..) {
+            let _ = worker.join();
         }
     }
 }
@@ -204,15 +240,42 @@ impl Fabric {
             fabric: self.inner_arc(),
             local_mr,
             page_size,
+            queue: Arc::new(JobQueue::new()),
             shutdown: AtomicBool::new(false),
             inflight: AtomicU64::new(0),
         });
+
+        // Spawn the persistent worker pool before posting recvs so a
+        // request that lands immediately has a consumer waiting. Pin to
+        // this shard's worker index (Phase 2: not the hardcoded
+        // `WorkerIdx(0)`) so handler scratch/MR access stays NUMA-local.
+        let runtime = shared.fabric.cfg.runtime.clone();
+        let worker_idx = shared.fabric.cfg.worker_idx;
+        let pool_size = shared.fabric.cfg.rpc_worker_threads.max(1);
+        let mut workers = Vec::with_capacity(pool_size);
+        for _ in 0..pool_size {
+            let queue = shared.queue.clone();
+            workers.push(runtime.spawn_pinned(
+                worker_idx,
+                "fabric-rpc-worker",
+                Box::new(move || worker_loop(&queue)),
+            ));
+        }
+
         let max_inflight = shared.fabric.cfg.max_inflight;
         let posted = posted_request_recvs(shared.fabric.cfg.rpc_posted_recvs, max_inflight);
         for _ in 0..posted {
             post_request_recv::<R, H>(&shared, &handler)?;
         }
-        Ok(RpcServerHandle { shared })
+        Ok(RpcServerHandle { shared, workers })
+    }
+}
+
+/// Body of each persistent pool thread: pull jobs and run them until
+/// the queue is closed and drained.
+fn worker_loop(queue: &JobQueue) {
+    while let Some(job) = queue.pop_blocking() {
+        job();
     }
 }
 
@@ -277,20 +340,38 @@ where
 
         let _ = post_request_recv::<R, H>(&shared_for_handler, &handler_for_handler);
 
-        let shared_for_worker = shared_for_handler.clone();
-        let handler_for_worker = handler_for_handler.clone();
         let src_addr = info.src_addr;
-        shared_for_worker.inflight.fetch_add(1, Ordering::AcqRel);
-        let shared_for_decr = shared_for_worker.clone();
-        let runtime = shared_for_worker.fabric.cfg.runtime.clone();
-        let _h = runtime.spawn_pinned(
-            WorkerIdx(0),
-            "fabric-rpc-worker",
-            Box::new(move || {
-                run_worker::<R, H>(shared_for_worker, handler_for_worker, header, req, src_addr);
-                shared_for_decr.inflight.fetch_sub(1, Ordering::AcqRel);
-            }),
-        );
+        // Back-pressure: bound the number of requests queued or being
+        // served to `max_inflight`. A request over the cap is shed with
+        // a fast "server overloaded" ack instead of being enqueued, so
+        // an overloaded server stops the queue from growing unboundedly.
+        // This runs on the progress thread, so the rejection ack is
+        // fire-and-forget (see `reject_overloaded`).
+        let max_inflight = shared_for_handler.fabric.cfg.max_inflight as u64;
+        let prev = shared_for_handler.inflight.fetch_add(1, Ordering::AcqRel);
+        if prev >= max_inflight {
+            shared_for_handler.inflight.fetch_sub(1, Ordering::AcqRel);
+            let _ = reject_overloaded(&shared_for_handler, src_addr, header.request_id);
+            return;
+        }
+
+        let shared_for_job = shared_for_handler.clone();
+        let handler_for_job = handler_for_handler.clone();
+        let job: Job = Box::new(move || {
+            run_worker::<R, H>(
+                shared_for_job.clone(),
+                handler_for_job,
+                header,
+                req,
+                src_addr,
+            );
+            shared_for_job.inflight.fetch_sub(1, Ordering::AcqRel);
+        });
+        if shared_for_handler.queue.push(job).is_err() {
+            // Queue closed (server shutting down): the job never runs, so
+            // release the in-flight reservation it would have decremented.
+            shared_for_handler.inflight.fetch_sub(1, Ordering::AcqRel);
+        }
     });
     let ctx = slot.into_raw();
     // SAFETY: ep, buf_ptr, ctx all live for the call.
@@ -360,14 +441,19 @@ fn run_worker<R, H>(
     // the duration of run_worker; we never move it.
     let mut stream = unsafe { std::pin::Pin::new_unchecked(&mut stream) };
 
+    // A real parking waker, created once for this request. Production
+    // handler streams drive synchronously and never register it, so the
+    // bounded `park_timeout` below is the safety net that re-polls and
+    // re-checks the shutdown flag; if a handler ever did register and
+    // wake it, the worker would unpark promptly instead.
+    let waker = thread_waker();
+    let mut task_cx = std::task::Context::from_waker(&waker);
     let mut next_idx: u32 = 0;
     loop {
         if shared.shutdown.load(Ordering::Acquire) {
             let _ = send_error_ack(&shared, src_addr, header.request_id, "server shutting down");
             return;
         }
-        let waker = noop_waker();
-        let mut task_cx = std::task::Context::from_waker(&waker);
         match stream.as_mut().poll_next(&mut task_cx) {
             std::task::Poll::Ready(Some(Ok(page))) => {
                 match write_page(&shared, &local_mr, src_addr, &header, next_idx, page) {
@@ -375,12 +461,18 @@ fn run_worker<R, H>(
                         next_idx = next_idx.saturating_add(1);
                     }
                     Err(e) => {
-                        let _ = send_error_ack(
-                            &shared,
-                            src_addr,
-                            header.request_id,
-                            &format!("write_page: {e}"),
-                        );
+                        // A write failure during shutdown is expected
+                        // (the wait was interrupted); skip the ack so we
+                        // do not chain another blocking send while the
+                        // server is tearing down, and just stop.
+                        if !shared.shutdown.load(Ordering::Acquire) {
+                            let _ = send_error_ack(
+                                &shared,
+                                src_addr,
+                                header.request_id,
+                                &format!("write_page: {e}"),
+                            );
+                        }
                         return;
                     }
                 }
@@ -394,7 +486,7 @@ fn run_worker<R, H>(
                 return;
             }
             std::task::Poll::Pending => {
-                std::thread::sleep(Duration::from_millis(5));
+                std::thread::park_timeout(Duration::from_millis(5));
             }
         }
     }
@@ -451,7 +543,7 @@ fn write_page(
             }
             return Err(FabricError::Pkg("fi_write", rc as i32));
         }
-        match block_on(fut, Duration::from_secs(10)) {
+        match block_on(fut, Duration::from_secs(10), &shared.shutdown) {
             Ok(_) => break,
             Err(FabricError::Cq { prov_errno, err })
                 if prov_errno == ffi::ENOTCONN && std::time::Instant::now() < deadline =>
@@ -602,6 +694,27 @@ fn submit_small_send(
     tag: u64,
     payload: &[u8],
 ) -> FabResult<()> {
+    let fut = enqueue_small_send(shared, dest, tag, payload, Duration::from_secs(10))?;
+    wait_for_small_send(fut, Duration::from_secs(10), &shared.shutdown)
+}
+
+/// Submit a small tagged send and return its completion future without
+/// waiting. The send buffer is freed by the slot handler when the send
+/// completes, so dropping the returned future is safe: the completion
+/// still fires on the progress thread and reclaims the buffer.
+///
+/// `submit_backoff` bounds the `-FI_EAGAIN` submit retry. Worker
+/// threads pass a generous budget so a send survives the `tcp` RDM
+/// connection still establishing; the progress thread (overload
+/// rejection) passes `Duration::ZERO` for a single non-blocking attempt
+/// so it never stalls completion progress.
+fn enqueue_small_send(
+    shared: &Arc<ServerShared>,
+    dest: u64,
+    tag: u64,
+    payload: &[u8],
+    submit_backoff: Duration,
+) -> FabResult<CompletionFuture> {
     let inner = &shared.fabric;
     let buf: Box<[u8]> = payload.to_vec().into_boxed_slice();
     let buf_len = buf.len();
@@ -622,9 +735,11 @@ fn submit_small_send(
     // Retry on `-FI_EAGAIN` while the `tcp` RDM connection back to the
     // requester finishes establishing or the transmit queue drains.
     // EAGAIN neither consumes the buffer nor produces a completion, so
-    // the same ctx/buffer are reused across attempts.
+    // the same ctx/buffer are reused across attempts. This is a submit
+    // wait, not a completion wait (nothing would wake a parked thread
+    // here), so it stays a bounded sleep-backoff.
     let rc = {
-        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let deadline = std::time::Instant::now() + submit_backoff;
         loop {
             let rc = unsafe {
                 ffi::ub_fi_tsend(
@@ -651,48 +766,61 @@ fn submit_small_send(
         };
         return Err(FabricError::Pkg("fi_tsend (small)", rc as i32));
     }
-    wait_for_small_send(fut, Duration::from_secs(10))
+    Ok(fut)
 }
 
-fn wait_for_small_send(fut: CompletionFuture, timeout: Duration) -> FabResult<()> {
-    block_on(fut, timeout).map(|_| ())
+/// Shed a request the server is too busy to admit. Runs on the progress
+/// thread (in the recv handler), so it must not block: the ErrorAck is
+/// submitted with a single non-blocking attempt and its completion is
+/// not awaited. Dropping the future is safe (the slot handler frees the
+/// send buffer when the completion is reaped).
+fn reject_overloaded(shared: &Arc<ServerShared>, dest: u64, request_id: u32) -> FabResult<()> {
+    let payload = bincode::serialize(&ErrorAck {
+        message: "server overloaded".to_string(),
+    })
+    .map_err(|_| FabricError::Pkg("bincode(ErrorAck)", 0))?;
+    let _fut = enqueue_small_send(
+        shared,
+        dest,
+        ERROR_ACK_TAG_BASE | (request_id as u64),
+        &payload,
+        Duration::ZERO,
+    )?;
+    Ok(())
 }
 
-fn noop_waker() -> std::task::Waker {
-    use std::task::{RawWaker, RawWakerVTable};
-    fn no(_: *const ()) {}
-    fn clone(_: *const ()) -> RawWaker {
-        RawWaker::new(ptr::null(), &VT)
-    }
-    static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-    // SAFETY: vtable never dereferences the data pointer.
-    unsafe { std::task::Waker::from_raw(RawWaker::new(ptr::null(), &VT)) }
+fn wait_for_small_send(
+    fut: CompletionFuture,
+    timeout: Duration,
+    shutdown: &AtomicBool,
+) -> FabResult<()> {
+    block_on(fut, timeout, shutdown).map(|_| ())
 }
 
-fn block_on(mut fut: CompletionFuture, timeout: Duration) -> FabResult<CompletionInfo> {
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    let waker = noop_waker();
-    let mut cx = Context::from_waker(&waker);
-    let mut fut = unsafe { Pin::new_unchecked(&mut fut) };
-    let started = std::time::Instant::now();
-    loop {
-        match fut.as_mut().poll(&mut cx) {
-            Poll::Ready(v) => return v,
-            Poll::Pending => {
-                if started.elapsed() >= timeout {
-                    return Err(FabricError::Timeout);
-                }
-                std::thread::sleep(Duration::from_millis(1));
-            }
-        }
+/// Block the calling worker thread on a libfabric completion, parking
+/// (not spinning) between polls. The progress-thread completion path
+/// (`CompletionSlot::complete` -> `AtomicWaker::wake`) unparks us, so
+/// the wait resolves as soon as the CQE is reaped. Returns
+/// `FabricError::Timeout` if `timeout` elapses first, or as soon as
+/// `shutdown` is set so a draining server does not block joining a
+/// worker stuck on a completion a dead peer will never deliver.
+fn block_on(
+    fut: CompletionFuture,
+    timeout: Duration,
+    shutdown: &AtomicBool,
+) -> FabResult<CompletionInfo> {
+    match park_block_on_until(fut, timeout, SHUTDOWN_POLL_SLICE, || {
+        shutdown.load(Ordering::Acquire)
+    }) {
+        Some(result) => result,
+        None => Err(FabricError::Timeout),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::noop_waker;
 
     #[test]
     fn posted_request_recvs_clamps_lower_bound_to_one() {
@@ -766,7 +894,7 @@ mod tests {
     fn wait_for_small_send_accepts_completion_success() {
         let fut = completion_future(Ok(completion_info()));
 
-        assert!(wait_for_small_send(fut, Duration::from_secs(1)).is_ok());
+        assert!(wait_for_small_send(fut, Duration::from_secs(1), &AtomicBool::new(false)).is_ok());
     }
 
     #[test]
@@ -776,7 +904,8 @@ mod tests {
             err: -5,
         }));
 
-        let err = wait_for_small_send(fut, Duration::from_secs(1)).unwrap_err();
+        let err =
+            wait_for_small_send(fut, Duration::from_secs(1), &AtomicBool::new(false)).unwrap_err();
 
         match err {
             FabricError::Cq { prov_errno, err } => {
@@ -792,7 +921,21 @@ mod tests {
         let reg = super::super::completion::CompletionRegistry::new(1);
         let (_slot, fut) = reg.allocate().unwrap();
 
-        let err = wait_for_small_send(fut, Duration::ZERO).unwrap_err();
+        let err = wait_for_small_send(fut, Duration::ZERO, &AtomicBool::new(false)).unwrap_err();
+
+        assert!(matches!(err, FabricError::Timeout));
+    }
+
+    #[test]
+    fn wait_for_small_send_abandons_wait_when_shutdown_is_set() {
+        // A never-completing send (slot never reaped) with a long
+        // timeout must still return promptly once shutdown is set, so a
+        // draining server is not blocked joining the worker.
+        let reg = super::super::completion::CompletionRegistry::new(1);
+        let (_slot, fut) = reg.allocate().unwrap();
+        let shutdown = AtomicBool::new(true);
+
+        let err = wait_for_small_send(fut, Duration::from_secs(3600), &shutdown).unwrap_err();
 
         assert!(matches!(err, FabricError::Timeout));
     }

--- a/cmd/unbounded-storage/src/fabric/rpc_queue.rs
+++ b/cmd/unbounded-storage/src/fabric/rpc_queue.rs
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Bounded work queue feeding the RPC server's persistent worker pool.
+//!
+//! The recv-completion handler runs on the fabric progress thread; it
+//! cannot block serving a request without stalling completion
+//! progress. Instead it builds a type-erased [`Job`] and hands it to
+//! this queue, where one of the pool's long-lived worker threads picks
+//! it up. The queue is the only synchronization point between the
+//! progress thread (producer) and the workers (consumers).
+//!
+//! Jobs are erased to `Box<dyn FnOnce() + Send>` so the queue and the
+//! [`RpcServerHandle`](super::rpc::RpcServerHandle) stay free of the
+//! request/handler type parameters; the completion handler captures
+//! those in the closure it pushes.
+//!
+//! Shutdown is cooperative: [`JobQueue::close`] wakes every blocked
+//! worker so an idle pool drains promptly, while already-queued jobs
+//! are still handed out (each observes the server's shutdown flag and
+//! finishes fast) so no enqueued request is silently dropped.
+
+use std::collections::VecDeque;
+use std::sync::{Condvar, Mutex};
+
+/// A unit of work erased of its request/handler types. Running it
+/// serves one RPC request to completion.
+pub(crate) type Job = Box<dyn FnOnce() + Send + 'static>;
+
+/// MPSC job queue with a single `Condvar` for blocking consumers.
+pub(crate) struct JobQueue {
+    inner: Mutex<Inner>,
+    not_empty: Condvar,
+}
+
+struct Inner {
+    jobs: VecDeque<Job>,
+    closed: bool,
+}
+
+impl JobQueue {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                jobs: VecDeque::new(),
+                closed: false,
+            }),
+            not_empty: Condvar::new(),
+        }
+    }
+
+    /// Enqueue `job`. Returns `Err(job)` if the queue is closed so the
+    /// caller can unwind any accounting it did for the rejected work.
+    pub(crate) fn push(&self, job: Job) -> Result<(), Job> {
+        let mut inner = self.inner.lock().expect("job queue poisoned");
+        if inner.closed {
+            return Err(job);
+        }
+        inner.jobs.push_back(job);
+        drop(inner);
+        self.not_empty.notify_one();
+        Ok(())
+    }
+
+    /// Block until a job is available, returning `None` only once the
+    /// queue is both closed and drained. Closing drains in FIFO order
+    /// so queued requests are still served (and can observe shutdown)
+    /// rather than discarded.
+    pub(crate) fn pop_blocking(&self) -> Option<Job> {
+        let mut inner = self.inner.lock().expect("job queue poisoned");
+        loop {
+            if let Some(job) = inner.jobs.pop_front() {
+                return Some(job);
+            }
+            if inner.closed {
+                return None;
+            }
+            inner = self.not_empty.wait(inner).expect("job queue poisoned");
+        }
+    }
+
+    /// Mark the queue closed and wake every blocked worker. Idempotent.
+    pub(crate) fn close(&self) {
+        let mut inner = self.inner.lock().expect("job queue poisoned");
+        inner.closed = true;
+        drop(inner);
+        self.not_empty.notify_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn pop_runs_pushed_job() {
+        let q = JobQueue::new();
+        let ran = Arc::new(AtomicU32::new(0));
+        let r = ran.clone();
+        assert!(
+            q.push(Box::new(move || {
+                r.fetch_add(1, Ordering::SeqCst);
+            }))
+            .is_ok(),
+            "push on open queue"
+        );
+
+        let job = q.pop_blocking().expect("job available");
+        job();
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn push_after_close_is_rejected() {
+        let q = JobQueue::new();
+        q.close();
+        let rejected = q.push(Box::new(|| {}));
+        assert!(rejected.is_err(), "closed queue must reject pushes");
+    }
+
+    #[test]
+    fn close_drains_remaining_then_returns_none() {
+        let q = JobQueue::new();
+        assert!(q.push(Box::new(|| {})).is_ok());
+        assert!(q.push(Box::new(|| {})).is_ok());
+        q.close();
+
+        assert!(q.pop_blocking().is_some(), "first queued job drains");
+        assert!(q.pop_blocking().is_some(), "second queued job drains");
+        assert!(
+            q.pop_blocking().is_none(),
+            "drained closed queue signals exit"
+        );
+    }
+
+    #[test]
+    fn blocked_pop_wakes_on_close() {
+        let q = Arc::new(JobQueue::new());
+        let consumer = q.clone();
+        let handle = std::thread::spawn(move || consumer.pop_blocking().is_none());
+
+        // Give the consumer time to block on the condvar, then close.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        q.close();
+
+        assert!(
+            handle.join().expect("consumer thread"),
+            "a blocked consumer must wake with None when the queue closes"
+        );
+    }
+
+    #[test]
+    fn producer_consumer_drains_every_job() {
+        const N: u32 = 1000;
+        let q = Arc::new(JobQueue::new());
+        let ran = Arc::new(AtomicU32::new(0));
+
+        let consumer_q = q.clone();
+        let consumer_ran = ran.clone();
+        let handle = std::thread::spawn(move || {
+            while let Some(job) = consumer_q.pop_blocking() {
+                job();
+            }
+            consumer_ran.load(Ordering::SeqCst)
+        });
+
+        for _ in 0..N {
+            let r = ran.clone();
+            assert!(
+                q.push(Box::new(move || {
+                    r.fetch_add(1, Ordering::SeqCst);
+                }))
+                .is_ok(),
+                "push on open queue"
+            );
+        }
+        q.close();
+
+        let observed = handle.join().expect("consumer thread");
+        assert_eq!(
+            observed, N,
+            "every pushed job must run before the consumer exits"
+        );
+    }
+}

--- a/cmd/unbounded-storage/src/fabric/tests.rs
+++ b/cmd/unbounded-storage/src/fabric/tests.rs
@@ -407,16 +407,9 @@ fn drain_stream<'a, S: PageStream + ?Sized>(
     mut stream: std::pin::Pin<&mut S>,
     timeout: Duration,
 ) -> Vec<Result<PageRef, crate::bufferpool::Error>> {
-    use std::ptr;
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{Context, Poll};
 
-    fn no(_: *const ()) {}
-    fn clone(_: *const ()) -> RawWaker {
-        RawWaker::new(ptr::null(), &VT)
-    }
-    static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-    // SAFETY: vtable never deref's the data pointer.
-    let waker = unsafe { Waker::from_raw(RawWaker::new(ptr::null(), &VT)) };
+    let waker = crate::runtime::noop_waker();
     let mut cx = Context::from_waker(&waker);
 
     let started = std::time::Instant::now();
@@ -668,15 +661,8 @@ fn rpc_mid_stream_cancellation() {
         // explicitly to trigger the client-side cancellation path.
         let mut s = unsafe { std::pin::Pin::new_unchecked(&mut stream) };
         // Poll until we observe the first PAGE_ACK or hit a timeout.
-        use std::ptr;
-        use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
-        fn no(_: *const ()) {}
-        fn clone(_: *const ()) -> RawWaker {
-            RawWaker::new(ptr::null(), &VT)
-        }
-        static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-        // SAFETY: vtable never derefs the data pointer.
-        let waker = unsafe { Waker::from_raw(RawWaker::new(ptr::null(), &VT)) };
+        use std::task::{Context, Poll};
+        let waker = crate::runtime::noop_waker();
         let mut cx = Context::from_waker(&waker);
         let started = std::time::Instant::now();
         let mut got_first = false;

--- a/cmd/unbounded-storage/src/fabric/transport.rs
+++ b/cmd/unbounded-storage/src/fabric/transport.rs
@@ -816,8 +816,8 @@ fn remove_recv_context(ctxs: &mut Vec<*mut std::ffi::c_void>, completed: usize) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::noop_waker;
     use serde::ser::Serializer;
-    use std::task::{RawWaker, RawWakerVTable};
 
     struct NoRoute;
 
@@ -936,16 +936,6 @@ mod tests {
                 payload: Vec::new(),
             }),
         });
-    }
-
-    fn noop_waker() -> std::task::Waker {
-        fn no(_: *const ()) {}
-        fn clone(_: *const ()) -> RawWaker {
-            RawWaker::new(ptr::null(), &VT)
-        }
-        static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-        // SAFETY: vtable never dereferences the data pointer.
-        unsafe { std::task::Waker::from_raw(RawWaker::new(ptr::null(), &VT)) }
     }
 
     fn poll_once<R>(

--- a/cmd/unbounded-storage/src/fabric/transport.rs
+++ b/cmd/unbounded-storage/src/fabric/transport.rs
@@ -85,17 +85,19 @@ pub struct FabricTransport<R, P> {
     fabric: Arc<Fabric>,
     mr: MrHandle,
     router: P,
+    page_size: usize,
     next_request_id: AtomicU32,
     _marker: PhantomData<fn() -> R>,
 }
 
 impl<R, P> FabricTransport<R, P> {
     /// Build a transport bound to `fabric` with destination MR `mr`.
-    /// `page_size` must divide `mr.len`; it is used only as a
-    /// construction-time sanity check that the caller's MR geometry
-    /// matches the pool's. The server-side wire planner still derives
-    /// page geometry from a crate-level constant - see the TODO in
-    /// `fabric/rpc.rs::plan_page_write`.
+    /// `page_size` must divide `mr.len`. It is the page geometry the
+    /// pool and the server-side wire planner share: the server
+    /// addresses each destination page as `dest_mr_base + ordinal *
+    /// page_size`, and the originating client uses `page_size` to shift
+    /// `dest_mr_base` to the caller's physical slot (see
+    /// `bulk_get_with_ttl`).
     pub fn new(fabric: Arc<Fabric>, mr: MrHandle, router: P, page_size: usize) -> FabResult<Self> {
         if page_size == 0 {
             return Err(FabricError::BadConfig("page_size must be > 0"));
@@ -109,6 +111,7 @@ impl<R, P> FabricTransport<R, P> {
             fabric,
             mr,
             router,
+            page_size,
             next_request_id: AtomicU32::new(1),
             _marker: PhantomData,
         })
@@ -141,6 +144,16 @@ where
     /// entry point delegates here with [`crate::fabric::MAX_HOPS`];
     /// the recursive-forwarding handler uses this to forward with a
     /// decremented `hops_remaining`.
+    ///
+    /// The wire protocol addresses each destination page as
+    /// `dest_mr_base + ordinal * page_size`, but the pool hands us
+    /// `dsts` pointing at arbitrary physical slots from its free list.
+    /// We therefore shift `dest_mr_base` by `dsts[0].page_idx *
+    /// page_size` so the server's ordinal-relative writes land in the
+    /// caller's actual slots, exactly as [`Self::bulk_get_forward`]
+    /// does for a recursive relay. This requires the `dsts` slots to be
+    /// physically contiguous (the pool's single-page fetches trivially
+    /// satisfy this); see the debug assertion below.
     pub(crate) fn bulk_get_with_ttl<'a>(
         &'a self,
         req: &'a R,
@@ -148,7 +161,20 @@ where
         dsts: &'a [PageRef],
         ttl: u32,
     ) -> FabricBulkStream<'a, R> {
-        FabricBulkStream::new_unstarted(self, req, src, dsts, ttl, self.mr)
+        let dest_mr = match dsts.first() {
+            Some(first) => {
+                debug_assert!(
+                    dsts.iter()
+                        .enumerate()
+                        .all(|(i, d)| { d.page_idx as usize == first.page_idx as usize + i }),
+                    "fabric bulk_get requires physically contiguous dst slots; \
+                     the wire protocol addresses pages by ordinal from dest_mr_base",
+                );
+                forward_dest_mr(self.mr, first.page_idx as usize * self.page_size)
+            }
+            None => self.mr,
+        };
+        FabricBulkStream::new_unstarted(self, req, src, dsts, ttl, dest_mr)
     }
 
     /// Forward `req` to the next hop, landing the downstream page(s)

--- a/cmd/unbounded-storage/src/frontend/http_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/http_serve.rs
@@ -44,9 +44,10 @@ use crate::frontend::FrontendError;
 use crate::frontend::range::{ByteRange, RangeError, ResolvedRange, full_object, stripe_set};
 use crate::http::{
     FdGuard, HttpRequest, MAX_HEADER_BYTES, Method, ParseError, RECV_CHUNK, bind_listener,
-    noop_waker, send_all, serialize_response_head, split_query,
+    send_all, serialize_response_head, split_query,
 };
 use crate::ring::NetHandle;
+use crate::runtime::noop_waker;
 use crate::storage::{OriginRef, StripeReq};
 
 /// HTTP serving frontend factory. Built once per [`FrontendSpec`];

--- a/cmd/unbounded-storage/src/frontend/s3_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/s3_serve.rs
@@ -30,9 +30,7 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll, Waker};
 
-use ::http::header::{
-    ACCEPT_RANGES, CONNECTION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE,
-};
+use ::http::header::{ACCEPT_RANGES, CONNECTION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE};
 use ::http::{Response, StatusCode};
 
 use crate::bufferpool::{BufferPool, Error};
@@ -42,9 +40,10 @@ use crate::frontend::range::{ByteRange, RangeError, ResolvedRange, full_object, 
 use crate::frontend::s3_xml::{S3ErrorCode, error_xml};
 use crate::http::{
     FdGuard, HttpRequest, MAX_HEADER_BYTES, Method, ParseError, RECV_CHUNK, bind_listener,
-    noop_waker, send_all, serialize_response_head, split_query,
+    send_all, serialize_response_head, split_query,
 };
 use crate::ring::NetHandle;
+use crate::runtime::noop_waker;
 use crate::storage::{OriginRef, StripeReq};
 
 /// The `x-amz-request-id` response header name. Present on every
@@ -297,8 +296,13 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
         Method::GET => false,
         Method::HEAD => true,
         _ => {
-            let bytes =
-                error_bytes(S3ErrorCode::MethodNotAllowed, &path, &request_id, false, None);
+            let bytes = error_bytes(
+                S3ErrorCode::MethodNotAllowed,
+                &path,
+                &request_id,
+                false,
+                None,
+            );
             let _ = send_all(handle, conn_fd, bytes).await;
             return Ok(());
         }
@@ -310,8 +314,13 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
         Some(v) => match ByteRange::parse(v) {
             Ok(r) => Some(r),
             Err(_) => {
-                let bytes =
-                    error_bytes(S3ErrorCode::InvalidRequest, &path, &request_id, is_head, None);
+                let bytes = error_bytes(
+                    S3ErrorCode::InvalidRequest,
+                    &path,
+                    &request_id,
+                    is_head,
+                    None,
+                );
                 let _ = send_all(handle, conn_fd, bytes).await;
                 return Ok(());
             }
@@ -331,8 +340,13 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
             return Ok(());
         }
         LenResult::Other => {
-            let bytes =
-                error_bytes(S3ErrorCode::InternalError, &path, &request_id, is_head, None);
+            let bytes = error_bytes(
+                S3ErrorCode::InternalError,
+                &path,
+                &request_id,
+                is_head,
+                None,
+            );
             let _ = send_all(handle, conn_fd, bytes).await;
             return Ok(());
         }
@@ -358,8 +372,13 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
                 return Ok(());
             }
             Err(_) => {
-                let bytes =
-                    error_bytes(S3ErrorCode::InvalidRequest, &path, &request_id, is_head, None);
+                let bytes = error_bytes(
+                    S3ErrorCode::InvalidRequest,
+                    &path,
+                    &request_id,
+                    is_head,
+                    None,
+                );
                 let _ = send_all(handle, conn_fd, bytes).await;
                 return Ok(());
             }
@@ -530,8 +549,8 @@ fn error_bytes(
     is_head: bool,
     content_range: Option<u64>,
 ) -> Vec<u8> {
-    let status = StatusCode::from_u16(code.http_status_u16())
-        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let status =
+        StatusCode::from_u16(code.http_status_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
     if is_head {
         let mut builder = Response::builder()

--- a/cmd/unbounded-storage/src/http/mod.rs
+++ b/cmd/unbounded-storage/src/http/mod.rs
@@ -35,7 +35,7 @@ pub use response::{ResponseHead, serialize_response_head};
 
 /// Cross-platform, storage-policy-free server plumbing reused by the
 /// HTTP serving frontends.
-pub(crate) use server::{MAX_HEADER_BYTES, RECV_CHUNK, noop_waker, split_query};
+pub(crate) use server::{MAX_HEADER_BYTES, RECV_CHUNK, split_query};
 
 /// Linux-only server plumbing that depends on `libc` and the io_uring
 /// [`NetHandle`](crate::ring::NetHandle).

--- a/cmd/unbounded-storage/src/http/server.rs
+++ b/cmd/unbounded-storage/src/http/server.rs
@@ -7,20 +7,16 @@
 //! This file owns the reusable, opinion-free pieces a server-side
 //! frontend needs regardless of which object protocol it speaks: the
 //! `SO_REUSEPORT` listener helper, the RAII socket-fd closer, the
-//! request-target query splitter, the full-buffer send loop, the noop
-//! waker for the cooperative driver, and the size constants. None of it
-//! knows about ranges, stripe geometry, or which status a frontend
-//! returns; that policy lives with the concrete frontend
-//! (`crate::frontend::http_serve`) and a future S3 frontend can reuse
-//! everything here unchanged.
+//! request-target query splitter, the full-buffer send loop, and the
+//! size constants. None of it knows about ranges, stripe geometry, or
+//! which status a frontend returns; that policy lives with the concrete
+//! frontend (`crate::frontend::http_serve`) and a future S3 frontend
+//! can reuse everything here unchanged.
 //!
 //! The libc/`io_uring`-bearing helpers ([`bind_listener`], [`FdGuard`],
 //! [`send_all`]) are Linux-gated because they depend on `libc` and the
 //! io_uring [`NetHandle`](crate::ring::NetHandle); the pure helpers
-//! ([`split_query`], [`noop_waker`]) and the constants are
-//! cross-platform.
-
-use std::task::{RawWaker, RawWakerVTable, Waker};
+//! ([`split_query`]) and the constants are cross-platform.
 
 #[cfg(target_os = "linux")]
 use std::net::SocketAddr;
@@ -182,17 +178,6 @@ pub(crate) fn split_query(target: &str) -> (&str, &str) {
         Some((p, q)) => (p, q),
         None => (target, ""),
     }
-}
-
-/// A noop waker for polling a serving engine's internal future set,
-/// mirroring `ShardLoop`'s cooperative discipline.
-pub(crate) fn noop_waker() -> Waker {
-    fn raw() -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VTABLE)
-    }
-    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-    // SAFETY: VTABLE clone/wake/drop are all no-ops over static data.
-    unsafe { Waker::from_raw(raw()) }
 }
 
 #[cfg(test)]

--- a/cmd/unbounded-storage/src/io/mod.rs
+++ b/cmd/unbounded-storage/src/io/mod.rs
@@ -1,0 +1,278 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared async-IO completion vocabulary spanning the crate's two
+//! asynchronous IO backends: the io_uring engine ([`crate::ring`]) and
+//! the libfabric engine ([`crate::fabric`]).
+//!
+//! The two backends are intentionally NOT one type. io_uring is
+//! `!Send` (single-core, `Rc`/`RefCell`, op identity is a monotonic
+//! `user_data` into a per-thread slot map); libfabric is `Send + Sync`
+//! (`Arc`/atomics, op identity is a boxed `op_context` pointer handed
+//! to the provider, completed cross-thread by a progress thread). That
+//! divergence is deliberate and is preserved.
+//!
+//! What this module unifies is the *contract* both backends already
+//! honor, expressed as a small shared vocabulary:
+//!
+//!  * [`IoResult`] / [`Completed`] / [`IoError`] - the one result type
+//!    the io_uring `i32` CQE `res` and the libfabric `CompletionInfo`
+//!    both collapse to at the consumer boundary.
+//!  * [`CompletionOutcome`] - implemented by each backend's raw
+//!    completion value so it can collapse to [`IoResult`].
+//!  * [`Unified`] - an adapter future that drives any backend
+//!    completion future and yields [`IoResult`]. Wrapping does not
+//!    change drop behavior, so each backend's "dropping the future
+//!    does NOT cancel the in-flight op" contract is preserved exactly.
+//!  * [`BackPressure`] / [`BackPressurePolicy`] - names the admission
+//!    policy each backend uses (io_uring parks; libfabric fails on a
+//!    full registry) and exposes a uniform introspection surface.
+//!
+//! The shared types are opt-in: backend-specific detail (raw `i32`,
+//! `CompletionInfo` with its tag/src_addr, the parking `SubmitSlot`,
+//! the capacity-checked `allocate`) stays available where a caller
+//! needs it. This module is the common surface, not a replacement.
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Successful completion outcome at the unified boundary. `bytes` is
+/// the transferred byte count (io_uring's non-negative CQE `res`, or
+/// libfabric's `CompletionInfo::bytes`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Completed {
+    pub bytes: usize,
+}
+
+/// Unified failure at the boundary. Backend-specific richness is
+/// preserved as far as it maps cleanly; anything that does not is
+/// rendered into [`IoError::Other`].
+#[derive(Debug, Clone)]
+pub enum IoError {
+    /// An OS errno. The io_uring path produces these (a negative CQE
+    /// `res` of `-errno` maps to `Os(errno)`).
+    Os(i32),
+    /// A provider/completion-queue error carrying the provider errno
+    /// alongside the libfabric error code.
+    Provider { prov_errno: i32, err: i32 },
+    /// Any other backend error, rendered to a message. Used for the
+    /// libfabric error variants that have no numeric boundary form.
+    Other(String),
+}
+
+impl fmt::Display for IoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IoError::Os(errno) => write!(f, "io error: errno={errno}"),
+            IoError::Provider { prov_errno, err } => {
+                write!(f, "io provider error: err={err} prov_errno={prov_errno}")
+            }
+            IoError::Other(msg) => write!(f, "io error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for IoError {}
+
+/// Unified result both backends collapse to at the consumer boundary.
+pub type IoResult = Result<Completed, IoError>;
+
+/// A backend's raw completion value that can collapse to the unified
+/// [`IoResult`]. Implemented for the io_uring `i32` CQE `res` here, and
+/// for the libfabric `Result<CompletionInfo>` next to that type.
+pub trait CompletionOutcome {
+    fn into_io_result(self) -> IoResult;
+}
+
+impl CompletionOutcome for i32 {
+    /// io_uring convention: negative is `-errno`, non-negative is a
+    /// byte count (or other success value).
+    fn into_io_result(self) -> IoResult {
+        if self < 0 {
+            Err(IoError::Os(-self))
+        } else {
+            Ok(Completed {
+                bytes: self as usize,
+            })
+        }
+    }
+}
+
+/// Adapter future that drives any backend completion future and
+/// collapses its backend-specific output to the unified [`IoResult`].
+///
+/// Wrapping is semantically transparent: dropping a `Unified` drops
+/// the inner future, so whatever drop behavior the backend defines
+/// (io_uring issues a best-effort cancel and keeps the slot alive
+/// until reaped; libfabric lets the result land unwatched) is
+/// preserved unchanged. In particular, dropping a `Unified` does NOT
+/// cancel the in-flight operation.
+pub struct Unified<F> {
+    inner: F,
+}
+
+impl<F> Unified<F> {
+    pub fn new(inner: F) -> Self {
+        Self { inner }
+    }
+
+    /// Recover the wrapped backend future.
+    pub fn into_inner(self) -> F {
+        self.inner
+    }
+}
+
+impl<F> Future for Unified<F>
+where
+    F: Future + Unpin,
+    F::Output: CompletionOutcome,
+{
+    type Output = IoResult;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner)
+            .poll(cx)
+            .map(CompletionOutcome::into_io_result)
+    }
+}
+
+/// How a backend admits new in-flight operations. Naming the policy
+/// keeps the divergence explicit at the shared boundary; the actual
+/// admission still lives in each backend (io_uring's `SubmitSlot`
+/// park, libfabric's capacity-checked `allocate`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackPressurePolicy {
+    /// Submitters PARK until an in-flight op completes and frees a
+    /// slot. Used by the io_uring engine, whose ring depth is a hard
+    /// kernel bound.
+    Parking,
+    /// Admission FAILS immediately once the in-flight count reaches
+    /// capacity. Used by the libfabric engine, whose registry returns
+    /// an error the transport surfaces as back-pressure.
+    Capacity,
+}
+
+/// Uniform introspection over a backend's admission control. This
+/// describes the bound and the live count; it does not itself admit or
+/// release (each backend owns that, to keep its counters authoritative).
+pub trait BackPressure {
+    /// Maximum number of simultaneously in-flight operations.
+    fn capacity(&self) -> usize;
+
+    /// Operations currently submitted and not yet reaped.
+    fn in_flight(&self) -> usize;
+
+    /// Which admission policy this backend applies on overflow.
+    fn policy(&self) -> BackPressurePolicy;
+
+    /// Remaining admission headroom.
+    fn available(&self) -> usize {
+        self.capacity().saturating_sub(self.in_flight())
+    }
+
+    /// Whether one more operation would be admitted right now without
+    /// parking (Parking policy) or erroring (Capacity policy).
+    fn admits(&self) -> bool {
+        self.in_flight() < self.capacity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::noop_waker;
+
+    #[test]
+    fn i32_outcome_maps_sign() {
+        match 4096_i32.into_io_result() {
+            Ok(Completed { bytes }) => assert_eq!(bytes, 4096),
+            Err(e) => panic!("expected Ok, got {e}"),
+        }
+        match (-libc::EIO).into_io_result() {
+            Err(IoError::Os(errno)) => assert_eq!(errno, libc::EIO),
+            other => panic!("expected Os errno, got {other:?}"),
+        }
+        match 0_i32.into_io_result() {
+            Ok(Completed { bytes }) => assert_eq!(bytes, 0),
+            Err(e) => panic!("expected Ok(0), got {e}"),
+        }
+    }
+
+    /// A minimal backend-agnostic completion future used to exercise
+    /// the [`Unified`] adapter without pulling in either real engine.
+    struct ReadyOutcome(i32);
+    impl Future for ReadyOutcome {
+        type Output = i32;
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<i32> {
+            Poll::Ready(self.0)
+        }
+    }
+
+    #[test]
+    fn unified_collapses_inner_output() {
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+
+        let mut ok = Unified::new(ReadyOutcome(512));
+        match Pin::new(&mut ok).poll(&mut cx) {
+            Poll::Ready(Ok(Completed { bytes })) => assert_eq!(bytes, 512),
+            other => panic!("expected Ready Ok, got {other:?}"),
+        }
+
+        let mut err = Unified::new(ReadyOutcome(-libc::ENOSPC));
+        match Pin::new(&mut err).poll(&mut cx) {
+            Poll::Ready(Err(IoError::Os(errno))) => assert_eq!(errno, libc::ENOSPC),
+            other => panic!("expected Ready Os err, got {other:?}"),
+        }
+    }
+
+    struct FakeBp {
+        cap: usize,
+        live: usize,
+        policy: BackPressurePolicy,
+    }
+    impl BackPressure for FakeBp {
+        fn capacity(&self) -> usize {
+            self.cap
+        }
+        fn in_flight(&self) -> usize {
+            self.live
+        }
+        fn policy(&self) -> BackPressurePolicy {
+            self.policy
+        }
+    }
+
+    #[test]
+    fn backpressure_defaults_derive_from_capacity_and_live() {
+        let full = FakeBp {
+            cap: 4,
+            live: 4,
+            policy: BackPressurePolicy::Capacity,
+        };
+        assert_eq!(full.available(), 0);
+        assert!(!full.admits());
+        assert_eq!(full.policy(), BackPressurePolicy::Capacity);
+
+        let room = FakeBp {
+            cap: 8,
+            live: 3,
+            policy: BackPressurePolicy::Parking,
+        };
+        assert_eq!(room.available(), 5);
+        assert!(room.admits());
+        assert_eq!(room.policy(), BackPressurePolicy::Parking);
+
+        // `available` saturates rather than underflowing if live ever
+        // exceeds capacity (defensive; should not happen in practice).
+        let over = FakeBp {
+            cap: 2,
+            live: 5,
+            policy: BackPressurePolicy::Capacity,
+        };
+        assert_eq!(over.available(), 0);
+        assert!(!over.admits());
+    }
+}

--- a/cmd/unbounded-storage/src/lib.rs
+++ b/cmd/unbounded-storage/src/lib.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod fabric;
 pub mod frontend;
 pub mod http;
+pub mod io;
 pub mod memory;
 pub mod p2p;
 pub mod ring;

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -15,9 +15,7 @@ use std::time::Duration;
 
 use clap::Parser;
 
-use unbounded_storage::backend::{
-    FixedRegion, HttpBackend, OriginBackend, OriginRing, S3Backend,
-};
+use unbounded_storage::backend::{FixedRegion, HttpBackend, OriginBackend, OriginRing, S3Backend};
 use unbounded_storage::bufferpool::{Pool, PoolConfig, PoolGroup, Req, ShardDescriptor, StripeKey};
 use unbounded_storage::config::{
     self, BackendKind, BackendSpec, Config, FabricCfg, FrontendKind, FrontendSpec,
@@ -53,7 +51,8 @@ const DEFAULT_STRIPE_SIZE_BYTES: u64 = 4 * 1024 * 1024;
 /// the main thread plus every shard thread.
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
-type ShardPool = Pool<RoutedTransport<StripeReq, OriginBackend>, Arc<LiveShardLocalStore>, StripeReq>;
+type ShardPool =
+    Pool<RoutedTransport<StripeReq, OriginBackend>, Arc<LiveShardLocalStore>, StripeReq>;
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -402,6 +401,7 @@ fn run_shard(
     cfg.listen = true;
     cfg.listen_addr = Some(fabric_cfg.listen_addr.clone());
     cfg.max_inflight = fabric_cfg.max_inflight;
+    cfg.rpc_worker_threads = fabric_cfg.rpc_worker_threads;
     cfg.progress_threads = fabric_cfg.progress_threads;
     cfg.progress_poll_us = fabric_cfg.progress_poll_us;
     cfg.numa = worker.numa;
@@ -597,6 +597,19 @@ fn run_shard(
     // order (see the drop sequence below).
     let pool = Rc::new(pool);
 
+    // Make cancelled fixed-buffer RECVs into pool pages sound without
+    // blocking the dropping task: a cancelled RECV's destination page is
+    // withheld from the free list until the kernel finishes with it (its
+    // RECV CQE is reaped). Only the shard socket ring receives into pool
+    // pages, so the quarantine is installed on it alone; the RPC worker
+    // rings receive into their own scratch backing and keep the blocking
+    // drain fallback. Installed before serving begins so every cancelled
+    // RECV is covered.
+    unbounded_storage::backend::install_recv_quarantine(
+        &socket.borrow(),
+        pool.recv_quarantine_handle(),
+    );
+
     // Bring up the per-shard RPC server so remote peers can fetch
     // stripes this node has resident locally (a peer "cache hit") and
     // so this node can act as an intermediate Chord hop, forwarding to
@@ -677,11 +690,13 @@ fn run_shard(
             fabric.clone(),
             scratch_mr,
             page_size,
-            // The handler runs on an ephemeral `fabric-rpc-worker`
-            // thread per inbound RPC, so it must NOT touch the shard
-            // ring (the shard thread progresses it concurrently; a
+            // The handler runs on one of the persistent
+            // `fabric-rpc-worker` pool threads, so it must NOT touch the
+            // shard ring (the shard thread progresses it concurrently; a
             // cross-thread `RefCell` borrow panics). A worker-local ring
-            // keeps every origin op on the serving thread.
+            // keeps every origin op on the serving thread; it is lazily
+            // initialized once per long-lived pool thread and reused
+            // across the many RPCs that thread serves.
             match make_origin_backend(
                 OriginRing::WorkerLocal {
                     queue_depth: 256,
@@ -845,9 +860,10 @@ fn run_shard(
     //      holds an `Arc<Fabric>` clone that must go before `fabric`.
     //      The pool's `HttpBackend` also holds an `Rc<socket>` clone.
     //   3. `socket` - the last shard-local `Rc<socket>` clone.
-    //   4. `rpc_server` - signals shutdown to outstanding RPC workers
-    //      and waits briefly for them; this must complete while `fabric`
-    //      (which they use) is still alive.
+    //   4. `rpc_server` - signals shutdown to the persistent RPC worker
+    //      pool, closes its job queue, and joins every worker thread;
+    //      this must complete while `fabric` (which they use) is still
+    //      alive.
     //   5. `fabric` last - joins its progress threads, closes the
     //      scratch MR the RPC server used, and tears libfabric down.
     drop(shard_loop);

--- a/cmd/unbounded-storage/src/p2p/handler.rs
+++ b/cmd/unbounded-storage/src/p2p/handler.rs
@@ -40,7 +40,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll};
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -51,6 +51,7 @@ use crate::fabric::Result as FabResult;
 use crate::fabric::{Fabric, FabricTransport, Handler, HandlerStream, MrHandle, PeerId};
 use crate::memory::Backing;
 use crate::p2p::{FingerRouter, FingerTable, NodeId, RingId, stripe_to_ring};
+use crate::runtime::{block_on_cooperative, noop_waker};
 
 /// Error surfaced by [`RecursiveHandler`]'s response stream.
 #[derive(Debug)]
@@ -487,25 +488,9 @@ fn drive_page_stream<P: PageStream>(stream: P) -> Result<(), crate::bufferpool::
 /// spin-poller; the underlying disk I/O makes progress on its own
 /// io_uring threads while this spins.
 fn block_on_local<F: std::future::Future>(fut: F) -> F::Output {
-    let waker = noop_waker();
-    let mut cx = Context::from_waker(&waker);
-    let mut fut = Box::pin(fut);
-    loop {
-        match fut.as_mut().poll(&mut cx) {
-            Poll::Ready(v) => return v,
-            Poll::Pending => std::thread::sleep(std::time::Duration::from_micros(50)),
-        }
-    }
-}
-
-fn noop_waker() -> Waker {
-    fn no(_: *const ()) {}
-    fn clone(_: *const ()) -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VT)
-    }
-    static VT: RawWakerVTable = RawWakerVTable::new(clone, no, no, no);
-    // SAFETY: the vtable never dereferences the data pointer.
-    unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VT)) }
+    block_on_cooperative(fut, || {
+        std::thread::sleep(std::time::Duration::from_micros(50))
+    })
 }
 
 #[cfg(test)]

--- a/cmd/unbounded-storage/src/p2p/tests.rs
+++ b/cmd/unbounded-storage/src/p2p/tests.rs
@@ -10,23 +10,15 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::pin;
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll};
 
 use crate::p2p::{FingerTable, FingerTableConfig, NodeId, PeerEntry, RingId, TopologyLabels};
+use crate::runtime::noop_waker;
 
 // ---------------------------------------------------------------------------
-// Noop-waker block_on, copied from src/bufferpool/tests.rs to keep
-// the crate runtime-agnostic.
+// Noop-waker block_on built on the shared `runtime::noop_waker` helper
+// to keep the crate runtime-agnostic.
 // ---------------------------------------------------------------------------
-
-fn noop_waker() -> Waker {
-    fn raw() -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VTABLE)
-    }
-    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-    // SAFETY: the vtable functions never dereference the data pointer.
-    unsafe { Waker::from_raw(raw()) }
-}
 
 fn block_on<F: Future>(future: F) -> F::Output {
     let waker = noop_waker();

--- a/cmd/unbounded-storage/src/p2p/transport.rs
+++ b/cmd/unbounded-storage/src/p2p/transport.rs
@@ -150,7 +150,7 @@ mod tests {
     use std::collections::HashMap;
     use std::pin::Pin;
     use std::sync::Arc;
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{Context, Poll};
 
     use crate::backend::Backend;
     use crate::bufferpool::{BulkRef, Error, PageRef, PageStream, Req, StripeKey};
@@ -159,6 +159,7 @@ mod tests {
         FingerTable, FingerTableConfig, NodeId, PeerEntry, RingId, TopologyLabels, node_to_ring,
         stripe_to_ring,
     };
+    use crate::runtime::noop_waker;
     use serde::{Deserialize, Serialize};
 
     use super::RoutedStream;
@@ -228,15 +229,6 @@ mod tests {
 
     fn node_to_peer_map(nodes: &[u64]) -> Arc<HashMap<NodeId, PeerId>> {
         Arc::new(nodes.iter().map(|&n| (NodeId(n), PeerId(n))).collect())
-    }
-
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        // SAFETY: VTABLE clone/wake/drop are all no-ops on static data.
-        unsafe { Waker::from_raw(raw()) }
     }
 
     /// Build a `RoutedTransport` whose `FabricTransport` is never

--- a/cmd/unbounded-storage/src/ring/core.rs
+++ b/cmd/unbounded-storage/src/ring/core.rs
@@ -58,6 +58,26 @@ pub(crate) struct RingSetup {
     pub defer_taskrun: bool,
 }
 
+/// Sink that defers reuse of a fixed-buffer RECV's destination page
+/// until the kernel is provably done writing into it.
+///
+/// When a fixed-buffer RECV is cancelled on early drop, the kernel may
+/// still complete the RECV into the destination page after the dropping
+/// task returns. Returning that page to a free list immediately is
+/// therefore unsound. Instead the ring calls [`RecvQuarantine::quarantine`]
+/// on drop to withhold the page, and [`RecvQuarantine::reclaim`] once the
+/// RECV's CQE is reaped in [`RingCore::progress`], at which point the
+/// kernel no longer owns the page and it may be reused. Both are keyed
+/// by the destination's byte offset into the registered backing.
+///
+/// Rings whose RECV destinations are not pool-managed leave no sink
+/// installed; their drop path falls back to the blocking-but-sound
+/// [`RingCore::cancel_and_drain`].
+pub(crate) trait RecvQuarantine {
+    fn quarantine(&self, page_byte_offset: usize);
+    fn reclaim(&self, page_byte_offset: usize);
+}
+
 /// One io_uring ring plus the shared slot / buffer / back-pressure
 /// machinery every facade in this module is built on. Pinned to the
 /// thread that constructed it.
@@ -89,6 +109,15 @@ pub(crate) struct RingCore {
     more_completions: Cell<u64>,
     setup: RingSetup,
     queue_depth: u32,
+    /// Optional sink that withholds a cancelled fixed-buffer RECV's
+    /// destination page until its CQE is reaped (see [`RecvQuarantine`]).
+    /// `None` on rings whose RECV destinations are not pool-managed; such
+    /// rings fall back to the blocking [`Self::cancel_and_drain`].
+    recv_quarantine: RefCell<Option<Rc<dyn RecvQuarantine>>>,
+    /// Maps the `user_data` of a cancelled, quarantined fixed-buffer
+    /// RECV to its destination byte offset, so [`Self::progress`] can
+    /// `reclaim` the page when the RECV's CQE is finally reaped.
+    pending_recv_cancel: RefCell<HashMap<u64, usize>>,
     _no_send: PhantomData<*const ()>,
 }
 
@@ -213,6 +242,8 @@ impl RingCore {
             more_completions: Cell::new(0),
             setup,
             queue_depth,
+            recv_quarantine: RefCell::new(None),
+            pending_recv_cancel: RefCell::new(HashMap::new()),
             _no_send: PhantomData,
         })
     }
@@ -384,6 +415,7 @@ impl RingCore {
         }
 
         let mut to_wake: Vec<Waker> = Vec::new();
+        let mut to_reclaim: Vec<usize> = Vec::new();
         let mut drained = 0u32;
         {
             let mut ring = self.ring.borrow_mut();
@@ -420,6 +452,9 @@ impl RingCore {
                 }
                 slot.notified.set(true);
                 self.slots.borrow_mut().remove(&ud);
+                if let Some(off) = self.pending_recv_cancel.borrow_mut().remove(&ud) {
+                    to_reclaim.push(off);
+                }
                 let n = self.submitted.get();
                 self.submitted.set(n.saturating_sub(1));
                 if let Some(w) = slot.waker.borrow_mut().take() {
@@ -433,6 +468,17 @@ impl RingCore {
 
         for w in to_wake {
             w.wake();
+        }
+        // Release any quarantined pages whose RECV CQE was just reaped.
+        // Done after the ring borrow is dropped: `reclaim` touches the
+        // bufferpool free list, never the ring, so this cannot reenter
+        // the borrow above, but deferring past it is defensive.
+        if !to_reclaim.is_empty() {
+            if let Some(q) = self.recv_quarantine.borrow().clone() {
+                for off in to_reclaim {
+                    q.reclaim(off);
+                }
+            }
         }
         Ok(submitted_n > 0 || drained > 0)
     }
@@ -524,6 +570,45 @@ impl RingCore {
         }
     }
 
+    /// Install the sink used to defer reuse of a cancelled fixed-buffer
+    /// RECV's destination page until its CQE is reaped. Without it,
+    /// [`Self::cancel_fixed_recv`] falls back to the blocking-but-sound
+    /// [`Self::cancel_and_drain`].
+    pub(crate) fn set_recv_quarantine(&self, q: Rc<dyn RecvQuarantine>) {
+        *self.recv_quarantine.borrow_mut() = Some(q);
+    }
+
+    /// Cancel a fixed-buffer RECV on early drop.
+    ///
+    /// If a [`RecvQuarantine`] sink is installed, this is non-blocking:
+    /// the destination page is handed to the sink (which withholds it
+    /// from reuse), the op is recorded so [`Self::progress`] reclaims the
+    /// page once its CQE is reaped, and a best-effort cancel is issued.
+    /// The dropping task never blocks, yet the page is provably not
+    /// reused while the kernel may still write into it.
+    ///
+    /// With no sink installed, falls back to the blocking-but-sound
+    /// [`Self::cancel_and_drain`], which drains the op to completion
+    /// before returning.
+    pub(crate) fn cancel_fixed_recv(
+        &self,
+        target_user_data: u64,
+        page_byte_offset: usize,
+        slot: &Slot,
+    ) {
+        let q = self.recv_quarantine.borrow().clone();
+        match q {
+            Some(q) => {
+                self.pending_recv_cancel
+                    .borrow_mut()
+                    .insert(target_user_data, page_byte_offset);
+                q.quarantine(page_byte_offset);
+                self.cancel(target_user_data);
+            }
+            None => self.cancel_and_drain(target_user_data, slot),
+        }
+    }
+
     /// Number of live (submitted, not yet reaped) ops. Used by tests to
     /// assert the back-pressure bound.
     pub(crate) fn in_flight(&self) -> u32 {
@@ -547,6 +632,25 @@ impl RingCore {
     /// Used by tests to assert the two-CQE path executed.
     pub(crate) fn more_completions(&self) -> u64 {
         self.more_completions.get()
+    }
+}
+
+/// io_uring admits via the [`SubmitSlot`] park: when `submitted ==
+/// queue_depth` a submitter yields `Pending` until a completion frees a
+/// slot, so the policy is [`BackPressurePolicy::Parking`]. This impl is
+/// purely the shared introspection surface; the actual parking still
+/// lives in [`SubmitSlot`].
+impl crate::io::BackPressure for RingCore {
+    fn capacity(&self) -> usize {
+        self.queue_depth as usize
+    }
+
+    fn in_flight(&self) -> usize {
+        self.submitted.get() as usize
+    }
+
+    fn policy(&self) -> crate::io::BackPressurePolicy {
+        crate::io::BackPressurePolicy::Parking
     }
 }
 
@@ -707,5 +811,46 @@ mod tests {
         assert_eq!(check_res(5).unwrap(), 5);
         let e = check_res(-libc::EIO).unwrap_err();
         assert_eq!(e.raw_os_error(), Some(libc::EIO));
+    }
+
+    /// Registering two distinct regions hands back sequential buffer
+    /// indices, and each region resolves back to its own index. This is
+    /// the success-path registration coverage the standalone io_uring
+    /// block device carried before its engine was consolidated onto
+    /// [`RingCore`].
+    #[test]
+    fn register_buffer_assigns_distinct_indices_and_resolves() {
+        const PAGE: usize = 4096;
+        // Back the regions before the core so they outlive the ring's
+        // registered table, which Drop unregisters.
+        let mut buf_a = vec![0u8; PAGE];
+        let mut buf_b = vec![0u8; PAGE];
+        let base_a = buf_a.as_mut_ptr();
+        let base_b = buf_b.as_mut_ptr();
+
+        let core = RingCore::new(8, RingSetup::default()).expect("core");
+
+        assert_eq!(core.register_buffer(base_a, PAGE).expect("register a"), 0);
+        assert_eq!(core.register_buffer(base_b, PAGE).expect("register b"), 1);
+
+        // Each registered region resolves back to the index it was
+        // handed, proving the sparse table stays parallel to the
+        // kernel-side registration.
+        assert_eq!(core.resolve_buf_index(base_a, PAGE).expect("resolve a"), 0);
+        assert_eq!(core.resolve_buf_index(base_b, PAGE).expect("resolve b"), 1);
+    }
+
+    /// The ring reports itself through the shared [`crate::io::BackPressure`]
+    /// surface as a parking backend bounded by its queue depth.
+    #[test]
+    fn backpressure_surface_reports_parking_policy() {
+        use crate::io::{BackPressure, BackPressurePolicy};
+
+        let core = RingCore::new(8, RingSetup::default()).expect("core");
+        assert_eq!(core.capacity(), 8);
+        assert_eq!(core.in_flight(), 0);
+        assert_eq!(core.available(), 8);
+        assert!(core.admits());
+        assert_eq!(core.policy(), BackPressurePolicy::Parking);
     }
 }

--- a/cmd/unbounded-storage/src/ring/mod.rs
+++ b/cmd/unbounded-storage/src/ring/mod.rs
@@ -14,6 +14,7 @@ mod network;
 mod registry;
 mod storage;
 
+pub(crate) use core::RecvQuarantine;
 pub use network::{NetHandle, NetworkRing, SockAddr};
 pub use registry::{
     clear_current_storage_ring, current_storage_ring, set_current_storage_ring,

--- a/cmd/unbounded-storage/src/ring/network.rs
+++ b/cmd/unbounded-storage/src/ring/network.rs
@@ -35,7 +35,7 @@ use std::task::{Context, Poll};
 
 use io_uring::{opcode, types};
 
-use super::core::{OpFut, OpResource, RingCore, RingSetup, Slot, check_res};
+use super::core::{OpFut, OpResource, RecvQuarantine, RingCore, RingSetup, Slot, check_res};
 
 /// Thin owned wrapper around a `libc::sockaddr` plus its length, so
 /// `connect` can hand a stable pointer to the kernel for the op's
@@ -160,6 +160,15 @@ impl NetworkRing {
         let idx = self.core.register_buffer(base, len)?;
         debug_assert_eq!(idx, 0, "region must be the first registered buffer");
         Ok(())
+    }
+
+    /// Install the sink that defers reuse of a cancelled fixed-buffer
+    /// RECV's destination page until its CQE is reaped (see
+    /// [`RecvQuarantine`]). Install it before any `recv_fixed` is issued
+    /// so every cancelled RECV is covered. Without it, the drop path
+    /// falls back to the blocking [`RingCore::cancel_and_drain`].
+    pub(crate) fn set_recv_quarantine(&self, q: Rc<dyn RecvQuarantine>) {
+        self.core.set_recv_quarantine(q);
     }
 
     /// Push queued SQEs and drain available CQEs. Returns `true` if any
@@ -526,14 +535,16 @@ impl NetHandle {
                 // SAFETY: `ptr` points inside the registered backing; the
                 // caller holds the destination page until this future
                 // resolves (the RECV completion CQE). If the future is
-                // dropped early, `OwnedNetFut::draining` drains the RECV
-                // to completion before returning, so the kernel never
-                // writes into the page after the caller reuses it.
+                // dropped early, `OwnedNetFut::fixed_recv` either hands
+                // the destination page to the ring's recv-quarantine sink
+                // (held until the RECV CQE is reaped) or, with no sink
+                // installed, drains the RECV to completion, so the kernel
+                // never writes into the page after the caller reuses it.
                 let slot = r.core.submit_now(sqe, false, OpResource::None)?;
                 (ud, slot)
             };
             let res = OwnedNetFut::new(Rc::clone(&ring), ud, slot)
-                .draining()
+                .fixed_recv(page_byte_offset)
                 .await;
             check_res(res).map(|n| n as usize)
         }
@@ -549,12 +560,14 @@ struct OwnedNetFut {
     ring: Rc<RefCell<NetworkRing>>,
     user_data: u64,
     slot: Rc<Slot>,
-    /// When set, dropping before completion blocks until the op's CQE is
-    /// reaped (see [`RingCore::cancel_and_drain`]) instead of issuing a
-    /// best-effort cancel. Required for ops that write into caller-owned
-    /// memory the caller may reuse the instant this future drops (the
-    /// fixed-buffer RECV path).
-    drain_on_drop: bool,
+    /// When `Some(offset)`, this future is a fixed-buffer RECV whose
+    /// destination begins at byte `offset` in the registered backing.
+    /// Dropping it before completion routes through
+    /// [`RingCore::cancel_fixed_recv`], which quarantines that page
+    /// (non-blocking) or drains the op (blocking fallback) so the kernel
+    /// never writes into a page the caller may reuse. `None` for ops
+    /// whose memory the ring owns, where a best-effort cancel suffices.
+    fixed_recv_offset: Option<usize>,
 }
 
 impl OwnedNetFut {
@@ -563,14 +576,15 @@ impl OwnedNetFut {
             ring,
             user_data,
             slot,
-            drain_on_drop: false,
+            fixed_recv_offset: None,
         }
     }
 
-    /// Mark this future so that dropping it before completion drains the
-    /// in-flight op to completion rather than best-effort cancelling it.
-    fn draining(mut self) -> Self {
-        self.drain_on_drop = true;
+    /// Mark this future as a fixed-buffer RECV writing into the backing
+    /// at byte `page_byte_offset`, so dropping it before completion
+    /// makes that destination page safe to reuse (see the field docs).
+    fn fixed_recv(mut self, page_byte_offset: usize) -> Self {
+        self.fixed_recv_offset = Some(page_byte_offset);
         self
     }
 }
@@ -595,10 +609,11 @@ impl Drop for OwnedNetFut {
     fn drop(&mut self) {
         if !self.slot.is_done() {
             if let Ok(ring) = self.ring.try_borrow() {
-                if self.drain_on_drop {
-                    ring.core.cancel_and_drain(self.user_data, &self.slot);
-                } else {
-                    ring.core.cancel(self.user_data);
+                match self.fixed_recv_offset {
+                    Some(off) => {
+                        ring.core.cancel_fixed_recv(self.user_data, off, &self.slot);
+                    }
+                    None => ring.core.cancel(self.user_data),
                 }
             }
         }
@@ -609,18 +624,10 @@ impl Drop for OwnedNetFut {
 mod tests {
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Context, Poll};
 
     use super::*;
-
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-    fn noop_waker() -> Waker {
-        Arc::new(NoopWake).into()
-    }
+    use crate::runtime::noop_waker;
 
     fn block_on<F: Future>(ring: &NetworkRing, mut fut: Pin<&mut F>) -> F::Output {
         let waker = noop_waker();
@@ -1031,6 +1038,121 @@ mod tests {
             ring.borrow().core.in_flight(),
             0,
             "dropping a draining recv_fixed must reap the in-flight op",
+        );
+
+        unsafe {
+            libc::close(a);
+            libc::close(b);
+        }
+    }
+
+    /// With a quarantine sink installed, dropping a parked fixed RECV
+    /// must NOT block to drain the op: the destination page is handed to
+    /// the sink (quarantined) and only reclaimed once the cancelled
+    /// RECV's CQE is later reaped by `progress()`. This is the Phase 5
+    /// soundness guarantee: the page is withheld from reuse for the whole
+    /// window the kernel might still write to it, without a blocking drop.
+    #[test]
+    fn drop_in_flight_recv_fixed_quarantines_until_reaped() {
+        #[derive(Clone)]
+        struct TestQ {
+            events: Rc<RefCell<Vec<(&'static str, usize)>>>,
+        }
+        impl RecvQuarantine for TestQ {
+            fn quarantine(&self, page_byte_offset: usize) {
+                self.events
+                    .borrow_mut()
+                    .push(("quarantine", page_byte_offset));
+            }
+
+            fn reclaim(&self, page_byte_offset: usize) {
+                self.events.borrow_mut().push(("reclaim", page_byte_offset));
+            }
+        }
+
+        let ring = match NetworkRing::new(16) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("quarantine_until_reaped: ring unavailable: {e}; skipping");
+                return;
+            }
+        };
+
+        const PAGE: usize = 4096;
+        let mut store = vec![0u8; PAGE * 2];
+        let backing = crate::memory::Backing {
+            base: store.as_mut_ptr(),
+            page_size: PAGE,
+            page_count: 2,
+            _own: Box::new(()),
+        };
+        if let Err(e) = ring.register_backing(&backing) {
+            eprintln!("quarantine_until_reaped: register_backing failed: {e}; skipping");
+            return;
+        }
+
+        let events = Rc::new(RefCell::new(Vec::new()));
+        ring.set_recv_quarantine(Rc::new(TestQ {
+            events: Rc::clone(&events),
+        }));
+
+        let ring = Rc::new(RefCell::new(ring));
+        let handle = NetHandle::new(Rc::clone(&ring));
+
+        let Some((a, b)) = tcp_loopback_pair() else {
+            eprintln!("quarantine_until_reaped: tcp loopback pair failed; skipping");
+            return;
+        };
+
+        // No bytes written to `a`, so the RECV on `b` parks in the kernel.
+        // The destination is page 1 (byte offset PAGE).
+        let fut = handle.recv_fixed(b, 0, PAGE, PAGE);
+        let mut fut = Box::pin(fut);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(_) => {
+                unsafe {
+                    libc::close(a);
+                    libc::close(b);
+                }
+                return;
+            }
+            Poll::Pending => {}
+        }
+        assert_eq!(
+            ring.borrow().core.in_flight(),
+            1,
+            "the RECV should be outstanding after the first poll",
+        );
+
+        // Dropping with a sink installed must be non-blocking: the op is
+        // still in flight (not drained) and the page is quarantined, not
+        // yet reclaimed.
+        drop(fut);
+        assert_eq!(
+            ring.borrow().core.in_flight(),
+            1,
+            "dropping a quarantined recv_fixed must not block to drain",
+        );
+        assert_eq!(
+            events.borrow().as_slice(),
+            &[("quarantine", PAGE)],
+            "the destination page must be quarantined on drop, not reclaimed",
+        );
+
+        // Pump progress() until the cancelled RECV's CQE is reaped. Only
+        // then is the page reclaimed back to the free list.
+        let mut spins = 0u32;
+        while ring.borrow().core.in_flight() != 0 {
+            ring.borrow().progress();
+            spins += 1;
+            assert!(spins < 5_000_000, "cancelled RECV was never reaped");
+        }
+        assert_eq!(
+            events.borrow().as_slice(),
+            &[("quarantine", PAGE), ("reclaim", PAGE)],
+            "the page must be reclaimed only after its RECV CQE is reaped",
         );
 
         unsafe {

--- a/cmd/unbounded-storage/src/ring/storage.rs
+++ b/cmd/unbounded-storage/src/ring/storage.rs
@@ -228,21 +228,13 @@ mod tests {
     use std::os::fd::AsRawFd;
     use std::path::PathBuf;
     use std::pin::Pin;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Context, Poll};
 
     use super::*;
+    use crate::runtime::noop_waker;
 
     static SEQ: AtomicU64 = AtomicU64::new(0);
-
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-    fn noop_waker() -> Waker {
-        Arc::new(NoopWake).into()
-    }
 
     /// Drive multiple futures cooperatively, calling `ring.progress()`
     /// between polls. Returns the outputs in submission order.

--- a/cmd/unbounded-storage/src/runtime/executor.rs
+++ b/cmd/unbounded-storage/src/runtime/executor.rs
@@ -1,0 +1,314 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! The crate's shared, runtime-agnostic `block_on` executors.
+//!
+//! `unbounded-storage` deliberately pulls in no async runtime (no
+//! tokio, no async-std): futures are driven by hand wherever a
+//! synchronous thread needs to wait on one. This module owns the two
+//! ways the crate does that so every subsystem shares one
+//! implementation instead of re-rolling a noop waker and a poll loop.
+//!
+//! # Cooperative mode (DST-safe)
+//!
+//! [`noop_waker`] plus [`block_on_cooperative`] drive a future to
+//! completion by re-polling, never relying on a wakeup. Between
+//! `Poll::Pending`s the caller's `idle` closure runs (a short sleep on
+//! production threads, a spin-count assertion in tests), so forward
+//! progress comes from work happening on *other* threads (io_uring
+//! completion threads, the fabric progress thread) that the next poll
+//! observes. This mode constructs no thread handle and reads no clock,
+//! so it is the only mode that may run inside the deterministic
+//! simulation executor.
+//!
+//! # Parked mode (production OS threads only)
+//!
+//! [`thread_waker`] plus [`park_block_on_until`] drive a future with a
+//! *real* waker: `wake()` unparks the blocked thread, so a completion
+//! posted from another thread resolves the wait immediately instead of
+//! paying a fixed poll interval of latency on the fast path. This is
+//! what the RPC worker pool uses while blocked on libfabric
+//! completions.
+//!
+//! **NEVER use the parked mode in the deterministic simulation
+//! executor.** It spawns nothing but it parks real OS threads and reads
+//! the wall clock, both of which the DST forbids; the DST keeps the
+//! cooperative mode.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Wake, Waker};
+use std::thread::{self, Thread};
+use std::time::{Duration, Instant};
+
+/// A [`Waker`] whose `wake`, `clone`, and `drop` are all no-ops. The
+/// crate's single canonical noop waker: hand it to a [`Context`] when a
+/// poll loop makes progress by re-polling rather than by being woken.
+pub fn noop_waker() -> Waker {
+    fn raw() -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
+    // SAFETY: clone returns the same static vtable and wake/drop are
+    // no-ops, so the waker carries no state; the data pointer is never
+    // dereferenced.
+    unsafe { Waker::from_raw(raw()) }
+}
+
+/// Drive `fut` to completion on the current thread with a [`noop_waker`],
+/// running `idle` on every `Poll::Pending`.
+///
+/// Forward progress must come from elsewhere: the noop waker never
+/// resolves the wait, so this only terminates once `fut` itself returns
+/// `Poll::Ready` (because work on another thread completed). `idle` is
+/// where the caller decides how to spend the gap between polls. A
+/// production caller sleeps a few microseconds; a test passes a closure
+/// that counts spins and asserts a bound so a stuck future fails loudly
+/// instead of hanging.
+///
+/// This is the cooperative drive mode: it constructs no thread handle
+/// and reads no clock of its own, so it is safe under the deterministic
+/// simulation executor.
+pub fn block_on_cooperative<Fut, Idle>(fut: Fut, mut idle: Idle) -> Fut::Output
+where
+    Fut: Future,
+    Idle: FnMut(),
+{
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = std::pin::pin!(fut);
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(v) => return v,
+            Poll::Pending => idle(),
+        }
+    }
+}
+
+/// Waker that unparks a specific OS thread. A clone handed to a future
+/// (and, via the completion registry, stored in its `AtomicWaker`)
+/// unparks whichever thread constructed it.
+struct ThreadWaker {
+    thread: Thread,
+}
+
+impl Wake for ThreadWaker {
+    fn wake(self: Arc<Self>) {
+        self.thread.unpark();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.thread.unpark();
+    }
+}
+
+/// A [`Waker`] that unparks the calling thread. Hand it to a `Context`
+/// and `thread::park`/`park_timeout` between polls; any clone of it
+/// unparks this same thread. Use when a caller must interleave its own
+/// work between polls (the RPC worker writes a page between handler
+/// stream polls) and so cannot delegate to [`park_block_on_until`].
+///
+/// Parked mode: real OS threads only, never under the DST.
+pub fn thread_waker() -> Waker {
+    Waker::from(Arc::new(ThreadWaker {
+        thread: thread::current(),
+    }))
+}
+
+/// Drive `fut` to completion on the current thread, parking between
+/// polls, but abandon the wait early (returning `None`) once `timeout`
+/// elapses or `interrupt` reports `true`. `interrupt` is consulted
+/// before every poll, and each `Poll::Pending` parks for at most
+/// `slice` (capped further by the remaining budget) so a caller blocked
+/// on a completion that may never fire still observes an external
+/// signal - server shutdown, say - within one `slice` even if nothing
+/// unparks it. A wakeup that *does* arrive (the completion path unparks
+/// via the thread waker) resolves immediately, so the fast path pays no
+/// extra latency. `None` is returned for both the interrupt and the
+/// timeout; the caller treats either as "give up". Pass a `slice` equal
+/// to `timeout` and a `|| false` interrupt for a plain park-until-timeout.
+///
+/// Parked mode: real OS threads only, never under the DST.
+///
+/// # Wakeup race
+///
+/// `Thread::unpark` records a token if the thread is not currently
+/// parked, so a completion that fires between a `Poll::Pending` and the
+/// following `park`/`park_timeout` is not lost: the park returns
+/// immediately and the next poll observes the stored result. Spurious
+/// wakeups are equally harmless because every wakeup re-polls.
+pub fn park_block_on_until<F, I>(
+    fut: F,
+    timeout: Duration,
+    slice: Duration,
+    mut interrupt: I,
+) -> Option<F::Output>
+where
+    F: Future,
+    I: FnMut() -> bool,
+{
+    let waker = thread_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = std::pin::pin!(fut);
+    let deadline = Instant::now() + timeout;
+    loop {
+        if interrupt() {
+            return None;
+        }
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(v) => return Some(v),
+            Poll::Pending => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return None;
+                }
+                thread::park_timeout((deadline - now).min(slice));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+    #[test]
+    fn cooperative_resolves_when_a_later_poll_is_ready() {
+        // Pending for the first two polls, then ready: the idle closure
+        // counts the gaps so we can assert it ran exactly twice.
+        let polls = AtomicU32::new(0);
+        let idle_runs = std::cell::Cell::new(0u32);
+        let fut = std::future::poll_fn(|_cx| {
+            if polls.fetch_add(1, Ordering::Relaxed) < 2 {
+                Poll::Pending
+            } else {
+                Poll::Ready(99u32)
+            }
+        });
+        let out = block_on_cooperative(fut, || idle_runs.set(idle_runs.get() + 1));
+        assert_eq!(out, 99);
+        assert_eq!(idle_runs.get(), 2);
+    }
+
+    #[test]
+    fn cooperative_returns_ready_without_idling() {
+        let idled = std::cell::Cell::new(false);
+        let out = block_on_cooperative(std::future::ready(7u32), || idled.set(true));
+        assert_eq!(out, 7);
+        assert!(!idled.get(), "a ready future must not run the idle closure");
+    }
+
+    /// Future that resolves to `42` once `complete` is called, storing
+    /// the polling waker so the completer can wake it from any thread.
+    struct Signal {
+        ready: Mutex<bool>,
+        waker: Mutex<Option<Waker>>,
+    }
+
+    struct SignalFuture(Arc<Signal>);
+
+    impl Future for SignalFuture {
+        type Output = u32;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<u32> {
+            if *self.0.ready.lock().unwrap() {
+                return Poll::Ready(42);
+            }
+            *self.0.waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    fn complete(sig: &Arc<Signal>) {
+        *sig.ready.lock().unwrap() = true;
+        if let Some(w) = sig.waker.lock().unwrap().take() {
+            w.wake();
+        }
+    }
+
+    #[test]
+    fn ready_future_returns_without_parking() {
+        let out = park_block_on_until(
+            std::future::ready(7u32),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            || false,
+        );
+        assert_eq!(out, Some(7));
+    }
+
+    #[test]
+    fn pending_future_times_out() {
+        let out = park_block_on_until(
+            std::future::pending::<u32>(),
+            Duration::from_millis(10),
+            Duration::from_millis(10),
+            || false,
+        );
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn interrupt_abandons_a_pending_wait_before_timeout() {
+        // A future that never completes, a generous timeout, but an
+        // interrupt that is already set: the wait must give up at once
+        // (return `None`) instead of parking out the full timeout.
+        let out = park_block_on_until(
+            std::future::pending::<u32>(),
+            Duration::from_secs(3600),
+            Duration::from_millis(5),
+            || true,
+        );
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn interrupt_set_after_first_park_is_observed_within_a_slice() {
+        // The interrupt flips true shortly after the wait parks; the
+        // bounded slice guarantees the next loop iteration sees it and
+        // returns `None` well inside the (effectively unbounded) timeout.
+        let flag = Arc::new(AtomicBool::new(false));
+        let setter = flag.clone();
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(20));
+            setter.store(true, Ordering::Release);
+        });
+        let out = park_block_on_until(
+            std::future::pending::<u32>(),
+            Duration::from_secs(3600),
+            Duration::from_millis(5),
+            || flag.load(Ordering::Acquire),
+        );
+        handle.join().unwrap();
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn wakes_when_completed_from_another_thread() {
+        let sig = Arc::new(Signal {
+            ready: Mutex::new(false),
+            waker: Mutex::new(None),
+        });
+        let completer = sig.clone();
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(20));
+            complete(&completer);
+        });
+
+        // A timeout far longer than the completer's delay: the only way
+        // this resolves quickly is the wake/unpark path, not a poll
+        // interval. A slice equal to the timeout proves the resolution
+        // comes from the unpark, not from slice-bounded re-polling.
+        let out = park_block_on_until(
+            SignalFuture(sig),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            || false,
+        );
+        handle.join().unwrap();
+        assert_eq!(out, Some(42));
+    }
+}

--- a/cmd/unbounded-storage/src/runtime/mod.rs
+++ b/cmd/unbounded-storage/src/runtime/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 #[cfg(target_os = "linux")]
 mod pinned;
 
+mod executor;
 mod shard;
 
 #[cfg(target_os = "linux")]
@@ -17,6 +18,7 @@ pub use pinned::{PinnedRuntime, WorkerSpec};
 #[cfg(target_os = "linux")]
 pub use context::ShardContext;
 
+pub use executor::{block_on_cooperative, noop_waker, park_block_on_until, thread_waker};
 pub use shard::ShardLoop;
 
 /// Universal identifier for a worker slot. The bufferpool runs one

--- a/cmd/unbounded-storage/src/storage/blockdev/core_local.rs
+++ b/cmd/unbounded-storage/src/storage/blockdev/core_local.rs
@@ -3,11 +3,10 @@
 
 //! `BlockDevice` backed by the current storage core's [`StorageRing`].
 //!
-//! Unlike [`UringBlockDevice`], which owns its ring and is therefore
-//! `!Send`, a [`CoreLocalDevice`] owns no ring at all. It carries only
-//! the small, copyable disk metadata (page size, capacity, write queue
-//! depth) plus the registered `Fixed` file index for its disk, and
-//! resolves the actual ring at call time from the thread-local registry
+//! A [`CoreLocalDevice`] owns no ring at all. It carries only the small,
+//! copyable disk metadata (page size, capacity, write queue depth) plus
+//! the registered `Fixed` file index for its disk, and resolves the
+//! actual ring at call time from the thread-local registry
 //! ([`crate::ring`]). That makes it trivially `Send + Sync`:
 //! the engine that holds it can be published to any thread, but every
 //! [`BlockDevice`] call only succeeds on the storage core whose ring
@@ -15,8 +14,6 @@
 //! [`set_current_storage_ring`](crate::ring::set_current_storage_ring)).
 //! Off-core calls fail with `Err(Io(ENXIO))` rather than touching a
 //! foreign ring.
-//!
-//! [`UringBlockDevice`]: crate::storage::blockdev::UringBlockDevice
 
 use crate::ring::{current_storage_ring, with_current_storage_ring};
 use crate::storage::blockdev::BlockDevice;
@@ -139,19 +136,11 @@ fn off_core_err() -> Error {
 mod tests {
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Context, Poll};
 
     use super::*;
     use crate::ring::clear_current_storage_ring;
-
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-    fn noop_waker() -> Waker {
-        Arc::new(NoopWake).into()
-    }
+    use crate::runtime::noop_waker;
 
     fn block_on<F: Future>(mut fut: F) -> F::Output {
         let waker = noop_waker();

--- a/cmd/unbounded-storage/src/storage/blockdev/mock.rs
+++ b/cmd/unbounded-storage/src/storage/blockdev/mock.rs
@@ -158,7 +158,7 @@ impl BlockDevice for MockDevice {
     async fn read(&self, lba: Lba, dst: &mut [u8]) -> Result<(), Error> {
         self.read_count.set(self.read_count.get() + 1);
         let cfg = self.cfg.get();
-        // Match `UringBlockDevice::read`: reject empty buffers and
+        // Match `CoreLocalDevice::read`: reject empty buffers and
         // any length that is not a whole multiple of `page_size`.
         // The two implementations are interchangeable behind the
         // `BlockDevice` trait, so their input contracts must agree.

--- a/cmd/unbounded-storage/src/storage/blockdev/mod.rs
+++ b/cmd/unbounded-storage/src/storage/blockdev/mod.rs
@@ -26,7 +26,7 @@ pub use mock::{MockDevice, MockDeviceConfig, MockFaultMode};
 pub use scratch::{AcquireFut, ScratchPage, ScratchPool};
 
 #[cfg(target_os = "linux")]
-pub use uring::{OpenDisk, OpenError, UringBlockDevice, UringConfig, UringDevice, provision_file};
+pub use uring::{OpenDisk, OpenError, UringDevice, provision_file};
 
 use crate::storage::types::{Error, Lba};
 

--- a/cmd/unbounded-storage/src/storage/blockdev/scratch.rs
+++ b/cmd/unbounded-storage/src/storage/blockdev/scratch.rs
@@ -251,20 +251,11 @@ impl Future for AcquireFut {
 mod tests {
     use std::future::Future;
     use std::pin::pin;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Context, Poll};
 
     use super::*;
+    use crate::runtime::noop_waker;
     use crate::storage::blockdev::{MockDevice, MockDeviceConfig};
-
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    fn noop_waker() -> Waker {
-        Arc::new(NoopWake).into()
-    }
 
     fn block_on<F: Future>(f: F) -> F::Output {
         let w = noop_waker();

--- a/cmd/unbounded-storage/src/storage/blockdev/tests.rs
+++ b/cmd/unbounded-storage/src/storage/blockdev/tests.rs
@@ -5,22 +5,17 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Wake, Waker};
+use std::task::{Context, Poll};
 
 use super::{BlockDevice, MockDevice, MockDeviceConfig, MockFaultMode};
+use crate::runtime::noop_waker;
 use crate::storage::types::{Error, Lba};
 
 // Minimal noop-waker block_on so we can exercise async fns without
 // pulling in tokio. Matches the pattern documented in the crate
 // AGENTS.md.
-struct NoopWake;
-impl Wake for NoopWake {
-    fn wake(self: Arc<Self>) {}
-}
-
 fn block_on<F: Future>(fut: F) -> F::Output {
-    let waker: Waker = Arc::new(NoopWake).into();
+    let waker = noop_waker();
     let mut cx = Context::from_waker(&waker);
     let mut fut = Box::pin(fut);
     let mut spins = 0u32;
@@ -122,12 +117,19 @@ fn peek_poke_match_read_write() {
 
 #[cfg(target_os = "linux")]
 mod uring_tests {
+    use std::future::Future;
     use std::io::Write as _;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+    use std::pin::Pin;
+    use std::rc::Rc;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::task::{Context, Poll};
 
-    use super::super::{BlockDevice, UringBlockDevice, UringConfig};
-    use super::block_on;
+    use super::super::{BlockDevice, CoreLocalDevice, OpenDisk, UringDevice};
+    use crate::ring::{
+        StorageRing, StorageRingConfig, clear_current_storage_ring, set_current_storage_ring,
+    };
+    use crate::runtime::noop_waker;
     use crate::storage::types::{Error, Lba};
 
     static SEQ: AtomicU64 = AtomicU64::new(0);
@@ -159,9 +161,61 @@ mod uring_tests {
         }
     }
 
+    /// RAII guard that keeps a [`StorageRing`] installed as this thread's
+    /// storage ring for the body of a test and tears it down in the
+    /// right order on drop.
+    ///
+    /// A [`CoreLocalDevice`] resolves its ring from the thread-local
+    /// registry, so a ring must be installed before any device I/O. On
+    /// drop the thread-local is cleared first (so a later test reusing
+    /// this pooled thread never observes a stale ring), then `ring`
+    /// drops - unregistering the disk fd - and finally `_file` closes
+    /// it.
+    struct Installed {
+        ring: Rc<StorageRing>,
+        _file: std::fs::File,
+    }
+
+    impl Drop for Installed {
+        fn drop(&mut self) {
+            clear_current_storage_ring();
+        }
+    }
+
+    /// Open `path` through the production [`UringDevice::open`] path with
+    /// the tmpfile-friendly `test_local` ring config (no IOPOLL, no
+    /// O_DIRECT), install the returned ring, and hand back the
+    /// [`CoreLocalDevice`] plus the install guard.
+    fn open_installed(path: &Path, page_size: usize) -> (CoreLocalDevice, Installed) {
+        let OpenDisk { device, ring, file } =
+            UringDevice::open(path, StorageRingConfig::test_local(), false, page_size)
+                .expect("open uring device");
+        let ring = Rc::new(ring);
+        set_current_storage_ring(ring.clone());
+        (device, Installed { ring, _file: file })
+    }
+
+    /// Drive a single block-device future to completion, pumping the
+    /// installed ring's `progress()` between polls so submitted SQEs are
+    /// reaped (mirrors the production storage-core loop).
+    fn run_io<O>(installed: &Installed, fut: impl Future<Output = O>) -> O {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = Box::pin(fut);
+        let mut spins = 0u32;
+        loop {
+            if let Poll::Ready(v) = Pin::as_mut(&mut fut).poll(&mut cx) {
+                return v;
+            }
+            installed.ring.progress().expect("ring progress");
+            spins += 1;
+            assert!(spins < 1_000_000, "run_io spun without progress");
+        }
+    }
+
     fn aligned_buffer(len: usize) -> (Vec<u8>, *mut u8) {
-        // Page-aligned via Box<[u64]> backing.
-        let words = (len + 7) / 8;
+        // Page-aligned via an oversized Vec we offset into.
+        let words = len.div_ceil(8);
         let mut v = vec![0u8; words * 8 + 4096];
         let raw = v.as_mut_ptr();
         let aligned_off = raw.align_offset(4096);
@@ -177,23 +231,22 @@ mod uring_tests {
     fn open_reports_capacity() {
         let (page_size, pages) = geometry();
         let path = TempPath(make_tempfile(pages, page_size));
-        let dev =
-            UringBlockDevice::open(&path.0, UringConfig::test_local()).expect("open uring device");
-        assert_eq!(dev.page_size(), page_size);
-        assert_eq!(dev.capacity_pages(), pages);
-        assert_eq!(dev.write_queue_depth(), 8);
+        let (device, _installed) = open_installed(&path.0, page_size);
+        assert_eq!(device.page_size(), page_size);
+        assert_eq!(device.capacity_pages(), pages);
+        assert_eq!(device.write_queue_depth(), 8);
     }
 
     #[test]
     fn read_back_what_we_wrote() {
         let (page_size, pages) = geometry();
         let path = TempPath(make_tempfile(pages, page_size));
-        let dev =
-            UringBlockDevice::open(&path.0, UringConfig::test_local()).expect("open uring device");
+        let (device, installed) = open_installed(&path.0, page_size);
 
         let buf_len = page_size * 4;
         let (_owner, base) = aligned_buffer(buf_len);
-        dev.register_buffers(base, buf_len)
+        device
+            .register_buffers(base, buf_len)
             .expect("register buffers");
 
         // SAFETY: we own the buffer for the duration of the test.
@@ -201,12 +254,12 @@ mod uring_tests {
         for (i, b) in src.iter_mut().enumerate() {
             *b = (i as u8).wrapping_mul(31).wrapping_add(7);
         }
-        block_on(dev.write(Lba(3), src)).expect("write");
+        run_io(&installed, device.write(Lba(3), src)).expect("write");
 
         let dst_ptr = unsafe { base.add(page_size * 2) };
         let dst = unsafe { std::slice::from_raw_parts_mut(dst_ptr, page_size) };
         dst.fill(0);
-        block_on(dev.read(Lba(3), dst)).expect("read");
+        run_io(&installed, device.read(Lba(3), dst)).expect("read");
 
         for (i, b) in dst.iter().enumerate() {
             assert_eq!(*b, (i as u8).wrapping_mul(31).wrapping_add(7), "byte {i}");
@@ -217,16 +270,15 @@ mod uring_tests {
     fn read_unwritten_page_returns_seed_bytes() {
         let (page_size, pages) = geometry();
         let path = TempPath(make_tempfile(pages, page_size));
-        let dev =
-            UringBlockDevice::open(&path.0, UringConfig::test_local()).expect("open uring device");
+        let (device, installed) = open_installed(&path.0, page_size);
 
         let buf_len = page_size;
         let (_owner, base) = aligned_buffer(buf_len);
-        dev.register_buffers(base, buf_len).unwrap();
+        device.register_buffers(base, buf_len).unwrap();
 
         let dst = unsafe { std::slice::from_raw_parts_mut(base, page_size) };
         dst.fill(0);
-        block_on(dev.read(Lba(0), dst)).expect("read");
+        run_io(&installed, device.read(Lba(0), dst)).expect("read");
         // make_tempfile seeds the file with 0xa5.
         assert!(dst.iter().all(|b| *b == 0xa5));
     }
@@ -235,14 +287,13 @@ mod uring_tests {
     fn out_of_range_lba_rejected_without_io() {
         let (page_size, pages) = geometry();
         let path = TempPath(make_tempfile(pages, page_size));
-        let dev =
-            UringBlockDevice::open(&path.0, UringConfig::test_local()).expect("open uring device");
+        let (device, installed) = open_installed(&path.0, page_size);
 
         let buf_len = page_size;
         let (_owner, base) = aligned_buffer(buf_len);
-        dev.register_buffers(base, buf_len).unwrap();
+        device.register_buffers(base, buf_len).unwrap();
         let dst = unsafe { std::slice::from_raw_parts_mut(base, page_size) };
-        let err = block_on(dev.read(Lba(pages), dst));
+        let err = run_io(&installed, device.read(Lba(pages), dst));
         assert!(matches!(err, Err(Error::OutOfRange)));
     }
 
@@ -250,12 +301,11 @@ mod uring_tests {
     fn write_without_registered_buffer_errors() {
         let (page_size, pages) = geometry();
         let path = TempPath(make_tempfile(pages, page_size));
-        let dev =
-            UringBlockDevice::open(&path.0, UringConfig::test_local()).expect("open uring device");
+        let (device, installed) = open_installed(&path.0, page_size);
 
         let (_owner, base) = aligned_buffer(page_size);
         let src = unsafe { std::slice::from_raw_parts(base, page_size) };
-        let err = block_on(dev.write(Lba(0), src));
+        let err = run_io(&installed, device.write(Lba(0), src));
         assert!(matches!(err, Err(Error::Io(_))));
     }
 }

--- a/cmd/unbounded-storage/src/storage/blockdev/uring.rs
+++ b/cmd/unbounded-storage/src/storage/blockdev/uring.rs
@@ -1,562 +1,35 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Linux io_uring backend for [`BlockDevice`].
+//! Linux io_uring disk-open path plus file provisioning helpers.
 //!
-//! Each [`UringBlockDevice`] owns exactly one ring and the file
-//! descriptor for one disk. The ring is set up with
-//! `IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_DEFER_TASKRUN |
-//! IORING_SETUP_IOPOLL` in production so submission and completion
-//! reaping both run on a single pinned shard thread; the device is
-//! therefore `!Send + !Sync` by construction.
+//! [`UringDevice::open`] is the production entry point for bringing a
+//! disk online on a pinned storage core: it builds the [`StorageRing`]
+//! the core drives, opens and sizes the backing file (regular file or
+//! raw block device via `BLKGETSIZE64`), registers the file descriptor
+//! to obtain a `Fixed` index, and binds the geometry into a
+//! `Send + Sync` [`CoreLocalDevice`] that resolves the ring from the
+//! thread-local registry at call time. The ring, device, and owned file
+//! are returned together in an [`OpenDisk`] so the caller controls
+//! installation into the registry and teardown order.
 //!
-//! All I/O is issued via `READ_FIXED` / `WRITE_FIXED` against a
-//! sparse table of `IORING_REGISTER_BUFFERS` slots. Each call to
-//! [`UringBlockDevice::register_buffers`] fills the next free slot;
-//! per-I/O the device resolves the right `buf_index` by locating
-//! the destination pointer inside one of the registered regions.
-//! A single registered file (`IORING_REGISTER_FILES`, `Fixed(0)`)
-//! is also installed at open time.
-//!
-//! ## Concurrency model
-//!
-//! The device is fully asynchronous: each in-flight op owns an
-//! [`IoSlot`] holding its eventual CQE result and the [`Waker`] of
-//! the task awaiting it. The executor is expected to call
-//! [`UringBlockDevice::progress`] periodically (and implicitly via
-//! the [`BlockDevice::progress`] trait method) to push queued SQEs
-//! to the kernel and reap any pending CQEs, waking the matching
-//! task and freeing a back-pressure slot.
-//!
-//! Submission depth is capped at `queue_depth`; callers attempting
-//! to issue beyond that point park on a `submit_waiters` queue and
-//! resume in FIFO order as completions free slots.
-//!
-//! Tests and any non-NVMe usage use [`UringConfig::test_local`]
-//! which disables `IOPOLL`, `SINGLE_ISSUER`, `DEFER_TASKRUN`, and
-//! `O_DIRECT` so the same code path runs on a regular tmpfile.
+//! [`provision_file`] and the private capacity helpers round out the
+//! `kind = "file"` disk lifecycle: create-and-size a backing file on
+//! startup and derive its page capacity.
 
-use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
 use std::ffi::CString;
 use std::fs::File;
-use std::future::Future;
 use std::io;
-use std::marker::PhantomData;
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::path::Path;
-use std::pin::Pin;
-use std::ptr::NonNull;
-use std::rc::Rc;
-use std::task::{Context, Poll, Waker};
 
-use io_uring::{IoUring, opcode, types};
-
-use super::{BlockDevice, CoreLocalDevice};
+use super::CoreLocalDevice;
 use crate::ring::{StorageRing, StorageRingConfig};
-use crate::storage::types::{Error, Lba};
-
-/// Knobs for opening a [`UringBlockDevice`]. The defaults are what
-/// production NVMe configuration wants; [`UringConfig::test_local`]
-/// strips out every flag that requires real hardware so the same
-/// code can be exercised against a tmpfile from `cargo test`.
-#[derive(Copy, Clone, Debug)]
-pub struct UringConfig {
-    /// Set `IORING_SETUP_IOPOLL`. Requires `o_direct == true` and a
-    /// block device that supports polling.
-    pub iopoll: bool,
-    /// Set `IORING_SETUP_SINGLE_ISSUER`. Requires the same thread to
-    /// own submit + reap for the lifetime of the ring.
-    pub single_issuer: bool,
-    /// Set `IORING_SETUP_DEFER_TASKRUN`. Pairs with `single_issuer`.
-    pub defer_taskrun: bool,
-    /// Open the underlying file with `O_DIRECT`. Mandatory for
-    /// `iopoll` and recommended whenever the page cache is not in
-    /// the data path.
-    pub o_direct: bool,
-    /// Submission queue depth (the same depth is used for the
-    /// completion queue by the kernel).
-    pub queue_depth: u32,
-    /// Block-device page size. Must match the engine's
-    /// `EngineConfig::page_size_bytes` for the disk-side path and
-    /// the value used to compute LBAs.
-    pub page_size: usize,
-}
-
-impl Default for UringConfig {
-    fn default() -> Self {
-        Self {
-            iopoll: true,
-            single_issuer: true,
-            defer_taskrun: true,
-            o_direct: true,
-            queue_depth: 256,
-            page_size: 4096,
-        }
-    }
-}
-
-impl UringConfig {
-    /// Knob set that works against a regular file on any reasonable
-    /// filesystem. Used by the inline tests in this file and by
-    /// anyone exercising the engine without a real NVMe namespace.
-    pub fn test_local() -> Self {
-        Self {
-            iopoll: false,
-            single_issuer: false,
-            defer_taskrun: false,
-            o_direct: false,
-            queue_depth: 8,
-            page_size: 4096,
-        }
-    }
-}
-
-/// One ring + one file descriptor + a sparse table of registered
-/// buffers. Pinned to the thread that opened it;
-/// `PhantomData<*const ()>` makes that non-negotiable to the type
-/// system.
-pub struct UringBlockDevice {
-    file: File,
-    ring: RefCell<IoUring>,
-    /// Pre-registered I/O buffer slots. Each call to
-    /// [`Self::register_buffers`] fills the next entry; reads and
-    /// writes locate their slot by pointer.
-    registered: RefCell<Vec<RegisteredBuf>>,
-    /// Number of slots the sparse table was created with.
-    /// Registrations beyond this fail with `-ENOSPC`.
-    slot_capacity: u32,
-    /// Per-in-flight-op state, keyed by `user_data`. Entries are
-    /// inserted at submit time and removed in [`Self::progress`]
-    /// once the matching CQE is reaped.
-    slots: RefCell<HashMap<u64, Rc<IoSlot>>>,
-    /// Number of SQEs currently submitted (or pending submission)
-    /// against the kernel. Bounded by `queue_depth` via the
-    /// `submit_waiters` back-pressure queue.
-    submitted: Cell<u32>,
-    /// High-water mark of `submitted` since the device was opened,
-    /// recorded at increment time in [`Self::submit_fixed_io`]. Lets
-    /// callers (and tests) observe that ops actually went in-flight
-    /// even when each op completes within its own poll - the
-    /// transient peak is invisible to an external sample of
-    /// `submitted`, which can return to zero before it is read.
-    peak_submitted: Cell<u32>,
-    /// FIFO of wakers parked because `submitted == queue_depth`
-    /// at submit time. Drained one-per-completion in `progress`.
-    submit_waiters: RefCell<Vec<Waker>>,
-    next_user_data: Cell<u64>,
-    page_size: usize,
-    capacity_pages: u64,
-    queue_depth: u32,
-    _no_send: PhantomData<*const ()>,
-}
-
-#[derive(Copy, Clone)]
-struct RegisteredBuf {
-    base: NonNull<u8>,
-    len: usize,
-}
-
-/// Maximum number of distinct registered regions a single ring
-/// can hold. Sized for "bufferpool backing + a small handful of
-/// scratch / extra backings" with comfortable headroom; bump if a
-/// real deployment ever needs more than this.
-const MAX_REGISTERED_SLOTS: u32 = 32;
-
-/// Per-op completion slot. The waker is registered by the
-/// [`IoFut`] poll path; the result is filled by
-/// [`UringBlockDevice::progress`] when the matching CQE is reaped.
-struct IoSlot {
-    result: Cell<Option<i32>>,
-    waker: RefCell<Option<Waker>>,
-}
-
-impl IoSlot {
-    fn new() -> Self {
-        Self {
-            result: Cell::new(None),
-            waker: RefCell::new(None),
-        }
-    }
-}
-
-impl UringBlockDevice {
-    /// Open `path` and build a ring configured per `cfg`.
-    ///
-    /// The file is opened `O_RDWR` plus `O_DIRECT` when `cfg.o_direct`
-    /// is set. Capacity is derived from `metadata().len() /
-    /// page_size`; raw block devices return their full size from
-    /// `metadata()` on Linux, so this works for both regular files
-    /// and `/dev/nvmeXnY`.
-    pub fn open(path: &Path, cfg: UringConfig) -> Result<Self, Error> {
-        if cfg.page_size == 0 || cfg.queue_depth == 0 {
-            return Err(Error::Io(libc::EINVAL));
-        }
-        let file = open_file(path, cfg.o_direct)?;
-        let capacity_pages = file_capacity_pages(&file, cfg.page_size)?;
-
-        let mut builder = IoUring::builder();
-        if cfg.iopoll {
-            builder.setup_iopoll();
-        }
-        if cfg.single_issuer {
-            builder.setup_single_issuer();
-        }
-        if cfg.defer_taskrun {
-            builder.setup_defer_taskrun();
-        }
-        let ring = builder.build(cfg.queue_depth).map_err(io_err_to_storage)?;
-
-        ring.submitter()
-            .register_files(&[file.as_raw_fd()])
-            .map_err(io_err_to_storage)?;
-
-        Ok(Self {
-            file,
-            ring: RefCell::new(ring),
-            registered: RefCell::new(Vec::new()),
-            slot_capacity: MAX_REGISTERED_SLOTS,
-            slots: RefCell::new(HashMap::new()),
-            submitted: Cell::new(0),
-            peak_submitted: Cell::new(0),
-            submit_waiters: RefCell::new(Vec::new()),
-            next_user_data: Cell::new(1),
-            page_size: cfg.page_size,
-            capacity_pages,
-            queue_depth: cfg.queue_depth,
-            _no_send: PhantomData,
-        })
-    }
-
-    /// Push queued SQEs to the kernel and reap any available CQEs,
-    /// waking the awaiting futures and freeing back-pressure slots.
-    ///
-    /// Always non-blocking: never calls `submit_and_wait(N > 0)`.
-    /// The executor is responsible for calling this periodically
-    /// (typically from its idle hook) so in-flight ops can complete.
-    pub fn progress(&self) -> Result<(), Error> {
-        // 1. Push any newly-queued SQEs to the kernel without
-        // waiting. With IOPOLL, this also gives the kernel a chance
-        // to drive polling.
-        {
-            let ring = self.ring.borrow_mut();
-            ring.submitter().submit().map_err(io_err_to_storage)?;
-        }
-
-        // 2. Drain the completion queue. Collect wakers under the
-        // ring borrow, then drop the borrow before waking so wake
-        // handlers are free to re-enter the device.
-        let mut to_wake: Vec<Waker> = Vec::new();
-        {
-            let mut ring = self.ring.borrow_mut();
-            let mut cq = ring.completion();
-            cq.sync();
-            while let Some(cqe) = cq.next() {
-                let ud = cqe.user_data();
-                let res = cqe.result();
-                if let Some(slot) = self.slots.borrow_mut().remove(&ud) {
-                    slot.result.set(Some(res));
-                    if let Some(w) = slot.waker.borrow_mut().take() {
-                        to_wake.push(w);
-                    }
-                }
-                // submitted count tracks live slots, not CQEs in
-                // the abstract: decrement once per reaped op.
-                let n = self.submitted.get();
-                debug_assert!(n > 0, "completion without outstanding submission");
-                self.submitted.set(n.saturating_sub(1));
-
-                // Free one back-pressure waiter per completion.
-                if let Some(w) = pop_front_waker(&mut self.submit_waiters.borrow_mut()) {
-                    to_wake.push(w);
-                }
-            }
-        }
-
-        for w in to_wake {
-            w.wake();
-        }
-        Ok(())
-    }
-
-    fn alloc_user_data(&self) -> u64 {
-        let v = self.next_user_data.get();
-        // Avoid u64::MAX so it can be reserved by callers if needed.
-        let next = v.checked_add(1).unwrap_or(1);
-        self.next_user_data.set(next);
-        v
-    }
-
-    fn resolve_buf_index(&self, ptr: *const u8, len: usize) -> Result<u16, Error> {
-        let regs = self.registered.borrow();
-        if regs.is_empty() {
-            return Err(Error::Io(libc::EINVAL));
-        }
-        let start = ptr as usize;
-        let end = start.checked_add(len).ok_or(Error::Io(libc::EOVERFLOW))?;
-        for (idx, reg) in regs.iter().enumerate() {
-            let base = reg.base.as_ptr() as usize;
-            if start >= base && end <= base + reg.len {
-                return Ok(idx as u16);
-            }
-        }
-        Err(Error::Io(libc::EFAULT))
-    }
-
-    /// Wait (cooperatively) for a free submission slot, then push
-    /// `sqe` and resolve once the kernel completes it.
-    async fn submit_fixed_io(
-        &self,
-        sqe: io_uring::squeue::Entry,
-        expected_len: usize,
-    ) -> Result<(), Error> {
-        SubmitSlot { dev: self }.await;
-
-        let user_data = sqe.get_user_data();
-        let slot = Rc::new(IoSlot::new());
-        self.slots.borrow_mut().insert(user_data, Rc::clone(&slot));
-        self.submitted.set(self.submitted.get() + 1);
-        if self.submitted.get() > self.peak_submitted.get() {
-            self.peak_submitted.set(self.submitted.get());
-        }
-
-        // SAFETY: SQE references caller-owned buffers within the
-        // registered region; the caller keeps them alive until this
-        // future resolves. The ring is !Send so no other thread can
-        // drop the slot under us.
-        let push_res = unsafe {
-            let mut ring = self.ring.borrow_mut();
-            let mut sq = ring.submission();
-            sq.push(&sqe)
-        };
-        if push_res.is_err() {
-            // Roll back bookkeeping if the SQ was unexpectedly full.
-            self.slots.borrow_mut().remove(&user_data);
-            self.submitted.set(self.submitted.get().saturating_sub(1));
-            // Some waiter may now fit; wake one.
-            if let Some(w) = pop_front_waker(&mut self.submit_waiters.borrow_mut()) {
-                w.wake();
-            }
-            return Err(Error::Io(libc::ENOMEM));
-        }
-
-        let res = IoFut {
-            dev: self,
-            slot,
-            done: false,
-        }
-        .await?;
-
-        if res < 0 {
-            return Err(Error::Io(-res));
-        }
-        if res as usize != expected_len {
-            return Err(Error::Io(libc::EIO));
-        }
-        Ok(())
-    }
-}
-
-impl BlockDevice for UringBlockDevice {
-    fn page_size(&self) -> usize {
-        self.page_size
-    }
-
-    fn capacity_pages(&self) -> u64 {
-        self.capacity_pages
-    }
-
-    fn register_buffers(&self, base: *mut u8, len: usize) -> Result<(), Error> {
-        let nn = NonNull::new(base).ok_or(Error::Io(libc::EINVAL))?;
-        // Compute `was_nonempty` up front so we do not hold a borrow
-        // of `self.registered` across the unsafe block, where the
-        // mirror gets mutated.
-        let was_nonempty = {
-            let regs = self.registered.borrow();
-            if regs.len() as u32 >= self.slot_capacity {
-                return Err(Error::Io(libc::ENOSPC));
-            }
-            !regs.is_empty()
-        };
-        // The io-uring 0.6 surface only exposes the "replace the
-        // whole table" form, so re-register every region every time.
-        //
-        // INVARIANT: `self.registered` must always mirror the
-        // kernel-side table. This path is NOT open-time only:
-        // `shard_view::replay_locked` re-registers buffers at runtime
-        // during a hot-swap. `unregister_buffers` empties the kernel
-        // table, so if the subsequent `register_buffers` fails we must
-        // leave the mirror EMPTY (matching the now-empty kernel table)
-        // rather than the stale prior set; otherwise `resolve_buf_index`
-        // would hand out indices into a table the kernel no longer has
-        // and every later READ_FIXED/WRITE_FIXED would fail with EFAULT.
-        // The error is still propagated, so the caller (replay) must
-        // tolerate a returned error.
-        let mut new_regs = self.registered.borrow().clone();
-        new_regs.push(RegisteredBuf { base: nn, len });
-        let iovs: Vec<libc::iovec> = new_regs
-            .iter()
-            .map(|r| libc::iovec {
-                iov_base: r.base.as_ptr() as *mut libc::c_void,
-                iov_len: r.len,
-            })
-            .collect();
-        // SAFETY: every (base, len) in `new_regs` was provided by a
-        // caller that owns the region for the lifetime of the
-        // device; we keep `new_regs` parallel to the kernel-side
-        // table.
-        let register_result = unsafe {
-            let submitter = self.ring.borrow();
-            let submitter = submitter.submitter();
-            // If there is already a table, drop it first; the
-            // kernel rejects a second `register_buffers` otherwise.
-            if was_nonempty {
-                let _ = submitter.unregister_buffers();
-            }
-            submitter.register_buffers(&iovs).map_err(io_err_to_storage)
-        };
-        let mut mirror = self.registered.borrow_mut();
-        apply_registration_result(&mut mirror, new_regs, register_result)
-    }
-
-    async fn read(&self, lba: Lba, dst: &mut [u8]) -> Result<(), Error> {
-        if dst.is_empty() || dst.len() % self.page_size != 0 {
-            return Err(Error::Io(libc::EINVAL));
-        }
-        let n_pages = (dst.len() / self.page_size) as u64;
-        if lba
-            .0
-            .checked_add(n_pages)
-            .is_none_or(|end| end > self.capacity_pages)
-        {
-            return Err(Error::OutOfRange);
-        }
-        // Locate which registered region holds `dst` so we can
-        // address it via READ_FIXED's buf_index. -EFAULT here
-        // surfaces as a clean Err rather than a kernel rejection.
-        let buf_index = self.resolve_buf_index(dst.as_ptr(), dst.len())?;
-        let user_data = self.alloc_user_data();
-        let offset = lba.0.saturating_mul(self.page_size as u64);
-        let sqe = opcode::ReadFixed::new(
-            types::Fixed(0),
-            dst.as_mut_ptr(),
-            dst.len() as u32,
-            buf_index,
-        )
-        .offset(offset)
-        .build()
-        .user_data(user_data);
-        self.submit_fixed_io(sqe, dst.len()).await
-    }
-
-    async fn write(&self, lba: Lba, src: &[u8]) -> Result<(), Error> {
-        if src.is_empty() || src.len() % self.page_size != 0 {
-            return Err(Error::Io(libc::EINVAL));
-        }
-        let n_pages = (src.len() / self.page_size) as u64;
-        if lba
-            .0
-            .checked_add(n_pages)
-            .is_none_or(|end| end > self.capacity_pages)
-        {
-            return Err(Error::OutOfRange);
-        }
-        // See [`Self::read`] for buf_index resolution.
-        let buf_index = self.resolve_buf_index(src.as_ptr(), src.len())?;
-        let user_data = self.alloc_user_data();
-        let offset = lba.0.saturating_mul(self.page_size as u64);
-        let sqe =
-            opcode::WriteFixed::new(types::Fixed(0), src.as_ptr(), src.len() as u32, buf_index)
-                .offset(offset)
-                .build()
-                .user_data(user_data);
-        self.submit_fixed_io(sqe, src.len()).await
-    }
-
-    fn write_queue_depth(&self) -> u32 {
-        self.queue_depth
-    }
-
-    fn progress(&self) -> Result<(), Error> {
-        UringBlockDevice::progress(self)
-    }
-}
-
-impl Drop for UringBlockDevice {
-    fn drop(&mut self) {
-        // Best-effort cleanup. The ring's own Drop will close the
-        // ring fd; we unregister so that the kernel releases the
-        // pinned buffer/file table immediately rather than waiting
-        // for fd teardown.
-        let sub = self.ring.get_mut().submitter();
-        let _ = sub.unregister_buffers();
-        let _ = sub.unregister_files();
-        let _ = &self.file; // keep the file alive until drop runs.
-    }
-}
-
-/// Back-pressure park: yields `Pending` while `submitted ==
-/// queue_depth`, registering the caller's waker on each poll so
-/// `progress` can resume it when a slot frees up.
-struct SubmitSlot<'a> {
-    dev: &'a UringBlockDevice,
-}
-
-impl<'a> Future for SubmitSlot<'a> {
-    type Output = ();
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        let dev = self.dev;
-        if dev.submitted.get() < dev.queue_depth {
-            return Poll::Ready(());
-        }
-        // Try to opportunistically drive completions to free a slot
-        // before parking.
-        let _ = dev.progress();
-        if dev.submitted.get() < dev.queue_depth {
-            return Poll::Ready(());
-        }
-        dev.submit_waiters.borrow_mut().push(cx.waker().clone());
-        Poll::Pending
-    }
-}
-
-/// Future that resolves once the kernel returns a CQE for a slot.
-struct IoFut<'a> {
-    dev: &'a UringBlockDevice,
-    slot: Rc<IoSlot>,
-    done: bool,
-}
-
-impl<'a> Future for IoFut<'a> {
-    type Output = Result<i32, Error>;
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<i32, Error>> {
-        let this = self.get_mut();
-        if this.done {
-            return Poll::Pending;
-        }
-        if let Some(res) = this.slot.result.get() {
-            this.done = true;
-            return Poll::Ready(Ok(res));
-        }
-        // Opportunistically peek the CQ; if the kernel has the
-        // result ready we can finish without a re-poll round-trip.
-        if let Err(e) = this.dev.progress() {
-            this.done = true;
-            return Poll::Ready(Err(e));
-        }
-        if let Some(res) = this.slot.result.get() {
-            this.done = true;
-            return Poll::Ready(Ok(res));
-        }
-        *this.slot.waker.borrow_mut() = Some(cx.waker().clone());
-        Poll::Pending
-    }
-}
+use crate::storage::types::Error;
 
 /// Opens a disk for a pinned storage core.
 ///
-/// Unlike [`UringBlockDevice`], which owns its ring and is therefore
-/// `!Send`, this path produces a [`StorageRing`] the storage core owns
+/// This path produces a [`StorageRing`] the storage core owns
 /// separately (so it can install the ring into the thread-local
 /// registry and drive it alongside the engine) plus a `Send + Sync`
 /// [`CoreLocalDevice`] that resolves that ring at call time. The whole
@@ -567,10 +40,15 @@ pub struct UringDevice;
 
 impl UringDevice {
     /// Open `path` for a storage core: build the ring per `ring_cfg`,
-    /// open the file (`O_DIRECT` when the ring uses `IOPOLL`), size it
-    /// (via `metadata().len()`, falling back to `BLKGETSIZE64` for raw
-    /// block devices), register its fd to get a `Fixed` index, and bind
-    /// the geometry into a [`CoreLocalDevice`].
+    /// open the file (`O_DIRECT` when `o_direct` is set), size it (via
+    /// `metadata().len()`, falling back to `BLKGETSIZE64` for raw block
+    /// devices), register its fd to get a `Fixed` index, and bind the
+    /// geometry into a [`CoreLocalDevice`].
+    ///
+    /// `o_direct` is decoupled from the ring's `IOPOLL` flag so callers
+    /// can choose them independently (a tmpfile benchmark may want
+    /// neither, production NVMe wants both). `IOPOLL` still requires
+    /// `O_DIRECT`, so production callers pass `o_direct = ring_cfg.iopoll`.
     ///
     /// The syscall order is exactly: ring construction, file open,
     /// capacity probe, file registration. The returned [`OpenDisk`]
@@ -583,11 +61,11 @@ impl UringDevice {
     pub fn open(
         path: &Path,
         ring_cfg: StorageRingConfig,
+        o_direct: bool,
         page_size: usize,
     ) -> Result<OpenDisk, OpenError> {
         let ring = StorageRing::new(ring_cfg).map_err(OpenError::Ring)?;
-        // IOPOLL requires O_DIRECT; mirror that on the file open.
-        let file = open_file(path, ring_cfg.iopoll).map_err(OpenError::OpenFile)?;
+        let file = open_file(path, o_direct).map_err(OpenError::OpenFile)?;
         let capacity_pages = file_capacity_pages(&file, page_size).map_err(OpenError::Capacity)?;
         let file_index = ring
             .register_file(file.as_raw_fd())
@@ -617,6 +95,7 @@ pub struct OpenDisk {
 /// Failure from [`UringDevice::open`], tagged by the phase that failed
 /// so the supervisor surfaces the same diagnostic it did when this
 /// logic was inline on the storage-core thread.
+#[derive(Debug)]
 pub enum OpenError {
     Ring(Error),
     OpenFile(Error),
@@ -631,42 +110,6 @@ impl std::fmt::Display for OpenError {
             OpenError::OpenFile(e) => write!(f, "open disk: {e}"),
             OpenError::Capacity(e) => write!(f, "disk capacity: {e}"),
             OpenError::RegisterFile(e) => write!(f, "register file: {e}"),
-        }
-    }
-}
-
-/// Pop the oldest waker from `v`, treating it as a FIFO. `Vec` is
-/// fine here because the queue is bounded by `queue_depth` and we
-/// only manipulate it on the owning thread.
-fn pop_front_waker(v: &mut Vec<Waker>) -> Option<Waker> {
-    if v.is_empty() {
-        None
-    } else {
-        Some(v.remove(0))
-    }
-}
-
-/// Reconcile the local mirror of the kernel registered-buffer table
-/// after a "unregister then register" swap.
-///
-/// By the time this is called the kernel table has already been
-/// emptied (`unregister_buffers`) and re-registration attempted. On
-/// success the mirror becomes the full `new_regs` table. On failure
-/// the kernel table is empty, so the mirror is cleared to match rather
-/// than left describing the stale prior set; the error is returned.
-fn apply_registration_result(
-    mirror: &mut Vec<RegisteredBuf>,
-    new_regs: Vec<RegisteredBuf>,
-    register_result: Result<(), Error>,
-) -> Result<(), Error> {
-    match register_result {
-        Ok(()) => {
-            *mirror = new_regs;
-            Ok(())
-        }
-        Err(e) => {
-            mirror.clear();
-            Err(e)
         }
     }
 }
@@ -785,213 +228,18 @@ fn io_err_to_storage(e: io::Error) -> Error {
 
 #[cfg(test)]
 mod tests {
-    use std::future::Future;
-    use std::io::Write as _;
     use std::path::PathBuf;
-    use std::pin::Pin;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::task::{Context, Poll, Wake, Waker};
 
     use super::*;
 
     static SEQ: AtomicU64 = AtomicU64::new(0);
-
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
-    fn noop_waker() -> Waker {
-        Arc::new(NoopWake).into()
-    }
-
-    /// Drive multiple futures cooperatively while calling
-    /// `dev.progress()` between polls. Returns the collected outputs
-    /// in submission order once every future is ready.
-    fn pump<O>(
-        dev: &UringBlockDevice,
-        mut futs: Vec<Pin<Box<dyn Future<Output = O> + '_>>>,
-    ) -> Vec<O> {
-        let waker = noop_waker();
-        let mut cx = Context::from_waker(&waker);
-        let mut out: Vec<Option<O>> = (0..futs.len()).map(|_| None).collect();
-        let mut spins = 0u32;
-        loop {
-            let mut made_progress = false;
-            for (i, fut) in futs.iter_mut().enumerate() {
-                if out[i].is_some() {
-                    continue;
-                }
-                if let Poll::Ready(v) = Pin::as_mut(fut).poll(&mut cx) {
-                    out[i] = Some(v);
-                    made_progress = true;
-                }
-            }
-            dev.progress().expect("progress");
-            if out.iter().all(|o| o.is_some()) {
-                return out.into_iter().map(|o| o.unwrap()).collect();
-            }
-            if !made_progress {
-                spins += 1;
-                assert!(spins < 1_000_000, "pump spun without progress");
-            } else {
-                spins = 0;
-            }
-        }
-    }
-
-    fn make_tempfile(pages: u64, page_size: usize, fill: u8) -> PathBuf {
-        let n = SEQ.fetch_add(1, Ordering::Relaxed);
-        let mut p = std::env::temp_dir();
-        p.push(format!("uring-async-{}-{}.bin", std::process::id(), n));
-        let mut f = std::fs::OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(&p)
-            .expect("create tempfile");
-        let block = vec![fill; page_size];
-        for _ in 0..pages {
-            f.write_all(&block).expect("seed tempfile");
-        }
-        f.sync_all().expect("sync tempfile");
-        p
-    }
 
     struct TempPath(PathBuf);
     impl Drop for TempPath {
         fn drop(&mut self) {
             let _ = std::fs::remove_file(&self.0);
         }
-    }
-
-    fn aligned_buffer(len: usize) -> (Vec<u8>, *mut u8) {
-        let words = (len + 7) / 8;
-        let mut v = vec![0u8; words * 8 + 4096];
-        let raw = v.as_mut_ptr();
-        let aligned_off = raw.align_offset(4096);
-        let base = unsafe { raw.add(aligned_off) };
-        (v, base)
-    }
-
-    #[test]
-    fn concurrent_reads_complete_correctly() {
-        const PAGE: usize = 4096;
-        const PAGES: u64 = 16;
-        let path = TempPath(make_tempfile(PAGES, PAGE, 0xa5));
-        let cfg = UringConfig {
-            queue_depth: 16,
-            ..UringConfig::test_local()
-        };
-        let dev = UringBlockDevice::open(&path.0, cfg).expect("open");
-
-        // Register one buffer big enough for 8 distinct destination
-        // slices.
-        let buf_len = PAGE * 8;
-        let (_owner, base) = aligned_buffer(buf_len);
-        dev.register_buffers(base, buf_len).unwrap();
-
-        // Issue 8 concurrent reads against the first 8 LBAs into
-        // disjoint slices of the registered buffer.
-        let mut futs: Vec<Pin<Box<dyn Future<Output = Result<(), Error>> + '_>>> =
-            Vec::with_capacity(8);
-        let mut dst_ptrs = Vec::with_capacity(8);
-        for i in 0..8u64 {
-            let ptr = unsafe { base.add((i as usize) * PAGE) };
-            dst_ptrs.push(ptr);
-            let slice = unsafe { std::slice::from_raw_parts_mut(ptr, PAGE) };
-            slice.fill(0);
-            futs.push(Box::pin(dev.read(Lba(i), slice)));
-        }
-
-        let results = pump(&dev, futs);
-        for r in &results {
-            r.as_ref().expect("read ok");
-        }
-        for ptr in dst_ptrs {
-            let slice = unsafe { std::slice::from_raw_parts(ptr, PAGE) };
-            assert!(slice.iter().all(|b| *b == 0xa5), "each page seeded 0xa5");
-        }
-    }
-
-    #[test]
-    fn submit_backpressure_parks_and_resumes() {
-        const PAGE: usize = 4096;
-        const PAGES: u64 = 16;
-        const QD: u32 = 4;
-        let path = TempPath(make_tempfile(PAGES, PAGE, 0));
-        let cfg = UringConfig {
-            queue_depth: QD,
-            ..UringConfig::test_local()
-        };
-        let dev = UringBlockDevice::open(&path.0, cfg).expect("open");
-
-        // Register a single page-sized buffer; all 16 writes share
-        // it (write-only semantics on the device don't require
-        // unique source bytes for this back-pressure test).
-        let buf_len = PAGE;
-        let (_owner, base) = aligned_buffer(buf_len);
-        dev.register_buffers(base, buf_len).unwrap();
-        let src = unsafe { std::slice::from_raw_parts_mut(base, PAGE) };
-        for (i, b) in src.iter_mut().enumerate() {
-            *b = (i as u8).wrapping_mul(7);
-        }
-        let src_const: &[u8] = unsafe { std::slice::from_raw_parts(base, PAGE) };
-
-        let mut futs: Vec<Pin<Box<dyn Future<Output = Result<(), Error>> + '_>>> =
-            Vec::with_capacity(16);
-        for i in 0..16u64 {
-            futs.push(Box::pin(dev.write(Lba(i), src_const)));
-        }
-
-        // Drive the pump and check the invariant on every step.
-        let waker = noop_waker();
-        let mut cx = Context::from_waker(&waker);
-        let mut out: Vec<Option<Result<(), Error>>> = (0..futs.len()).map(|_| None).collect();
-        let mut spins = 0u32;
-        loop {
-            let mut made_progress = false;
-            for (i, fut) in futs.iter_mut().enumerate() {
-                if out[i].is_some() {
-                    continue;
-                }
-                if let Poll::Ready(v) = Pin::as_mut(fut).poll(&mut cx) {
-                    out[i] = Some(v);
-                    made_progress = true;
-                }
-                assert!(
-                    dev.submitted.get() <= QD,
-                    "submitted={} exceeds queue_depth={}",
-                    dev.submitted.get(),
-                    QD,
-                );
-            }
-            dev.progress().expect("progress");
-            assert!(dev.submitted.get() <= QD);
-            if out.iter().all(|o| o.is_some()) {
-                break;
-            }
-            if !made_progress {
-                spins += 1;
-                assert!(spins < 1_000_000, "pump spun without progress");
-            } else {
-                spins = 0;
-            }
-        }
-        for r in &out {
-            r.as_ref().unwrap().as_ref().expect("write ok");
-        }
-        // The per-poll assertions above prove the ceiling held. The
-        // peak high-water mark is read from the device rather than
-        // sampled externally: with buffered I/O each write can complete
-        // within its own poll (the opportunistic `progress` in
-        // `IoFut::poll` reaps the CQE and decrements `submitted` back to
-        // zero before this loop ever samples it), so an external sample
-        // can legitimately never observe a non-zero in-flight count.
-        let peak = dev.peak_submitted.get();
-        assert!(peak > 0, "should have had in-flight ops");
-        assert!(peak <= QD);
     }
 
     fn unique_path(name: &str) -> PathBuf {
@@ -1038,66 +286,5 @@ mod tests {
             std::fs::metadata(&path.0).unwrap().len(),
             (12 * PAGE) as u64
         );
-    }
-
-    fn dummy_reg(addr: usize, len: usize) -> RegisteredBuf {
-        RegisteredBuf {
-            base: NonNull::new(addr as *mut u8).expect("nonnull"),
-            len,
-        }
-    }
-
-    /// On a failed re-register, the mirror must be left EMPTY to match
-    /// the now-empty kernel table, never the stale prior set. This is
-    /// the core of the desync bug: a non-empty stale mirror would feed
-    /// `resolve_buf_index` indices the kernel no longer has.
-    #[test]
-    fn apply_registration_result_clears_mirror_on_failure() {
-        let mut mirror = vec![dummy_reg(0x1000, 4096)];
-        let new_regs = vec![dummy_reg(0x1000, 4096), dummy_reg(0x2000, 4096)];
-        let res = apply_registration_result(&mut mirror, new_regs, Err(Error::Io(libc::EFAULT)));
-        assert!(matches!(res, Err(Error::Io(libc::EFAULT))));
-        assert!(
-            mirror.is_empty(),
-            "mirror must be empty after a failed re-register, got {} entries",
-            mirror.len()
-        );
-    }
-
-    /// On success the mirror adopts the full new table.
-    #[test]
-    fn apply_registration_result_adopts_table_on_success() {
-        let mut mirror = vec![dummy_reg(0x1000, 4096)];
-        let new_regs = vec![dummy_reg(0x1000, 4096), dummy_reg(0x2000, 4096)];
-        let res = apply_registration_result(&mut mirror, new_regs, Ok(()));
-        assert!(res.is_ok());
-        assert_eq!(mirror.len(), 2);
-        assert_eq!(mirror[0].base.as_ptr() as usize, 0x1000);
-        assert_eq!(mirror[1].base.as_ptr() as usize, 0x2000);
-    }
-
-    /// The success path through the real device keeps the mirror
-    /// consistent with the kernel: both registered regions resolve to
-    /// distinct buffer indices.
-    #[test]
-    fn register_buffers_success_keeps_mirror_consistent() {
-        const PAGE: usize = 4096;
-        const PAGES: u64 = 16;
-        let path = TempPath(make_tempfile(PAGES, PAGE, 0));
-        let dev = UringBlockDevice::open(&path.0, UringConfig::test_local()).expect("open");
-
-        let (_owner_a, base_a) = aligned_buffer(PAGE);
-        dev.register_buffers(base_a, PAGE).expect("register a");
-        assert_eq!(dev.registered.borrow().len(), 1);
-
-        let (_owner_b, base_b) = aligned_buffer(PAGE);
-        dev.register_buffers(base_b, PAGE).expect("register b");
-        assert_eq!(dev.registered.borrow().len(), 2);
-
-        // Both regions remain addressable via their buffer indices,
-        // proving the re-register left the mirror parallel to the
-        // kernel table.
-        assert_eq!(dev.resolve_buf_index(base_a, PAGE).unwrap(), 0);
-        assert_eq!(dev.resolve_buf_index(base_b, PAGE).unwrap(), 1);
     }
 }

--- a/cmd/unbounded-storage/src/storage/btree/tests.rs
+++ b/cmd/unbounded-storage/src/storage/btree/tests.rs
@@ -6,21 +6,14 @@
 use std::future::Future;
 use std::pin::pin;
 use std::sync::Arc;
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll};
 
+use crate::runtime::noop_waker;
 use crate::storage::alloc::Allocator;
 use crate::storage::blockdev::{BlockDevice, MockDevice, MockDeviceConfig, ScratchPool};
 use crate::storage::btree::page::{self, Decoded, META_SLOT_A, META_SLOT_B};
 use crate::storage::btree::{BTreeIndex, LeafEntry, Mutation};
 use crate::storage::types::{Checksum, Lba, PageKey};
-
-fn noop_waker() -> Waker {
-    fn raw() -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VTABLE)
-    }
-    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-    unsafe { Waker::from_raw(raw()) }
-}
 
 fn block_on<F: Future>(f: F) -> F::Output {
     let w = noop_waker();

--- a/cmd/unbounded-storage/src/storage/disks/channels.rs
+++ b/cmd/unbounded-storage/src/storage/disks/channels.rs
@@ -5,13 +5,15 @@
 //!
 //! `DiskChannelDirectory` owns the set of currently-open disks (each
 //! represented by a [`PageChannel`] to its storage core) and
-//! publishes a `(channels, generation)` pair via `ArcSwap`. Every
-//! successful [`Self::apply_channels`] call builds a fresh pair and
-//! stores it as a single atomic publication, so consumers that
-//! resolve through [`Self::snapshot`] observe the channel set and its
-//! generation together. Per-shard registration caches key off that
-//! generation, so "registered against gen N" always refers to the
-//! snapshot that was published as gen N.
+//! publishes a `(channels, generation)` pair via `ArcSwap`. A
+//! [`Self::apply_channels`] call that actually changes the set builds
+//! a fresh pair and stores it as a single atomic publication, so
+//! consumers that resolve through [`Self::snapshot`] observe the
+//! channel set and its generation together; an apply of the identical
+//! set is skipped so the generation does not churn. Per-shard
+//! registration caches key off that generation, so "registered
+//! against gen N" always refers to the snapshot that was published as
+//! gen N.
 //!
 //! Channels are not opened here. The disk supervisor opens each disk
 //! on its own pinned storage core and hands the resulting
@@ -29,7 +31,7 @@ use crate::storage::PageChannel;
 /// disks are open and the data path is offline.
 pub type ChannelSnapshot = Option<Arc<Vec<PageChannel>>>;
 
-/// Owns the published per-disk channel set. Each
+/// Owns the published per-disk channel set. A change-bearing
 /// [`Self::apply_channels`] bumps the generation and publishes a
 /// fresh, path-sorted [`PageChannel`] vector so `disk_for` indices
 /// stay stable across consumers.
@@ -45,6 +47,10 @@ pub struct DiskChannelDirectory {
 struct ChannelSnapshotInner {
     channels: ChannelSnapshot,
     generation: u64,
+    /// Path-sorted `(path, service identity)` of the published set,
+    /// retained so a re-apply of the identical set is recognized as a
+    /// no-op and skipped. Empty when no channels are published.
+    key: Vec<(PathBuf, usize)>,
 }
 
 impl DiskChannelDirectory {
@@ -55,17 +61,36 @@ impl DiskChannelDirectory {
             current: ArcSwap::new(Arc::new(ChannelSnapshotInner {
                 channels: None,
                 generation: 0,
+                key: Vec::new(),
             })),
         })
     }
 
     /// Replace the channel set with `channels`, published in
     /// path-sorted order so the `disk_for` index of any given page
-    /// is stable. Generation is bumped on every call regardless of
-    /// whether the set changed, so consumers re-resolve any cached
-    /// snapshot and reseat per-shard registrations.
+    /// is stable. The generation is bumped only when the published
+    /// set actually changes (a different path set, or the same path
+    /// bound to a different storage-core service); a re-apply of the
+    /// identical set is a no-op so consumers do not needlessly
+    /// reseat per-shard registrations.
     pub fn apply_channels(&self, mut channels: Vec<(PathBuf, PageChannel)>) {
         channels.sort_by(|a, b| a.0.cmp(&b.0));
+        let key: Vec<(PathBuf, usize)> = channels
+            .iter()
+            .map(|(p, c)| (p.clone(), c.service_id()))
+            .collect();
+
+        // `apply_channels` is the only writer of `current`; callers
+        // serialize it (the supervisor reconciles on one thread), so
+        // reading the previous bundle and storing the new one is
+        // race-free.
+        let prev = self.current.load();
+        if prev.key == key {
+            // Identical publication: nothing downstream needs to
+            // reseat, so skip the generation bump and the store.
+            return;
+        }
+
         let ordered: Vec<PageChannel> = channels.into_iter().map(|(_, c)| c).collect();
         let n = ordered.len();
         let snapshot: ChannelSnapshot = if ordered.is_empty() {
@@ -74,16 +99,14 @@ impl DiskChannelDirectory {
             Some(Arc::new(ordered))
         };
 
-        // `apply_channels` is the only writer of `current`; callers
-        // serialize it (the supervisor reconciles on one thread), so
-        // reading the previous generation and storing the new bundle
-        // is race-free. The atomic `ArcSwap::store` is the entire
-        // publication: any consumer that loads the bundle sees both
-        // fields from the same generation.
-        let gen_n = self.current.load().generation + 1;
+        // The atomic `ArcSwap::store` is the entire publication: any
+        // consumer that loads the bundle sees both fields from the
+        // same generation.
+        let gen_n = prev.generation + 1;
         self.current.store(Arc::new(ChannelSnapshotInner {
             channels: snapshot,
             generation: gen_n,
+            key,
         }));
         eprintln!("disks: hot-swap to generation {gen_n} (cache cold; channel count={n})");
     }
@@ -204,5 +227,56 @@ mod tests {
         // Each apply publishes a fresh vector, so the returned `Arc`s
         // do not alias across generations.
         assert!(!Arc::ptr_eq(&c1, &c2));
+    }
+
+    #[test]
+    fn identical_reapply_is_a_noop() {
+        // Re-applying the same path bound to the same service (clones
+        // of one channel share identity) must not bump the generation
+        // or republish, so consumers keep their seated registrations.
+        let t = DiskChannelDirectory::new();
+        let c = dummy_channel();
+        t.apply_channels(vec![(PathBuf::from("/a"), c.clone())]);
+        assert_eq!(t.generation(), 1);
+        let first = t.current().expect("snapshot present");
+
+        t.apply_channels(vec![(PathBuf::from("/a"), c.clone())]);
+        assert_eq!(t.generation(), 1, "identical re-apply must not bump");
+        let second = t.current().expect("snapshot still present");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "no-op apply must not republish a fresh snapshot",
+        );
+    }
+
+    #[test]
+    fn same_path_new_service_bumps_generation() {
+        // Same path, but a distinct service identity (a fresh channel)
+        // is a real change and must republish.
+        let t = DiskChannelDirectory::new();
+        t.apply_channels(vec![(PathBuf::from("/a"), dummy_channel())]);
+        assert_eq!(t.generation(), 1);
+        t.apply_channels(vec![(PathBuf::from("/a"), dummy_channel())]);
+        assert_eq!(t.generation(), 2);
+    }
+
+    #[test]
+    fn reapply_after_reorder_is_a_noop() {
+        // Input order does not matter: the set is path-sorted before
+        // comparison, so supplying the same channels in a different
+        // order is still a no-op.
+        let t = DiskChannelDirectory::new();
+        let a = dummy_channel();
+        let b = dummy_channel();
+        t.apply_channels(vec![
+            (PathBuf::from("/a"), a.clone()),
+            (PathBuf::from("/b"), b.clone()),
+        ]);
+        assert_eq!(t.generation(), 1);
+        t.apply_channels(vec![
+            (PathBuf::from("/b"), b.clone()),
+            (PathBuf::from("/a"), a.clone()),
+        ]);
+        assert_eq!(t.generation(), 1);
     }
 }

--- a/cmd/unbounded-storage/src/storage/disks/mod.rs
+++ b/cmd/unbounded-storage/src/storage/disks/mod.rs
@@ -68,8 +68,9 @@ pub trait DiskTarget: Send + Sync + 'static {
 /// in an error crate.
 #[derive(Debug)]
 pub enum DiskError {
-    /// The underlying [`UringBlockDevice::open`] call or engine open
-    /// failed.
+    /// The underlying
+    /// [`UringDevice::open`](crate::storage::blockdev::UringDevice::open) call
+    /// or engine open failed.
     Open(String),
 }
 

--- a/cmd/unbounded-storage/src/storage/disks/shard_view.rs
+++ b/cmd/unbounded-storage/src/storage/disks/shard_view.rs
@@ -245,6 +245,7 @@ impl BlockStore for LiveShardLocalStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::noop_waker;
     use crate::storage::PageService;
     use crate::storage::blockdev::{BlockDevice, MockDevice, MockDeviceConfig};
     use crate::storage::types::{Error as DevError, Lba};
@@ -254,17 +255,9 @@ mod tests {
     use std::pin::{Pin, pin};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::mpsc::channel as std_channel;
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{Context, Poll};
     use std::thread::JoinHandle;
     use std::time::Duration;
-
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        unsafe { Waker::from_raw(raw()) }
-    }
 
     fn block_on<F: Future>(f: F) -> F::Output {
         let w = noop_waker();

--- a/cmd/unbounded-storage/src/storage/disks/uring.rs
+++ b/cmd/unbounded-storage/src/storage/disks/uring.rs
@@ -51,13 +51,13 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crate::config::schema::{DiskKind, DiskSpec};
 use crate::ring::{StorageRingConfig, clear_current_storage_ring, set_current_storage_ring};
-use crate::runtime::{PinnedRuntime, WorkerSpec};
+use crate::runtime::{PinnedRuntime, WorkerSpec, noop_waker};
 use crate::storage::blockdev::{
     BlockDevice, CoreLocalDevice, OpenDisk, UringDevice, provision_file,
 };
@@ -205,7 +205,7 @@ fn run_storage_core(
         // Held for the storage core's lifetime: the ring addresses this
         // fd by its registered Fixed index, so it must outlive the ring.
         file: _disk_file,
-    } = match UringDevice::open(&path, ring_cfg, page_size) {
+    } = match UringDevice::open(&path, ring_cfg, ring_cfg.iopoll, page_size) {
         Ok(d) => d,
         Err(e) => {
             let _ = ready_tx.send(Err(e.to_string()));
@@ -420,16 +420,6 @@ fn engine_config_from(spec: &DiskSpec) -> EngineConfig {
 /// size `page_size_bytes`.
 fn device_page_size(cfg: &EngineConfig) -> usize {
     cfg.btree_page_bytes
-}
-
-/// Build a noop [`Waker`] for the storage-core poll loop, which makes
-/// forward progress by re-polling rather than by wakeups.
-fn noop_waker() -> Waker {
-    fn raw() -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VTABLE)
-    }
-    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-    unsafe { Waker::from_raw(raw()) }
 }
 
 #[cfg(test)]

--- a/cmd/unbounded-storage/src/storage/engine.rs
+++ b/cmd/unbounded-storage/src/storage/engine.rs
@@ -35,7 +35,7 @@ use crate::storage::alloc::Allocator;
 use crate::storage::blockdev::{BlockDevice, ScratchPool};
 use crate::storage::btree::{BTreeIndex, LeafEntry, Mutation};
 use crate::storage::lru::SieveLru;
-use crate::storage::mutator::{MutatorOutcome, MutatorQueue, MutatorReply, MutatorReq, yield_once};
+use crate::storage::mutator::{MutatorOutcome, MutatorQueue, MutatorReply, MutatorReq};
 use crate::storage::refcount::RefcountTable;
 use crate::storage::singleflight::{Acquire, Singleflight};
 use crate::storage::traits::{PageChecksum, Xxh3Checksum};
@@ -49,8 +49,30 @@ pub struct EngineConfig {
     /// Btree page size, in bytes. Must equal the device's atomic
     /// write unit (default 4 KiB).
     pub btree_page_bytes: usize,
+    /// Maximum number of mutator requests folded into a single
+    /// `BTreeIndex::apply_batch` commit. Larger batches amortize
+    /// the CoW B+tree commit cost; the mutator never exceeds this
+    /// per commit.
     pub commit_batch_max: usize,
+    /// Target batch-coalescing latency, in microseconds. This is a
+    /// logical hint, not a value the engine reads as elapsed time:
+    /// the deterministic-simulation harness forbids reading the
+    /// wall clock, so the mutator realizes this budget as
+    /// [`Self::commit_batch_ticks`] cooperative yields rather than
+    /// a real deadline. Retained for documentation and future
+    /// production tuning.
     pub commit_batch_deadline_us: u64,
+    /// Number of cooperative yields the mutator may spend waiting
+    /// for more requests to coalesce into a batch that has not yet
+    /// reached [`Self::commit_batch_max`]. This is the
+    /// wall-clock-free realization of
+    /// [`Self::commit_batch_deadline_us`]: each yield lets the
+    /// executor interleave producers that are about to enqueue, so
+    /// the batch grows under load while a drained or closed queue
+    /// commits immediately. Default 8 (roughly
+    /// `commit_batch_deadline_us / 25us` per yield); 0 disables
+    /// coalescing.
+    pub commit_batch_ticks: u32,
     pub eviction_watermark: f32,
     pub probationary_fraction: f32,
     pub admission_sketch_multiplier: usize,
@@ -76,6 +98,7 @@ impl Default for EngineConfig {
             btree_page_bytes: 4096,
             commit_batch_max: 1024,
             commit_batch_deadline_us: 200,
+            commit_batch_ticks: 8,
             eviction_watermark: 0.9,
             probationary_fraction: 0.1,
             admission_sketch_multiplier: 2,
@@ -138,7 +161,7 @@ pub struct StorageEngine<B: BlockDevice> {
 // path goes through `ShardLocalStore` which never touches this
 // field. All other fields are `Arc`/`Mutex` wrappers that are
 // already `Send + Sync` because their `B: BlockDevice` is
-// (`UringBlockDevice` and `MockDevice` are both `Send + Sync`).
+// (`CoreLocalDevice` and `MockDevice` are both `Send + Sync`).
 unsafe impl<B: BlockDevice + Send + Sync> Send for StorageEngine<B> {}
 unsafe impl<B: BlockDevice + Send + Sync> Sync for StorageEngine<B> {}
 
@@ -685,19 +708,18 @@ impl<B: BlockDevice> StorageEngine<B> {
                 return;
             }
             let max = self.cfg.commit_batch_max.max(1);
-            let mut batch = self.mutator_queue.try_drain_up_to(max);
-            // Best-effort coalescing: if we did not fill the
-            // batch, yield once to let other producers enqueue
-            // before we commit. Wall-clock-free approximation of
-            // `commit_batch_deadline_us`; see the note on
-            // `mutator::yield_once`.
-            if batch.len() < max {
-                yield_once().await;
-                if batch.len() < max {
-                    let more = self.mutator_queue.try_drain_up_to(max - batch.len());
-                    batch.extend(more);
-                }
-            }
+            // Coalesce up to `commit_batch_max`, spending a bounded
+            // budget of cooperative yields (`commit_batch_ticks`)
+            // so producers that are about to enqueue join this
+            // commit. Wall-clock-free stand-in for
+            // `commit_batch_deadline_us`; see
+            // `MutatorQueue::drain_batch`. The drain stops early if
+            // the queue closes, so a draining shutdown still
+            // terminates.
+            let batch = self
+                .mutator_queue
+                .drain_batch(max, self.cfg.commit_batch_ticks)
+                .await;
 
             self.process_batch(batch).await;
             self.drain_pending_free();
@@ -832,15 +854,9 @@ mod tests {
     }
     use std::future::Future;
     use std::pin::{Pin, pin};
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{Context, Poll};
 
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        unsafe { Waker::from_raw(raw()) }
-    }
+    use crate::runtime::noop_waker;
 
     /// Pump `body` to completion while concurrently driving
     /// `mutator`. The mutator is expected to stay pending until

--- a/cmd/unbounded-storage/src/storage/local.rs
+++ b/cmd/unbounded-storage/src/storage/local.rs
@@ -379,20 +379,13 @@ mod tests {
     // assert itself is one line.
 
     use crate::bufferpool::BlockStore;
+    use crate::runtime::noop_waker;
     use crate::storage::blockdev::{MockDevice, MockDeviceConfig};
     use crate::storage::engine::{EngineConfig, StorageEngine};
     use std::future::Future;
     use std::pin::{Pin, pin};
     use std::sync::Arc;
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
-
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        unsafe { Waker::from_raw(raw()) }
-    }
+    use std::task::{Context, Poll};
 
     fn block_on<F: Future>(f: F) -> F::Output {
         let w = noop_waker();

--- a/cmd/unbounded-storage/src/storage/mutator.rs
+++ b/cmd/unbounded-storage/src/storage/mutator.rs
@@ -192,6 +192,14 @@ impl MutatorQueue {
         g.closed && g.items.is_empty()
     }
 
+    /// True once the queue has been closed via [`Self::close`].
+    /// The coalescing drain consults this so it stops spending its
+    /// yield budget on a queue that can no longer receive pushes,
+    /// letting a draining shutdown commit and exit promptly.
+    pub(crate) fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
     /// Number of items currently buffered. Used by shutdown
     /// invariants to verify the mutator drained all submitted
     /// requests before exiting.
@@ -211,6 +219,43 @@ impl MutatorQueue {
             }
         }
         out
+    }
+
+    /// Drain a coalesced batch of up to `max` items, spending at
+    /// most `ticks` cooperative yields to let in-flight producers
+    /// enqueue more before the consumer commits. Returns as soon
+    /// as the batch reaches `max`, the queue is closed, or the
+    /// yield budget is exhausted.
+    ///
+    /// This is the wall-clock-free realization of
+    /// [`crate::storage::EngineConfig::commit_batch_deadline_us`]:
+    /// the DST harness forbids reading elapsed time, so the
+    /// deadline is expressed as a budget of `ticks` logical yields
+    /// (see [`crate::storage::EngineConfig::commit_batch_ticks`]).
+    /// Each [`yield_once`] gives the executor a chance to
+    /// interleave producers that are about to push, so batches
+    /// grow under load while a drained or closed queue never
+    /// stalls. `ticks == 0` disables coalescing (a single drain).
+    ///
+    /// Callers gate on [`Self::wait_nonempty`] first, so the
+    /// returned batch is non-empty in practice; it can only be
+    /// empty if the caller raced an empty, non-closed queue.
+    pub(crate) async fn drain_batch(&self, max: usize, ticks: u32) -> Vec<MutatorReq> {
+        let mut batch = self.try_drain_up_to(max);
+        let mut spent = 0u32;
+        while batch.len() < max && spent < ticks {
+            // A closed queue will receive no further pushes, so
+            // stop waiting and let the consumer commit what it has
+            // and observe the close on its next loop.
+            if self.is_closed() {
+                break;
+            }
+            yield_once().await;
+            spent += 1;
+            let more = self.try_drain_up_to(max - batch.len());
+            batch.extend(more);
+        }
+        batch
     }
 
     /// Park the consumer until something is queued or the queue
@@ -250,15 +295,14 @@ impl Future for WaitNonEmpty {
 }
 
 /// Yield exactly once, registering the current waker to be woken
-/// immediately. Used by the mutator loop to invite further
-/// submissions to coalesce into the current batch without
-/// reaching for wall-clock time, which the DST harness forbids.
-///
-/// The crate's `commit_batch_deadline_us` config field exists to
-/// let production tune coalescing latency; here we approximate
-/// it as a single yield so the executor can interleave producers
-/// that are about to enqueue. Replacing this with a tick-aware
-/// scheme is a follow-up once a tick abstraction lands.
+/// immediately so the executor can interleave other tasks before
+/// re-polling. This is the single-tick building block the mutator
+/// uses to coalesce batches without reaching for wall-clock time,
+/// which the DST harness forbids: [`MutatorQueue::drain_batch`]
+/// spends a bounded number of these yields (see
+/// [`crate::storage::EngineConfig::commit_batch_ticks`]) to invite
+/// in-flight producers to enqueue into the current batch before it
+/// commits.
 pub(crate) fn yield_once() -> YieldOnce {
     YieldOnce { yielded: false }
 }
@@ -283,17 +327,10 @@ impl Future for YieldOnce {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::noop_waker;
     use std::future::Future;
     use std::pin::pin;
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
-
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        unsafe { Waker::from_raw(raw()) }
-    }
+    use std::task::{Context, Poll};
 
     fn block_on<F: Future>(f: F) -> F::Output {
         let w = noop_waker();
@@ -355,5 +392,75 @@ mod tests {
         q.close();
         let ok = block_on(q.wait_nonempty());
         assert!(!ok);
+    }
+
+    fn push_n(q: &Arc<MutatorQueue>, n: usize) {
+        for _ in 0..n {
+            q.push(MutatorReq::Delete {
+                keys: vec![],
+                done: MutatorReply::new(),
+            });
+        }
+    }
+
+    /// Drive a `drain_batch` future to completion under a noop
+    /// waker, invoking `on_pending` before each re-poll. Returns
+    /// the drained batch and the number of `Poll::Pending`s
+    /// observed, i.e. the number of yields the drain actually
+    /// spent.
+    fn drive_drain(
+        q: &Arc<MutatorQueue>,
+        max: usize,
+        ticks: u32,
+        mut on_pending: impl FnMut(),
+    ) -> (Vec<MutatorReq>, u32) {
+        let w = noop_waker();
+        let mut cx = Context::from_waker(&w);
+        let mut fut = pin!(q.drain_batch(max, ticks));
+        let mut pendings = 0u32;
+        loop {
+            match fut.as_mut().poll(&mut cx) {
+                Poll::Ready(b) => return (b, pendings),
+                Poll::Pending => {
+                    on_pending();
+                    pendings += 1;
+                    assert!(pendings < 1_000, "drain_batch did not converge");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn drain_batch_coalesces_toward_max() {
+        let q = Arc::new(MutatorQueue::new());
+        push_n(&q, 2);
+        // Two more producers enqueue on every yield, so the batch
+        // climbs to `max` within the tick budget.
+        let (batch, _) = drive_drain(&q, 8, 8, || push_n(&q, 2));
+        assert_eq!(batch.len(), 8);
+    }
+
+    #[test]
+    fn drain_batch_stops_at_tick_budget_when_starved() {
+        let q = Arc::new(MutatorQueue::new());
+        push_n(&q, 1);
+        // No producer enqueues, so the drain spends its whole
+        // budget and returns the partial batch rather than
+        // stalling forever.
+        let (batch, pendings) = drive_drain(&q, 8, 3, || {});
+        assert_eq!(pendings, 3);
+        assert_eq!(batch.len(), 1);
+    }
+
+    #[test]
+    fn drain_batch_on_closed_queue_commits_without_yielding() {
+        let q = Arc::new(MutatorQueue::new());
+        push_n(&q, 2);
+        q.close();
+        // A closed queue must not spend any of the yield budget so
+        // a draining shutdown terminates promptly.
+        let (batch, pendings) = drive_drain(&q, 8, 8, || panic!("closed queue must not yield"));
+        assert_eq!(pendings, 0);
+        assert_eq!(batch.len(), 2);
     }
 }

--- a/cmd/unbounded-storage/src/storage/page_channel.rs
+++ b/cmd/unbounded-storage/src/storage/page_channel.rs
@@ -41,9 +41,10 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
 use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll, Waker};
 
 use crate::bufferpool::{Error, StripeKey};
+use crate::runtime::noop_waker;
 use crate::storage::blockdev::BlockDevice;
 use crate::storage::engine::StorageEngine;
 
@@ -146,6 +147,17 @@ impl PageChannel {
             })
             .map_err(|_| Error::Io(libc::EPIPE))?;
         spin_block_on_with_alive(reply.wait(), &self.service_alive)
+    }
+
+    /// Stable identity of the storage-core service this channel
+    /// targets. All clones of one channel share it; a channel built by
+    /// a distinct [`Self::new`] has a distinct identity. Used by the
+    /// channel directory to skip republishing an unchanged channel set
+    /// (the `service_alive` allocation is kept alive by the holder for
+    /// as long as the channel is published, so the pointer is a sound
+    /// identity for live channels).
+    pub(crate) fn service_id(&self) -> usize {
+        Arc::as_ptr(&self.service_alive) as usize
     }
 }
 
@@ -507,22 +519,13 @@ fn spin_block_on_with_alive<T>(fut: ReplyWait<T>, service_alive: &AtomicBool) ->
     }
 }
 
-fn noop_waker() -> Waker {
-    fn raw() -> RawWaker {
-        RawWaker::new(std::ptr::null(), &VTABLE)
-    }
-    static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-    // SAFETY: the vtable functions are no-ops or return the same
-    // vtable, so the waker can be cloned and dropped freely.
-    unsafe { Waker::from_raw(raw()) }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::storage::blockdev::{MockDevice, MockDeviceConfig};
     use crate::storage::engine::EngineConfig;
     use std::sync::mpsc::channel as std_channel;
+    use std::task::{RawWaker, RawWakerVTable};
     use std::time::Duration;
 
     fn block_on<F: Future>(mut fut: F) -> F::Output {

--- a/cmd/unbounded-storage/src/storage/singleflight.rs
+++ b/cmd/unbounded-storage/src/storage/singleflight.rs
@@ -168,18 +168,10 @@ impl Future for LeaseWait {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::noop_waker;
     use crate::storage::types::{Checksum, Lba};
     use std::future::Future;
     use std::pin::pin;
-    use std::task::{RawWaker, RawWakerVTable, Waker};
-
-    fn noop_waker() -> Waker {
-        fn raw() -> RawWaker {
-            RawWaker::new(std::ptr::null(), &VTABLE)
-        }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(|_| raw(), |_| {}, |_| {}, |_| {});
-        unsafe { Waker::from_raw(raw()) }
-    }
 
     fn key(i: u32) -> PageKey {
         PageKey::new([0u8; 32], i)

--- a/hack/smoke-storage.py
+++ b/hack/smoke-storage.py
@@ -42,6 +42,7 @@ import os
 import resource
 import signal
 import socket
+import struct
 import subprocess
 import sys
 import tempfile
@@ -68,10 +69,26 @@ HTTP_OBJECT_PATH = "/smoke-object"
 S3_OBJECT_PATH = "/smoke-bucket/smoke-object"
 VALID_OBJECTS = frozenset({HTTP_OBJECT_PATH, S3_OBJECT_PATH})
 
-BODY = b"unbounded-storage smoke test payload :: " * 50  # ~2000 bytes, one stripe
+# A 1 GiB object. Built by tiling a fixed pattern so the body is fully
+# deterministic and verifiable, but cheap to construct. At this size the
+# object spans many stripes (see STRIPE_SIZE), so it can no longer fit in
+# a single in-memory buffer-pool: it must be streamed stripe-by-stripe
+# through the frontend and cached to disk, exercising the multi-stripe
+# read, eviction, and cross-node fetch paths that a single-stripe object
+# never touches.
+OBJECT_SIZE = 1 << 30  # 1 GiB
+# Position-encoded body: every 4096-byte page is filled with its own
+# page index as a little-endian u64, repeated. This makes the payload
+# fully deterministic *and* self-describing: any reordering, duplication,
+# truncation, or cross-stripe mixup in the read path shows up as a page
+# whose bytes name a different page, which a periodic/random body would
+# hide. Construction is one pass over the 262144 pages, so it stays cheap.
+_PAGE = 4096
+_PAGES = OBJECT_SIZE // _PAGE
+BODY = b"".join(struct.pack("<Q", p) * (_PAGE // 8) for p in range(_PAGES))
 
-STRIPE_SIZE = 65536  # power of two, larger than BODY so the object is one stripe
-DISK_SIZE = "64M"  # multiple of the 4096-byte page size
+STRIPE_SIZE = 4 * 1024 * 1024  # 4 MiB; the 1 GiB object spans 256 stripes
+DISK_SIZE = "2G"  # multiple of the 4096-byte page size; holds all stripes of one node
 
 DEVNULL = subprocess.DEVNULL
 
@@ -391,6 +408,49 @@ def fetch(
 # ============================================================================
 
 
+def _analyze_corruption(label: str, body: bytes) -> set[int]:
+    """Per-page diff of *body* vs BODY; return the set of corrupted stripes.
+
+    Each 4096-byte page of BODY is filled with its own LE-u64 page index, so
+    a mismatching page can be decoded back to whichever page's data actually
+    landed there. We log a histogram of (got_page - expected_page) deltas and
+    the corrupted-stripe set so local-vs-cross-node displacement is visible.
+    """
+    pages_per_stripe = STRIPE_SIZE // _PAGE
+    bad_stripes: set[int] = set()
+    deltas: dict[int, int] = {}
+    n_bad = 0
+    first_bad = -1
+    for p in range(min(len(body), len(BODY)) // _PAGE):
+        off = p * _PAGE
+        exp = BODY[off : off + _PAGE]
+        got = body[off : off + _PAGE]
+        if got == exp:
+            continue
+        n_bad += 1
+        if first_bad < 0:
+            first_bad = p
+        bad_stripes.add(p // pages_per_stripe)
+        got_page = struct.unpack("<Q", got[:8])[0]
+        delta = got_page - p
+        deltas[delta] = deltas.get(delta, 0) + 1
+    log(f"  [{label}] {n_bad} corrupted pages, first at page {first_bad}")
+    log(f"  [{label}] {len(bad_stripes)} corrupted stripes: {sorted(bad_stripes)[:16]}")
+    top = sorted(deltas.items(), key=lambda kv: -kv[1])[:8]
+    log(f"  [{label}] page-delta histogram (got_page - expected_page): {top}")
+    return bad_stripes
+
+
+def _report_corruption(corrupt: dict[str, set[int]]) -> None:
+    if "A" in corrupt and "B" in corrupt:
+        both = corrupt["A"] & corrupt["B"]
+        only_a = corrupt["A"] - corrupt["B"]
+        only_b = corrupt["B"] - corrupt["A"]
+        log(f"  stripes corrupt in BOTH A and B: {len(both)} -> {sorted(both)[:16]}")
+        log(f"  stripes corrupt only via A: {len(only_a)} -> {sorted(only_a)[:16]}")
+        log(f"  stripes corrupt only via B: {len(only_b)} -> {sorted(only_b)[:16]}")
+
+
 def run_scenario(kind: str, origin_addr: str, object_path: str, origin: Any) -> None:
     """Bring up a fresh two-node ring of frontend/backend *kind* and fetch.
 
@@ -459,17 +519,21 @@ def run_scenario(kind: str, origin_addr: str, object_path: str, origin: Any) -> 
         # Scope the origin GET assertion to this scenario's requests.
         origin.requests = []
 
+        corrupt: dict[str, set[int]] = {}
         for label, fe_port in (("A", fe_a), ("B", fe_b)):
             log(f"Fetching object through frontend {label}")
             status, body = fetch(f"http://127.0.0.1:{fe_port}{object_path}", procs)
             if status != 200:
                 die(f"frontend {label} returned status {status}, expected 200")
             if body != BODY:
-                die(
-                    f"frontend {label} body mismatch: got {len(body)} bytes, "
-                    f"expected {len(BODY)}"
-                )
-            log(f"  frontend {label} returned correct body")
+                bad_stripes = _analyze_corruption(label, body)
+                corrupt[label] = bad_stripes
+            else:
+                log(f"  frontend {label} returned correct body")
+
+        if corrupt:
+            _report_corruption(corrupt)
+            die("body mismatch (see corruption analysis above)")
 
         # The stub origin must have been hit, proving traffic traversed
         # frontend -> storage stack -> {kind} backend -> origin.


### PR DESCRIPTION
- drive libfabric IO with a pool of threads instead of thread per connection
- flatten all futures drivers across the codebase into one shared impl
