### PR TITLE
gantry: filter self DHT providers by peer id

### DIFF
--- a/cmd/gantry/main.go
+++ b/cmd/gantry/main.go
@@ -574,6 +574,7 @@ func runAgent(args []string) error {
 		}),
 		mirror.WithDiscovery(disco, peerClient),
 		mirror.WithSelfNodeID(memberView.Self()),
+		mirror.WithSelfPeerID(ifaces.NodeID(disco.PeerID().String())),
 		mirror.WithPeerMetrics(
 			func(outcome string) { p2.peerFetch.WithLabelValues(outcome).Inc() },
 			func(success bool) {

--- a/internal/gantry/mirror/mirror.go
+++ b/internal/gantry/mirror/mirror.go
@@ -87,6 +87,7 @@ type Server struct {
 	peerFetchBudget  time.Duration
 	maxPeerAttempts  int
 	selfNodeID       ifaces.NodeID
+	selfPeerID       ifaces.NodeID
 
 	staleProviderTTL     time.Duration
 	unavailablePeerTTL   time.Duration
@@ -479,10 +480,18 @@ func WithPeerBudgets(lookup, fetch time.Duration, maxAttempts int) Option {
 	}
 }
 
-// WithSelfNodeID configures the local node identity used to filter stale self
-// provider records from DHT lookup results after a local cache miss.
+// WithSelfNodeID configures the local Kubernetes node identity used to filter
+// stale self provider records after a local cache miss. Membership/cold-start
+// providers use Kubernetes node names as NodeID values.
 func WithSelfNodeID(id ifaces.NodeID) Option {
 	return func(s *Server) { s.selfNodeID = id }
+}
+
+// WithSelfPeerID configures the local libp2p peer identity used to filter stale
+// self provider records from DHT lookup results after a local cache miss. DHT
+// providers use libp2p peer IDs as NodeID values.
+func WithSelfPeerID(id ifaces.NodeID) Option {
+	return func(s *Server) { s.selfPeerID = id }
 }
 
 // WithProviderFailureCacheTTL configures TTLs used to suppress immediate
@@ -1581,7 +1590,7 @@ func (s *Server) filterProvidersForDigest(d digest.Digest, providers []ifaces.Pr
 	var summary peerAttemptSummary
 
 	for _, p := range providers {
-		if s.selfNodeID != "" && p.NodeID == s.selfNodeID {
+		if s.isSelfProvider(p) {
 			summary.selfFiltered++
 			continue
 		}
@@ -1606,6 +1615,11 @@ func (s *Server) filterProvidersForDigest(d digest.Digest, providers []ifaces.Pr
 	}
 
 	return filtered, summary
+}
+
+func (s *Server) isSelfProvider(p ifaces.Provider) bool {
+	return (s.selfNodeID != "" && p.NodeID == s.selfNodeID) ||
+		(s.selfPeerID != "" && p.NodeID == s.selfPeerID)
 }
 
 func updatePeerSummary(summary peerAttemptSummary, outcome peerFetchOutcomeKind) peerAttemptSummary {

--- a/internal/gantry/mirror/mirror_peer_test.go
+++ b/internal/gantry/mirror/mirror_peer_test.go
@@ -331,6 +331,7 @@ func TestMirror_PeerFallback_FiltersSelfProviderAfterLocalMiss(t *testing.T) {
 	dht := fakes.NewDHT()
 	dht.Inject(d,
 		ifaces.Provider{NodeID: "self-node", Addr: "127.0.0.1:1"},
+		ifaces.Provider{NodeID: "self-peer-id", Addr: "127.0.0.1:2"},
 		ifaces.Provider{NodeID: "peer-good", Addr: peerAddr},
 	)
 
@@ -339,6 +340,7 @@ func TestMirror_PeerFallback_FiltersSelfProviderAfterLocalMiss(t *testing.T) {
 	m := mirror.New(cfg, c, oc,
 		mirror.WithDiscovery(dht, transfer.NewClient()),
 		mirror.WithSelfNodeID("self-node"),
+		mirror.WithSelfPeerID("self-peer-id"),
 		mirror.WithPeerBudgets(time.Second, 2*time.Second, 1),
 		mirror.WithPeerMetrics(func(outcome string) {
 			if outcome == "hit" {


### PR DESCRIPTION
## PR Intent

This PR fixes a self-filtering bug in Gantry's peer fallback path.

Gantry discovers providers for a blob from two places:

- Kubernetes membership / cold-start logic.
- The libp2p DHT.

Those two sources use different IDs:

- Kubernetes membership uses the Kubernetes node name, like `node-a`.
- DHT uses the libp2p peer ID, like `12D3Koo...`.

## Problem

Before this PR, Gantry only knew its own Kubernetes node name:

```go
mirror.WithSelfNodeID(memberView.Self())
```

So it could filter this provider:

```go
Provider{NodeID: "node-a"}
```

But it could not filter this provider:

```go
Provider{NodeID: "12D3Koo..."}
```

That matters because DHT provider records can include the local node itself.

If the local node no longer has the blob locally, it may still find an old DHT record saying this node provides the blob. Then Gantry tries to fetch the blob from itself over the transfer endpoint.

That wastes one peer attempt and can slow or degrade fallback.

## Fix

This PR adds the local libp2p peer ID to the mirror:

```go
mirror.WithSelfPeerID(ifaces.NodeID(disco.PeerID().String()))
```

Then the mirror filters self providers by either identity:

```go
selfNodeID == provider.NodeID
selfPeerID == provider.NodeID
```

So now Gantry filters both provider forms:

```go
Provider{NodeID: "node-a"}
Provider{NodeID: "12D3Koo..."}
```

## Summary

Gantry now recognizes itself no matter whether the provider came from Kubernetes membership or the DHT.