### PR TITLE
Mount storage and IB devices into the nspawn environment

### DIFF
--- a/docs/content/reference/agent/nspawn.md
+++ b/docs/content/reference/agent/nspawn.md
@@ -106,6 +106,23 @@ When the KVM character device (`/dev/kvm`) is present on the host, the agent
 automatically bind-mounts it into the container so that workloads inside the
 container can use hardware virtualisation (e.g. QEMU/KVM virtual machines).
 
+The agent also auto-mounts host storage and InfiniBand hardware:
+
+- **Block (storage) devices.** Every entry under `/sys/class/block` is
+  bind-mounted by its device node (e.g. `/dev/sda`, `/dev/sda1`,
+  `/dev/nvme0n1`, `/dev/nvme0n1p1`), including whole disks and their
+  partitions as well as device-mapper (`/dev/dm-*`) and software RAID
+  (`/dev/md*`) nodes. Pseudo and virtual devices are excluded: `loop*`,
+  `ram*`, `zram*`, `fd*`, and `sr*` (optical).
+- **InfiniBand HCA devices.** Every character device under
+  `/dev/infiniband` (e.g. `uverbs0`, `umad0`, `issm0`, `rdma_cm`) is
+  bind-mounted so that RDMA workloads inside the container can reach the
+  host's HCAs.
+
+Device discovery runs once when the machine is provisioned. Disks or HCAs
+hot-plugged after the machine has started are not picked up until the machine
+is re-provisioned or soft-rebooted.
+
 The configuration is written to two files on the host before the machine boots:
 
 | File | Path |
@@ -126,8 +143,10 @@ The configuration is written to two files on the host before the machine boots:
 | `SYSTEMD_NSPAWN_UNIFIED_HIERARCHY=1` | Service override | Forces cgroups v2 inside the container. |
 | `SYSTEMD_NSPAWN_API_VFS_WRITABLE=network` | Service override | Makes `/proc/sys/net` writable for CNI and kube-proxy. |
 | `Bind=/dev/kvm` | nspawn config | KVM device bind-mount (auto-generated when `/dev/kvm` is present). |
+| `Bind=<block device>` | nspawn config | Storage block device bind-mount (auto-generated for non-virtual `/sys/class/block` entries, including partitions, `dm-*`, and `md*`). |
+| `Bind=/dev/infiniband/*` | nspawn config | InfiniBand HCA device bind-mount (auto-generated when `/dev/infiniband` devices are present). |
 | `Bind=` / `BindReadOnly=` | nspawn config | GPU device and library bind-mounts (auto-generated when GPUs are present). |
-| `DeviceAllow=` | Service override | Cgroup device permissions for GPU nodes (auto-generated when GPUs are present). |
+| `DeviceAllow=` | Service override | Cgroup device permissions for all bind-mounted host device nodes (KVM, block, InfiniBand, GPU). |
 
 #### System call filter
 

--- a/pkg/agent/goalstates/hostdevices.go
+++ b/pkg/agent/goalstates/hostdevices.go
@@ -5,24 +5,87 @@ package goalstates
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 )
 
-const kvmDevicePath = "/dev/kvm"
+const (
+	kvmDevicePath = "/dev/kvm"
+	// sysClassBlockDir is the canonical kernel listing of block devices.
+	// It contains both whole disks (e.g. sda, nvme0n1) and their partitions
+	// (e.g. sda1, nvme0n1p1), which is why it is preferred over /sys/block.
+	sysClassBlockDir = "/sys/class/block"
+	// infinibandDir holds InfiniBand/RDMA HCA character devices
+	// (e.g. uverbs0, umad0, issm0, rdma_cm).
+	infinibandDir = "/dev/infiniband"
+)
 
-// DiscoverHostDevicePaths probes the host for device nodes that should be
-// bind-mounted into the nspawn container and returns their paths in a stable
-// order so that repeated calls produce the same config output.
-func DiscoverHostDevicePaths() []string {
+// excludedBlockDevicePrefixes lists /sys/class/block entry name prefixes that
+// are pseudo or virtual devices rather than real storage and so should not be
+// bind-mounted into the container. Device-mapper (dm-*) and software RAID
+// (md*) are intentionally NOT excluded: they back real storage.
+var excludedBlockDevicePrefixes = []string{
+	"loop", // loopback devices
+	"ram",  // ramdisks
+	"zram", // compressed ramdisks
+	"fd",   // floppy devices
+	"sr",   // SCSI optical (cdrom) devices
+}
+
+// HostDevices groups host device node paths by category so that callers can
+// report per-type discovery results while still bind-mounting the union of all
+// paths into the nspawn container.
+type HostDevices struct {
+	// KVM holds the KVM character device path (/dev/kvm) when present.
+	KVM []string
+	// Block holds storage block device node paths derived from
+	// /sys/class/block (whole disks and partitions, excluding virtual
+	// devices such as loop/ram/zram).
+	Block []string
+	// Infiniband holds InfiniBand/RDMA HCA character device node paths from
+	// /dev/infiniband.
+	Infiniband []string
+}
+
+// Paths returns every discovered device node path merged into a single
+// de-duplicated, sorted slice. This is the form the nspawn templates consume
+// to emit Bind= and DeviceAllow= directives.
+func (d HostDevices) Paths() []string {
+	seen := make(map[string]bool)
+
 	var paths []string
 
-	if p := discoverKVMDevicePath(kvmDevicePath); p != "" {
-		paths = append(paths, p)
+	for _, group := range [][]string{d.KVM, d.Block, d.Infiniband} {
+		for _, p := range group {
+			if seen[p] {
+				continue
+			}
+
+			seen[p] = true
+			paths = append(paths, p)
+		}
 	}
 
 	sort.Strings(paths)
 
 	return paths
+}
+
+// DiscoverHostDevices probes the host for device nodes that should be
+// bind-mounted into the nspawn container, grouped by category. Repeated calls
+// produce the same output because each group is returned in a stable order.
+func DiscoverHostDevices() HostDevices {
+	var devices HostDevices
+
+	if p := discoverKVMDevicePath(kvmDevicePath); p != "" {
+		devices.KVM = append(devices.KVM, p)
+	}
+
+	devices.Block = discoverBlockDevicePaths(sysClassBlockDir, devDir)
+	devices.Infiniband = discoverInfinibandDevicePaths(infinibandDir)
+
+	return devices
 }
 
 // discoverKVMDevicePath checks whether path exists on the filesystem and
@@ -36,4 +99,78 @@ func discoverKVMDevicePath(path string) string {
 	}
 
 	return path
+}
+
+// discoverBlockDevicePaths enumerates storage block devices from
+// sysClassBlockDir and returns the corresponding device node paths under
+// devDir in sorted order. Whole disks and partitions are included; pseudo and
+// virtual devices (loop/ram/zram/fd/sr) are excluded. A sysfs entry is only
+// included when its device node actually exists under devDir. Returns nil (not
+// an error) when the directory cannot be read.
+func discoverBlockDevicePaths(sysClassBlockDir, devDir string) []string {
+	entries, err := os.ReadDir(sysClassBlockDir)
+	if err != nil {
+		return nil
+	}
+
+	var paths []string
+
+	for _, e := range entries {
+		name := e.Name()
+		if isExcludedBlockDevice(name) {
+			continue
+		}
+
+		// sysfs encodes '/' in device names as '!' (e.g. cciss!c0d0 maps to
+		// the device node /dev/cciss/c0d0).
+		nodeName := strings.ReplaceAll(name, "!", "/")
+		nodePath := filepath.Join(devDir, nodeName)
+
+		if _, err := os.Stat(nodePath); err != nil {
+			continue
+		}
+
+		paths = append(paths, nodePath)
+	}
+
+	sort.Strings(paths)
+
+	return paths
+}
+
+// isExcludedBlockDevice reports whether a /sys/class/block entry name belongs
+// to a pseudo or virtual device that should not be bind-mounted.
+func isExcludedBlockDevice(name string) bool {
+	for _, prefix := range excludedBlockDevicePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// discoverInfinibandDevicePaths enumerates InfiniBand/RDMA HCA character
+// devices under infinibandDir and returns their device node paths in sorted
+// order. Returns nil (not an error) when the directory is absent, which is the
+// common case on hosts without RDMA hardware.
+func discoverInfinibandDevicePaths(infinibandDir string) []string {
+	entries, err := os.ReadDir(infinibandDir)
+	if err != nil {
+		return nil
+	}
+
+	var paths []string
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+
+		paths = append(paths, filepath.Join(infinibandDir, e.Name()))
+	}
+
+	sort.Strings(paths)
+
+	return paths
 }

--- a/pkg/agent/goalstates/hostdevices_test.go
+++ b/pkg/agent/goalstates/hostdevices_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDiscoverKVMDevicePath_Present(t *testing.T) {
@@ -32,4 +34,123 @@ func TestDiscoverKVMDevicePath_Absent(t *testing.T) {
 	if got != "" {
 		t.Errorf("discoverKVMDevicePath(absent) = %q, want empty string", got)
 	}
+}
+
+func TestDiscoverBlockDevicePaths(t *testing.T) {
+	t.Parallel()
+
+	sysDir := t.TempDir()
+	devDir := t.TempDir()
+
+	// Entries that appear in /sys/class/block. Whole disks, partitions,
+	// device-mapper, and software RAID are real storage; loop/ram/zram/fd/sr
+	// are virtual and must be excluded.
+	sysEntries := []string{
+		"sda", "sda1", "nvme0n1", "nvme0n1p1", "dm-0", "md0",
+		"loop0", "ram0", "zram0", "sr0", "fd0",
+	}
+	for _, name := range sysEntries {
+		require.NoError(t, os.Mkdir(filepath.Join(sysDir, name), 0o755))
+	}
+
+	// Only create device nodes for a subset to prove a sysfs entry without a
+	// matching /dev node is dropped (here: md0 has no node).
+	devNodes := []string{
+		"sda", "sda1", "nvme0n1", "nvme0n1p1", "dm-0",
+		"loop0", "ram0", "zram0", "sr0", "fd0",
+	}
+	for _, name := range devNodes {
+		f, err := os.Create(filepath.Join(devDir, name))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	got := discoverBlockDevicePaths(sysDir, devDir)
+
+	want := []string{
+		filepath.Join(devDir, "dm-0"),
+		filepath.Join(devDir, "nvme0n1"),
+		filepath.Join(devDir, "nvme0n1p1"),
+		filepath.Join(devDir, "sda"),
+		filepath.Join(devDir, "sda1"),
+	}
+	require.Equal(t, want, got)
+}
+
+func TestDiscoverBlockDevicePaths_SysfsBangTranslation(t *testing.T) {
+	t.Parallel()
+
+	sysDir := t.TempDir()
+	devDir := t.TempDir()
+
+	// sysfs encodes '/' as '!': cciss!c0d0 maps to /dev/cciss/c0d0.
+	require.NoError(t, os.Mkdir(filepath.Join(sysDir, "cciss!c0d0"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(devDir, "cciss"), 0o755))
+
+	f, err := os.Create(filepath.Join(devDir, "cciss", "c0d0"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	got := discoverBlockDevicePaths(sysDir, devDir)
+	require.Equal(t, []string{filepath.Join(devDir, "cciss", "c0d0")}, got)
+}
+
+func TestDiscoverBlockDevicePaths_MissingDir(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, discoverBlockDevicePaths("/nonexistent/sys/class/block", "/dev"))
+}
+
+func TestDiscoverInfinibandDevicePaths(t *testing.T) {
+	t.Parallel()
+
+	ibDir := t.TempDir()
+
+	for _, name := range []string{"uverbs0", "umad0", "rdma_cm"} {
+		f, err := os.Create(filepath.Join(ibDir, name))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	// A subdirectory must be skipped.
+	require.NoError(t, os.Mkdir(filepath.Join(ibDir, "subdir"), 0o755))
+
+	got := discoverInfinibandDevicePaths(ibDir)
+
+	want := []string{
+		filepath.Join(ibDir, "rdma_cm"),
+		filepath.Join(ibDir, "umad0"),
+		filepath.Join(ibDir, "uverbs0"),
+	}
+	require.Equal(t, want, got)
+}
+
+func TestDiscoverInfinibandDevicePaths_MissingDir(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, discoverInfinibandDevicePaths("/nonexistent/dev/infiniband"))
+}
+
+func TestHostDevices_Paths_MergesDedupesSorts(t *testing.T) {
+	t.Parallel()
+
+	d := HostDevices{
+		KVM:        []string{"/dev/kvm"},
+		Block:      []string{"/dev/sdb", "/dev/sda", "/dev/kvm"},
+		Infiniband: []string{"/dev/infiniband/uverbs0"},
+	}
+
+	want := []string{
+		"/dev/infiniband/uverbs0",
+		"/dev/kvm",
+		"/dev/sda",
+		"/dev/sdb",
+	}
+	require.Equal(t, want, d.Paths())
+}
+
+func TestHostDevices_Paths_Empty(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, HostDevices{}.Paths())
 }

--- a/pkg/agent/goalstates/resolve.go
+++ b/pkg/agent/goalstates/resolve.go
@@ -87,7 +87,7 @@ func ResolveMachine(log *slog.Logger, cfg *config.AgentConfig, machineName strin
 		Downloads:         downloads,
 		OCIImage:          ociImage,
 		Nvidia:            nvidia,
-		HostDevicePaths:   DiscoverHostDevicePaths(),
+		HostDevices:       DiscoverHostDevices(),
 	}
 
 	nodeStart := &NodeStart{

--- a/pkg/agent/goalstates/rootfs.go
+++ b/pkg/agent/goalstates/rootfs.go
@@ -34,8 +34,9 @@ type RootFS struct {
 	// container. Empty on non-GPU hosts.
 	Nvidia NvidiaHost
 
-	// HostDevicePaths lists host device node paths to be bind-mounted into
-	// the nspawn container (e.g. ["/dev/kvm"]). Device nodes are discovered
-	// at agent startup. Empty on hosts without any supported devices.
-	HostDevicePaths []string
+	// HostDevices holds host device nodes to be bind-mounted into the
+	// nspawn container, grouped by category (KVM, block storage, InfiniBand
+	// HCA). Device nodes are discovered at agent startup. Empty on hosts
+	// without any supported devices.
+	HostDevices HostDevices
 }

--- a/pkg/agent/phases/rootfs/nspawn.go
+++ b/pkg/agent/phases/rootfs/nspawn.go
@@ -85,17 +85,21 @@ func (e *ensureNSpawnWorkspace) writeNSpawnConfigs() error {
 	// "/var/lib/machines/kube1"); nspawn always names the machine after that
 	// directory.
 	machineName := filepath.Base(e.goalState.MachineDir)
+	hostDevicePaths := e.goalState.HostDevices.Paths()
 	templateData := nspawnTemplateData{
 		MachineName:          machineName,
 		BPFFSMountPath:       goalstates.BPFFSMountPath(machineName),
-		HostDevicePaths:      e.goalState.HostDevicePaths,
+		HostDevicePaths:      hostDevicePaths,
 		NvidiaGPUDevicePaths: e.goalState.Nvidia.GPUDevicePaths,
 		NvidiaLibDirMounts:   e.goalState.Nvidia.LibDirMounts,
 	}
 
-	if len(e.goalState.HostDevicePaths) > 0 {
+	if len(hostDevicePaths) > 0 {
 		e.log.Info("host devices detected, configuring nspawn bind-mounts",
-			"count", len(e.goalState.HostDevicePaths))
+			"total", len(hostDevicePaths),
+			"kvm", len(e.goalState.HostDevices.KVM),
+			"block", len(e.goalState.HostDevices.Block),
+			"infiniband", len(e.goalState.HostDevices.Infiniband))
 	}
 
 	if len(e.goalState.Nvidia.GPUDevicePaths) > 0 {

--- a/pkg/agent/phases/rootfs/nspawn_render_test.go
+++ b/pkg/agent/phases/rootfs/nspawn_render_test.go
@@ -61,6 +61,33 @@ func TestServiceOverride_HostDevicesDeviceAllow(t *testing.T) {
 	require.Less(t, strings.Index(out, "[Service]"), strings.Index(out, "DeviceAllow=/dev/kvm rwm"))
 }
 
+func TestServiceOverride_MultipleHostDevices(t *testing.T) {
+	t.Parallel()
+
+	devices := []string{"/dev/kvm", "/dev/sda", "/dev/infiniband/uverbs0"}
+
+	var nspawnBuf bytes.Buffer
+	require.NoError(t, nspawnTemplates.ExecuteTemplate(&nspawnBuf, "nspawn.conf", nspawnTemplateData{
+		BPFFSMountPath:  goalstates.BPFFSMountPath("kube1"),
+		HostDevicePaths: devices,
+	}))
+
+	var overrideBuf bytes.Buffer
+	require.NoError(t, nspawnTemplates.ExecuteTemplate(&overrideBuf, "service-override.conf", nspawnTemplateData{
+		MachineName:     "kube1",
+		BPFFSMountPath:  goalstates.BPFFSMountPath("kube1"),
+		HostDevicePaths: devices,
+	}))
+
+	// Every host device must get both a bind mount in the .nspawn config and a
+	// matching cgroup DeviceAllow in the service drop-in; otherwise the node is
+	// either invisible or blocked inside the container.
+	for _, dev := range devices {
+		require.Contains(t, nspawnBuf.String(), "Bind="+dev)
+		require.Contains(t, overrideBuf.String(), "DeviceAllow="+dev+" rwm")
+	}
+}
+
 func TestServiceOverride_NoHostDevicesNoDeviceAllow(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Mount storage and IB devices into the nspawn environment for unbounded-storage.

This allows unbounded-storage to run inside our isolated environment, but it still has control over local disks and the ability to use the IB devices.