### PR TITLE
Fix an issue where fabric tests could bind the wrong interface and fail.

### DIFF
--- a/cmd/unbounded-storage/AGENTS.md
+++ b/cmd/unbounded-storage/AGENTS.md
@@ -114,6 +114,17 @@ usually too old, so the Makefile builds a pinned release from source:
   automatically, so prefer the Makefile targets over raw `cargo`. If you
   must run `cargo` directly, point it at the pinned install yourself.
 
+The in-process fabric FFI tests (`src/fabric/tests.rs` and the inline
+loopback test in `src/fabric/fabric.rs`) require a loopback-capable
+`tcp` provider and pin their source bind to `127.0.0.1`. This is
+deliberate: with a null bind address libfabric selects the first
+routable NIC, so on multi-NIC or containerized dev boxes the paired
+loopback fabrics land on different interfaces (e.g. `eth0` vs a docker
+bridge) and the tcp RDM data path never makes progress, hanging every
+completion-dependent test. Pinning `127.0.0.1:0` keeps both fabrics on
+`lo`. If you hit these timeouts on an older checkout, `FI_TCP_IFACE=lo`
+is the manual override.
+
 ## Testing patterns
 
 There are three distinct in-process test styles in this crate plus an

--- a/cmd/unbounded-storage/src/fabric/fabric.rs
+++ b/cmd/unbounded-storage/src/fabric/fabric.rs
@@ -460,6 +460,11 @@ mod tests {
         // the test lean.
         cfg.progress_threads = 1;
         cfg.max_inflight = 16;
+        // Pin the source bind to loopback so self_address() is
+        // deterministic on multi-NIC hosts (see tcp_loopback_cfg in
+        // fabric/tests.rs for the full rationale).
+        cfg.listen = true;
+        cfg.listen_addr = Some("127.0.0.1:0".to_string());
 
         let fabric = Fabric::new(cfg)
             .expect("Fabric::new should succeed after tcp provider availability is established");

--- a/cmd/unbounded-storage/src/fabric/tests.rs
+++ b/cmd/unbounded-storage/src/fabric/tests.rs
@@ -66,6 +66,16 @@ fn tcp_loopback_cfg() -> FabricConfig {
     cfg.provider = Provider::Tcp;
     cfg.progress_threads = 1;
     cfg.max_inflight = 64;
+    // Pin the source address to loopback. Without this, fi_getinfo with
+    // a null node lets libfabric pick the first routable NIC; on
+    // multi-NIC or containerized hosts the paired fabrics land on
+    // different interfaces and the tcp RDM data path never makes
+    // progress, so every completion-dependent test times out. The ":0"
+    // port lets the OS assign a free ephemeral port per fabric;
+    // listen=true is required so fi_getinfo treats the address as a
+    // source bind (FI_SOURCE) rather than a destination.
+    cfg.listen = true;
+    cfg.listen_addr = Some("127.0.0.1:0".to_string());
     cfg
 }
 


### PR DESCRIPTION
The tests that depended on libfabric were failing for me, but not always others. Turns out my test runs were binding an extra interface I have in WSL. We should have the tests always binding the loopback.