### PR TITLE
Preserve route metadata and document Cilium migration

### DIFF
--- a/cmd/unbounded-net-node/status_server.go
+++ b/cmd/unbounded-net-node/status_server.go
@@ -2199,13 +2199,6 @@ func (s *nodeStatusServer) getNodeStatus() *NodeStatusResponse {
 		NodeErrors: filterExpiredNodeErrors(s.state.nodeErrors, time.Now(), time.Minute),
 	}
 
-	// Append link stats warnings as node errors if any interfaces have incrementing counters.
-	if s.state.linkStatsMonitor != nil {
-		for _, w := range s.state.linkStatsMonitor.GetWarnings() {
-			status.NodeErrors = append(status.NodeErrors, NodeError{Type: "link-stats", Message: w})
-		}
-	}
-
 	// Append kube-proxy health warning if the health check is failing.
 	if s.state.kubeProxyMonitor != nil {
 		if w := s.state.kubeProxyMonitor.GetWarning(); w != "" {
@@ -2592,6 +2585,12 @@ func (s *nodeStatusServer) getNodeStatus() *NodeStatusResponse {
 		status.RoutingTable.ManagedRouteCount = len(installed)
 	}
 
+	// Append link stats warnings as node errors after peers are known so
+	// benign WireGuard receive errors on healthy peers do not mark the node unhealthy.
+	if s.state.linkStatsMonitor != nil {
+		status.NodeErrors = append(status.NodeErrors, linkStatsWarningsAsNodeErrors(s.state.linkStatsMonitor.GetWarnings(), status.Peers, time.Now())...)
+	}
+
 	// Collect BPF trie entries.
 	status.BpfEntries = s.collectBpfEntries()
 
@@ -2607,6 +2606,94 @@ func (s *nodeStatusServer) getNodeStatus() *NodeStatusResponse {
 	}
 
 	return status
+}
+
+func linkStatsWarningsAsNodeErrors(warnings []string, peers []WireGuardPeerStatus, now time.Time) []NodeError {
+	if len(warnings) == 0 {
+		return nil
+	}
+
+	result := make([]NodeError, 0, len(warnings))
+	for _, warning := range warnings {
+		if suppressHealthyWireGuardRxErrors(warning, peers, now) {
+			continue
+		}
+
+		result = append(result, NodeError{Type: "link-stats", Message: warning})
+	}
+
+	return result
+}
+
+func suppressHealthyWireGuardRxErrors(warning string, peers []WireGuardPeerStatus, now time.Time) bool {
+	iface, deltas, ok := parseLinkStatsWarning(warning)
+	if !ok || len(deltas) != 1 || !strings.HasPrefix(deltas[0], "rx_errors +") {
+		return false
+	}
+
+	matched := false
+
+	for _, peer := range peers {
+		if peer.Tunnel.Interface != iface {
+			continue
+		}
+
+		matched = true
+
+		if !peerStatusHealthy(peer, now) {
+			return false
+		}
+	}
+
+	return matched
+}
+
+func parseLinkStatsWarning(warning string) (string, []string, bool) {
+	const prefix = "interface "
+
+	warning = strings.TrimSpace(warning)
+	if !strings.HasPrefix(warning, prefix) {
+		return "", nil, false
+	}
+
+	rest := strings.TrimPrefix(warning, prefix)
+
+	idx := strings.Index(rest, ":")
+	if idx < 0 {
+		return "", nil, false
+	}
+
+	iface := strings.TrimPrefix(strings.TrimSpace(rest[:idx]), "/")
+	if iface == "" {
+		return "", nil, false
+	}
+
+	rawDeltas := strings.Split(rest[idx+1:], ",")
+
+	deltas := make([]string, 0, len(rawDeltas))
+	for _, delta := range rawDeltas {
+		trimmed := strings.TrimSpace(delta)
+		if trimmed != "" {
+			deltas = append(deltas, trimmed)
+		}
+	}
+
+	return iface, deltas, len(deltas) > 0
+}
+
+func peerStatusHealthy(peer WireGuardPeerStatus, now time.Time) bool {
+	if peer.HealthCheck != nil {
+		status := strings.TrimSpace(peer.HealthCheck.Status)
+		if peer.HealthCheck.Enabled || status != "" {
+			return strings.EqualFold(status, "up")
+		}
+	}
+
+	if peer.Tunnel.LastHandshake.IsZero() || peer.Tunnel.LastHandshake.Unix() <= 0 {
+		return false
+	}
+
+	return now.Sub(peer.Tunnel.LastHandshake) < 3*time.Minute
 }
 
 // collectRoutingTableFromKernel reads routes from the kernel via netlink.

--- a/cmd/unbounded-net-node/status_server_test.go
+++ b/cmd/unbounded-net-node/status_server_test.go
@@ -521,6 +521,88 @@ func TestGetNodeStatusIncludesNodeErrors(t *testing.T) {
 	}
 }
 
+func TestLinkStatsWarningsSuppressHealthyWireGuardRxErrors(t *testing.T) {
+	warnings := []string{"interface /wg51820: rx_errors +24"}
+	peers := []WireGuardPeerStatus{
+		{
+			Name: "healthy-peer",
+			Tunnel: PeerTunnelStatus{
+				Interface:     "wg51820",
+				LastHandshake: testStatusTime.Add(-30 * time.Second),
+			},
+			HealthCheck: &HealthCheckPeerStatus{Enabled: true, Status: "up"},
+		},
+	}
+
+	got := linkStatsWarningsAsNodeErrors(warnings, peers, testStatusTime)
+	if len(got) != 0 {
+		t.Fatalf("expected healthy WireGuard rx_errors warning to be suppressed, got %#v", got)
+	}
+}
+
+func TestLinkStatsWarningsKeepWireGuardRxErrorsWhenPeerUnhealthy(t *testing.T) {
+	warnings := []string{"interface /wg51820: rx_errors +24"}
+	peers := []WireGuardPeerStatus{
+		{
+			Name: "down-peer",
+			Tunnel: PeerTunnelStatus{
+				Interface: "wg51820",
+			},
+			HealthCheck: &HealthCheckPeerStatus{Enabled: true, Status: "down"},
+		},
+	}
+
+	got := linkStatsWarningsAsNodeErrors(warnings, peers, testStatusTime)
+	if len(got) != 1 {
+		t.Fatalf("expected unhealthy WireGuard rx_errors warning to remain, got %#v", got)
+	}
+
+	if got[0].Type != "link-stats" || !strings.Contains(got[0].Message, "rx_errors") {
+		t.Fatalf("unexpected node error: %#v", got[0])
+	}
+}
+
+func TestLinkStatsWarningsKeepWireGuardTxAndDropErrors(t *testing.T) {
+	warnings := []string{
+		"interface /wg51820: tx_errors +12, tx_dropped +120",
+		"interface /wg51820: rx_dropped +20",
+	}
+	peers := []WireGuardPeerStatus{
+		{
+			Name: "healthy-peer",
+			Tunnel: PeerTunnelStatus{
+				Interface:     "wg51820",
+				LastHandshake: testStatusTime.Add(-30 * time.Second),
+			},
+			HealthCheck: &HealthCheckPeerStatus{Enabled: true, Status: "up"},
+		},
+	}
+
+	got := linkStatsWarningsAsNodeErrors(warnings, peers, testStatusTime)
+	if len(got) != 2 {
+		t.Fatalf("expected tx/drop warnings to remain, got %#v", got)
+	}
+}
+
+func TestLinkStatsWarningsKeepRxErrorsWithNoMatchingPeer(t *testing.T) {
+	warnings := []string{"interface /wg51820: rx_errors +24"}
+	peers := []WireGuardPeerStatus{
+		{
+			Name: "other-peer",
+			Tunnel: PeerTunnelStatus{
+				Interface:     "wg51821",
+				LastHandshake: testStatusTime.Add(-30 * time.Second),
+			},
+			HealthCheck: &HealthCheckPeerStatus{Enabled: true, Status: "up"},
+		},
+	}
+
+	got := linkStatsWarningsAsNodeErrors(warnings, peers, testStatusTime)
+	if len(got) != 1 {
+		t.Fatalf("expected warning with no matching peer to remain, got %#v", got)
+	}
+}
+
 // TestTryDirectRecoveryProbeClearsNodeErrors tests TryDirectRecoveryProbeClearsNodeErrors.
 func TestTryDirectRecoveryProbeClearsNodeErrors(t *testing.T) {
 	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/docs/content/reference/networking/operations.md
+++ b/docs/content/reference/networking/operations.md
@@ -152,6 +152,47 @@ kubectl unbounded net node show <name> peers   # peers
 kubectl unbounded net node show <name> json    # full status
 ```
 
+### Migrating from Cilium
+
+When unbounded-net becomes the primary CNI on a node that previously ran
+Cilium, run Cilium's documented cleanup before starting unbounded-net. Cilium
+can leave host routes, links, cgroup socket-LB programs, and service-LB maps
+that continue to affect pod and ClusterIP traffic after the DaemonSet is gone.
+
+Recommended migration flow:
+
+1. Drain or otherwise quiesce workloads on the node.
+2. Uninstall or scale down Cilium so `cilium-agent` is no longer running.
+3. Run Cilium's post-uninstall cleanup on every node:
+
+   ```bash
+   cilium-dbg post-uninstall-cleanup --all-state -f
+   ```
+
+4. Verify Cilium host datapath state is gone:
+
+   ```bash
+   ip -d link show cilium_host cilium_net cilium_vxlan
+   ip rule show | grep 'fwmark 0x200/0xf00 lookup 2004'
+   ip route get <remote-pod-ip> # should not use cilium_host
+   ```
+
+5. Verify Cilium socket-LB/service-LB state is gone:
+
+   ```bash
+   bpftool prog list | grep cil_sock
+   bpftool map list | grep cilium_lb
+   ```
+
+6. Remove any remaining Cilium CNI config from `/etc/cni/net.d`.
+7. Deploy unbounded-net and confirm pod routes use `unbounded0`.
+
+If this cleanup is skipped or incomplete, direct pod IP traffic can still use
+`cilium_host`, and kube-dns ClusterIP traffic can still be rewritten by stale
+Cilium service-LB maps to old CoreDNS pod IPs. Manual Cilium BPF map edits can
+repair a live incident, but they should not be treated as the normal migration
+procedure.
+
 ### Interface Verification
 
 **eBPF mode:**

--- a/docs/net/troubleshooting.md
+++ b/docs/net/troubleshooting.md
@@ -84,6 +84,42 @@ Each node agent exposes status on port 9998:
 - Check: `ip route show dev unbounded0` -- should show supernet routes
 - Phantom routes on wg*/geneve0/vxlan0 that are "expected but not present" are normal in eBPF mode and should be suppressed by the annotation system
 
+### Migrating a node from Cilium to unbounded-net
+
+When replacing Cilium with unbounded-net as the primary CNI, clean Cilium state
+before starting unbounded-net on the node. Stale Cilium host routes, interfaces,
+socket-LB programs, or service-LB maps can keep owning pod CIDR or ClusterIP
+traffic even after the Cilium DaemonSet is gone.
+
+Recommended migration flow:
+
+1. Drain or otherwise quiesce workloads on the node.
+2. Uninstall or scale down Cilium so `cilium-agent` is no longer running.
+3. Run Cilium's documented post-uninstall cleanup on every node, for example:
+   `cilium-dbg post-uninstall-cleanup --all-state -f`
+4. Verify Cilium host datapath state is gone:
+   `ip -d link show cilium_host cilium_net cilium_vxlan`
+   `ip rule show | grep 'fwmark 0x200/0xf00 lookup 2004'`
+   `ip route get <remote-pod-ip>` should not select `cilium_host`
+5. Verify Cilium socket-LB/service-LB state is gone:
+   `bpftool prog list | grep cil_sock`
+   `bpftool map list | grep cilium_lb`
+6. Remove Cilium CNI config files from `/etc/cni/net.d`.
+7. Start unbounded-net and verify new pod traffic routes through `unbounded0`.
+
+If cleanup is skipped or incomplete, common symptoms include:
+
+- `ip route get <remote-pod-ip>` selects `cilium_host` instead of `unbounded0`
+- direct pod IP traffic times out until stale Cilium host routes/interfaces are removed
+- direct CoreDNS pod IPs work, but kube-dns ClusterIP lookups fail or are
+  rewritten to old CoreDNS pod IPs
+
+Incident signature: DNS queries from pods are rewritten before kube-proxy or
+unbounded routing, then forwarded through the overlay to stale CoreDNS pod IPs.
+Use Cilium's cleanup tooling or rebuild the node to remove stale state. Manual
+BPF map edits can repair a live node, but they are not a declarative migration
+procedure.
+
 ### Cross-site connectivity not working
 
 1. Verify gateway route advertisement: `kubectl get gatewaypoolnode <name> -o yaml` -- check status.routes

--- a/internal/net/netlink/route_manager.go
+++ b/internal/net/netlink/route_manager.go
@@ -67,6 +67,8 @@ type installedRouteState struct {
 	table        int
 	linkScope    bool
 	hasEncap     bool                      // true when route has lightweight tunnel encap
+	flags        int                       // route flags, e.g. unix.RTNH_F_ONLINK
+	scopeGlobal  bool                      // true when gatewayless routes use scope global
 	peerNexthops map[string]DesiredNexthop // peerID -> nexthop info
 }
 
@@ -256,15 +258,20 @@ func (m *UnifiedRouteManager) SyncRoutes(desired []DesiredRoute) error {
 				existing.Encap = dr.Encap
 			}
 
+			existing.Flags |= dr.Flags
+			existing.ScopeGlobal = existing.ScopeGlobal || dr.ScopeGlobal
+
 			desiredSet[key] = existing
 		} else {
 			desiredSet[key] = DesiredRoute{
-				Prefix:   normalized,
-				Nexthops: dr.Nexthops,
-				Metric:   dr.Metric,
-				MTU:      dr.MTU,
-				Table:    dr.Table,
-				Encap:    dr.Encap,
+				Prefix:      normalized,
+				Nexthops:    dr.Nexthops,
+				Metric:      dr.Metric,
+				MTU:         dr.MTU,
+				Table:       dr.Table,
+				Encap:       dr.Encap,
+				Flags:       dr.Flags,
+				ScopeGlobal: dr.ScopeGlobal,
 			}
 		}
 	}
@@ -776,6 +783,8 @@ func (m *UnifiedRouteManager) buildInstalledState(dr DesiredRoute, active []Desi
 		table:        dr.Table,
 		linkScope:    isLinkScopeRoute(active),
 		hasEncap:     dr.Encap != nil,
+		flags:        dr.Flags,
+		scopeGlobal:  dr.ScopeGlobal,
 		peerNexthops: peerNH,
 	}
 }
@@ -789,6 +798,14 @@ func (m *UnifiedRouteManager) routeNeedsUpdate(installed *installedRouteState, d
 
 	// Detect encap changes (e.g. route switching from plain to VXLAN encap).
 	if installed.hasEncap != (desired.Encap != nil) {
+		return true
+	}
+
+	if installed.flags != desired.Flags {
+		return true
+	}
+
+	if installed.scopeGlobal != desired.ScopeGlobal {
 		return true
 	}
 

--- a/internal/net/netlink/route_manager_test.go
+++ b/internal/net/netlink/route_manager_test.go
@@ -7,6 +7,9 @@ import (
 	"net"
 	"sort"
 	"testing"
+
+	vnetlink "github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 // ---------------------------------------------------------------------------
@@ -551,6 +554,28 @@ func TestRouteNeedsUpdate_GatewayChanged(t *testing.T) {
 	}
 }
 
+func TestRouteNeedsUpdate_FlagsChanged(t *testing.T) {
+	m := NewUnifiedRouteManager("test", 0, "wg", "unbounded0")
+
+	installed := &installedRouteState{flags: 0, peerNexthops: map[string]DesiredNexthop{}}
+	desired := DesiredRoute{Flags: unix.RTNH_F_ONLINK}
+
+	if !m.routeNeedsUpdate(installed, desired, nil) {
+		t.Error("route should need update when flags changed")
+	}
+}
+
+func TestRouteNeedsUpdate_ScopeGlobalChanged(t *testing.T) {
+	m := NewUnifiedRouteManager("test", 0, "wg", "unbounded0")
+
+	installed := &installedRouteState{scopeGlobal: false, peerNexthops: map[string]DesiredNexthop{}}
+	desired := DesiredRoute{ScopeGlobal: true}
+
+	if !m.routeNeedsUpdate(installed, desired, nil) {
+		t.Error("route should need update when gatewayless route scope changed")
+	}
+}
+
 func TestSetPreferredSourceIPs(t *testing.T) {
 	m := NewUnifiedRouteManager("test", 0, "wg", "unbounded0")
 
@@ -598,10 +623,12 @@ func TestBuildInstalledState(t *testing.T) {
 	_, prefix, _ := net.ParseCIDR("10.0.0.0/24")
 
 	dr := DesiredRoute{
-		Prefix: *prefix,
-		Metric: 100,
-		MTU:    1400,
-		Table:  1001,
+		Prefix:      *prefix,
+		Metric:      100,
+		MTU:         1400,
+		Table:       1001,
+		Flags:       unix.RTNH_F_ONLINK,
+		ScopeGlobal: true,
 	}
 	active := []DesiredNexthop{
 		{PeerID: "peer-a", LinkIndex: 1},
@@ -623,6 +650,14 @@ func TestBuildInstalledState(t *testing.T) {
 
 	if state.linkScope {
 		t.Error("should not be link-scope with multiple nexthops")
+	}
+
+	if state.flags != unix.RTNH_F_ONLINK {
+		t.Errorf("flags = %d, want %d", state.flags, unix.RTNH_F_ONLINK)
+	}
+
+	if !state.scopeGlobal {
+		t.Error("scopeGlobal should be preserved")
 	}
 
 	if len(state.peerNexthops) != 2 {
@@ -728,6 +763,39 @@ func TestBuildKernelRoute_LinkScope(t *testing.T) {
 
 	if route.MultiPath != nil {
 		t.Error("link-scope route should not have MultiPath")
+	}
+
+	if route.Scope != vnetlink.SCOPE_LINK {
+		t.Errorf("Scope = %d, want %d", route.Scope, vnetlink.SCOPE_LINK)
+	}
+}
+
+func TestBuildKernelRoute_GatewaylessScopeGlobal(t *testing.T) {
+	m := NewUnifiedRouteManager("test", 0, "wg", "unbounded0")
+	_, prefix, _ := net.ParseCIDR("10.0.0.0/14")
+
+	dr := DesiredRoute{
+		Prefix:      *prefix,
+		Flags:       unix.RTNH_F_ONLINK,
+		ScopeGlobal: true,
+	}
+	active := []DesiredNexthop{{PeerID: "unbounded0", LinkIndex: 7}}
+
+	route := m.buildKernelRoute(dr, active)
+	if route == nil {
+		t.Fatal("expected non-nil route")
+	}
+
+	if route.LinkIndex != 7 {
+		t.Errorf("LinkIndex = %d, want 7", route.LinkIndex)
+	}
+
+	if route.Scope != vnetlink.SCOPE_UNIVERSE {
+		t.Errorf("Scope = %d, want %d", route.Scope, vnetlink.SCOPE_UNIVERSE)
+	}
+
+	if route.Flags != unix.RTNH_F_ONLINK {
+		t.Errorf("Flags = %d, want %d", route.Flags, unix.RTNH_F_ONLINK)
 	}
 }
 
@@ -929,6 +997,49 @@ func TestSyncRoutes_ExplicitTableNotOverridden(t *testing.T) {
 	}
 
 	t.Logf("route not in installed state (likely non-root), key verified: %s", wantKey)
+}
+
+func TestSyncRoutes_PreservesGatewaylessRouteMetadata(t *testing.T) {
+	m := NewUnifiedRouteManager("test", 0, "wg", "unbounded0")
+
+	_, prefix, _ := net.ParseCIDR("10.244.0.0/14")
+	nh := DesiredNexthop{PeerID: "unbounded0", LinkIndex: 7}
+	desired := []DesiredRoute{
+		{
+			Prefix:      *prefix,
+			Nexthops:    []DesiredNexthop{nh},
+			Flags:       unix.RTNH_F_ONLINK,
+			ScopeGlobal: true,
+		},
+	}
+
+	_ = m.SyncRoutes(desired)
+
+	if len(m.desiredRoutes) != 1 {
+		t.Fatalf("desiredRoutes length = %d, want 1", len(m.desiredRoutes))
+	}
+
+	got := m.desiredRoutes[0]
+	if !got.ScopeGlobal {
+		t.Fatal("ScopeGlobal was not preserved through SyncRoutes")
+	}
+
+	if got.Flags != unix.RTNH_F_ONLINK {
+		t.Fatalf("Flags = %d, want %d", got.Flags, unix.RTNH_F_ONLINK)
+	}
+
+	route := m.buildKernelRoute(got, got.Nexthops)
+	if route == nil {
+		t.Fatal("expected non-nil route")
+	}
+
+	if route.Scope != vnetlink.SCOPE_UNIVERSE {
+		t.Errorf("Scope = %d, want %d", route.Scope, vnetlink.SCOPE_UNIVERSE)
+	}
+
+	if route.Flags != unix.RTNH_F_ONLINK {
+		t.Errorf("Flags = %d, want %d", route.Flags, unix.RTNH_F_ONLINK)
+	}
 }
 
 // TestValidateRoutes_DedicatedTable_NoFilterNeeded verifies that a manager


### PR DESCRIPTION
## Why

During the Azure Linux/CNI investigation, the route manager was found to drop route metadata that callers explicitly set. Separately, the live incident ultimately traced to stale Cilium state during CNI takeover, so the normal migration guidance should point operators at Cilium's own cleanup flow rather than relying on ad hoc repair.

The same live validation also showed low-rate WireGuard `rx_errors` can persist while peers, handshakes, Ray smoke, and pod datapath are healthy. Those receive-only counter deltas should stay visible in logs/diagnostics but should not force node status to `Errors` when the corresponding peers are healthy.

## What changed

- Preserve `Flags` and `ScopeGlobal` while `UnifiedRouteManager.SyncRoutes` normalizes and merges desired routes.
- Track those fields in installed route state so drift detection catches flag/scope changes.
- Add regression coverage for gatewayless `unbounded0` route metadata preservation and route update detection.
- Document Cilium-to-unbounded migration steps, including `cilium-dbg post-uninstall-cleanup --all-state -f` and checks for stale `cilium_host`, fwmark rules, `cil_sock*`, and `cilium_lb*` state.
- Suppress WireGuard `rx_errors`-only link-stat node errors when all peers on that interface are healthy, while preserving tx/drop and unhealthy-peer link-stat warnings as node errors.

## Notes for reviewers

The Cilium cleanup is intentionally documentation only in this PR. The live repair proved stale Cilium host/service-LB state can break ClusterIP DNS after takeover, but full Cilium cleanup should be handled by Cilium tooling or a separately scoped operational repair.

The link-stats change is intentionally narrow: it only suppresses `rx_errors`-only warnings for interfaces whose peers are healthy. `tx_errors`, drops, missing peers, or unhealthy peers still surface as node errors.

## Validation

- `go test ./internal/net/netlink -run 'TestRouteNeedsUpdate_FlagsChanged|TestRouteNeedsUpdate_ScopeGlobalChanged|TestBuildInstalledState|TestBuildKernelRoute_GatewaylessScopeGlobal|TestSyncRoutes_PreservesGatewaylessRouteMetadata' -count=1 -v` in a Linux container
- `go test ./cmd/unbounded-net-node -run 'TestLinkStatsWarningsSuppressHealthyWireGuardRxErrors|TestLinkStatsWarningsKeepWireGuardRxErrorsWhenPeerUnhealthy|TestLinkStatsWarningsKeepWireGuardTxAndDropErrors|TestLinkStatsWarningsKeepRxErrorsWithNoMatchingPeer' -count=1 -v` in a Linux container
- `GOOS=linux GOARCH=amd64 golangci-lint run -c .golangci.yaml -E wsl_v5 ./cmd/unbounded-net-node ./cmd/unbounded-net-controller ./cmd/kubectl-unbounded`
- Linux-target compile checks for `cmd/unbounded-net-node`, `cmd/unbounded-net-controller`, and `cmd/kubectl-unbounded`
- Earlier validation also covered Linux-target compile checks for `internal/net/netlink`, `internal/net/ebpf`, and `cmd/unroute`

AI assistance was used to prepare this change; the final diff and validation were reviewed before opening the PR.
