### PR TITLE
gantry: validate OCI repository names

### DIFF
--- a/internal/gantry/coord/coord.go
+++ b/internal/gantry/coord/coord.go
@@ -51,6 +51,7 @@ import (
 	"github.com/Azure/unbounded/internal/gantry/hrw"
 	"github.com/Azure/unbounded/internal/gantry/ifaces"
 	"github.com/Azure/unbounded/internal/gantry/inflight"
+	"github.com/Azure/unbounded/internal/gantry/oci"
 	coordv1 "github.com/Azure/unbounded/internal/gantry/proto/coord/v1"
 )
 
@@ -465,6 +466,10 @@ func (s *Server) StartLocalPull(ctx context.Context, registry, repository string
 		return nil, errors.New("start_local_pull: missing registry/repository")
 	}
 
+	if err := oci.ValidateRepositoryName(repository); err != nil {
+		return nil, fmt.Errorf("start_local_pull: %w", err)
+	}
+
 	out := make([]ifaces.PleasePullOutcome, 0, len(digests))
 	for _, d := range digests {
 		oc := ifaces.PleasePullOutcome{Digest: d}
@@ -501,6 +506,11 @@ func (s *Server) servePleasePull(ctx context.Context, _ peer.ID, req *coordv1.Pl
 	// the design doc invariant: one repo per batch. Empty / malformed -> reject.
 	if req.GetUpstreamRegistry() == "" || req.GetRepository() == "" {
 		return nil, errors.New("please_pull: missing registry/repository")
+	}
+
+	if err := oci.ValidateRepositoryName(req.GetRepository()); err != nil {
+		s.bumpStreamErr()
+		return nil, fmt.Errorf("please_pull: %w", err)
 	}
 
 	if len(req.GetDigests()) == 0 {

--- a/internal/gantry/coord/coord_test.go
+++ b/internal/gantry/coord/coord_test.go
@@ -539,3 +539,63 @@ func rep(c byte, n int) string {
 
 	return string(b)
 }
+
+// TestPleasePull_RejectsInvalidRepository asserts the server rejects a
+// please_pull whose repository is outside the OCI name grammar before it
+// reaches the puller pump, so an unvalidated repository never flows into
+// origin URL construction.
+func TestPleasePull_RejectsInvalidRepository(t *testing.T) {
+	hClient, hServer := makeHostPair(t)
+
+	c := fakes.NewCache()
+	members := fakes.NewMembers(ifaces.NodeID(hServer.ID().String()))
+	infl := inflight.New(inflight.DefaultStalls(), nil)
+
+	var pumpCalls int32
+
+	pump := coord.PullerPump(func(_ context.Context, _, _ string, _ digest.Digest, _ ifaces.OriginRefKind) (time.Time, bool, *coord.NegativeEntry) {
+		atomic.AddInt32(&pumpCalls, 1)
+		return time.Now(), false, nil
+	})
+	srv := coord.NewServer(c, members, infl, coord.WithPullerPump(pump))
+	srv.Bind(hServer)
+
+	cli := coord.NewClient(hClient)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	d := digest.MustParse("sha256:" + rep('a', 64))
+	if _, err := cli.PleasePull(ctx, ifaces.NodeID(hServer.ID().String()), "reg", "../../etc/passwd", ifaces.KindBlob, []digest.Digest{d}); err == nil {
+		t.Fatal("PleasePull: want rejection for invalid repository, got nil error")
+	}
+
+	if got := atomic.LoadInt32(&pumpCalls); got != 0 {
+		t.Fatalf("pumpCalls = %d, want 0 (invalid repository must not reach pump)", got)
+	}
+}
+
+// TestStartLocalPull_RejectsInvalidRepository asserts the in-process
+// self-pull path applies the same repository validation.
+func TestStartLocalPull_RejectsInvalidRepository(t *testing.T) {
+	c := fakes.NewCache()
+	members := fakes.NewMembers("self")
+	infl := inflight.New(inflight.DefaultStalls(), nil)
+
+	var pumpCalls int32
+
+	pump := coord.PullerPump(func(_ context.Context, _, _ string, _ digest.Digest, _ ifaces.OriginRefKind) (time.Time, bool, *coord.NegativeEntry) {
+		atomic.AddInt32(&pumpCalls, 1)
+		return time.Now(), false, nil
+	})
+	srv := coord.NewServer(c, members, infl, coord.WithPullerPump(pump))
+
+	d := digest.MustParse("sha256:" + rep('a', 64))
+	if _, err := srv.StartLocalPull(context.Background(), "reg", "Bad Repo?", ifaces.KindBlob, []digest.Digest{d}); err == nil {
+		t.Fatal("StartLocalPull: want rejection for invalid repository, got nil error")
+	}
+
+	if got := atomic.LoadInt32(&pumpCalls); got != 0 {
+		t.Fatalf("pumpCalls = %d, want 0 (invalid repository must not reach pump)", got)
+	}
+}

--- a/internal/gantry/oci/path.go
+++ b/internal/gantry/oci/path.go
@@ -7,10 +7,59 @@
 package oci
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Azure/unbounded/internal/gantry/ifaces"
 )
+
+// MaxRepositoryNameLength bounds a repository name per the OCI
+// Distribution spec (the full <name> must be at most 255 characters).
+const MaxRepositoryNameLength = 255
+
+// repositoryNameRe matches the OCI Distribution-spec repository name
+// grammar:
+//
+//	name           := path-component ['/' path-component]*
+//	path-component := alphanum [separator alphanum]*
+//	alphanum       := [a-z0-9]+
+//	separator      := [._] | __ | [-]+
+//
+// RE2 (Go's regexp engine) is backtracking-free, so matching is
+// linear-time and safe against ReDoS even on adversarial input.
+var repositoryNameRe = func() *regexp.Regexp {
+	const (
+		alphaNum  = `[a-z0-9]+`
+		separator = `(?:[._]|__|-+)`
+		component = alphaNum + `(?:` + separator + alphaNum + `)*`
+	)
+
+	return regexp.MustCompile(`^` + component + `(?:/` + component + `)*$`)
+}()
+
+// ValidateRepositoryName reports whether repo is a well-formed OCI
+// Distribution-spec repository name. It rejects empty values, empty path
+// components, names over MaxRepositoryNameLength, and any value outside
+// the name grammar - so `..`, `?`, `#`, whitespace, control characters,
+// and uppercase are all rejected. Callers use it to keep untrusted
+// repository strings from reaching origin URL construction, containerd
+// keys, and logs.
+func ValidateRepositoryName(repo string) error {
+	if repo == "" {
+		return fmt.Errorf("oci: repository name is empty")
+	}
+
+	if len(repo) > MaxRepositoryNameLength {
+		return fmt.Errorf("oci: repository name too long: %d > %d", len(repo), MaxRepositoryNameLength)
+	}
+
+	if !repositoryNameRe.MatchString(repo) {
+		return fmt.Errorf("oci: invalid repository name %q", repo)
+	}
+
+	return nil
+}
 
 // ParseV2Path matches a Distribution-spec `/v2/<repo>/(manifests|blobs)/<reference>`
 // URL. Returns the repository path (which may itself contain slashes -
@@ -21,6 +70,12 @@ import (
 // name like `cdn/manifests-mirror/foo` doesn't get clipped at the first
 // `/manifests/` substring - the canonical Distribution semantics are
 // "last occurrence wins".
+//
+// The extracted repository is validated against ValidateRepositoryName;
+// a path whose repository component is outside the OCI name grammar
+// (path traversal, query/fragment characters, control characters, empty
+// components, uppercase) returns ok=false so the untrusted value never
+// reaches origin URL construction or the peer endpoint.
 //
 // Two-package call sites (mirror + transfer) MUST go through this
 // function so they stay byte-for-byte aligned; otherwise a path the
@@ -34,11 +89,21 @@ func ParseV2Path(path string) (repo string, kind ifaces.OriginRefKind, ref strin
 
 	rest := path[len(prefix):]
 	if idx := strings.LastIndex(rest, "/manifests/"); idx >= 0 {
-		return rest[:idx], ifaces.KindManifest, rest[idx+len("/manifests/"):], true
+		repo = rest[:idx]
+		if ValidateRepositoryName(repo) != nil {
+			return "", 0, "", false
+		}
+
+		return repo, ifaces.KindManifest, rest[idx+len("/manifests/"):], true
 	}
 
 	if idx := strings.LastIndex(rest, "/blobs/"); idx >= 0 {
-		return rest[:idx], ifaces.KindBlob, rest[idx+len("/blobs/"):], true
+		repo = rest[:idx]
+		if ValidateRepositoryName(repo) != nil {
+			return "", 0, "", false
+		}
+
+		return repo, ifaces.KindBlob, rest[idx+len("/blobs/"):], true
 	}
 
 	return "", 0, "", false

--- a/internal/gantry/oci/path.go
+++ b/internal/gantry/oci/path.go
@@ -66,10 +66,14 @@ func ValidateRepositoryName(repo string) error {
 // e.g. `library/nginx`), the resource kind (manifest vs blob), the
 // reference (tag or digest), and ok=false if the path doesn't match.
 //
-// The match uses `strings.LastIndex` on the kind separators so a repo
-// name like `cdn/manifests-mirror/foo` doesn't get clipped at the first
-// `/manifests/` substring - the canonical Distribution semantics are
-// "last occurrence wins".
+// The kind separator is the RIGHTMOST `/manifests/` or `/blobs/` in the
+// path, not the first one of a fixed kind. A repository path component may
+// itself be named `manifests` or `blobs` (both match the OCI name grammar),
+// so a path like `/v2/acme/manifests/cache/blobs/<digest>` must parse as
+// repo=`acme/manifests/cache`, kind=blob - testing `/manifests/` first would
+// wrongly clip it to repo=`acme`. The reference (tag or digest) never
+// contains a slash, so the last separator of either kind unambiguously splits
+// repo from reference; whichever separator sits further right wins.
 //
 // The extracted repository is validated against ValidateRepositoryName;
 // a path whose repository component is outside the OCI name grammar
@@ -88,23 +92,36 @@ func ParseV2Path(path string) (repo string, kind ifaces.OriginRefKind, ref strin
 	}
 
 	rest := path[len(prefix):]
-	if idx := strings.LastIndex(rest, "/manifests/"); idx >= 0 {
-		repo = rest[:idx]
-		if ValidateRepositoryName(repo) != nil {
-			return "", 0, "", false
-		}
 
-		return repo, ifaces.KindManifest, rest[idx+len("/manifests/"):], true
+	const (
+		manifestsSep = "/manifests/"
+		blobsSep     = "/blobs/"
+	)
+
+	mIdx := strings.LastIndex(rest, manifestsSep)
+	bIdx := strings.LastIndex(rest, blobsSep)
+
+	// Pick the rightmost separator. Indices are distinct when both are
+	// present (the two literals can't start at the same offset), so there is
+	// no tie to break.
+	var (
+		sep    string
+		sepIdx int
+	)
+
+	switch {
+	case mIdx < 0 && bIdx < 0:
+		return "", 0, "", false
+	case bIdx > mIdx:
+		kind, sep, sepIdx = ifaces.KindBlob, blobsSep, bIdx
+	default:
+		kind, sep, sepIdx = ifaces.KindManifest, manifestsSep, mIdx
 	}
 
-	if idx := strings.LastIndex(rest, "/blobs/"); idx >= 0 {
-		repo = rest[:idx]
-		if ValidateRepositoryName(repo) != nil {
-			return "", 0, "", false
-		}
-
-		return repo, ifaces.KindBlob, rest[idx+len("/blobs/"):], true
+	repo = rest[:sepIdx]
+	if ValidateRepositoryName(repo) != nil {
+		return "", 0, "", false
 	}
 
-	return "", 0, "", false
+	return repo, kind, rest[sepIdx+len(sep):], true
 }

--- a/internal/gantry/oci/path_test.go
+++ b/internal/gantry/oci/path_test.go
@@ -53,6 +53,26 @@ func TestParseV2Path(t *testing.T) {
 			wantOK:   true,
 		},
 		{
+			// Repo component literally named "manifests" preceding a
+			// /blobs/ separator: the rightmost separator (blobs) must win.
+			name:     "manifests-named component before blobs separator",
+			path:     "/v2/acme/manifests/cache/blobs/sha256:abc",
+			wantRepo: "acme/manifests/cache",
+			wantKind: ifaces.KindBlob,
+			wantRef:  "sha256:abc",
+			wantOK:   true,
+		},
+		{
+			// Symmetric case: repo component named "blobs" preceding a
+			// /manifests/ separator; rightmost separator (manifests) wins.
+			name:     "blobs-named component before manifests separator",
+			path:     "/v2/acme/blobs/cache/manifests/v1.0",
+			wantRepo: "acme/blobs/cache",
+			wantKind: ifaces.KindManifest,
+			wantRef:  "v1.0",
+			wantOK:   true,
+		},
+		{
 			name:   "not /v2/ prefix",
 			path:   "/v1/library/nginx/manifests/latest",
 			wantOK: false,

--- a/internal/gantry/oci/path_test.go
+++ b/internal/gantry/oci/path_test.go
@@ -4,6 +4,7 @@
 package oci_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Azure/unbounded/internal/gantry/ifaces"
@@ -61,6 +62,36 @@ func TestParseV2Path(t *testing.T) {
 			path:   "/v2/library/nginx/latest",
 			wantOK: false,
 		},
+		{
+			name:   "path traversal repository rejected",
+			path:   "/v2/../../etc/manifests/latest",
+			wantOK: false,
+		},
+		{
+			name:   "repository with dot-dot component rejected",
+			path:   "/v2/foo/../bar/blobs/sha256:abc",
+			wantOK: false,
+		},
+		{
+			name:   "repository with query character rejected",
+			path:   "/v2/foo?x=1/manifests/latest",
+			wantOK: false,
+		},
+		{
+			name:   "repository with fragment character rejected",
+			path:   "/v2/foo#frag/blobs/sha256:abc",
+			wantOK: false,
+		},
+		{
+			name:   "uppercase repository rejected",
+			path:   "/v2/Library/Nginx/manifests/latest",
+			wantOK: false,
+		},
+		{
+			name:   "empty repository component rejected",
+			path:   "/v2/foo//bar/blobs/sha256:abc",
+			wantOK: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -78,5 +109,57 @@ func TestParseV2Path(t *testing.T) {
 					repo, kind, ref, tc.wantRepo, tc.wantKind, tc.wantRef)
 			}
 		})
+	}
+}
+
+func TestValidateRepositoryName(t *testing.T) {
+	valid := []string{
+		"nginx",
+		"library/nginx",
+		"a/b/c/d",
+		"cdn/manifests-mirror/foo",
+		"my_repo.v2/sub__component",
+		"repo-with-dashes/x",
+	}
+	for _, repo := range valid {
+		if err := oci.ValidateRepositoryName(repo); err != nil {
+			t.Errorf("ValidateRepositoryName(%q) = %v; want nil", repo, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"..",
+		"foo/../bar",
+		"foo/./bar",
+		"/leading-slash",
+		"trailing-slash/",
+		"double//slash",
+		"UpperCase",
+		"foo?x=1",
+		"foo#frag",
+		"foo bar",
+		"foo\tbar",
+		"foo\nbar",
+		"foo:tag",
+		"-leading-sep",
+		"trailing-sep-/x",
+	}
+	for _, repo := range invalid {
+		if err := oci.ValidateRepositoryName(repo); err == nil {
+			t.Errorf("ValidateRepositoryName(%q) = nil; want error", repo)
+		}
+	}
+}
+
+func TestValidateRepositoryName_TooLong(t *testing.T) {
+	long := strings.Repeat("a", oci.MaxRepositoryNameLength+1)
+	if err := oci.ValidateRepositoryName(long); err == nil {
+		t.Fatalf("ValidateRepositoryName(len=%d) = nil; want too-long error", len(long))
+	}
+
+	atLimit := strings.Repeat("a", oci.MaxRepositoryNameLength)
+	if err := oci.ValidateRepositoryName(atLimit); err != nil {
+		t.Fatalf("ValidateRepositoryName(len=%d) = %v; want nil", len(atLimit), err)
 	}
 }

--- a/internal/gantry/origin/origin.go
+++ b/internal/gantry/origin/origin.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/Azure/unbounded/internal/gantry/config"
 	"github.com/Azure/unbounded/internal/gantry/ifaces"
+	"github.com/Azure/unbounded/internal/gantry/oci"
 )
 
 // Client is the concrete OriginPuller. It fans out to one *registry per
@@ -147,6 +148,13 @@ func (c *Client) Pull(ctx context.Context, ref ifaces.OriginRef) (io.ReadCloser,
 		c.metrics.onPullStart(kind)
 	}
 
+	if err := oci.ValidateRepositoryName(ref.Repository); err != nil {
+		err := &ifaces.OriginError{Ref: ref, Class: ifaces.FailureNotFound, Err: err}
+		c.recordFailure(kind, err)
+
+		return nil, 0, err
+	}
+
 	r, ok := c.registries[ref.Registry]
 	if !ok {
 		err := &ifaces.OriginError{
@@ -211,6 +219,10 @@ func (c *Client) recordFailure(kind string, err error) {
 // surface to operators via the mirror's HTTP status and
 // access log alone.
 func (c *Client) Head(ctx context.Context, ref ifaces.OriginRef) (int64, string, error) {
+	if err := oci.ValidateRepositoryName(ref.Repository); err != nil {
+		return 0, "", &ifaces.OriginError{Ref: ref, Class: ifaces.FailureNotFound, Err: err}
+	}
+
 	r, ok := c.registries[ref.Registry]
 	if !ok {
 		return 0, "", &ifaces.OriginError{

--- a/internal/gantry/origin/origin.go
+++ b/internal/gantry/origin/origin.go
@@ -148,8 +148,8 @@ func (c *Client) Pull(ctx context.Context, ref ifaces.OriginRef) (io.ReadCloser,
 		c.metrics.onPullStart(kind)
 	}
 
-	if err := oci.ValidateRepositoryName(ref.Repository); err != nil {
-		err := &ifaces.OriginError{Ref: ref, Class: ifaces.FailureNotFound, Err: err}
+	if verr := oci.ValidateRepositoryName(ref.Repository); verr != nil {
+		err := &ifaces.OriginError{Ref: ref, Class: ifaces.FailureNotFound, Err: verr}
 		c.recordFailure(kind, err)
 
 		return nil, 0, err

--- a/internal/gantry/origin/origin_test.go
+++ b/internal/gantry/origin/origin_test.go
@@ -193,6 +193,71 @@ func TestPull_UnknownRegistry(t *testing.T) {
 	}
 }
 
+func TestPull_InvalidRepositoryRejectedBeforeRequest(t *testing.T) {
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var failures int32
+
+	c, err := New(&config.Config{UpstreamRegistries: []config.UpstreamRegistry{{Name: "reg", Endpoint: srv.URL}}}, WithMetrics(nil, func(_, _ string) {
+		atomic.AddInt32(&failures, 1)
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := digestOf([]byte("x"))
+	_, _, err = c.Pull(context.Background(), ifaces.OriginRef{Registry: "reg", Repository: "../../etc", Digest: d})
+	if err == nil {
+		t.Fatal("Pull: expected invalid repository error")
+	}
+
+	var oe *ifaces.OriginError
+	if !errors.As(err, &oe) || oe.Class != ifaces.FailureNotFound {
+		t.Fatalf("err = %v, want OriginError{Class=not_found}", err)
+	}
+
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("origin requests = %d, want 0", got)
+	}
+
+	if got := atomic.LoadInt32(&failures); got != 1 {
+		t.Fatalf("failure callbacks = %d, want 1", got)
+	}
+}
+
+func TestHead_InvalidRepositoryRejectedBeforeRequest(t *testing.T) {
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newClient(t, config.UpstreamRegistry{Name: "reg", Endpoint: srv.URL})
+	d := digestOf([]byte("x"))
+
+	_, _, err := c.Head(context.Background(), ifaces.OriginRef{Registry: "reg", Repository: "foo?bar", Digest: d})
+	if err == nil {
+		t.Fatal("Head: expected invalid repository error")
+	}
+
+	var oe *ifaces.OriginError
+	if !errors.As(err, &oe) || oe.Class != ifaces.FailureNotFound {
+		t.Fatalf("err = %v, want OriginError{Class=not_found}", err)
+	}
+
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("origin requests = %d, want 0", got)
+	}
+}
+
 func TestPull_BearerTokenFlow(t *testing.T) {
 	body := []byte("token-protected")
 	d := digestOf(body)

--- a/internal/gantry/origin/origin_test.go
+++ b/internal/gantry/origin/origin_test.go
@@ -212,6 +212,7 @@ func TestPull_InvalidRepositoryRejectedBeforeRequest(t *testing.T) {
 	}
 
 	d := digestOf([]byte("x"))
+
 	_, _, err = c.Pull(context.Background(), ifaces.OriginRef{Registry: "reg", Repository: "../../etc", Digest: d})
 	if err == nil {
 		t.Fatal("Pull: expected invalid repository error")

--- a/internal/gantry/transfer/client.go
+++ b/internal/gantry/transfer/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Azure/unbounded/internal/gantry/digest"
 	"github.com/Azure/unbounded/internal/gantry/ifaces"
+	"github.com/Azure/unbounded/internal/gantry/oci"
 )
 
 // Client implements ifaces.PeerDialer over HTTP/2 cleartext (h2c).
@@ -133,8 +134,11 @@ func buildPeerURL(peerAddr string, ref ifaces.OriginRef) (string, error) {
 	repo := ref.Repository
 	if repo == "" {
 		// Peer endpoint doesn't actually use the repo path, but OCI URL
-		// shape requires one. Use a placeholder.
-		repo = "_"
+		// shape requires one. Use a valid placeholder so our own transfer
+		// server's repository validation accepts the URL.
+		repo = "gantry"
+	} else if err := oci.ValidateRepositoryName(repo); err != nil {
+		return "", err
 	}
 	// Construct: http://<peerAddr>/v2/<repo>/{manifests|blobs}/<digest>
 	return "http://" + peerAddr + "/v2/" + repo + "/" + kind + "/" + ref.Digest.String(), nil

--- a/internal/gantry/transfer/client_test.go
+++ b/internal/gantry/transfer/client_test.go
@@ -243,7 +243,13 @@ func TestBuildPeerURL(t *testing.T) {
 			name: "missing-repo",
 			addr: "10.0.0.1:5001",
 			ref:  ifaces.OriginRef{Digest: d},
-			want: "http://10.0.0.1:5001/v2/_/blobs/" + d.String(),
+			want: "http://10.0.0.1:5001/v2/gantry/blobs/" + d.String(),
+		},
+		{
+			name: "invalid-repo",
+			addr: "10.0.0.1:5001",
+			ref:  ifaces.OriginRef{Repository: "../../etc", Digest: d},
+			err:  true,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

This PR validates OCI repository names before Gantry uses them to build mirror, transfer, coord, or origin URLs.

## Why This Matters

Gantry receives repository names from HTTP paths and peer requests.

Valid examples look like this:

```text
library/nginx
my-org/my-image
repo.with.dots/name
repo_with_underscore/name
```

Before this PR, some code paths accepted the repository string and used it directly to build URLs like:

```text
/v2/<repository>/blobs/<digest>
/v2/<repository>/manifests/<digest>
```

That was risky because an invalid repository string could contain URL-significant or path-like content, such as:

```text
../../etc/passwd
foo/../bar
foo?x=1
foo#fragment
Bad Repo
foo//bar
```

Those are not valid OCI repository names, and they can change the shape of the URL Gantry builds.

## What Changed

This PR adds a shared validator:

```go
oci.ValidateRepositoryName(...)
```

The validator enforces the OCI Distribution repository-name grammar.

It rejects:

- Empty repository names.
- Empty path components.
- Names longer than 255 characters.
- Uppercase letters.
- Whitespace and control characters.
- Query or fragment characters like `?` and `#`.
- Path traversal patterns like `..`.
- Any value outside the OCI repository-name grammar.

## Where Validation Is Applied

### 1. Mirror and Transfer HTTP Paths

`oci.ParseV2Path(...)` now validates the repository extracted from paths like:

```text
/v2/library/nginx/blobs/<digest>
/v2/library/nginx/manifests/<digest>
```

If the repository is invalid, parsing fails.

This protects both:

- The mirror HTTP endpoint.
- The transfer HTTP endpoint.

### 2. Coord `please_pull`

A peer can send a coord request like:

```text
please_pull registry=<registry> repository=<repository> digest=<digest>
```

This PR rejects invalid repositories before the request reaches the puller pump.

That prevents bad repository strings from reaching origin-pull logic.

### 3. Local Pull Path

The in-process `StartLocalPull(...)` path also validates repositories.

That keeps local/self pull behavior consistent with remote `please_pull`.

### 4. Origin Client

The origin client builds upstream registry URLs like:

```text
/v2/<repository>/blobs/<digest>
/v2/<repository>/manifests/<digest>
```

This PR validates the repository before constructing those URLs.

That means invalid repository names cannot reach origin registry URL construction.

### 5. Transfer Client

The transfer client builds peer URLs for fetching content from another Gantry node.

This PR validates repository names before constructing those peer URLs.

## Placeholder Repository Change

The transfer client previously used `_` as a placeholder repository when no repository was provided.

However, `_` by itself is not a valid OCI repository name.

This PR changes the placeholder to:

```text
gantry
```

That value is valid and still only serves as a path placeholder.

## Tests Added

This PR adds or updates tests for:

- Valid OCI repository names.
- Invalid repository names.
- Path traversal attempts.
- Query and fragment characters.
- Uppercase repository names.
- Empty path components.
- Over-length repository names.
- Invalid repositories in `please_pull`.
- Invalid repositories in `StartLocalPull(...)`.
- Invalid repositories before origin HTTP requests.
- Invalid repositories before transfer peer URL construction.

## Result

Gantry now validates repository names before using them in URLs or peer/origin requests.

In plain English:

```text
Gantry now checks that repository names look like real OCI repository names before trusting them.
```