### PR TITLE
release-upgrade: switch to workflow_run trigger, add smoke tests

### DIFF
--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -4,26 +4,75 @@
 name: release upgrade
 
 # ---------------------------------------------------------------------------
-# Auto-deploys a published Unbounded release to a target Kubernetes cluster.
+# Deploys an Unbounded release to the integration cluster (unbounded-stable)
+# so it can soak before being published to end users.
 #
-# Triggers:
-#   release (released)  - fires on full releases (excludes pre-releases) and
-#                          deploys the released tag to the target cluster.
-#   workflow_dispatch    - manual run; required for the very first install
-#                          (set force_init=true) and for re-deploys.
+# Lifecycle this workflow is part of:
 #
+#   1. Cut a release. Push a tag (or use the `unbounded release` workflow's
+#      workflow_dispatch). That workflow (release.yaml) builds binaries,
+#      container images, the manifests tarball, signs everything, and
+#      creates a DRAFT GitHub Release with all assets attached.
+#
+#   2. Auto-deploy to integration. As soon as `unbounded release` finishes
+#      successfully, THIS workflow fires via `workflow_run` and deploys
+#      the release onto the `unbounded-stable` cluster.
+#
+#   3. Smoke + soak. Immediately after deploy, the `smoke-tests` job runs
+#      an extensible matrix of fast post-deploy validation tasks against
+#      the freshly deployed cluster (see hack/release/smoke/). The release
+#      then soaks as a DRAFT in unbounded-stable - invisible to end users
+#      and to krew - while real workloads exercise it for a few days.
+#      Ongoing soak observation relies on the cluster's existing
+#      monitoring/alerts and is not this workflow's responsibility.
+#
+#   4. Publish. When the operator is satisfied with the soak, they flip
+#      the draft to non-draft (GitHub UI, or `gh release edit <tag>
+#      --draft=false`). The `released` event fires but nothing listens to
+#      it, so publish is purely the user-visibility / advertise-to-krew
+#      gate and not a deploy gate.
+#
+# Why workflow_run and not `release: [released]`?
+#   The previous trigger fired on draft -> published, which made the
+#   deploy race the asset uploads in release.yaml. If the operator
+#   published the draft before release.yaml's `finalize` job attached the
+#   manifests, the deploy would fail with "no assets to download". Every
+#   release from v0.1.3 onward failed that way. workflow_run fires only
+#   after release.yaml has uploaded everything to the draft, which by
+#   construction means assets are present.
+#
+# Target cluster
+# --------------
 # The target cluster is configured via the `unbounded-stable` GitHub
 # Environment, which provides:
 #   - secret KUBECONFIG          (raw kubeconfig file contents)
 #   - vars   SITE_NAME, CLUSTER_NODE_CIDR, CLUSTER_POD_CIDR,
 #            SITE_NODE_CIDR, SITE_POD_CIDR, MANAGE_CNI_PLUGIN
 #
-# See hack/scripts/setup-deploy-environment.sh.
+# To redirect this workflow at a different cluster: create a new
+# Environment (e.g. `unbounded-canary`), set its secrets/vars, change
+# `environment:` on the deploy and smoke-tests jobs, and update the
+# concurrency group key if you want the new cluster to deploy in parallel
+# with stable. See hack/scripts/setup-deploy-environment.sh.
+#
+# Customization points (search for "CUSTOMIZE:" in this file)
+# ------------------------------------------------------------
+#   - Add a smoke test       -> drop a script in hack/release/smoke/
+#                               (see the smoke-tests job for the contract)
+#   - Change target cluster  -> change `environment:` on the relevant jobs
+#   - Add Teams/Slack notify -> see commented-out notify job at the bottom
+#   - Exclude prereleases    -> tighten the resolve job's tag regex
 # ---------------------------------------------------------------------------
 
 on:
-  release:
-    types: [released]
+  # PRIMARY trigger. The upstream workflow name must match release.yaml's
+  # top-level `name:` field exactly. If release.yaml is ever renamed,
+  # update the string below.
+  workflow_run:
+    workflows: ["unbounded release"]
+    types: [completed]
+
+  # Manual trigger for re-deploys, backfills, and the first-ever bootstrap.
   workflow_dispatch:
     inputs:
       tag:
@@ -34,20 +83,53 @@ on:
         type: boolean
         default: false
 
+# workflow_run-triggered workflows default to read-only. We only need read
+# access for checkout and `gh release download`. Made explicit so future
+# additions don't accidentally inherit broader scopes.
 permissions:
   contents: read
 
+# Prevent two deploys for the same tag from racing. We key on the upstream
+# workflow_run's head_branch (the tag name for tag-push triggers) or the
+# manual input. Different tags can deploy concurrently; the same tag
+# serializes.
 concurrency:
-  group: deploy-stable-${{ github.event.release.tag_name || inputs.tag }}
+  group: deploy-stable-${{ github.event.workflow_run.head_branch || inputs.tag }}
   cancel-in-progress: false
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Resolve the release tag we are deploying. For release events we use the
-  # event payload; for manual runs we use the user-supplied input.
+  # Resolve the release tag we are deploying.
+  #
+  #   workflow_run triggers: read the tag from the upstream run's
+  #     head_branch. For tag pushes, GitHub puts the bare tag name there
+  #     (no refs/tags/ prefix). We filter to:
+  #       - this repo (safety on forks)
+  #       - successful upstream runs
+  #       - upstream runs triggered by tag push (excludes workflow_dispatch
+  #         and dry_run runs of release.yaml, whose head_branch is a branch
+  #         name)
+  #       - tags starting with `v` (cheap pre-filter; full semver regex
+  #         below)
+  #
+  #   workflow_dispatch: read the tag from the user's input.
+  #
+  # The full semver regex allows prerelease suffixes (e.g. v1.2.3-rc1).
+  # Prerelease tags ARE deployed to unbounded-stable by design - the
+  # integration cluster is where we exercise prereleases.
+  #
+  # CUSTOMIZE: to exclude prereleases, drop the `(-[0-9A-Za-z.-]+)?`
+  # group from the regex below.
   # ---------------------------------------------------------------------------
   resolve:
-    if: github.repository == 'Azure/unbounded'
+    if: |
+      github.repository == 'Azure/unbounded' && (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'workflow_run'
+         && github.event.workflow_run.conclusion == 'success'
+         && github.event.workflow_run.event == 'push'
+         && startsWith(github.event.workflow_run.head_branch, 'v'))
+      )
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
@@ -56,11 +138,11 @@ jobs:
         id: resolve
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            TAG="${{ github.event.release.tag_name }}"
-          else
-            TAG="${{ inputs.tag }}"
-          fi
+          case "${{ github.event_name }}" in
+            workflow_run)      TAG="${{ github.event.workflow_run.head_branch }}" ;;
+            workflow_dispatch) TAG="${{ inputs.tag }}" ;;
+            *)                 echo "::error::unexpected event ${{ github.event_name }}"; exit 1 ;;
+          esac
 
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Tag must be in vX.Y.Z[-suffix] format, got: ${TAG}"
@@ -76,8 +158,12 @@ jobs:
   #   MODE=init     -> 'kubectl unbounded site init' using the embedded
   #                    manifests bundled into the released plugin binary.
   #                    Used for the very first bootstrap of a cluster.
-  #   MODE=upgrade  -> server-side 'kubectl apply' of the rendered manifests
-  #                    that were attached to the GitHub Release.
+  #   MODE=upgrade  -> server-side 'kubectl apply' of the rendered
+  #                    manifests that were attached to the GitHub Release.
+  #
+  # Note: `gh release download` works on DRAFT releases as long as the
+  # token has `contents: read`. That's intentional - this workflow deploys
+  # the release before it's published to end users.
   # ---------------------------------------------------------------------------
   deploy:
     needs: resolve
@@ -92,6 +178,8 @@ jobs:
       SITE_NODE_CIDR: ${{ vars.SITE_NODE_CIDR }}
       SITE_POD_CIDR: ${{ vars.SITE_POD_CIDR }}
       MANAGE_CNI_PLUGIN: ${{ vars.MANAGE_CNI_PLUGIN }}
+    outputs:
+      mode: ${{ steps.mode.outputs.mode }}
     steps:
       - name: Validate environment configuration
         run: |
@@ -110,6 +198,10 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # Check out the deployed tag, not the default branch. The deploy
+          # steps below use tag-pinned content (manifests tarball, cosign
+          # cert identity, etc.). The workflow definition itself always
+          # comes from the default branch - that's a workflow_run quirk.
           ref: ${{ needs.resolve.outputs.tag }}
 
       - name: Install kubectl
@@ -185,6 +277,7 @@ jobs:
           "$RUNNER_TEMP/bin/kubectl-unbounded" --help >/dev/null
 
       - name: Determine deploy mode
+        id: mode
         run: |
           set -euo pipefail
           MODE=upgrade
@@ -201,6 +294,7 @@ jobs:
             echo "Site '${SITE_NAME}' exists; selecting upgrade mode"
           fi
           echo "MODE=${MODE}" >> "$GITHUB_ENV"
+          echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
 
       - name: Run site init (first install)
         if: env.MODE == 'init'
@@ -271,3 +365,146 @@ jobs:
             kubectl -n unbounded-kube get deploy machina-controller       -o jsonpath='{.spec.template.spec.containers[*].image}{"\n"}' 2>/dev/null || true
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Discover smoke tests to run after deploy. Lists hack/release/smoke/*.sh
+  # and emits a JSON matrix. If the directory has no scripts, has_tasks is
+  # false and the smoke-tests job is skipped (GitHub Actions errors on an
+  # empty matrix, so we have to gate it explicitly).
+  # ---------------------------------------------------------------------------
+  smoke-discover:
+    needs: [resolve, deploy]
+    runs-on: ubuntu-latest
+    outputs:
+      tasks: ${{ steps.list.outputs.tasks }}
+      has_tasks: ${{ steps.list.outputs.has_tasks }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Discover smoke tasks
+        id: list
+        run: |
+          set -euo pipefail
+          tasks=$(
+            find hack/release/smoke -maxdepth 1 -type f -name '*.sh' 2>/dev/null \
+              | sort \
+              | jq -R -s -c 'split("\n") | map(select(length>0)) |
+                  map({name: (. | sub(".*/"; "") | sub(".sh$"; "")), script: .})'
+          )
+          if [[ -z "$tasks" || "$tasks" == "[]" ]]; then
+            echo "has_tasks=false" >> "$GITHUB_OUTPUT"
+            echo "tasks=[]" >> "$GITHUB_OUTPUT"
+            echo "No smoke tasks found in hack/release/smoke/"
+          else
+            echo "has_tasks=true" >> "$GITHUB_OUTPUT"
+            echo "tasks=${tasks}" >> "$GITHUB_OUTPUT"
+            echo "Discovered smoke tasks:"
+            echo "${tasks}" | jq .
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Smoke tests. Runs ONCE per deploy. Each task must complete within the
+  # per-task timeout (15 minutes by default below). Long-running validation
+  # is NOT this job's responsibility - rely on the cluster's monitoring
+  # for that.
+  #
+  # Not to be confused with hack/smoke-metalman.py / hack/smoke-storage.py,
+  # which are component-level smoke tests used by CI workflows. Those run
+  # against ephemeral test environments; this runs against the deployed
+  # unbounded-stable cluster.
+  #
+  # CUSTOMIZE: ADD A SMOKE TEST
+  #   1. Drop an executable script in hack/release/smoke/ named
+  #      hack/release/smoke/<name>.sh. The basename (minus .sh) becomes
+  #      the matrix task name and shows up as its own job in the Actions
+  #      UI.
+  #   2. The script must complete within 15 minutes (see timeout-minutes
+  #      below).
+  #   3. The script runs from the repo root at the deployed tag's commit
+  #      with the following env exported:
+  #        TAG          - the deployed tag (e.g. v0.1.12)
+  #        KUBECONFIG   - path to the cluster's kubeconfig
+  #        SITE_NAME    - the configured site name on this cluster
+  #      Anything from the `unbounded-stable` environment is also in scope.
+  #   4. Exit 0 for pass, non-zero for fail. Failures do NOT roll back the
+  #      deploy - rollback during soak is a human decision (re-run this
+  #      workflow's workflow_dispatch with the previous tag).
+  #
+  # See hack/release/smoke/core-namespaces-ready.sh as a template.
+  # ---------------------------------------------------------------------------
+  smoke-tests:
+    needs: [resolve, deploy, smoke-discover]
+    if: needs.smoke-discover.outputs.has_tasks == 'true'
+    runs-on: ubuntu-latest
+    environment: unbounded-stable
+    strategy:
+      # Run every smoke task even if one fails so we get full signal.
+      fail-fast: false
+      matrix:
+        task: ${{ fromJSON(needs.smoke-discover.outputs.tasks) }}
+    name: smoke (${{ matrix.task.name }})
+    env:
+      TAG: ${{ needs.resolve.outputs.tag }}
+      SITE_NAME: ${{ vars.SITE_NAME }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+
+      - name: Write kubeconfig
+        env:
+          KUBECONFIG_CONTENT: ${{ secrets.KUBECONFIG }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${KUBECONFIG_CONTENT}" ]]; then
+            echo "::error::Environment secret KUBECONFIG is empty"
+            exit 1
+          fi
+          umask 077
+          printf '%s' "$KUBECONFIG_CONTENT" > "$RUNNER_TEMP/kubeconfig"
+          echo "KUBECONFIG=$RUNNER_TEMP/kubeconfig" >> "$GITHUB_ENV"
+
+      - name: Run smoke task ${{ matrix.task.name }}
+        timeout-minutes: 15
+        run: |
+          set -euo pipefail
+          chmod +x "${{ matrix.task.script }}"
+          "${{ matrix.task.script }}"
+
+  # ---------------------------------------------------------------------------
+  # CUSTOMIZE: Teams notification (NOT YET ENABLED)
+  #
+  # When we want Teams notifications:
+  #   1. Provision an Incoming Webhook (Workflows / Power Automate) on the
+  #      target channel; capture the URL.
+  #   2. Add it as a secret on the `unbounded-stable` environment named
+  #      TEAMS_WEBHOOK_URL.
+  #   3. Uncomment the notify job below.
+  #
+  # notify:
+  #   needs: [resolve, deploy, smoke-tests]
+  #   if: always() && needs.resolve.result == 'success'
+  #   runs-on: ubuntu-latest
+  #   environment: unbounded-stable
+  #   steps:
+  #     - name: Post to Teams
+  #       env:
+  #         WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
+  #         TAG: ${{ needs.resolve.outputs.tag }}
+  #         DEPLOY_STATUS: ${{ needs.deploy.result }}
+  #         SMOKE_STATUS: ${{ needs.smoke-tests.result }}
+  #         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  #       run: |
+  #         # Adaptive Card payload; see https://adaptivecards.io
+  #         jq -n --arg tag "$TAG" \
+  #               --arg deploy "$DEPLOY_STATUS" \
+  #               --arg smoke "$SMOKE_STATUS" \
+  #               --arg url "$RUN_URL" \
+  #           '{ ... }' \
+  #           | curl -sS -H 'Content-Type: application/json' -d @- "$WEBHOOK"
+  # ---------------------------------------------------------------------------

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -136,12 +136,26 @@ jobs:
     steps:
       - name: Resolve tag
         id: resolve
+        # Bind workflow-context values to env vars so they enter the
+        # shell script as data, not as code. Inline `${{ ... }}` in a
+        # `run:` block is template-expanded BEFORE bash parses the
+        # script, so any shell metacharacter in the source value would
+        # become script syntax. workflow_run runs in the privileged
+        # default-branch context and can poison the Actions cache or
+        # exfiltrate environment secrets, so this matters even though
+        # the source values here are constrained to authenticated
+        # repo-writers.
+        # See CodeQL rule actions/cache-poisoning/code-injection.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          UPSTREAM_TAG: ${{ github.event.workflow_run.head_branch }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          case "${{ github.event_name }}" in
-            workflow_run)      TAG="${{ github.event.workflow_run.head_branch }}" ;;
-            workflow_dispatch) TAG="${{ inputs.tag }}" ;;
-            *)                 echo "::error::unexpected event ${{ github.event_name }}"; exit 1 ;;
+          case "$EVENT_NAME" in
+            workflow_run)      TAG="$UPSTREAM_TAG" ;;
+            workflow_dispatch) TAG="$INPUT_TAG" ;;
+            *)                 echo "::error::unexpected event $EVENT_NAME"; exit 1 ;;
           esac
 
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
@@ -471,10 +485,19 @@ jobs:
 
       - name: Run smoke task ${{ matrix.task.name }}
         timeout-minutes: 15
+        # SMOKE_SCRIPT comes from a matrix entry that smoke-discover
+        # built from `find hack/release/smoke/*.sh` output. The values
+        # are committed repo paths today, but we still bind via `env:`
+        # rather than inline `${{ matrix.task.script }}` so that any
+        # future change to how the matrix is populated cannot silently
+        # introduce a code-injection sink. The `name:` above is workflow
+        # metadata, not a shell context, so inlining is fine there.
+        env:
+          SMOKE_SCRIPT: ${{ matrix.task.script }}
         run: |
           set -euo pipefail
-          chmod +x "${{ matrix.task.script }}"
-          "${{ matrix.task.script }}"
+          chmod +x "$SMOKE_SCRIPT"
+          "$SMOKE_SCRIPT"
 
   # ---------------------------------------------------------------------------
   # CUSTOMIZE: Teams notification (NOT YET ENABLED)

--- a/hack/release/smoke/core-namespaces-ready.sh
+++ b/hack/release/smoke/core-namespaces-ready.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# release-smoke: core-namespaces-ready
+#
+# Verifies that the core Unbounded namespaces exist on the deployed cluster
+# and that every pod in those namespaces is Running and Ready.
+#
+# This script is the canonical TEMPLATE for release smoke tests. Copy it
+# as the starting point for new smoke checks under hack/release/smoke/.
+#
+# Contract (provided by .github/workflows/release-upgrade.yaml):
+#   TAG          The deployed release tag, e.g. v0.1.12.
+#   KUBECONFIG   Path to a kubeconfig pointed at unbounded-stable.
+#   SITE_NAME    Site name configured for the cluster.
+#
+# Conventions for new smoke tests:
+#   - set -euo pipefail at the top so any unchecked failure aborts.
+#   - Print what you are checking; the run log is the primary debugging
+#     surface.
+#   - Keep the check focused. One concept per script.
+#   - Cap your kubectl calls with --request-timeout so a stuck apiserver
+#     fails fast instead of consuming the per-task 15-minute budget.
+#   - Exit 0 on pass, non-zero on fail.
+#   - Use GitHub Actions workflow commands ("::error::msg") to surface
+#     failures as red annotations in the run summary. See
+#     https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+
+set -euo pipefail
+
+: "${TAG:?TAG must be set}"
+: "${KUBECONFIG:?KUBECONFIG must be set}"
+
+NAMESPACES=(unbounded-kube unbounded-net)
+KUBECTL=(kubectl --request-timeout=30s)
+
+echo "Smoke: validate core namespaces and pod readiness for ${TAG}"
+
+# ---------------------------------------------------------------------------
+# 1. Namespaces exist.
+# ---------------------------------------------------------------------------
+for ns in "${NAMESPACES[@]}"; do
+  echo "Checking namespace ${ns} exists"
+  if ! "${KUBECTL[@]}" get namespace "${ns}" >/dev/null; then
+    echo "::error::namespace ${ns} not found on cluster"
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Every pod in the target namespaces is Running and Ready.
+#    Completed pods (Job-style workloads in phase Succeeded) are ignored;
+#    they are not a failure even though they are not Running.
+# ---------------------------------------------------------------------------
+failures=0
+for ns in "${NAMESPACES[@]}"; do
+  echo "Checking pod readiness in ${ns}"
+  # Emit "<name>\t<phase>\t<ready_status>" per pod. ready_status is the
+  # status of the Ready condition (True/False/<empty> if missing).
+  while IFS=$'\t' read -r name phase ready; do
+    [[ -z "${name}" ]] && continue
+    if [[ "${phase}" == "Succeeded" ]]; then
+      continue
+    fi
+    if [[ "${phase}" != "Running" || "${ready}" != "True" ]]; then
+      echo "::error::pod ${ns}/${name} not ready (phase=${phase} ready=${ready:-<none>})"
+      failures=$((failures + 1))
+    fi
+  done < <("${KUBECTL[@]}" -n "${ns}" get pods \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}')
+done
+
+if (( failures > 0 )); then
+  echo "::error::${failures} pod(s) not ready across ${NAMESPACES[*]}"
+  exit 1
+fi
+
+echo "OK: namespaces present and all pods Running+Ready"


### PR DESCRIPTION
## Why

The `release-upgrade` workflow has been firing on `release: [released]`, which races the asset uploads in `release.yaml`. Every `release-upgrade` run since v0.1.3 has failed with "no assets to download" because the draft release is typically published before `release.yaml`'s `finalize` job has attached the manifests tarball. The integration cluster (`unbounded-stable`) has been stuck on whatever was last manually deployed (currently v0.1.5) as a result.

See the failed run for v0.1.11 for a representative example: https://github.com/Azure/unbounded/actions/runs/26971164378

## What changes

### Trigger

`release-upgrade.yaml` now fires on `workflow_run: types: [completed]` against the upstream `unbounded release` workflow. The `if:` gate filters to successful runs that were triggered by a tag push for a `v*` ref in this repo. The deploy therefore only fires once `release.yaml` has uploaded every asset.

Manual `workflow_dispatch` with `tag` and `force_init` inputs is preserved for re-deploys, backfills, and first-ever bootstrap.

### Lifecycle

The intended operator flow becomes:

1. Cut a release (push a tag, or use `release.yaml`'s `workflow_dispatch`). `release.yaml` builds and signs everything into a **draft** GitHub Release with all assets attached.
2. `release-upgrade` fires automatically and deploys the draft to `unbounded-stable`.
3. Smoke tests run against the freshly deployed cluster.
4. The release **soaks as a draft** (invisible to end users and krew) for a few days. Soak monitoring relies on existing cluster observability.
5. When the operator is satisfied, they publish the draft. The publish becomes a pure user-visibility gate; the deploy already happened in step 2.

### Smoke tests

A new `smoke-tests` job discovers `hack/release/smoke/*.sh` and runs each as a matrix entry with a 15-minute per-task timeout. Adding a new smoke test is "drop a script in `hack/release/smoke/`." Each task gets `TAG`, `KUBECONFIG`, and `SITE_NAME` exported; failures emit `::error::` annotations but do not roll back the deploy.

The first smoke test, `hack/release/smoke/core-namespaces-ready.sh`, verifies that the `unbounded-kube` and `unbounded-net` namespaces exist and that every pod in them is `Running` + `Ready`. It is also intended as the canonical template for new smoke tests; the header comment block documents the conventions.

### Workflow comments

The workflow file now carries a comment block at the top describing the full lifecycle, why `workflow_run` was chosen over `released`, and where to find each "CUSTOMIZE:" hook (add smoke test, change target cluster, add Teams notification, exclude prereleases). The Teams notification job is included as a commented-out scaffold so it can be enabled by uncommenting and adding a `TEAMS_WEBHOOK_URL` secret to the environment.
