### PR TITLE
release-upgrade: workaround #235 by merging bundled machina-config with live

### DIFF
--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -345,6 +345,125 @@ jobs:
             exit 1
           fi
 
+      - name: Workaround for #235 - merge bundled machina-config with live ConfigMap
+        if: env.MODE == 'upgrade'
+        # WORKAROUND for https://github.com/Azure/unbounded/issues/235.
+        #
+        # The shipped 03-config.yaml ships a machina-config ConfigMap whose
+        # inner config.yaml lacks the per-cluster `apiServerEndpoint` field
+        # required by machina-controller v0.1.5+. Only
+        # `kubectl unbounded site init` ever populates that field on the
+        # live ConfigMap. If we let the bundled template apply unmodified,
+        # it silently overwrites the live value and the controller starts
+        # crashing on the next pod restart.
+        #
+        # Instead of skipping the file outright (which would also drop any
+        # new keys the bundle introduces), we MERGE: load the live
+        # ConfigMap's inner config.yaml, load the bundle's inner
+        # config.yaml, take the union with LIVE WINNING on conflicts
+        # (policy A), and rewrite the bundle file in place. The subsequent
+        # `kubectl apply` then pushes a manifest that preserves all
+        # operator state while adding any new keys this release
+        # introduces. Strict YAML round-trip verification at the end
+        # aborts if the merged manifest doesn't reparse.
+        #
+        # Caveats:
+        # - YAML comments in the bundled template are lost (PyYAML
+        #   safe_dump does not preserve them). The active values are
+        #   what matter for controller behavior.
+        # - When this workaround is no longer needed, the step warns and
+        #   continues (apply proceeds normally).
+        #
+        # REMOVE this step (and this comment) once issue #235 lands
+        # upstream (e.g. controller falls back to in-cluster discovery, or
+        # the release tarball stops shipping 03-config.yaml).
+        env:
+          BUNDLE_FILE: ${{ env.MANIFESTS_DIR }}/machina/03-config.yaml
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$BUNDLE_FILE" ]]; then
+            echo "::warning::Workaround for #235 expected ${BUNDLE_FILE} but it was not present; the workaround may no longer be needed"
+            exit 0
+          fi
+
+          # Fetch the live inner config (empty if the ConfigMap does not exist yet).
+          LIVE_INNER=$(kubectl -n unbounded-kube get cm machina-config \
+            -o jsonpath='{.data.config\.yaml}' --ignore-not-found)
+          export LIVE_INNER
+
+          python3 - <<'PY'
+          import os
+          import sys
+          import yaml
+
+          # Use block-scalar (`|`) style for any multi-line string so the
+          # rewritten data.config.yaml is human-readable in the manifest.
+          def _str_representer(dumper, data):
+              style = "|" if "\n" in data else None
+              return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+          yaml.add_representer(str, _str_representer, Dumper=yaml.SafeDumper)
+
+          bundle_file = os.environ["BUNDLE_FILE"]
+          live_inner  = os.environ.get("LIVE_INNER", "")
+
+          # Parse the bundle file. Strict: any parse failure exits non-zero.
+          with open(bundle_file) as f:
+              bundle = yaml.safe_load(f)
+          if not isinstance(bundle, dict):
+              sys.exit(f"bundle file {bundle_file} did not parse as a YAML mapping")
+
+          bundle_inner_str = (bundle.get("data") or {}).get("config.yaml") or ""
+          bundle_inner = yaml.safe_load(bundle_inner_str) or {}
+          if not isinstance(bundle_inner, dict):
+              sys.exit("bundled data.config.yaml did not parse as a YAML mapping")
+
+          if live_inner.strip():
+              live = yaml.safe_load(live_inner) or {}
+              if not isinstance(live, dict):
+                  sys.exit("live data.config.yaml did not parse as a YAML mapping")
+
+              # Policy A: live wins on conflicts; bundle contributes new keys only.
+              # Output order: live keys in live order, then bundle-only keys appended.
+              merged = dict(live)
+              added = []
+              for k, v in bundle_inner.items():
+                  if k not in merged:
+                      merged[k] = v
+                      added.append(k)
+
+              print(f"Preserved {len(live)} key(s) from live ConfigMap")
+              if added:
+                  print(f"Added {len(added)} new key(s) from bundle: {', '.join(added)}")
+              else:
+                  print("No new keys from bundle")
+          else:
+              print("No live machina-config ConfigMap; using bundle as-is")
+              merged = bundle_inner
+
+          # Ensure the inner string ends with a newline so the block scalar
+          # renders cleanly and matches kubectl's normal serialization.
+          inner_dump = yaml.safe_dump(merged, default_flow_style=False, sort_keys=False)
+          if not inner_dump.endswith("\n"):
+              inner_dump += "\n"
+          bundle["data"]["config.yaml"] = inner_dump
+
+          with open(bundle_file, "w") as f:
+              yaml.safe_dump(bundle, f, default_flow_style=False)
+
+          # Strict round-trip verification: the rewritten manifest must reparse
+          # cleanly and the inner config.yaml must reparse as a mapping.
+          with open(bundle_file) as f:
+              check = yaml.safe_load(f)
+          if not isinstance(check, dict) or "data" not in check:
+              sys.exit("rewritten bundle file failed to round-trip")
+          inner_check = yaml.safe_load(check["data"].get("config.yaml", ""))
+          if not isinstance(inner_check, dict):
+              sys.exit("rewritten inner data.config.yaml failed to round-trip as a mapping")
+          PY
+
+          echo "Merged config.yaml that will be applied to the cluster:"
+          python3 -c "import yaml,sys; print(yaml.safe_load(open(sys.argv[1]))['data']['config.yaml'])" "$BUNDLE_FILE"
+
       - name: Apply manifests (upgrade)
         if: env.MODE == 'upgrade'
         run: |

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -345,6 +345,25 @@ jobs:
             exit 1
           fi
 
+      - name: Fetch release tooling from default branch (workaround for #235)
+        if: env.MODE == 'upgrade'
+        # The deploy job's primary checkout is pinned to the deployed tag,
+        # but the merge script for the #235 workaround lives under
+        # hack/release/ on the default branch and may not exist at older
+        # tags (e.g. when backfilling a release that predates the script).
+        # Pull just hack/release/ from the default branch into a tools
+        # subdirectory so the next step can invoke it regardless of the
+        # deployed tag.
+        #
+        # Mirrors the pattern used by smoke-discover and smoke-tests for
+        # hack/release/smoke/.
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: _release-tools
+          sparse-checkout: hack/release
+          sparse-checkout-cone-mode: true
+
       - name: Workaround for #235 - merge bundled machina-config with live ConfigMap
         if: env.MODE == 'upgrade'
         # WORKAROUND for https://github.com/Azure/unbounded/issues/235.
@@ -364,21 +383,19 @@ jobs:
         # (policy A), and rewrite the bundle file in place. The subsequent
         # `kubectl apply` then pushes a manifest that preserves all
         # operator state while adding any new keys this release
-        # introduces. Strict YAML round-trip verification at the end
-        # aborts if the merged manifest doesn't reparse.
+        # introduces.
         #
-        # Caveats:
-        # - YAML comments in the bundled template are lost (PyYAML
-        #   safe_dump does not preserve them). The active values are
-        #   what matter for controller behavior.
-        # - When this workaround is no longer needed, the step warns and
-        #   continues (apply proceeds normally).
+        # The merge logic lives in hack/release/merge-machina-config.py
+        # and is fetched from the default branch by the step above so
+        # backfills of older tags still get the latest version.
         #
-        # REMOVE this step (and this comment) once issue #235 lands
-        # upstream (e.g. controller falls back to in-cluster discovery, or
-        # the release tarball stops shipping 03-config.yaml).
+        # REMOVE this step (along with the sparse checkout above and the
+        # merge script under hack/release/) once issue #235 lands upstream
+        # (e.g. controller falls back to in-cluster discovery, or the
+        # release tarball stops shipping 03-config.yaml).
         env:
           BUNDLE_FILE: ${{ env.MANIFESTS_DIR }}/machina/03-config.yaml
+          MERGE_SCRIPT: _release-tools/hack/release/merge-machina-config.py
         run: |
           set -euo pipefail
           if [[ ! -f "$BUNDLE_FILE" ]]; then
@@ -391,75 +408,7 @@ jobs:
             -o jsonpath='{.data.config\.yaml}' --ignore-not-found)
           export LIVE_INNER
 
-          python3 - <<'PY'
-          import os
-          import sys
-          import yaml
-
-          # Use block-scalar (`|`) style for any multi-line string so the
-          # rewritten data.config.yaml is human-readable in the manifest.
-          def _str_representer(dumper, data):
-              style = "|" if "\n" in data else None
-              return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
-          yaml.add_representer(str, _str_representer, Dumper=yaml.SafeDumper)
-
-          bundle_file = os.environ["BUNDLE_FILE"]
-          live_inner  = os.environ.get("LIVE_INNER", "")
-
-          # Parse the bundle file. Strict: any parse failure exits non-zero.
-          with open(bundle_file) as f:
-              bundle = yaml.safe_load(f)
-          if not isinstance(bundle, dict):
-              sys.exit(f"bundle file {bundle_file} did not parse as a YAML mapping")
-
-          bundle_inner_str = (bundle.get("data") or {}).get("config.yaml") or ""
-          bundle_inner = yaml.safe_load(bundle_inner_str) or {}
-          if not isinstance(bundle_inner, dict):
-              sys.exit("bundled data.config.yaml did not parse as a YAML mapping")
-
-          if live_inner.strip():
-              live = yaml.safe_load(live_inner) or {}
-              if not isinstance(live, dict):
-                  sys.exit("live data.config.yaml did not parse as a YAML mapping")
-
-              # Policy A: live wins on conflicts; bundle contributes new keys only.
-              # Output order: live keys in live order, then bundle-only keys appended.
-              merged = dict(live)
-              added = []
-              for k, v in bundle_inner.items():
-                  if k not in merged:
-                      merged[k] = v
-                      added.append(k)
-
-              print(f"Preserved {len(live)} key(s) from live ConfigMap")
-              if added:
-                  print(f"Added {len(added)} new key(s) from bundle: {', '.join(added)}")
-              else:
-                  print("No new keys from bundle")
-          else:
-              print("No live machina-config ConfigMap; using bundle as-is")
-              merged = bundle_inner
-
-          # Ensure the inner string ends with a newline so the block scalar
-          # renders cleanly and matches kubectl's normal serialization.
-          inner_dump = yaml.safe_dump(merged, default_flow_style=False, sort_keys=False)
-          if not inner_dump.endswith("\n"):
-              inner_dump += "\n"
-          bundle["data"]["config.yaml"] = inner_dump
-
-          with open(bundle_file, "w") as f:
-              yaml.safe_dump(bundle, f, default_flow_style=False)
-
-          # Strict round-trip verification: the rewritten manifest must reparse
-          # cleanly and the inner config.yaml must reparse as a mapping.
-          with open(bundle_file) as f:
-              check = yaml.safe_load(f)
-          if not isinstance(check, dict) or "data" not in check:
-              sys.exit("rewritten bundle file failed to round-trip")
-          inner_check = yaml.safe_load(check["data"].get("config.yaml", ""))
-          if not isinstance(inner_check, dict):
-              sys.exit("rewritten inner data.config.yaml failed to round-trip as a mapping")
-          PY
+          python3 "$MERGE_SCRIPT"
 
           echo "Merged config.yaml that will be applied to the cluster:"
           python3 -c "import yaml,sys; print(yaml.safe_load(open(sys.argv[1]))['data']['config.yaml'])" "$BUNDLE_FILE"

--- a/hack/release/merge-machina-config.py
+++ b/hack/release/merge-machina-config.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Merge the bundled machina-config ConfigMap with the live cluster ConfigMap.
+
+WORKAROUND for https://github.com/Azure/unbounded/issues/235.
+
+The release manifests tarball ships a `machina-config` ConfigMap whose inner
+``data.config.yaml`` lacks the per-cluster ``apiServerEndpoint`` field that
+machina-controller v0.1.5+ requires. Only ``kubectl unbounded site init``
+populates that field on the live cluster. If the bundled template were
+applied unmodified during an upgrade, it would silently overwrite the live
+value and the controller would crash on the next pod restart.
+
+This script reads the bundled ConfigMap manifest and the live ConfigMap's
+inner config.yaml, merges them with **policy A** (live wins on conflicts;
+bundle contributes new keys only), and rewrites the bundle file in place.
+The workflow's subsequent ``kubectl apply`` then pushes a manifest that
+preserves all operator state while adding any new keys this release
+introduces.
+
+Strict round-trip verification at the end aborts the process if the
+rewritten manifest does not reparse.
+
+Inputs (environment):
+    BUNDLE_FILE  Path to the bundled 03-config.yaml manifest. Required.
+    LIVE_INNER   The live ConfigMap's ``data.config.yaml`` value, as a
+                 string. Empty when no live ConfigMap exists (fresh
+                 cluster); the bundle is used as-is in that case.
+
+Caveats:
+    - YAML comments in the bundled template are lost; PyYAML's safe_dump
+      does not preserve them. The active values are what matter for
+      controller behavior.
+    - Policy A means an operator-set value is never overwritten by a new
+      bundle default. Operators who want a new default must update the
+      ConfigMap manually.
+
+Remove this script (and the workflow step that invokes it) once issue
+#235 is resolved upstream.
+"""
+
+import os
+import sys
+
+import yaml
+
+
+def _str_representer(dumper, data):
+    """Render multi-line strings as block scalars (``|``) for readability."""
+
+    style = "|" if "\n" in data else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
+yaml.add_representer(str, _str_representer, Dumper=yaml.SafeDumper)
+
+
+def main() -> int:
+    bundle_file = os.environ["BUNDLE_FILE"]
+    live_inner = os.environ.get("LIVE_INNER", "")
+
+    # Parse the bundle file. Strict: any parse failure exits non-zero.
+    with open(bundle_file) as f:
+        bundle = yaml.safe_load(f)
+    if not isinstance(bundle, dict):
+        sys.exit(f"bundle file {bundle_file} did not parse as a YAML mapping")
+
+    bundle_inner_str = (bundle.get("data") or {}).get("config.yaml") or ""
+    bundle_inner = yaml.safe_load(bundle_inner_str) or {}
+    if not isinstance(bundle_inner, dict):
+        sys.exit("bundled data.config.yaml did not parse as a YAML mapping")
+
+    if live_inner.strip():
+        live = yaml.safe_load(live_inner) or {}
+        if not isinstance(live, dict):
+            sys.exit("live data.config.yaml did not parse as a YAML mapping")
+
+        # Policy A: live wins on conflicts; bundle contributes new keys only.
+        # Output order: live keys in live order, then bundle-only keys appended.
+        merged = dict(live)
+        added = []
+        for k, v in bundle_inner.items():
+            if k not in merged:
+                merged[k] = v
+                added.append(k)
+
+        print(f"Preserved {len(live)} key(s) from live ConfigMap")
+        if added:
+            print(f"Added {len(added)} new key(s) from bundle: {', '.join(added)}")
+        else:
+            print("No new keys from bundle")
+    else:
+        print("No live machina-config ConfigMap; using bundle as-is")
+        merged = bundle_inner
+
+    # Ensure the inner string ends with a newline so the block scalar renders
+    # cleanly and matches kubectl's normal serialization.
+    inner_dump = yaml.safe_dump(merged, default_flow_style=False, sort_keys=False)
+    if not inner_dump.endswith("\n"):
+        inner_dump += "\n"
+    bundle["data"]["config.yaml"] = inner_dump
+
+    with open(bundle_file, "w") as f:
+        yaml.safe_dump(bundle, f, default_flow_style=False)
+
+    # Strict round-trip verification: the rewritten manifest must reparse
+    # cleanly and the inner config.yaml must reparse as a mapping.
+    with open(bundle_file) as f:
+        check = yaml.safe_load(f)
+    if not isinstance(check, dict) or "data" not in check:
+        sys.exit("rewritten bundle file failed to round-trip")
+    inner_check = yaml.safe_load(check["data"].get("config.yaml", ""))
+    if not isinstance(inner_check, dict):
+        sys.exit("rewritten inner data.config.yaml failed to round-trip as a mapping")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Temporary workaround for #235.

The release tarball ships a `machina-config` ConfigMap whose inner `config.yaml` is missing the per-cluster `apiServerEndpoint` field that `machina-controller` v0.1.5+ requires. Only `kubectl unbounded site init` populates that field on the live cluster (and explicitly skips the bundled template via `skipPaths`). The release-upgrade workflow does not do that skip - it runs `kubectl apply --server-side --force-conflicts -R -f .../machina/` which actively overwrites the live ConfigMap with the empty-of-apiServerEndpoint bundled template, crashing the controller on the next pod restart.

That is what happened to `unbounded-stable` on 2026-05-13 and kept the cluster broken for 26 days (every subsequent release-upgrade run failed at the asset-download step (#233), masking the underlying controller crash). The v0.1.11 backfill after #233 surfaced the crash and required a manual ConfigMap patch to unblock.

## What changes

Add a single step to `release-upgrade.yaml`, immediately before the existing `Apply manifests (upgrade)` step:

```
Workaround for #235 - merge bundled machina-config with live ConfigMap
```

It:

1. Reads the live `machina-config` ConfigMap (`--ignore-not-found` for fresh-cluster bootstrap).
2. Parses both the bundled `data.config.yaml` and the live `data.config.yaml`.
3. Merges with **policy A**: live values win on conflicts; bundle contributes new keys only.
4. Rewrites the bundle file in place so the existing `Apply manifests (upgrade)` step pushes the merged manifest.
5. **Strict** YAML round-trip verification at the end; any parse failure aborts the workflow.

If the bundled template ever stops shipping `03-config.yaml` (e.g. when issue #235 is fixed via option (ii)), the step emits a `::warning::` and exits cleanly so the workflow does not break.

## Tested locally against three fixtures

```
=== Test: live has overrides; bundle adds nothing new ===
Preserved 5 key(s) from live ConfigMap
No new keys from bundle
[live's apiServerEndpoint and overridden maxConcurrentReconciles preserved]

=== Test: bundle introduces a new key ===
Preserved 5 key(s) from live ConfigMap
Added 1 new key(s) from bundle: reachabilityProbeInterval
[live values preserved; new key appended]

=== Test: no live ConfigMap (fresh cluster) ===
No live machina-config ConfigMap; using bundle as-is
[bundle applied unchanged]
```

The merged manifest uses block-scalar (`|`) style for the inner `config.yaml` so it stays readable in the run log.

## Caveats (documented in the step's header comment)

- **Comments in the bundled template are lost.** PyYAML's `safe_dump` doesn't preserve them. The active config values are what matter for controller behavior.
- **Does not patch a cluster whose `apiServerEndpoint` has already been wiped.** If the field is missing when this step runs (e.g. left over from before this PR), the merge produces a manifest without the field, the apply pushes it, and the controller stays broken. `unbounded-stable` was hand-patched on 2026-06-08 to add the field back; this workaround prevents future runs from wiping it again.
- **Behavior on bundle changing the default of an existing key.** Policy A means the live value wins. If a future release changes `maxConcurrentReconciles` default from 50 to 100, an existing cluster keeps its current value. Operators wanting the new default must update the ConfigMap manually. Acceptable tradeoff for a workaround.

## Validation

- `actionlint .github/workflows/release-upgrade.yaml` clean.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-upgrade.yaml'))"` parses; 4 jobs intact.
- Fixture-based local testing of the Python merge logic across three scenarios (above).

## What this PR is NOT

This is a temporary workaround scoped to our deploy workflow, not a fix to the underlying bug. The real fix is tracked in #235 and would land in one of:

- The controller falling back to in-cluster API discovery so `apiServerEndpoint` becomes optional.
- The release pipeline dropping `03-config.yaml` from the tarball.
- A `kubectl unbounded site upgrade` subcommand that owns the skip semantics.

When any of those land, **remove this step entirely** (the comment block above the step says so explicitly).

## Related

- #233 - fixed the upstream workflow trigger so deploys actually attempt; this surfaced the underlying controller crash.
- #234 - fixed the smoke-discover step that was checking out an older tag.
- #235 - the underlying bug being worked around.
