### PR TITLE
storage: fix arm64 c_char FFI buffer

### DIFF
--- a/cmd/unbounded-storage/src/fabric/cm.rs
+++ b/cmd/unbounded-storage/src/fabric/cm.rs
@@ -751,7 +751,7 @@ fn getname_string(fid: *mut ffi::fid) -> Result<String> {
     check("fi_getname", rc)?;
     addr.truncate(len);
 
-    let mut out = [0i8; 128];
+    let mut out: [std::ffi::c_char; 128] = [0; 128];
     let written = unsafe {
         ffi::ub_fi_format_sockaddr(
             addr.as_ptr() as *const std::ffi::c_void,
@@ -895,7 +895,7 @@ mod tests {
     #[test]
     fn format_sockaddr_rejects_short_buffer() {
         let addr = [0u8];
-        let mut out = [0i8; 8];
+        let mut out: [std::ffi::c_char; 8] = [0; 8];
         let rc = unsafe {
             ffi::ub_fi_format_sockaddr(
                 addr.as_ptr() as *const std::ffi::c_void,


### PR DESCRIPTION
## Summary
- fix the unbounded-storage sockaddr formatting buffers to use platform c_char
- avoid assuming C char is signed, which breaks the arm64 release build where c_char is u8

## Root cause
The release workflow failed in storage-binaries (arm64) during make unbounded-storage-build because ub_fi_format_sockaddr expects *mut c_char, but cm.rs passed buffers typed as i8. On aarch64-unknown-linux-gnu, Rust c_char is u8, so the pointer types do not match.