### PR TITLE
ci: sign releases in tag context to fix cosign verification

### DIFF
--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -19,13 +19,38 @@ name: unbounded release prepare
 # triggers for tags pushed with GITHUB_TOKEN (loop prevention); a deploy-key
 # push is exempt, so it triggers release.yaml's `on: push: tags` in the
 # correct tag context.
+#
+# Modes (the `mode` input):
+#   release     Bump the latest FINAL tag by `bump` and cut vX.Y.Z.
+#   prerelease  Bump the latest FINAL tag by `bump` and cut vX.Y.Z-<pre>
+#               (e.g. pre=rc.1). Iterate a train by re-running with the same
+#               `bump` and an incremented `pre` (rc.1 -> rc.2 -> ...).
+#   promote     Finalize an in-flight prerelease to its release version, with
+#               NO bump. By default this promotes the highest prerelease
+#               train; set `version` (e.g. v0.2.0) to promote a specific one.
+#
+# Recovery: if a tag is pushed but no release.yaml run is triggered (for
+# example a misconfigured deploy key or disabled Actions), delete the tag
+# (`git push origin :refs/tags/<tag>`) and re-run this workflow. There is
+# deliberately NO workflow_dispatch fallback on release.yaml: a dispatched
+# run would sign as `@refs/heads/main` and fail deploy verification, which is
+# the exact problem this two-phase split exists to avoid.
 # ---------------------------------------------------------------------------
 
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "release: cut vX.Y.Z | prerelease: cut vX.Y.Z-<pre> | promote: finalize a prerelease"
+        required: true
+        type: choice
+        options:
+          - release
+          - prerelease
+          - promote
+        default: release
       bump:
-        description: "Version bump level"
+        description: "Version bump level (release/prerelease)"
         required: true
         type: choice
         options:
@@ -34,7 +59,12 @@ on:
           - major
         default: patch
       pre:
-        description: "Optional prerelease suffix (e.g. rc.1); leave blank for a normal release"
+        description: "Prerelease suffix for prerelease mode (e.g. rc.1)"
+        required: false
+        type: string
+        default: ""
+      version:
+        description: "promote only: explicit final version to cut (e.g. v0.2.0); blank = highest in-flight prerelease"
         required: false
         type: string
         default: ""
@@ -53,45 +83,122 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
+      # Always cut releases from the default branch, regardless of which ref
+      # the manual dispatch selected.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: main
           fetch-depth: 0
           # Wires git to push over SSH with the deploy key so the resulting
           # tag push triggers release.yaml.
           ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}
 
-      - name: Compute and push tag
-        # Bind inputs to env vars so they enter the shell as data, not as
-        # code. `pre` is free-form user input; inlining `${{ ... }}` in a
-        # run block is template-expanded before bash parses it, so any shell
-        # metacharacter would become script syntax.
+      - name: Preflight deploy key
+        # Fail fast before any tag is created if the deploy key is missing or
+        # cannot authenticate, so we never leave a pushed tag without a build.
         env:
-          BUMP: ${{ inputs.bump }}
-          PRE: ${{ inputs.pre }}
+          HAS_KEY: ${{ secrets.RELEASE_TAG_DEPLOY_KEY != '' }}
         run: |
           set -euo pipefail
 
-          LATEST=$(git tag --list 'v*' --sort=-version:refname | head -n1)
-          if [[ -z "$LATEST" ]]; then
-            LATEST="v0.0.0"
+          if [[ "$HAS_KEY" != "true" ]]; then
+            echo "::error::RELEASE_TAG_DEPLOY_KEY secret is not set; cannot push the tag"
+            exit 1
           fi
 
-          # Strip any prerelease suffix from the base before bumping.
-          BASE="${LATEST%%-*}"
-          SEMVER="${BASE#v}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$SEMVER"
+          if ! git ls-remote origin >/dev/null 2>&1; then
+            echo "::error::cannot authenticate to origin with the deploy key (git ls-remote failed)"
+            exit 1
+          fi
 
-          case "$BUMP" in
-            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
-            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
-            patch) PATCH=$((PATCH + 1)) ;;
-            *) echo "::error::unexpected bump level: ${BUMP}"; exit 1 ;;
+          echo "Deploy key authenticates to origin."
+
+      - name: Compute and push tag
+        # Bind inputs to env vars so they enter the shell as data, not as
+        # code. `pre` and `version` are free-form user input; inlining
+        # `${{ ... }}` in a run block is template-expanded before bash parses
+        # it, so any shell metacharacter would become script syntax.
+        env:
+          MODE: ${{ inputs.mode }}
+          BUMP: ${{ inputs.bump }}
+          PRE: ${{ inputs.pre }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          # The `version` override only applies to promote.
+          if [[ -n "$VERSION" && "$MODE" != "promote" ]]; then
+            echo "::error::version is only valid with mode=promote (got mode=${MODE})"
+            exit 1
+          fi
+
+          # Latest FINAL (non-prerelease) tag, used as the bump base. Excluding
+          # prerelease tags avoids git's version sort ranking e.g. v0.2.0-rc.1
+          # above v0.2.0.
+          latest_final() {
+            git tag --list 'v*' --sort=-version:refname | grep -v -- '-' | head -n1
+          }
+
+          bump_version() {
+            local base="$1" level="$2"
+            local semver="${base#v}"
+            local major minor patch
+            IFS='.' read -r major minor patch <<< "$semver"
+            case "$level" in
+              major) major=$((major + 1)); minor=0; patch=0 ;;
+              minor) minor=$((minor + 1)); patch=0 ;;
+              patch) patch=$((patch + 1)) ;;
+              *) echo "::error::unexpected bump level: ${level}"; exit 1 ;;
+            esac
+            echo "v${major}.${minor}.${patch}"
+          }
+
+          case "$MODE" in
+            release)
+              FINAL="$(latest_final)"
+              [[ -z "$FINAL" ]] && FINAL="v0.0.0"
+              TAG="$(bump_version "$FINAL" "$BUMP")"
+              ;;
+
+            prerelease)
+              if [[ -z "$PRE" ]]; then
+                echo "::error::mode=prerelease requires a non-empty pre suffix"
+                exit 1
+              fi
+              FINAL="$(latest_final)"
+              [[ -z "$FINAL" ]] && FINAL="v0.0.0"
+              CORE="$(bump_version "$FINAL" "$BUMP")"
+              TAG="${CORE}-${PRE}"
+              ;;
+
+            promote)
+              if [[ -n "$VERSION" ]]; then
+                # Normalize a leading v and reject any prerelease suffix.
+                NORM="v${VERSION#v}"
+                if [[ ! "$NORM" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "::error::version must be a final vX.Y.Z (no suffix), got: ${VERSION}"
+                  exit 1
+                fi
+                if [[ -z "$(git tag --list "${NORM}-*")" ]]; then
+                  echo "::error::no prerelease train found for ${NORM} (no ${NORM}-* tags); use mode=release to cut it directly"
+                  exit 1
+                fi
+                TAG="$NORM"
+              else
+                PRELATEST="$(git tag --list 'v*-*' --sort=-version:refname | head -n1)"
+                if [[ -z "$PRELATEST" ]]; then
+                  echo "::error::mode=promote found no prerelease tags to finalize"
+                  exit 1
+                fi
+                TAG="${PRELATEST%%-*}"
+              fi
+              ;;
+
+            *)
+              echo "::error::unexpected mode: ${MODE}"
+              exit 1
+              ;;
           esac
-
-          TAG="v${MAJOR}.${MINOR}.${PATCH}"
-          if [[ -n "$PRE" ]]; then
-            TAG="${TAG}-${PRE}"
-          fi
 
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Tag must be in vX.Y.Z[-suffix] format, got: ${TAG}"
@@ -108,5 +215,5 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
-          echo "Pushed ${TAG}; release.yaml will build and sign it in tag context."
+          echo "Pushed ${TAG} (mode=${MODE}); release.yaml will build and sign it in tag context."
           echo "### Prepared release ${TAG}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: unbounded release prepare
+
+# ---------------------------------------------------------------------------
+# Phase 1 of the two-phase release. This workflow ONLY computes the next
+# version and pushes the git tag. It does not build, sign, or publish
+# anything.
+#
+# Why split it out: the build/sign workflow (release.yaml) must run in the
+# context of the version tag so that keyless cosign signatures carry the
+# identity `release.yaml@refs/tags/vX.Y.Z`. That identity is what the deploy
+# workflow verifies. A tag created mid-run by a workflow dispatched on a
+# branch would instead sign as `@refs/heads/main` and fail verification.
+#
+# The tag is pushed using an SSH deploy key (RELEASE_TAG_DEPLOY_KEY) rather
+# than the default GITHUB_TOKEN. GitHub deliberately suppresses workflow
+# triggers for tags pushed with GITHUB_TOKEN (loop prevention); a deploy-key
+# push is exempt, so it triggers release.yaml's `on: push: tags` in the
+# correct tag context.
+# ---------------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump level"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      pre:
+        description: "Optional prerelease suffix (e.g. rc.1); leave blank for a normal release"
+        required: false
+        type: string
+        default: ""
+
+# The tag push authenticates via the SSH deploy key, not GITHUB_TOKEN, so no
+# contents:write is needed here.
+permissions:
+  contents: read
+
+# Serialize prepares so two dispatches cannot race to mint tags.
+concurrency:
+  group: release-prepare
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          # Wires git to push over SSH with the deploy key so the resulting
+          # tag push triggers release.yaml.
+          ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}
+
+      - name: Compute and push tag
+        # Bind inputs to env vars so they enter the shell as data, not as
+        # code. `pre` is free-form user input; inlining `${{ ... }}` in a
+        # run block is template-expanded before bash parses it, so any shell
+        # metacharacter would become script syntax.
+        env:
+          BUMP: ${{ inputs.bump }}
+          PRE: ${{ inputs.pre }}
+        run: |
+          set -euo pipefail
+
+          LATEST=$(git tag --list 'v*' --sort=-version:refname | head -n1)
+          if [[ -z "$LATEST" ]]; then
+            LATEST="v0.0.0"
+          fi
+
+          # Strip any prerelease suffix from the base before bumping.
+          BASE="${LATEST%%-*}"
+          SEMVER="${BASE#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$SEMVER"
+
+          case "$BUMP" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+            *) echo "::error::unexpected bump level: ${BUMP}"; exit 1 ;;
+          esac
+
+          TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          if [[ -n "$PRE" ]]; then
+            TAG="${TAG}-${PRE}"
+          fi
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag must be in vX.Y.Z[-suffix] format, got: ${TAG}"
+            exit 1
+          fi
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+          echo "Pushed ${TAG}; release.yaml will build and sign it in tag context."
+          echo "### Prepared release ${TAG}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,16 @@
 name: unbounded release
 
 # ---------------------------------------------------------------------------
-# Single, unified release pipeline.
+# Phase 2 of the two-phase release: build, sign, and publish.
 #
-# Triggers:
-#   workflow_dispatch  - bump latest tag by selected level (patch/minor/major)
-#                         and run the full pipeline against the new tag.
-#   push (tags v*)     - run the pipeline against the pushed tag.
+# Trigger:
+#   push (tags v*)  - run the full pipeline against the pushed tag.
+#
+# This workflow is deliberately tag-driven only. The tag is minted by
+# release-prepare.yaml (Phase 1), which pushes it with an SSH deploy key so
+# this workflow runs in the tag's context. Running in tag context is what
+# makes keyless cosign signatures carry the identity
+# `release.yaml@refs/tags/vX.Y.Z`, which the deploy workflow verifies.
 #
 # Job topology:
 #   version
@@ -21,40 +25,14 @@ name: unbounded release
 #     -> component-images  (matrix: machina, machine-ops-controller, metalman, host-ubuntu2404)
 #     -> manifests-tarball (make release-manifests + cosign sign)
 #     -> storage-binaries  (matrix: amd64, arm64; binary + bundled libfabric)
-#     -> finalize          (attach extras + krew manifest; optional publish)
+#     -> finalize          (attach extras + krew manifest)
 #
-# All artifacts land on a single GitHub release that defaults to draft.
-# Pass `publish: true` on workflow_dispatch to publish immediately.
+# All artifacts land on a single GitHub release that is left as a draft.
+# Prerelease status is derived from the tag (a `-` suffix, e.g. v1.2.3-rc1).
+# Publishing is a manual step (GitHub UI or `gh release edit --draft=false`).
 # ---------------------------------------------------------------------------
 
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: "Version bump level"
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-        default: patch
-      prerelease:
-        description: "Mark as pre-release"
-        required: false
-        type: boolean
-        default: false
-      publish:
-        description: "Publish the release immediately (otherwise leave as draft)"
-        required: false
-        type: boolean
-        default: false
-      dry_run:
-        description: "Dry run (build everything, push and sign nothing, no release)"
-        required: false
-        type: boolean
-        default: false
-
   push:
     tags:
       - "v*"
@@ -79,16 +57,16 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Compute the release tag.
-  #
-  #   workflow_dispatch -> bump latest semver tag by the selected level
-  #   tag push          -> use the pushed tag as-is
+  # Resolve the release tag from the pushed ref (this workflow is tag-driven;
+  # the tag itself is minted by release-prepare.yaml). Also derive prerelease
+  # status from the tag: a `-` suffix (e.g. v1.2.3-rc1) marks a prerelease.
   # ---------------------------------------------------------------------------
   version:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version.outputs.tag }}
       version: ${{ steps.version.outputs.version }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -96,26 +74,10 @@ jobs:
 
       - name: Compute version
         id: version
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            TAG="${{ github.ref_name }}"
-          else
-            LATEST=$(git tag --list 'v*' --sort=-version:refname | head -n1)
-            if [[ -z "$LATEST" ]]; then
-              LATEST="v0.0.0"
-            fi
-
-            SEMVER="${LATEST#v}"
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$SEMVER"
-
-            case "${{ inputs.bump }}" in
-              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
-              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
-              patch) PATCH=$((PATCH + 1)) ;;
-            esac
-
-            TAG="v${MAJOR}.${MINOR}.${PATCH}"
-          fi
+          set -euo pipefail
 
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Tag must be in vX.Y.Z[-suffix] format, got: ${TAG}"
@@ -123,9 +85,16 @@ jobs:
           fi
 
           VERSION="${TAG#v}"
+          if [[ "$TAG" == *-* ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Release: ${TAG} (version: ${VERSION})"
+          echo "is_prerelease=${IS_PRERELEASE}" >> "$GITHUB_OUTPUT"
+          echo "Release: ${TAG} (version: ${VERSION}, prerelease: ${IS_PRERELEASE})"
 
       - name: Normalize container registry to lowercase
         run: echo "REGISTRY=${REGISTRY,,}" >> "$GITHUB_ENV"
@@ -192,7 +161,7 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------
-  # Create the git tag (workflow_dispatch only) and run GoReleaser.
+  # Run GoReleaser against the pushed tag.
   # GoReleaser produces kubectl-unbounded + unbounded-agent archives,
   # signs the checksums file, generates SBOMs, and creates a DRAFT GitHub
   # release. Subsequent jobs attach more artifacts to that draft.
@@ -209,20 +178,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Create tag (workflow_dispatch only)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          TAG="${{ needs.version.outputs.tag }}"
-          if git rev-parse "${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists, skipping creation"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG}"
-            git push origin "${TAG}"
-            echo "Created and pushed tag ${TAG}"
-          fi
-
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -232,7 +187,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: "~> v2"
-          args: release --clean ${{ inputs.dry_run == true && '--skip=publish,sign,sbom' || '' }}
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ needs.version.outputs.tag }}
@@ -299,7 +254,6 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Log in to ghcr.io
-        if: inputs.dry_run != true
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
@@ -384,7 +338,7 @@ jobs:
           file: images/net/Containerfile
           target: controller
           platforms: ${{ matrix.platform }}
-          push: ${{ inputs.dry_run != true }}
+          push: true
           provenance: false
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.go_version }}
@@ -403,7 +357,7 @@ jobs:
           file: images/net/Containerfile
           target: node
           platforms: ${{ matrix.platform }}
-          push: ${{ inputs.dry_run != true }}
+          push: true
           provenance: false
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.go_version }}
@@ -415,13 +369,11 @@ jobs:
           cache-to: type=gha,scope=net-node-${{ matrix.arch }},mode=max
 
       - name: Sign per-arch net images
-        if: inputs.dry_run != true
         run: |
           cosign sign --yes "${{ env.REGISTRY }}/unbounded-net-controller@${{ steps.push_controller.outputs.digest }}"
           cosign sign --yes "${{ env.REGISTRY }}/unbounded-net-node@${{ steps.push_node.outputs.digest }}"
 
       - name: Generate and attest controller SBOM
-        if: inputs.dry_run != true
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/unbounded-net-controller@${{ steps.push_controller.outputs.digest }}
@@ -432,7 +384,6 @@ jobs:
           output-file: sbom-net-controller-${{ matrix.arch }}.spdx.json
 
       - name: Attest controller SBOM
-        if: inputs.dry_run != true
         run: |
           cosign attest --yes \
             --predicate sbom-net-controller-${{ matrix.arch }}.spdx.json \
@@ -440,7 +391,6 @@ jobs:
             "${{ env.REGISTRY }}/unbounded-net-controller@${{ steps.push_controller.outputs.digest }}"
 
       - name: Generate and attest node SBOM
-        if: inputs.dry_run != true
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/unbounded-net-node@${{ steps.push_node.outputs.digest }}
@@ -451,7 +401,6 @@ jobs:
           output-file: sbom-net-node-${{ matrix.arch }}.spdx.json
 
       - name: Attest node SBOM
-        if: inputs.dry_run != true
         run: |
           cosign attest --yes \
             --predicate sbom-net-node-${{ matrix.arch }}.spdx.json \
@@ -464,7 +413,6 @@ jobs:
   # ---------------------------------------------------------------------------
   net-images-manifest:
     needs: [version, net-images]
-    if: ${{ inputs.dry_run != true }}
     runs-on: ubuntu-latest
     steps:
       - name: Normalize container registry to lowercase
@@ -541,7 +489,6 @@ jobs:
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to ghcr.io
-        if: inputs.dry_run != true
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
@@ -577,7 +524,7 @@ jobs:
           context: .
           file: ${{ matrix.component.file }}
           platforms: ${{ matrix.component.platforms }}
-          push: ${{ inputs.dry_run != true }}
+          push: true
           build-args: |
             VERSION=${{ needs.version.outputs.tag }}
             GIT_COMMIT=${{ github.sha }}
@@ -588,13 +535,11 @@ jobs:
           cache-to: type=gha,scope=${{ matrix.component.name }},mode=max
 
       - name: Sign container image
-        if: inputs.dry_run != true
         run: |
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ matrix.component.name }}@${{ steps.push.outputs.digest }}"
 
       - name: Generate and attach SBOM
-        if: inputs.dry_run != true
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ matrix.component.name }}@${{ steps.push.outputs.digest }}
@@ -605,7 +550,6 @@ jobs:
           output-file: sbom-${{ matrix.component.name }}.spdx.json
 
       - name: Attest SBOM to image
-        if: inputs.dry_run != true
         run: |
           cosign attest --yes \
             --predicate sbom-${{ matrix.component.name }}.spdx.json \
@@ -642,7 +586,6 @@ jobs:
             CONTAINER_REGISTRY="${{ env.REGISTRY }}"
 
       - name: Sign manifests tarball with cosign (keyless)
-        if: inputs.dry_run != true
         run: |
           TAG="${{ needs.version.outputs.tag }}"
           ARCHIVE="build/unbounded-manifests-${TAG}.tar.gz"
@@ -756,7 +699,6 @@ jobs:
             -o spdx-json="dist/${NAME}.tar.gz.spdx.json"
 
       - name: Sign storage tarball with cosign (keyless)
-        if: inputs.dry_run != true
         run: |
           set -euo pipefail
           ARCHIVE="dist/unbounded-storage-linux-${{ matrix.arch }}.tar.gz"
@@ -789,7 +731,6 @@ jobs:
       - component-images
       - manifests-tarball
       - storage-binaries
-    if: ${{ inputs.dry_run != true }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -849,15 +790,13 @@ jobs:
             gh release edit "${TAG}" --notes "${NOTES}"
           fi
 
-          # Flag prerelease if requested.
-          if [[ "${{ inputs.prerelease }}" == "true" ]]; then
+          # Flag prerelease when the tag carries a prerelease suffix
+          # (e.g. v1.2.3-rc1). GoReleaser also sets this via `prerelease: auto`;
+          # we reassert it here in case the draft was created differently.
+          if [[ "${{ needs.version.outputs.is_prerelease }}" == "true" ]]; then
             gh release edit "${TAG}" --prerelease
           fi
 
-          # Flip from draft to published when explicitly requested.
-          if [[ "${{ inputs.publish }}" == "true" ]]; then
-            gh release edit "${TAG}" --draft=false
-            echo "Published release ${TAG}"
-          else
-            echo "Release ${TAG} left as draft. Publish via the GitHub UI or 'gh release edit ${TAG} --draft=false'."
-          fi
+          # The release is always left as a draft. Publishing is a deliberate
+          # manual step once the release has soaked.
+          echo "Release ${TAG} left as draft. Publish via the GitHub UI or 'gh release edit ${TAG} --draft=false'."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -408,8 +408,7 @@ jobs:
             "${{ env.REGISTRY }}/unbounded-net-node@${{ steps.push_node.outputs.digest }}"
 
   # ---------------------------------------------------------------------------
-  # Stitch per-arch net image tags into multi-arch manifests for :TAG and
-  # :latest.
+  # Stitch per-arch net image tags into multi-arch manifests for :TAG.
   # ---------------------------------------------------------------------------
   net-images-manifest:
     needs: [version, net-images]
@@ -432,13 +431,11 @@ jobs:
           TAG="${{ needs.version.outputs.tag }}"
           for image in controller node; do
             SRC="${{ env.REGISTRY }}/unbounded-net-${image}"
-            for release_tag in "${TAG}" "latest"; do
-              echo "Creating manifest ${SRC}:${release_tag}..."
-              docker buildx imagetools create \
-                --tag "${SRC}:${release_tag}" \
-                "${SRC}:${TAG}-amd64" \
-                "${SRC}:${TAG}-arm64"
-            done
+            echo "Creating manifest ${SRC}:${TAG}..."
+            docker buildx imagetools create \
+              --tag "${SRC}:${TAG}" \
+              "${SRC}:${TAG}-amd64" \
+              "${SRC}:${TAG}-arm64"
           done
 
   # ---------------------------------------------------------------------------
@@ -528,9 +525,7 @@ jobs:
           build-args: |
             VERSION=${{ needs.version.outputs.tag }}
             GIT_COMMIT=${{ github.sha }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ matrix.component.name }}:${{ needs.version.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ matrix.component.name }}:latest
+          tags: ${{ env.REGISTRY }}/${{ matrix.component.name }}:${{ needs.version.outputs.tag }}
           cache-from: type=gha,scope=${{ matrix.component.name }}
           cache-to: type=gha,scope=${{ matrix.component.name }},mode=max
 


### PR DESCRIPTION
## Problem

The deploy pipeline (`release-upgrade.yaml`) verifies the release manifests tarball with a cosign **keyless** signature and requires the signing certificate identity to match:

```
^https://github.com/Azure/unbounded/.github/workflows/release.yaml@refs/tags/<tag>$
```

With keyless signing there is no key; trust is anchored in that identity, which encodes the workflow file **and the git ref it ran on**. The identity only ends in `@refs/tags/<tag>` when `release.yaml` runs because a **tag was pushed**.

But releases were being cut via `release.yaml`'s `workflow_dispatch` "bump" path. That run executes on `main`, and creating the tag mid-run does not change the ref the run is on. So every keyless signature was stamped `release.yaml@refs/heads/main`. The tag it pushed used the default `GITHUB_TOKEN`, which GitHub deliberately prevents from triggering further workflows, so no tag-context run ever happened.

The result is the deploy failing verification:

```
Error: failed to verify certificate identity: no matching CertificateIdentity found,
expected SAN value to match regex "...release.yaml@refs/tags/v0.1.16$",
got "...release.yaml@refs/heads/main"
```

This is a structural mismatch: the release supports a dispatch path that signs as `@refs/heads/main`, but the deploy is built to trust only `@refs/tags/<tag>`.

## Solution

Split the release into two phases so signing **always** happens in tag context:

- **`release-prepare.yaml` (new, Phase 1):** a `workflow_dispatch` that only computes the next version and pushes the tag. It pushes using an **SSH deploy key** (`RELEASE_TAG_DEPLOY_KEY`) rather than `GITHUB_TOKEN`, so the tag push is allowed to trigger Phase 2.
- **`release.yaml` (Phase 2):** now tag-driven only (`on: push: tags`). Removed the in-run tag creation; the build/sign jobs run from the pushed tag.

Because Phase 2 is triggered by the tag push and checks out the tag, every keyless signature now carries the identity `release.yaml@refs/tags/<tag>`. The deploy's verification passes **with no change to the verifier** and full provenance is preserved (version-pinned, immutable identity).

## How to cut a release (developer workflow)

The recommended way to cut a release is the **unbounded release prepare** workflow. (Pushing a tag by hand still works as a break-glass path; see below.)

1. Make sure `main` is at the commit you want to release (the tag is always cut from `main`, regardless of which ref you launch the workflow from).
2. In the GitHub UI, go to **Actions -> unbounded release prepare -> Run workflow**, and pick a `mode`:
   - **`release`** + `bump` (`patch`/`minor`/`major`) - cut a normal release. The next version is computed by bumping the latest **final** tag. Example: latest final `v0.2.3`, `bump=patch` -> `v0.2.4`.
   - **`prerelease`** + `bump` + `pre` - cut a prerelease. Example: latest final `v0.2.3`, `bump=minor`, `pre=rc.1` -> `v0.3.0-rc.1`. Iterate the same train by re-running with the **same** `bump` and an incremented `pre` (`rc.1` -> `rc.2`).
   - **`promote`** - finalize an in-flight prerelease to its release version, with **no** bump. By default it promotes the highest prerelease train (e.g. `v0.3.0-rc.2` -> `v0.3.0`). Set the optional `version` input (e.g. `v0.3.0`) to promote a specific train when several are in flight; that `vX.Y.Z-*` train must exist or the run fails.
3. The workflow pushes the tag, which automatically triggers `release.yaml` to build, sign, and create a **draft** GitHub release for that tag.
4. Verify the draft release and its artifacts, then **publish manually** (GitHub UI or `gh release edit <tag> --draft=false`). The tag push also auto-triggers the deploy to the `stable` soak cluster.

Notes:
- Prerelease status is derived from the tag (a `-` suffix marks a prerelease); there is no separate prerelease toggle.
- If a tag gets pushed but no `release.yaml` run starts (e.g. a deploy-key/policy issue), delete the tag (`git push origin :refs/tags/<tag>`) and re-run **release prepare**. There is intentionally no manual `release.yaml` trigger: a dispatched run would sign as `@refs/heads/main` and fail verification.

### Cutting a release by tag (supported but discouraged)

Manually pushing a `v*` tag still triggers `release.yaml` and produces a correct release: because the tag is pushed with your own credentials (not the bot `GITHUB_TOKEN`), the run executes in tag context and signs as `release.yaml@refs/tags/<tag>`, so verification and the auto-deploy work exactly as via **release prepare**.

```
git tag v0.3.0 && git push origin v0.3.0
```

It is discouraged because it bypasses the guardrails that **release prepare** provides:
- **The `ref: main` guard.** A hand-pushed tag can point at any commit on any branch, so you can accidentally release un-merged or feature-branch code. The signature still verifies (the identity is tag-based), so nothing downstream catches it.
- **Version computation and guards** (mode-based release/prerelease/promote, bump-from-latest-final, train iteration, duplicate/typo checks). With a manual tag you pick the version string yourself; only the basic `vX.Y.Z[-suffix]` format check in `release.yaml` applies.

Prefer **release prepare** for normal releases; reserve manual tagging for break-glass situations (e.g. the prepare workflow is unavailable).

## Also in this change
- Dropped the dry-run paths from `release.yaml` (build validation is covered by CI).
- Releases are always left as drafts; publishing remains a manual step.
- `release.yaml` no longer publishes `:latest` image tags. Nothing in the shipped/supported path consumes them (rendered manifests, the `kubectl-unbounded` plugin's embedded manifests, and the integration deploy all pin to `:vX.Y.Z`), and a mutable `:latest` is a footgun now that prereleases flow through the same pipeline (they would silently repoint `:latest` to an RC). Releases publish only the immutable `:vX.Y.Z` tag; existing `:latest` tags in the registry are left as-is.

## Setup required (already completed)
- An SSH deploy key with write access is added to the repo, and its private key is stored as the `RELEASE_TAG_DEPLOY_KEY` Actions secret.

## Behavior change to note
Real releases are now `push` events, so the deploy workflow auto-fires after each release (previously it was run manually).

## Verification
- `actionlint` passes on both workflows.
- Both files parse as valid YAML; no remaining dry-run/dispatch input references.
- The `release-prepare` version logic was traced across all modes against a scratch repo (release/prerelease/promote, the `version` override, and multi-train cases).
- End-to-end proof requires a live run: dispatch **release prepare**, confirm `release.yaml` runs from the tag, a signature shows `...release.yaml@refs/tags/<tag>`, and the deploy's cosign verify step passes.


