### PR TITLE
gantry: harden registry token credential handling

### DIFF
--- a/internal/gantry/origin/origin.go
+++ b/internal/gantry/origin/origin.go
@@ -264,7 +264,7 @@ func newRegistry(ur config.UpstreamRegistry, logger *slog.Logger) (*registry, er
 	r := &registry{
 		name:   ur.Name,
 		base:   u,
-		hc:     &http.Client{Timeout: 5 * time.Minute},
+		hc:     &http.Client{Timeout: 5 * time.Minute, CheckRedirect: checkRedirect},
 		logger: logger.With(slog.String("registry", ur.Name)),
 	}
 	if ur.CredentialsPath != "" {
@@ -562,7 +562,12 @@ func (r *registry) fetchBearerToken(ctx context.Context, challenge string) (stri
 
 	scope := params["scope"]
 
-	q := url.Values{}
+	// Build the token URL from the parsed/validated realm so the query is
+	// placed correctly even when the realm carries an existing query or a
+	// fragment. Concatenating onto the raw realm string could append the query
+	// after a "#fragment", which url.Parse then folds into the fragment and
+	// drops service/scope from the request that reaches the wire.
+	q := realmURL.Query()
 	if svc := params["service"]; svc != "" {
 		q.Set("service", svc)
 	}
@@ -571,18 +576,9 @@ func (r *registry) fetchBearerToken(ctx context.Context, challenge string) (stri
 		q.Set("scope", scope)
 	}
 
-	tokenURL := realm
+	realmURL.RawQuery = q.Encode()
 
-	if len(q) > 0 {
-		sep := "?"
-		if strings.Contains(realm, "?") {
-			sep = "&"
-		}
-
-		tokenURL = realm + sep + q.Encode()
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, realmURL.String(), nil)
 	if err != nil {
 		return "", 0, err
 	}
@@ -639,6 +635,25 @@ func (r *registry) fetchBearerToken(ctx context.Context, challenge string) (stri
 
 func (r *registry) canSendBasicAuth() bool {
 	return r.base != nil && strings.EqualFold(r.base.Scheme, "https")
+}
+
+// checkRedirect mirrors net/http's default policy (stop after 10 hops) while
+// additionally stripping the Authorization header on any redirect whose target
+// is not HTTPS. net/http already drops sensitive headers on cross-host
+// redirects, but it preserves them across a same-host HTTPS->HTTP downgrade,
+// which would leak Basic or bearer credentials onto a plaintext hop. This is
+// defense in depth on top of canSendBasicAuth and the bearer realm HTTPS
+// validation.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+
+	if !strings.EqualFold(req.URL.Scheme, "https") {
+		req.Header.Del("Authorization")
+	}
+
+	return nil
 }
 
 func (r *registry) cachedToken() string {

--- a/internal/gantry/origin/origin.go
+++ b/internal/gantry/origin/origin.go
@@ -533,7 +533,7 @@ func (r *registry) repeatWithoutToken(ctx context.Context, method, urlStr string
 		return nil, err
 	}
 
-	if r.username != "" {
+	if r.canSendBasicAuth() && r.username != "" {
 		req.SetBasicAuth(r.username, r.password)
 	}
 
@@ -549,6 +549,15 @@ func (r *registry) fetchBearerToken(ctx context.Context, challenge string) (stri
 	realm := params["realm"]
 	if realm == "" {
 		return "", 0, fmt.Errorf("bearer challenge missing realm: %q", challenge)
+	}
+
+	realmURL, err := url.Parse(realm)
+	if err != nil {
+		return "", 0, fmt.Errorf("bearer challenge invalid realm %q: %w", realm, err)
+	}
+
+	if !realmURL.IsAbs() || realmURL.Host == "" || !strings.EqualFold(realmURL.Scheme, "https") {
+		return "", 0, fmt.Errorf("bearer challenge realm %q: token endpoint must be an absolute https URL", realm)
 	}
 
 	scope := params["scope"]
@@ -578,7 +587,7 @@ func (r *registry) fetchBearerToken(ctx context.Context, challenge string) (stri
 		return "", 0, err
 	}
 
-	if r.username != "" {
+	if r.canSendBasicAuth() && r.username != "" {
 		req.SetBasicAuth(r.username, r.password)
 	}
 
@@ -626,6 +635,10 @@ func (r *registry) fetchBearerToken(ctx context.Context, challenge string) (stri
 	}
 
 	return tok, ttl, nil
+}
+
+func (r *registry) canSendBasicAuth() bool {
+	return r.base != nil && strings.EqualFold(r.base.Scheme, "https")
 }
 
 func (r *registry) cachedToken() string {

--- a/internal/gantry/origin/origin_test.go
+++ b/internal/gantry/origin/origin_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Azure/unbounded/internal/gantry/config"
 	"github.com/Azure/unbounded/internal/gantry/digest"
@@ -404,6 +405,151 @@ func TestHTTPRegistryDoesNotSendBasicToTokenEndpoint(t *testing.T) {
 
 	if got := atomic.LoadInt32(&tokenReqs); got != 1 {
 		t.Fatalf("token endpoint calls = %d, want 1", got)
+	}
+}
+
+// TestPullStripsAuthOnHTTPSDowngradeRedirect proves the registry's HTTP client
+// refuses to carry an Authorization header onto a plaintext hop when an HTTPS
+// endpoint redirects to HTTP on the same hostname. net/http copies the header
+// across same-hostname redirects (it only compares hostnames, not schemes), so
+// without the scheme-aware CheckRedirect wired up by newRegistry the bearer
+// token would arrive at the HTTP target in clear text.
+func TestPullStripsAuthOnHTTPSDowngradeRedirect(t *testing.T) {
+	body := []byte("downgrade-protected")
+	d := digestOf(body)
+
+	var leaked int32
+
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			atomic.StoreInt32(&leaked, 1)
+		}
+
+		_, _ = w.Write(body) //nolint:errcheck // best-effort write
+	}))
+	defer httpSrv.Close()
+
+	tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, httpSrv.URL+r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+	defer tlsSrv.Close()
+
+	c := newClient(t, config.UpstreamRegistry{Name: "reg", Endpoint: tlsSrv.URL})
+	reg := c.registries["reg"]
+
+	// Trust the test TLS cert but keep the production redirect policy so the
+	// credential-stripping behavior wired up by newRegistry is exercised. If
+	// newRegistry stopped setting CheckRedirect this copies nil and the test
+	// fails when net/http leaks the header to the plaintext target.
+	tlsClient := tlsSrv.Client()
+	tlsClient.CheckRedirect = reg.hc.CheckRedirect
+	reg.hc = tlsClient
+
+	// Seed a cached bearer token so do() attaches an Authorization header to
+	// the first request against the HTTPS endpoint.
+	reg.setToken("deadbeef", time.Hour)
+
+	rc, _, err := c.Pull(context.Background(), ifaces.OriginRef{
+		Registry: "reg", Repository: "library/nginx", Digest: d,
+	})
+	if err != nil {
+		t.Fatalf("Pull: %v", err)
+	}
+
+	got, _ := io.ReadAll(rc)
+	rc.Close()
+
+	if string(got) != string(body) {
+		t.Errorf("body = %q", got)
+	}
+
+	if atomic.LoadInt32(&leaked) != 0 {
+		t.Fatal("Authorization header leaked onto plain-HTTP redirect target")
+	}
+}
+
+func TestCheckRedirect(t *testing.T) {
+	t.Run("strips Authorization on http downgrade", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://reg.example.com/v2/", nil)
+		req.Header.Set("Authorization", "Bearer secret")
+
+		if err := checkRedirect(req, nil); err != nil {
+			t.Fatalf("checkRedirect: %v", err)
+		}
+
+		if got := req.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization preserved on http downgrade: %q", got)
+		}
+	})
+
+	t.Run("keeps Authorization on https redirect", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://reg.example.com/v2/", nil)
+		req.Header.Set("Authorization", "Bearer secret")
+
+		if err := checkRedirect(req, nil); err != nil {
+			t.Fatalf("checkRedirect: %v", err)
+		}
+
+		if got := req.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization stripped on https redirect: %q", got)
+		}
+	})
+
+	t.Run("stops after 10 redirects", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://reg.example.com/v2/", nil)
+
+		if err := checkRedirect(req, make([]*http.Request, 10)); err == nil {
+			t.Fatal("expected error after 10 redirects")
+		}
+	})
+}
+
+// TestFetchBearerTokenPreservesRealmQueryAndFragment verifies the token URL is
+// assembled from the parsed realm: a pre-existing realm query survives, the
+// service/scope params are added, and a realm fragment does not swallow them.
+// Raw string concatenation would have appended "&service=...&scope=..." after
+// the "#frag", which url.Parse folds into the fragment so those params never
+// reach the wire.
+func TestFetchBearerTokenPreservesRealmQueryAndFragment(t *testing.T) {
+	var gotService, gotScope, gotExtra string
+
+	tokenSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		gotService = q.Get("service")
+		gotScope = q.Get("scope")
+		gotExtra = q.Get("extra")
+
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "deadbeef"}) //nolint:errcheck // best-effort
+	}))
+	defer tokenSrv.Close()
+
+	r := &registry{
+		base: mustParseURL(t, "https://reg.example.com"),
+		hc:   tokenSrv.Client(),
+	}
+
+	realm := tokenSrv.URL + "/token?extra=keep#frag"
+	challenge := `Bearer realm="` + realm + `",service="reg",scope="repository:library/nginx:pull"`
+
+	tok, _, err := r.fetchBearerToken(context.Background(), challenge)
+	if err != nil {
+		t.Fatalf("fetchBearerToken: %v", err)
+	}
+
+	if tok != "deadbeef" {
+		t.Fatalf("token = %q, want deadbeef", tok)
+	}
+
+	if gotService != "reg" {
+		t.Errorf("service = %q, want reg", gotService)
+	}
+
+	if gotScope != "repository:library/nginx:pull" {
+		t.Errorf("scope = %q, want repository:library/nginx:pull", gotScope)
+	}
+
+	if gotExtra != "keep" {
+		t.Errorf("extra = %q, want keep (pre-existing realm query dropped)", gotExtra)
 	}
 }
 

--- a/internal/gantry/origin/origin_test.go
+++ b/internal/gantry/origin/origin_test.go
@@ -408,6 +408,44 @@ func TestHTTPRegistryDoesNotSendBasicToTokenEndpoint(t *testing.T) {
 	}
 }
 
+func TestHTTPRegistryRepeatWithoutTokenDoesNotSendBasic(t *testing.T) {
+	var reqs int32
+	var sawBasic int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&reqs, 1)
+
+		if _, _, ok := r.BasicAuth(); ok {
+			atomic.StoreInt32(&sawBasic, 1)
+		}
+
+		w.Header().Set("WWW-Authenticate", `Basic realm="reg"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	credsPath := filepath.Join(dir, "creds")
+	if err := os.WriteFile(credsPath, []byte("alice:secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := newClient(t, config.UpstreamRegistry{Name: "reg", Endpoint: srv.URL, CredentialsPath: credsPath})
+	d := digestOf([]byte("x"))
+	_, _, err := c.Pull(context.Background(), ifaces.OriginRef{Registry: "reg", Repository: "library/nginx", Digest: d})
+	if err == nil {
+		t.Fatal("expected Pull to fail")
+	}
+
+	if got := atomic.LoadInt32(&reqs); got != 2 {
+		t.Fatalf("requests = %d, want 2 (initial + repeatWithoutToken)", got)
+	}
+
+	if atomic.LoadInt32(&sawBasic) != 0 {
+		t.Fatal("Basic auth was sent to an http:// registry endpoint")
+	}
+}
+
 // TestPullStripsAuthOnHTTPSDowngradeRedirect proves the registry's HTTP client
 // refuses to carry an Authorization header onto a plaintext hop when an HTTPS
 // endpoint redirects to HTTP on the same hostname. net/http copies the header

--- a/internal/gantry/origin/origin_test.go
+++ b/internal/gantry/origin/origin_test.go
@@ -409,8 +409,7 @@ func TestHTTPRegistryDoesNotSendBasicToTokenEndpoint(t *testing.T) {
 }
 
 func TestHTTPRegistryRepeatWithoutTokenDoesNotSendBasic(t *testing.T) {
-	var reqs int32
-	var sawBasic int32
+	var reqs, sawBasic int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&reqs, 1)
@@ -425,6 +424,7 @@ func TestHTTPRegistryRepeatWithoutTokenDoesNotSendBasic(t *testing.T) {
 	defer srv.Close()
 
 	dir := t.TempDir()
+
 	credsPath := filepath.Join(dir, "creds")
 	if err := os.WriteFile(credsPath, []byte("alice:secret\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -432,6 +432,7 @@ func TestHTTPRegistryRepeatWithoutTokenDoesNotSendBasic(t *testing.T) {
 
 	c := newClient(t, config.UpstreamRegistry{Name: "reg", Endpoint: srv.URL, CredentialsPath: credsPath})
 	d := digestOf([]byte("x"))
+
 	_, _, err := c.Pull(context.Background(), ifaces.OriginRef{Registry: "reg", Repository: "library/nginx", Digest: d})
 	if err == nil {
 		t.Fatal("expected Pull to fail")

--- a/internal/gantry/origin/origin_test.go
+++ b/internal/gantry/origin/origin_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,6 +34,17 @@ func digestOf(b []byte) digest.Digest {
 	}
 
 	return d
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+
+	return u
 }
 
 func newClient(t *testing.T, ur config.UpstreamRegistry) *Client {
@@ -186,11 +198,7 @@ func TestPull_BearerTokenFlow(t *testing.T) {
 
 	var authReqs, tokenReqs, dataReqs int32
 
-	// Set up the token endpoint first so we know its URL.
 	tokenMux := http.NewServeMux()
-
-	tokenSrv := httptest.NewServer(tokenMux)
-	defer tokenSrv.Close()
 
 	tokenMux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&tokenReqs, 1)
@@ -203,11 +211,18 @@ func TestPull_BearerTokenFlow(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"token": "deadbeef"}) //nolint:errcheck // best-effort
 	})
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+
+	srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			tokenMux.ServeHTTP(w, r)
+			return
+		}
+
 		if r.Header.Get("Authorization") != "Bearer deadbeef" {
 			atomic.AddInt32(&authReqs, 1)
 			w.Header().Set("WWW-Authenticate",
-				`Bearer realm="`+tokenSrv.URL+`/token",service="reg",scope="repository:library/nginx:pull"`)
+				`Bearer realm="`+srv.URL+`/token",service="reg",scope="repository:library/nginx:pull"`)
 			w.WriteHeader(401)
 
 			return
@@ -227,6 +242,7 @@ func TestPull_BearerTokenFlow(t *testing.T) {
 	}
 
 	c := newClient(t, config.UpstreamRegistry{Name: "reg", Endpoint: srv.URL, CredentialsPath: credsPath})
+	c.registries["reg"].hc = srv.Client()
 
 	rc, _, err := c.Pull(context.Background(), ifaces.OriginRef{
 		Registry: "reg", Repository: "library/nginx", Digest: d,
@@ -259,6 +275,135 @@ func TestPull_BearerTokenFlow(t *testing.T) {
 
 	if atomic.LoadInt32(&tokenReqs) != 1 {
 		t.Errorf("tokenReqs after 2nd pull = %d, want 1 (cached)", tokenReqs)
+	}
+}
+
+func TestFetchBearerTokenRejectsHTTPRealm(t *testing.T) {
+	var tokenReqs int32
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&tokenReqs, 1)
+
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "deadbeef"}) //nolint:errcheck // best-effort
+	}))
+	defer tokenSrv.Close()
+
+	r := &registry{
+		base:     mustParseURL(t, "https://reg.example.com"),
+		username: "alice",
+		password: "secret",
+		hc:       tokenSrv.Client(),
+	}
+
+	_, _, err := r.fetchBearerToken(context.Background(), `Bearer realm="`+tokenSrv.URL+`/token",service="reg"`)
+	if err == nil {
+		t.Fatal("expected non-https token realm to be rejected")
+	}
+
+	if !strings.Contains(err.Error(), "absolute https URL") {
+		t.Fatalf("error = %v, want https URL rejection", err)
+	}
+
+	if got := atomic.LoadInt32(&tokenReqs); got != 0 {
+		t.Fatalf("token endpoint was called %d times; want 0", got)
+	}
+}
+
+func TestFetchBearerTokenAllowsCrossHostHTTPSRealm(t *testing.T) {
+	var tokenReqs int32
+
+	tokenSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenReqs, 1)
+
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "alice" || pass != "secret" {
+			t.Errorf("token auth missing/wrong: ok=%v user=%q", ok, user)
+		}
+
+		if r.URL.Query().Get("service") != "reg" {
+			t.Errorf("service query = %q", r.URL.Query().Get("service"))
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "deadbeef"}) //nolint:errcheck // best-effort
+	}))
+	defer tokenSrv.Close()
+
+	r := &registry{
+		base:     mustParseURL(t, "https://reg.example.com"),
+		username: "alice",
+		password: "secret",
+		hc:       tokenSrv.Client(),
+	}
+
+	tok, _, err := r.fetchBearerToken(context.Background(), `Bearer realm="`+tokenSrv.URL+`/token",service="reg"`)
+	if err != nil {
+		t.Fatalf("fetchBearerToken: %v", err)
+	}
+
+	if tok != "deadbeef" {
+		t.Fatalf("token = %q, want deadbeef", tok)
+	}
+
+	if got := atomic.LoadInt32(&tokenReqs); got != 1 {
+		t.Fatalf("token endpoint calls = %d, want 1", got)
+	}
+}
+
+func TestHTTPRegistryDoesNotSendBasicToTokenEndpoint(t *testing.T) {
+	body := []byte("token-protected")
+	d := digestOf(body)
+
+	var tokenReqs int32
+
+	tokenSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenReqs, 1)
+
+		if user, _, ok := r.BasicAuth(); ok {
+			t.Errorf("token request unexpectedly included Basic auth for user %q", user)
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "deadbeef"}) //nolint:errcheck // best-effort
+	}))
+	defer tokenSrv.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer deadbeef" {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="`+tokenSrv.URL+`/token",service="reg"`)
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		_, _ = w.Write(body) //nolint:errcheck // best-effort write
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+
+	credsPath := filepath.Join(dir, "creds")
+	if err := os.WriteFile(credsPath, []byte("alice:secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := newClient(t, config.UpstreamRegistry{Name: "reg", Endpoint: srv.URL, CredentialsPath: credsPath})
+	c.registries["reg"].hc = tokenSrv.Client()
+
+	rc, _, err := c.Pull(context.Background(), ifaces.OriginRef{
+		Registry: "reg", Repository: "library/nginx", Digest: d,
+	})
+	if err != nil {
+		t.Fatalf("Pull: %v", err)
+	}
+
+	got, _ := io.ReadAll(rc)
+	rc.Close()
+
+	if string(got) != string(body) {
+		t.Errorf("body = %q", got)
+	}
+
+	if got := atomic.LoadInt32(&tokenReqs); got != 1 {
+		t.Fatalf("token endpoint calls = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
- Require bearer-token realms to be absolute HTTPS URLs before exchanging for a token.
- Withhold Basic credentials for token exchange and unauthenticated retry when the configured registry endpoint is plain HTTP.
- Keep cross-host HTTPS token realms supported for Docker Hub-style auth flows.
- Add tests for HTTPS bearer flow, HTTP realm rejection, cross-host HTTPS realm acceptance, and HTTP registry credential withholding.

