### PR TITLE
feat: sync timeout configurable, add NF5 jitter cap, warn on unconfigured registry

### DIFF
--- a/cmd/gantry/main.go
+++ b/cmd/gantry/main.go
@@ -491,6 +491,7 @@ func runAgent(args []string) error {
 		nf5Ctrl = mirror.NewDirectOriginFallback(mirror.DirectOriginFallbackOptions{
 			Logger:           logger,
 			JitterBase:       c.NF5JitterBase,
+			JitterCap:        c.NF5JitterCap,
 			PerNodeRateLimit: c.NF5PerNodeRateLimit,
 			// Use bootstrapPeerCount (Running pods with published
 			// p2p-addrs annotations, irrespective of Ready). direct-origin-fallback
@@ -1085,7 +1086,12 @@ func buildMembers(ctx context.Context, c *config.Config, disco *discovery.Host, 
 	// dev mode warns and falls back to the single-self stub.
 	mgr.Start()
 
-	syncCtx, syncCancel := context.WithTimeout(ctx, memberSyncTimeout)
+	syncTimeout := memberSyncDefaultTimeout
+	if c.MembersSyncTimeout > 0 {
+		syncTimeout = c.MembersSyncTimeout
+	}
+
+	syncCtx, syncCancel := context.WithTimeout(ctx, syncTimeout)
 	syncErr := mgr.WaitForSync(syncCtx)
 
 	syncCancel()
@@ -1093,11 +1099,11 @@ func buildMembers(ctx context.Context, c *config.Config, disco *discovery.Host, 
 	if syncErr != nil {
 		if prodMode {
 			mgr.Stop()
-			return nil, nil, fmt.Errorf("members initial sync (timeout=%s): %w", memberSyncTimeout, syncErr)
+			return nil, nil, fmt.Errorf("members initial sync (timeout=%s): %w", syncTimeout, syncErr)
 		}
 
 		logger.Warn("members initial sync failed; falling back to single-self stub (dev mode)",
-			slog.Duration("timeout", memberSyncTimeout),
+			slog.Duration("timeout", syncTimeout),
 			slog.Any("err", syncErr),
 		)
 		mgr.Stop()
@@ -1113,14 +1119,18 @@ func buildMembers(ctx context.Context, c *config.Config, disco *discovery.Host, 
 	return mgr, mgr.Stop, nil
 }
 
-// memberSyncTimeout caps how long buildMembers waits for the initial
-// list+watch on the pod and node informers before failing (prod) or
-// degrading to the single-self stub (dev). 10s is generous for a
-// healthy apiserver - a real timeout almost always means RBAC, API
-// egress, or service-account permissions are broken; failing fast
-// surfaces that as an immediate deploy-time signal rather than a
-// silent "why isn't dedup working?" mystery.
-const memberSyncTimeout = 10 * time.Second
+// memberSyncDefaultTimeout is the built-in default for how long buildMembers
+// waits for the initial list+watch on the pod and node informers before
+// failing (prod) or degrading to the single-self stub (dev). Operators on
+// clusters with a slow API server or large-scale simultaneous DaemonSet
+// rollouts can override this via config.MembersSyncTimeout /
+// GANTRY_MEMBERS_SYNC_TIMEOUT / --members-sync-timeout.
+//
+// 30s is generous for a healthy apiserver - a real timeout almost always
+// means RBAC, API egress, or service-account permissions are broken; failing
+// fast surfaces that as an immediate deploy-time signal rather than a silent
+// "why isn't dedup working?" mystery.
+const memberSyncDefaultTimeout = 30 * time.Second
 
 // singleSelfMembers returns a single-entry Members view for dev/test
 // runs that have no Kubernetes cluster behind them.

--- a/internal/gantry/config/config.go
+++ b/internal/gantry/config/config.go
@@ -165,6 +165,15 @@ type Config struct {
 	// means in-cluster service-account discovery (the production path).
 	MembersKubeconfig string `yaml:"members_kubeconfig"`
 
+	// MembersSyncTimeout is how long the agent waits for the initial
+	// pod and node informer list-and-watch to complete at startup.
+	// In production mode a timeout is fatal (it surfaces broken RBAC /
+	// API egress early rather than silently degrading). Raise this on
+	// clusters with a slow API server or during large-scale simultaneous
+	// DaemonSet rollouts where the apiserver is under elevated load.
+	// Zero means "use the built-in default of 30s".
+	MembersSyncTimeout time.Duration `yaml:"members_sync_timeout"`
+
 	// ---------- Storage backend ----------
 
 	// StorageMode selects which backend the agent uses as the read/write
@@ -254,6 +263,14 @@ type Config struct {
 	// NF5JitterBase is the base delay in the direct-origin-fallback jitter window
 	// `[0, base * ln(N))` (the design doc default 3 s).
 	NF5JitterBase time.Duration `yaml:"nf5_jitter_base"`
+
+	// NF5JitterCap is a hard ceiling on the computed jitter window.
+	// Zero means no cap (original behaviour). Set this to bound worst-case
+	// cold-start latency on large clusters: at N=300 the uncapped window is
+	// ~17s; a cap of 10s limits the maximum additional delay imposed by NF5
+	// regardless of cluster size. The configured NF5JitterBase still
+	// controls the shape of the distribution up to the cap.
+	NF5JitterCap time.Duration `yaml:"nf5_jitter_cap"`
 
 	// NF5PerNodeRateLimit is the per-node direct-origin fallback rate
 	// (token bucket, fallbacks/minute; the design doc default 2).
@@ -349,6 +366,7 @@ func NewDefault() *Config {
 		MembersNamespace:     "",
 		MembersLabelSelector: "app.kubernetes.io/name=gantry",
 		MembersKubeconfig:    "",
+		MembersSyncTimeout:   0, // zero means use built-in default of 30s
 
 		StorageMode: StorageModeContainerd,
 
@@ -364,6 +382,7 @@ func NewDefault() *Config {
 		ZoneLabelKey:     "topology.kubernetes.io/zone",
 
 		NF5JitterBase:               3 * time.Second,
+		NF5JitterCap:                0, // no cap by default (original behaviour)
 		NF5PerNodeRateLimit:         2,
 		BootstrapWindow:             30 * time.Second,
 		BootstrapRoutingTablePct:    25,
@@ -451,6 +470,7 @@ func (c *Config) LoadEnv(env func(string) string) error {
 	setStr("MEMBERS_NAMESPACE", &c.MembersNamespace)
 	setStr("MEMBERS_LABEL_SELECTOR", &c.MembersLabelSelector)
 	setStr("MEMBERS_KUBECONFIG", &c.MembersKubeconfig)
+	setDur("MEMBERS_SYNC_TIMEOUT", &c.MembersSyncTimeout)
 
 	// Deprecated env vars (GANTRY_CACHE_DIR, GANTRY_CACHE_BUDGET_BYTES,
 	// GANTRY_CACHE_FORCED_EVICTION_HEADROOM_PCT,
@@ -471,6 +491,7 @@ func (c *Config) LoadEnv(env func(string) string) error {
 	setStr("ZONE_LABEL_KEY", &c.ZoneLabelKey)
 
 	setDur("NF5_JITTER_BASE", &c.NF5JitterBase)
+	setDur("NF5_JITTER_CAP", &c.NF5JitterCap)
 	setInt("NF5_PER_NODE_RATE_LIMIT", &c.NF5PerNodeRateLimit)
 	setDur("BOOTSTRAP_WINDOW", &c.BootstrapWindow)
 	setInt("BOOTSTRAP_ROUTING_TABLE_PCT", &c.BootstrapRoutingTablePct)
@@ -502,6 +523,7 @@ func (c *Config) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.MembersNamespace, "members-namespace", c.MembersNamespace, "namespace to scope the pod informer (REQUIRED when node_name+pod_name are set - AnnounceSelf needs it to self-patch; empty is dev-only)")
 	fs.StringVar(&c.MembersLabelSelector, "members-label-selector", c.MembersLabelSelector, "label selector identifying Gantry DaemonSet pods")
 	fs.StringVar(&c.MembersKubeconfig, "members-kubeconfig", c.MembersKubeconfig, "optional path to a kubeconfig file (empty = in-cluster)")
+	fs.DurationVar(&c.MembersSyncTimeout, "members-sync-timeout", c.MembersSyncTimeout, "how long to wait for the pod/node informer initial sync at startup (0 = use built-in default of 30s)")
 
 	// Deprecated cache flags (--cache-dir, --cache-budget-bytes,
 	// --cache-forced-eviction-headroom-pct,
@@ -522,6 +544,7 @@ func (c *Config) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.ZoneLabelKey, "zone-label-key", c.ZoneLabelKey, "Kubernetes node label identifying the zone (used when hrw-topology-scope=zone)")
 
 	fs.DurationVar(&c.NF5JitterBase, "nf5-jitter-base", c.NF5JitterBase, "base delay for the NF5 jitter window")
+	fs.DurationVar(&c.NF5JitterCap, "nf5-jitter-cap", c.NF5JitterCap, "hard ceiling on the NF5 jitter window (0 = no cap)")
 	fs.IntVar(&c.NF5PerNodeRateLimit, "nf5-per-node-rate-limit", c.NF5PerNodeRateLimit, "per-node direct-origin fallback rate (per minute)")
 	fs.DurationVar(&c.BootstrapWindow, "bootstrap-window", c.BootstrapWindow, "time after startup during which DHT-empty is not trusted as cold-start")
 	fs.IntVar(&c.BootstrapRoutingTablePct, "bootstrap-routing-table-pct", c.BootstrapRoutingTablePct, "routing-table-size percent that ends the bootstrap window")
@@ -694,6 +717,14 @@ func (c *Config) Validate() error {
 
 	if c.NF5JitterBase <= 0 {
 		errs = append(errs, fmt.Errorf("nf5_jitter_base: must be > 0, got %v", c.NF5JitterBase))
+	}
+
+	if c.NF5JitterCap < 0 {
+		errs = append(errs, fmt.Errorf("nf5_jitter_cap: must be >= 0, got %v", c.NF5JitterCap))
+	}
+
+	if c.NF5JitterCap > 0 && c.NF5JitterBase > 0 && c.NF5JitterCap < c.NF5JitterBase {
+		errs = append(errs, fmt.Errorf("nf5_jitter_cap (%v) must be >= nf5_jitter_base (%v) when set", c.NF5JitterCap, c.NF5JitterBase))
 	}
 
 	if c.NF5PerNodeRateLimit < 1 {

--- a/internal/gantry/mirror/mirror.go
+++ b/internal/gantry/mirror/mirror.go
@@ -679,7 +679,11 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request) {
 
 	upstream, err := s.resolveUpstream(r)
 	if err != nil {
-		s.logger.Debug("mirror: unknown ?ns=",
+		// The ?ns= value is not in upstream_registries. Log at Warn so
+		// operators notice misconfigured registry lists - this causes
+		// containerd to bypass the mirror entirely for that registry,
+		// defeating P2P distribution silently at Info log level.
+		s.logger.Warn("mirror: ignoring request for unconfigured registry - add it to upstream_registries",
 			slog.String("ns", r.URL.Query().Get("ns")),
 			slog.String("path", path),
 		)

--- a/internal/gantry/mirror/nf5.go
+++ b/internal/gantry/mirror/nf5.go
@@ -76,6 +76,11 @@ type DirectOriginFallbackOptions struct {
 	// The jitter window is `[0, JitterBase × ln(ClusterSize))`.
 	JitterBase time.Duration
 
+	// JitterCap is a hard ceiling on the computed jitter window
+	// (`nf5_jitter_cap`). Zero means no cap. When set, the effective
+	// window is min(JitterBase*ln(N), JitterCap).
+	JitterCap time.Duration
+
 	// PerNodeRateLimit is the `nf5_per_node_rate_limit`
 	// (default 2 tokens/minute when ≤0). Refill is continuous
 	// (fractional tokens accrue at PerNodeRateLimit/60 per second).
@@ -291,6 +296,10 @@ func (n *DirectOriginFallbackController) computeJitter() time.Duration {
 	maxJ := time.Duration(float64(n.opts.JitterBase) * math.Log(float64(N)))
 	if maxJ <= 0 {
 		return 0
+	}
+
+	if n.opts.JitterCap > 0 && maxJ > n.opts.JitterCap {
+		maxJ = n.opts.JitterCap
 	}
 
 	n.rngMu.Lock()


### PR DESCRIPTION
Three improvements found during a 300-node AKS cold-start benchmark:

- MembersSyncTimeout: the hardcoded 10s members informer sync timeout caused pod crashes under API server load when 300 pods started simultaneously. Raise the built-in default to 30s and expose it as a config field / env var / flag so operators on slow or loaded API servers can tune it without rebuilding.

- NF5JitterCap: the NF5 direct-origin fallback jitter window [0, JitterBase*ln(N)) has no hard ceiling. At N=300 it produces up to 17s of intentional delay; at N=1000 it would reach ~21s. Add an optional nf5_jitter_cap field (default 0 = no cap, preserving existing behaviour) that operators can set to bound worst-case cold-start latency on large clusters.

- Unconfigured registry warn: when containerd requests a pull for a registry not present in upstream_registries, the mirror was logging at Debug (invisible at the default info level) and returning 404, causing containerd to bypass the mirror entirely and pull directly from origin - defeating P2P distribution silently. Raise to Warn with an actionable message pointing to upstream_registries.