### PR TITLE
ci: add explicit CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  security-events: write
+  packages: read
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        if: ${{ matrix.language == 'go' }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Adds an explicit CodeQL workflow at `.github/workflows/codeql.yaml` that runs on pull requests to `main`, pushes to `main`, and manual dispatches without path filters. The workflow analyzes Go, JavaScript/TypeScript, and Rust with pinned action SHAs.

## Why

The repository ruleset requires CodeQL code-scanning results, but relying on dynamic/default setup can leave docs-only pull requests without a CodeQL run. A checked-in workflow ensures those pull requests still produce CodeQL analysis results for the required gate.

## Non-goals

- Does not modify PR #227 docs files.
- Does not change non-CodeQL CI triggers or path filters.
- Does not disable CodeQL default setup, which is a repository setting rather than a checked-in file.

## Testing

- Parsed `.github/workflows/codeql.yaml` with Ruby YAML.
- Confirmed `actionlint` is not installed locally, so no repository-provided Actions lint was available.
- Opened the PR and observed the new CodeQL workflow run. GitHub successfully uploads SARIF, then rejects processing with: `CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled`.

## Current CI note

The CodeQL jobs are expected to stay red until a repository admin disables CodeQL default setup for `Azure/unbounded`. GitHub does not allow advanced CodeQL workflow uploads to be processed while default setup is enabled, so this cannot be fixed by another workflow-only change without hiding the real gate failure.

## Risk

Limited to GitHub Actions code-scanning configuration. Rollback is reverting the workflow file. Before merging, disable default setup so this advanced workflow can become the source of CodeQL results.