### PR TITLE
release-upgrade: run smoke jobs from default branch and tolerate missing dir

### DIFF
--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -382,9 +382,20 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Discover smoke tests to run after deploy. Lists hack/release/smoke/*.sh
-  # and emits a JSON matrix. If the directory has no scripts, has_tasks is
-  # false and the smoke-tests job is skipped (GitHub Actions errors on an
-  # empty matrix, so we have to gate it explicitly).
+  # and emits a JSON matrix. If the directory is absent or has no scripts,
+  # has_tasks is false and the smoke-tests job is skipped (GitHub Actions
+  # errors on an empty matrix, so we have to gate it explicitly).
+  #
+  # Why check out the default branch instead of the deployed tag?
+  #   Smoke tests are validation of the *deployed cluster*, not of the
+  #   release artifacts. They are intentionally version-agnostic (they
+  #   check generic cluster health), and we want backfill deploys of older
+  #   tags to still benefit from the latest smoke checks. Without this,
+  #   backfilling a tag that predates hack/release/smoke/ would skip
+  #   smoke entirely; new smoke tests added on main would also never run
+  #   against old releases. If a smoke test ever needs to be tied to a
+  #   specific release, that's a signal it should live with the release
+  #   artifacts (e.g. as an integration test in CI), not here.
   # ---------------------------------------------------------------------------
   smoke-discover:
     needs: [resolve, deploy]
@@ -395,14 +406,26 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ needs.resolve.outputs.tag }}
+          # Use the default branch's hack/release/smoke/, not the deployed
+          # tag's. See the rationale above the job.
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Discover smoke tasks
         id: list
         run: |
           set -euo pipefail
+          # Bail out cleanly if the smoke directory does not exist (older
+          # checkouts, accidentally removed directory). `find` exits
+          # non-zero on a missing path even with stderr suppressed, which
+          # would abort under `set -e`.
+          if [[ ! -d hack/release/smoke ]]; then
+            echo "has_tasks=false" >> "$GITHUB_OUTPUT"
+            echo "tasks=[]" >> "$GITHUB_OUTPUT"
+            echo "hack/release/smoke does not exist at this ref; skipping smoke tests"
+            exit 0
+          fi
           tasks=$(
-            find hack/release/smoke -maxdepth 1 -type f -name '*.sh' 2>/dev/null \
+            find hack/release/smoke -maxdepth 1 -type f -name '*.sh' \
               | sort \
               | jq -R -s -c 'split("\n") | map(select(length>0)) |
                   map({name: (. | sub(".*/"; "") | sub(".sh$"; "")), script: .})'
@@ -436,8 +459,9 @@ jobs:
   #      UI.
   #   2. The script must complete within 15 minutes (see timeout-minutes
   #      below).
-  #   3. The script runs from the repo root at the deployed tag's commit
-  #      with the following env exported:
+  #   3. The script runs from the repo root at the default branch's HEAD
+  #      (NOT the deployed tag - see smoke-discover's rationale) with the
+  #      following env exported:
   #        TAG          - the deployed tag (e.g. v0.1.12)
   #        KUBECONFIG   - path to the cluster's kubeconfig
   #        SITE_NAME    - the configured site name on this cluster
@@ -465,7 +489,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ needs.resolve.outputs.tag }}
+          # Match smoke-discover: pull the smoke scripts from the default
+          # branch so backfills of older tags use the latest checks. See
+          # the comment block on smoke-discover for the rationale.
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Install kubectl
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -403,12 +403,23 @@ jobs:
     outputs:
       tasks: ${{ steps.list.outputs.tasks }}
       has_tasks: ${{ steps.list.outputs.has_tasks }}
+      smoke_sha: ${{ steps.pin.outputs.sha }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Use the default branch's hack/release/smoke/, not the deployed
           # tag's. See the rationale above the job.
           ref: ${{ github.event.repository.default_branch }}
+
+      - name: Pin smoke ref
+        id: pin
+        run: |
+          set -euo pipefail
+          # Record the exact commit the default branch points at right now.
+          # smoke-tests checks out this SHA rather than re-resolving the
+          # default branch, so it runs precisely the scripts this job
+          # enumerated even if the branch advances between jobs.
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Discover smoke tasks
         id: list
@@ -459,9 +470,9 @@ jobs:
   #      UI.
   #   2. The script must complete within 15 minutes (see timeout-minutes
   #      below).
-  #   3. The script runs from the repo root at the default branch's HEAD
-  #      (NOT the deployed tag - see smoke-discover's rationale) with the
-  #      following env exported:
+  #   3. The script runs from the repo root at the commit the default
+  #      branch pointed to when smoke-discover ran (NOT the deployed tag -
+  #      see smoke-discover's rationale) with the following env exported:
   #        TAG          - the deployed tag (e.g. v0.1.12)
   #        KUBECONFIG   - path to the cluster's kubeconfig
   #        SITE_NAME    - the configured site name on this cluster
@@ -489,10 +500,12 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # Match smoke-discover: pull the smoke scripts from the default
-          # branch so backfills of older tags use the latest checks. See
-          # the comment block on smoke-discover for the rationale.
-          ref: ${{ github.event.repository.default_branch }}
+          # Check out the exact commit smoke-discover enumerated, not a
+          # fresh resolve of the default branch (which may have advanced
+          # since). This guarantees we run precisely the scripts that
+          # populated the matrix. See the comment block on smoke-discover
+          # for why the smoke scripts come from the default branch at all.
+          ref: ${{ needs.smoke-discover.outputs.smoke_sha }}
 
       - name: Install kubectl
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0


### PR DESCRIPTION
## Why

The first run of `release-upgrade` for `v0.1.11` after #233 merged failed at the `smoke-discover` job. Run: https://github.com/Azure/unbounded/actions/runs/27178868989

- `deploy` succeeded in 16s; the cluster is on v0.1.11 and healthy.
- `smoke-discover` exited 1 with no useful log output.

Root cause: `smoke-discover` checked out the deployed tag (`v0.1.11`), where `hack/release/smoke/` does not exist (the directory was added by #233 four days after v0.1.11 was tagged). The discover script ran `find hack/release/smoke -maxdepth 1 -type f -name '*.sh' 2>/dev/null | ...`. With the path missing, `find` exits non-zero. `2>/dev/null` suppresses the stderr but not the exit code; `set -euo pipefail` then aborts the script before reaching the `has_tasks=false` branch.

## What changes

Two fixes, both in `.github/workflows/release-upgrade.yaml`:

### 1. `smoke-discover` and `smoke-tests` check out the default branch, not the deployed tag

```yaml
# was:  ref: ${{ needs.resolve.outputs.tag }}
# now:  ref: ${{ github.event.repository.default_branch }}
```

Smoke tests are validation of the *deployed cluster*, not of the release artifacts. They are intentionally version-agnostic (the current one just checks namespaces and pod readiness). Tying them to the release means:

- Backfilling an older tag that predates `hack/release/smoke/` skips smoke entirely (the current failure).
- New smoke tests added to `main` never run against existing releases.
- Improving a smoke test requires re-cutting a release to use the improvement.

Pulling smoke scripts from the default branch eliminates all three. If a smoke test ever needs to be tied to a specific release, that's a signal it should live with the release artifacts (e.g. as an integration test in CI), not under `hack/release/smoke/`.

### 2. `smoke-discover` tolerates a missing `hack/release/smoke/` directory

Defense in depth. The check-out-from-default-branch fix already prevents the failure mode that hit #233 in practice, but if the directory ever gets accidentally removed (or some future ref doesn't have it), the discover step should still cleanly emit `has_tasks=false` and let the workflow pass, not abort under `set -e`.

```bash
if [[ ! -d hack/release/smoke ]]; then
  echo "has_tasks=false" >> "$GITHUB_OUTPUT"
  echo "tasks=[]" >> "$GITHUB_OUTPUT"
  echo "hack/release/smoke does not exist at this ref; skipping smoke tests"
  exit 0
fi
```

The redundant `2>/dev/null` on `find` is dropped since we now know the path exists.

## Comments updated

- The header comment on `smoke-discover` now includes a "Why check out the default branch instead of the deployed tag?" section explaining the rationale.
- The `smoke-tests` header that documents the contract for new smoke tests now correctly says the script runs from the default branch's HEAD, not the deployed tag's commit.

## Validation

- `actionlint .github/workflows/release-upgrade.yaml` clean.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-upgrade.yaml'))"` parses; 4 jobs as expected.
- Manually exercised the new directory-existence check with both present and missing paths; behaves as expected.

## What this PR does NOT fix

The systemic bug from the earlier debug session: the release-upgrade workflow's `Apply manifests (upgrade)` step blindly applies `03-config.yaml` from the release tarball. The shipped template lacks the `apiServerEndpoint` field that `machina-controller` v0.1.5+ requires, so every release-upgrade silently overwrites that field back to empty and crashes the controller. The `unbounded-stable` cluster needed a manual `kubectl apply` to add the field back after this workflow ran. That fix is a separate PR.

## After this merges

Re-run release-upgrade for v0.1.11 to confirm the full run is green:

```
gh workflow run release-upgrade.yaml --repo Azure/unbounded --ref main -f tag=v0.1.11
```

Expected: deploy is a no-op (cluster already at v0.1.11), smoke-discover finds `core-namespaces-ready.sh` on main, smoke-tests runs it against the cluster, all pods are Ready, run goes green.
