### PR TITLE
storage: support persistent http connections

### DIFF
--- a/api/unbounded-storage/config.pb.go
+++ b/api/unbounded-storage/config.pb.go
@@ -1878,9 +1878,11 @@ func (*FrontendSpec_Loadgen) isFrontendSpec_Config() {}
 type HttpFrontendConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Socket address for HTTP listeners; each serving shard binds it with SO_REUSEPORT.
-	Addr          string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Addr string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	// Maximum requests served on one client connection. Defaults to 1024 when unset.
+	MaxRequestsPerConnection *uint32 `protobuf:"varint,2,opt,name=max_requests_per_connection,json=maxRequestsPerConnection,proto3,oneof" json:"max_requests_per_connection,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *HttpFrontendConfig) Reset() {
@@ -1918,6 +1920,13 @@ func (x *HttpFrontendConfig) GetAddr() string {
 		return x.Addr
 	}
 	return ""
+}
+
+func (x *HttpFrontendConfig) GetMaxRequestsPerConnection() uint32 {
+	if x != nil && x.MaxRequestsPerConnection != nil {
+		return *x.MaxRequestsPerConnection
+	}
+	return 0
 }
 
 type S3FrontendConfig struct {
@@ -2203,9 +2212,11 @@ const file_config_proto_rawDesc = "" +
 	"\x04http\x18\x03 \x01(\v2,.unbounded.storage.config.HttpFrontendConfigH\x00R\x04http\x12<\n" +
 	"\x02s3\x18\x04 \x01(\v2*.unbounded.storage.config.S3FrontendConfigH\x00R\x02s3\x12K\n" +
 	"\aloadgen\x18\x05 \x01(\v2/.unbounded.storage.config.LoadgenFrontendConfigH\x00R\aloadgenB\b\n" +
-	"\x06config\"(\n" +
+	"\x06config\"\x8c\x01\n" +
 	"\x12HttpFrontendConfig\x12\x12\n" +
-	"\x04addr\x18\x01 \x01(\tR\x04addr\"&\n" +
+	"\x04addr\x18\x01 \x01(\tR\x04addr\x12B\n" +
+	"\x1bmax_requests_per_connection\x18\x02 \x01(\rH\x00R\x18maxRequestsPerConnection\x88\x01\x01B\x1e\n" +
+	"\x1c_max_requests_per_connection\"&\n" +
 	"\x10S3FrontendConfig\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\tR\x04addr\"\xe8\x01\n" +
 	"\x15LoadgenFrontendConfig\x12\x1d\n" +
@@ -2339,6 +2350,7 @@ func file_config_proto_init() {
 		(*FrontendSpec_S3)(nil),
 		(*FrontendSpec_Loadgen)(nil),
 	}
+	file_config_proto_msgTypes[25].OneofWrappers = []any{}
 	file_config_proto_msgTypes[27].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/unbounded-storage/config.proto
+++ b/api/unbounded-storage/config.proto
@@ -305,6 +305,9 @@ message FrontendSpec {
 message HttpFrontendConfig {
   // Socket address for HTTP listeners; each serving shard binds it with SO_REUSEPORT.
   string addr = 1;
+
+  // Maximum requests served on one client connection. Defaults to 1024 when unset.
+  optional uint32 max_requests_per_connection = 2;
 }
 
 message S3FrontendConfig {

--- a/cmd/unbounded-storage/src/backend/azure.rs
+++ b/cmd/unbounded-storage/src/backend/azure.rs
@@ -9,12 +9,11 @@
 //! OpenSSL with kernel TLS (kTLS) so the body still lands zero-copy in
 //! the registered backing, with record-aware recv in [`crate::tls`].
 //!
-//! It mirrors the S3 backend's fetch/length structure and shares its
-//! cold-path simplicity (one TCP connection per fetch, one heap copy of
-//! the body into the registered backing). Like the S3 backend it carries
-//! the origin **host** for the `Host:` header and a separate **SNI**
-//! hostname for TLS (the TCP connect still dials the resolved IPv4
-//! [`SockAddr`]) and maps a `404 Not Found` to
+//! It mirrors the S3 backend's fetch/length structure and connection
+//! reuse rules. Like the S3 backend it carries the origin **host** for
+//! the `Host:` header and a separate **SNI** hostname for TLS (the TCP
+//! connect still dials the resolved IPv4 [`SockAddr`]) and maps a `404
+//! Not Found` to
 //! [`Error::OriginNotFound`](crate::bufferpool::Error::OriginNotFound).
 //!
 //! It diverges from the S3 backend in one wire-level way: every GET/HEAD
@@ -24,20 +23,22 @@
 //! authorization or shared-key signature.
 
 use std::future::Future;
-use std::os::fd::RawFd;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use ::http::header::{CONNECTION, HOST, RANGE};
+use ::http::header::{HOST, RANGE};
 
 use crate::bufferpool::{BulkRef, Error, PageRef, PageStream};
-use crate::http::{Method, ResponseHead, StatusCode, serialize_request};
+use crate::http::{Method, StatusCode, response_closes_after_body, serialize_request};
 use crate::ring::{NetHandle, SockAddr};
 use crate::storage::{ObjectMetadata, StripeReq};
 use crate::tls::TlsContext;
 
 use super::Backend;
+use super::conn::{
+    OriginConnPool, body_response_reusable, head_response_reusable, send_request_read_head,
+};
 use super::limiter::FetchLimiter;
 use super::origin_ring::OriginRing;
 
@@ -73,6 +74,7 @@ pub struct AzureBackend {
     page_size: usize,
     backing_base: *mut u8,
     limiter: FetchLimiter,
+    conns: OriginConnPool,
 }
 
 // SAFETY: mirrors `S3Backend`'s justification. `AzureBackend` is
@@ -111,6 +113,7 @@ impl AzureBackend {
             page_size,
             backing_base,
             limiter: FetchLimiter::new(http_concurrency),
+            conns: OriginConnPool::new(http_concurrency),
         }
     }
 
@@ -158,6 +161,7 @@ impl AzureBackend {
         let host = self.host.clone();
         let sni_host = self.sni_host.clone();
         let tls = self.tls.clone();
+        let conns = self.conns.clone();
 
         // A metadata entry is not a byte range of the object; it is a
         // synthetic one-page cache entry whose payload is the object's
@@ -178,6 +182,7 @@ impl AzureBackend {
                     backing_base,
                     page_size,
                     self.limiter.clone(),
+                    conns,
                 ),
             ));
             return AzureFetchStream::pending(fut, dsts_owned);
@@ -191,6 +196,7 @@ impl AzureBackend {
             len,
             fetch(
                 handle,
+                conns,
                 origin_addr,
                 host,
                 sni_host,
@@ -311,6 +317,7 @@ impl PageStream for AzureFetchStream<'_> {
 #[allow(clippy::too_many_arguments)]
 async fn fetch(
     handle: NetHandle,
+    conns: OriginConnPool,
     origin: SockAddr,
     host: String,
     sni_host: String,
@@ -336,40 +343,32 @@ async fn fetch(
         return Err(Error::from("azure backend: zero-length fetch requested"));
     }
 
-    // Bound concurrent origin dials to `http_concurrency`. The permit is
+    // Bound concurrent origin work to `http_concurrency`. The permit is
     // held for the whole fetch and returned to the pool on drop.
     let _permit = limiter.acquire().await;
-    let conn = TcpConn::open()?;
-    // See `HttpBackend::fetch` for why driving the ring on the current
-    // thread is sound (the op futures self-pump on their own thread's
-    // ring).
-    handle.connect(conn.fd, origin).await.map_err(io_to_err)?;
-
-    let is_tls = crate::tls::maybe_handshake(&tls, &handle, conn.fd, &sni_host).await?;
-
     let request = format_get_request(&path, &host, start, start + len - 1)?;
-    handle.send(conn.fd, request).await.map_err(io_to_err)?;
-
-    let mut buf: Vec<u8> = Vec::new();
-    let (status, header_end, content_length, content_range_start) = loop {
-        if let Some(h) = ResponseHead::parse(&buf)
-            .map_err(|_| Error::from("azure backend: malformed origin response head"))?
-        {
-            break (
-                h.status,
-                h.header_end,
-                h.content_length(),
-                h.content_range_start(),
-            );
-        }
-        let chunk = crate::tls::recv_chunk(&handle, conn.fd, is_tls).await?;
-        if chunk.is_empty() {
-            return Err(Error::from(
-                "azure backend: connection closed before response headers complete",
-            ));
-        }
-        buf.extend_from_slice(&chunk);
-    };
+    let (conn, head) = send_request_read_head(
+        &conns,
+        &handle,
+        origin,
+        &tls,
+        &sni_host,
+        request,
+        None,
+        "azure backend: malformed origin response head",
+        "azure backend: connection closed before response headers complete",
+        "azure backend: response head exceeds limit",
+    )
+    .await?;
+    let fd = conn.fd();
+    let is_tls = conn.is_tls();
+    let status = head.status;
+    let version_minor = head.version_minor;
+    let header_end = head.header_end;
+    let content_length = head.content_length;
+    let content_range_start = head.content_range_start;
+    let connection = head.connection;
+    let buf = head.buf;
 
     check_origin_status(status, start)?;
 
@@ -391,7 +390,13 @@ async fn fetch(
     // length, so the padding is never handed to a client. A connection
     // that closes before the advertised length is a genuine truncation.
     let body_start = header_end;
-    let body_len_mode = expected_body_len(status, content_length, len)?;
+    let body_len_mode = expected_body_len(
+        status,
+        version_minor,
+        connection.as_deref(),
+        content_length,
+        len,
+    )?;
 
     // `body_cap` is the most body bytes we will accept into the pages.
     // For a known Content-Length it is that length (already validated by
@@ -439,8 +444,7 @@ async fn fetch(
         // Pool reserves for this fetch across every await here; the
         // backend is shard-pinned so no other thread touches it. The
         // destination stays reserved until this future resolves.
-        let n_recv =
-            crate::tls::recv_fixed(&handle, conn.fd, is_tls, page_byte_off, recv_len).await?;
+        let n_recv = crate::tls::recv_fixed(&handle, fd, is_tls, page_byte_off, recv_len).await?;
         if n_recv == 0 {
             // EOF. With a known length this is a truncation; for the
             // close-delimited case it is the normal end of the body.
@@ -457,6 +461,16 @@ async fn fetch(
     // served reads to the object length, so this padding is never
     // returned to a client.
     zero_fill_pages_from(&dsts, filled, backing_base, page_size)?;
+    if body_response_reusable(
+        version_minor,
+        connection.as_deref(),
+        content_length,
+        body_cap,
+        leading.len(),
+        filled,
+    ) {
+        conns.put(&handle, conn);
+    }
     Ok(())
 }
 
@@ -475,6 +489,7 @@ async fn fetch_metadata(
     backing_base: *mut u8,
     page_size: usize,
     limiter: FetchLimiter,
+    conns: OriginConnPool,
 ) -> Result<(), Error> {
     let capacity: usize = dsts.iter().map(|p| p.len as usize).sum();
     if capacity < 8 {
@@ -483,40 +498,29 @@ async fn fetch_metadata(
         ));
     }
 
-    // Bound concurrent origin dials to `http_concurrency` (see `fetch`).
+    // Bound concurrent origin work to `http_concurrency` (see `fetch`).
     let _permit = limiter.acquire().await;
-    let conn = TcpConn::open()?;
-    // See `AzureBackend::fetch` for why driving the ring on the current
-    // thread is sound (the op futures self-pump on their own thread's
-    // ring).
-    handle.connect(conn.fd, origin).await.map_err(io_to_err)?;
-
-    let is_tls = crate::tls::maybe_handshake(&tls, &handle, conn.fd, &sni_host).await?;
-
     let request = format_head_request(&path, &host)?;
-    handle.send(conn.fd, request).await.map_err(io_to_err)?;
-
     const MAX_HEAD: usize = 64 * 1024;
-    let mut buf: Vec<u8> = Vec::new();
-    let (status, content_length) = loop {
-        if let Some(h) = ResponseHead::parse(&buf)
-            .map_err(|_| Error::from("azure backend: malformed origin response head"))?
-        {
-            break (h.status, h.content_length());
-        }
-        if buf.len() >= MAX_HEAD {
-            return Err(Error::from(
-                "azure backend: metadata HEAD response head exceeds 64 KiB",
-            ));
-        }
-        let chunk = crate::tls::recv_chunk(&handle, conn.fd, is_tls).await?;
-        if chunk.is_empty() {
-            return Err(Error::from(
-                "azure backend: connection closed before metadata HEAD headers complete",
-            ));
-        }
-        buf.extend_from_slice(&chunk);
-    };
+    let (conn, head) = send_request_read_head(
+        &conns,
+        &handle,
+        origin,
+        &tls,
+        &sni_host,
+        request,
+        Some(MAX_HEAD),
+        "azure backend: malformed origin response head",
+        "azure backend: connection closed before metadata HEAD headers complete",
+        "azure backend: metadata HEAD response head exceeds 64 KiB",
+    )
+    .await?;
+    let status = head.status;
+    let version_minor = head.version_minor;
+    let header_end = head.header_end;
+    let content_length = head.content_length;
+    let connection = head.connection;
+    let buf = head.buf;
 
     if status == StatusCode::NOT_FOUND {
         return Err(Error::OriginNotFound);
@@ -531,18 +535,28 @@ async fn fetch_metadata(
 
     let body = ObjectMetadata::new(length).encode()?;
     copy_body_into_pages(&body, &dsts, backing_base, page_size)?;
+    if head_response_reusable(version_minor, connection.as_deref(), header_end, buf.len()) {
+        conns.put(&handle, conn);
+    }
     Ok(())
 }
 
 /// Determine how many body bytes to read for this response, or `None`
-/// when the origin advertised no `Content-Length` and the caller must
-/// read until the `Connection: close` stream ends.
+/// when the origin advertised no `Content-Length` but its connection
+/// semantics still guarantee EOF will delimit the body.
 fn expected_body_len(
     status: StatusCode,
+    version_minor: u8,
+    connection: Option<&str>,
     content_length: Option<u64>,
     len: u64,
 ) -> Result<Option<u64>, Error> {
     let Some(cl) = content_length else {
+        if !response_closes_after_body(version_minor, connection) {
+            return Err(Error::from(
+                "azure backend: origin response missing Content-Length on keep-alive connection",
+            ));
+        }
         return Ok(None);
     };
     let n = if status == StatusCode::PARTIAL_CONTENT {
@@ -751,7 +765,6 @@ fn format_get_request(path: &str, host: &str, start: u64, end: u64) -> Result<Ve
         .header(HOST, host)
         .header(RANGE, format!("bytes={start}-{end}"))
         .header("x-ms-version", AZURE_MS_VERSION)
-        .header(CONNECTION, "close")
         .body(())
         .map_err(|_| Error::from("azure backend: failed to build origin GET request"))?;
     Ok(serialize_request(&req))
@@ -766,7 +779,6 @@ fn format_head_request(path: &str, host: &str) -> Result<Vec<u8>, Error> {
         .uri(path)
         .header(HOST, host)
         .header("x-ms-version", AZURE_MS_VERSION)
-        .header(CONNECTION, "close")
         .body(())
         .map_err(|_| Error::from("azure backend: failed to build origin HEAD request"))?;
     Ok(serialize_request(&req))
@@ -776,34 +788,6 @@ fn io_to_err(e: std::io::Error) -> Error {
     match e.raw_os_error() {
         Some(code) => Error::Io(code),
         None => Error::transport(e),
-    }
-}
-
-/// RAII wrapper around a libc TCP socket fd. The ring never creates
-/// fds; the backend opens the socket with `libc::socket` and closes it
-/// on drop (one connection per fetch in v1).
-struct TcpConn {
-    fd: RawFd,
-}
-
-impl TcpConn {
-    fn open() -> Result<Self, Error> {
-        // SAFETY: socket() with valid AF/type/protocol constants.
-        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
-        if fd < 0 {
-            return Err(io_to_err(std::io::Error::last_os_error()));
-        }
-        Ok(Self { fd })
-    }
-}
-
-impl Drop for TcpConn {
-    fn drop(&mut self) {
-        // SAFETY: fd was returned by socket() and is not used after
-        // this; closing it releases the kernel resource.
-        unsafe {
-            libc::close(self.fd);
-        }
     }
 }
 
@@ -853,7 +837,7 @@ mod tests {
         );
         assert!(s.contains("range: bytes=0-4095\r\n"), "got: {s}");
         assert!(s.contains("x-ms-version: 2021-08-06\r\n"), "got: {s}");
-        assert!(s.contains("connection: close\r\n"), "got: {s}");
+        assert!(!s.contains("connection:"), "got: {s}");
         // v1 is anonymous: no shared-key signature or SAS authorization.
         assert!(!s.contains("authorization"), "got: {s}");
         assert!(s.ends_with("\r\n\r\n"), "got: {s}");
@@ -875,6 +859,20 @@ mod tests {
         assert!(!s.contains("range:"), "got: {s}");
         assert!(!s.contains("authorization"), "got: {s}");
         assert!(s.ends_with("\r\n\r\n"), "got: {s}");
+    }
+
+    #[test]
+    fn expected_body_len_absent_content_length_requires_close() {
+        assert_eq!(
+            expected_body_len(StatusCode::OK, 1, Some("close"), None, 4096).unwrap(),
+            None
+        );
+        assert_eq!(
+            expected_body_len(StatusCode::OK, 0, None, None, 4096).unwrap(),
+            None
+        );
+        assert!(expected_body_len(StatusCode::OK, 1, None, None, 4096).is_err());
+        assert!(expected_body_len(StatusCode::OK, 0, Some("keep-alive"), None, 4096).is_err());
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/backend/conn.rs
+++ b/cmd/unbounded-storage/src/backend/conn.rs
@@ -1,0 +1,340 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Reusable origin TCP connections for HTTP-family backends.
+
+use std::collections::HashMap;
+use std::os::fd::RawFd;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use std::thread::ThreadId;
+
+use crate::bufferpool::Error;
+use crate::http::{ResponseHead, StatusCode, response_keep_alive};
+use crate::ring::{NetHandle, SockAddr};
+use crate::tls::TlsContext;
+
+#[derive(Clone)]
+pub(super) struct OriginConnPool {
+    inner: Arc<Mutex<PoolInner>>,
+}
+
+struct PoolInner {
+    max_idle_per_ring: usize,
+    idle: HashMap<PoolKey, Vec<TcpConn>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct PoolKey {
+    thread: ThreadId,
+    ring: usize,
+}
+
+impl OriginConnPool {
+    pub(super) fn new(max_idle_per_ring: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(PoolInner {
+                max_idle_per_ring: max_idle_per_ring.max(1),
+                idle: HashMap::new(),
+            })),
+        }
+    }
+
+    pub(super) fn checkout(&self, handle: &NetHandle) -> Option<TcpConn> {
+        let key = pool_key(handle);
+        loop {
+            let conn = self
+                .inner
+                .lock()
+                .expect("origin connection pool poisoned")
+                .idle
+                .get_mut(&key)
+                .and_then(Vec::pop)?;
+            if tcp_conn_is_reusable(conn.fd()) {
+                return Some(conn);
+            }
+        }
+    }
+
+    pub(super) fn put(&self, handle: &NetHandle, conn: TcpConn) {
+        let key = pool_key(handle);
+        let mut inner = self.inner.lock().expect("origin connection pool poisoned");
+        let max_idle = inner.max_idle_per_ring;
+        let idle = inner.idle.entry(key).or_default();
+        if idle.len() < max_idle {
+            idle.push(conn);
+        }
+    }
+}
+
+fn pool_key(handle: &NetHandle) -> PoolKey {
+    PoolKey {
+        thread: std::thread::current().id(),
+        ring: handle.ring_key(),
+    }
+}
+
+pub(super) struct TcpConn {
+    fd: RawFd,
+    tls: bool,
+}
+
+pub(super) struct OriginResponseHead {
+    pub(super) status: StatusCode,
+    pub(super) version_minor: u8,
+    pub(super) header_end: usize,
+    pub(super) content_length: Option<u64>,
+    pub(super) content_range_start: Option<u64>,
+    pub(super) connection: Option<String>,
+    pub(super) buf: Vec<u8>,
+}
+
+struct OriginConn {
+    conn: TcpConn,
+    reused: bool,
+}
+
+impl TcpConn {
+    pub(super) fn open() -> Result<Self, Error> {
+        // SAFETY: socket() with valid AF/type/protocol constants.
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
+        if fd < 0 {
+            return Err(io_to_err(std::io::Error::last_os_error()));
+        }
+        Ok(Self { fd, tls: false })
+    }
+
+    pub(super) fn fd(&self) -> RawFd {
+        self.fd
+    }
+
+    pub(super) fn is_tls(&self) -> bool {
+        self.tls
+    }
+}
+
+impl Drop for TcpConn {
+    fn drop(&mut self) {
+        // SAFETY: fd was returned by socket() and is not used after this.
+        unsafe {
+            libc::close(self.fd);
+        }
+    }
+}
+
+async fn checkout_or_connect(
+    pool: &OriginConnPool,
+    handle: &NetHandle,
+    origin: SockAddr,
+    tls: &Option<Rc<TlsContext>>,
+    sni_host: &str,
+) -> Result<OriginConn, Error> {
+    if let Some(conn) = pool.checkout(handle) {
+        return Ok(OriginConn { conn, reused: true });
+    }
+
+    let mut conn = TcpConn::open()?;
+    handle.connect(conn.fd(), origin).await.map_err(io_to_err)?;
+    conn.tls = crate::tls::maybe_handshake(tls, handle, conn.fd(), sni_host).await?;
+    Ok(OriginConn {
+        conn,
+        reused: false,
+    })
+}
+
+pub(super) async fn send_request_read_head(
+    pool: &OriginConnPool,
+    handle: &NetHandle,
+    origin: SockAddr,
+    tls: &Option<Rc<TlsContext>>,
+    sni_host: &str,
+    request: Vec<u8>,
+    max_head: Option<usize>,
+    malformed_msg: &'static str,
+    closed_msg: &'static str,
+    too_large_msg: &'static str,
+) -> Result<(TcpConn, OriginResponseHead), Error> {
+    let mut stale_retry = true;
+
+    'connect: loop {
+        let origin_conn = checkout_or_connect(pool, handle, origin, tls, sni_host).await?;
+        let conn = origin_conn.conn;
+        let reused = origin_conn.reused;
+        let fd = conn.fd();
+        let is_tls = conn.is_tls();
+
+        match handle.send(fd, request.clone()).await {
+            Ok(_) => {}
+            Err(e) if reused && stale_retry => {
+                stale_retry = false;
+                continue;
+            }
+            Err(e) => return Err(io_to_err(e)),
+        }
+
+        let mut buf: Vec<u8> = Vec::new();
+        loop {
+            if let Some(h) = ResponseHead::parse(&buf).map_err(|_| Error::from(malformed_msg))? {
+                let head = OriginResponseHead {
+                    status: h.status,
+                    version_minor: h.version_minor,
+                    header_end: h.header_end,
+                    content_length: h.content_length(),
+                    content_range_start: h.content_range_start(),
+                    connection: h.header("connection").map(ToOwned::to_owned),
+                    buf,
+                };
+                return Ok((conn, head));
+            }
+
+            if max_head.is_some_and(|max| buf.len() >= max) {
+                return Err(Error::from(too_large_msg));
+            }
+
+            match crate::tls::recv_chunk(handle, fd, is_tls).await {
+                Ok(chunk) if chunk.is_empty() && reused && stale_retry && buf.is_empty() => {
+                    stale_retry = false;
+                    continue 'connect;
+                }
+                Ok(chunk) if chunk.is_empty() => return Err(Error::from(closed_msg)),
+                Ok(chunk) => buf.extend_from_slice(&chunk),
+                Err(_) if reused && stale_retry && buf.is_empty() => {
+                    stale_retry = false;
+                    continue 'connect;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+pub(super) fn body_response_reusable(
+    version_minor: u8,
+    connection: Option<&str>,
+    content_length: Option<u64>,
+    body_cap: usize,
+    leading_len: usize,
+    filled: usize,
+) -> bool {
+    if !response_keep_alive(version_minor, connection)
+        || leading_len > body_cap
+        || filled != body_cap
+    {
+        return false;
+    }
+
+    content_length.and_then(|n| usize::try_from(n).ok()) == Some(body_cap)
+}
+
+pub(super) fn head_response_reusable(
+    version_minor: u8,
+    connection: Option<&str>,
+    header_end: usize,
+    received: usize,
+) -> bool {
+    response_keep_alive(version_minor, connection) && header_end == received
+}
+
+fn tcp_conn_is_reusable(fd: RawFd) -> bool {
+    let mut byte = [0u8; 1];
+    loop {
+        // SAFETY: `byte` is valid for one byte and `fd` is owned by the
+        // connection being considered for reuse. MSG_DONTWAIT avoids
+        // blocking the shard thread; MSG_PEEK leaves any byte in place.
+        let n = unsafe {
+            libc::recv(
+                fd,
+                byte.as_mut_ptr().cast(),
+                byte.len(),
+                libc::MSG_PEEK | libc::MSG_DONTWAIT,
+            )
+        };
+        if n == 0 {
+            return false;
+        }
+        if n > 0 {
+            return false;
+        }
+        let err = std::io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(code) if code == libc::EINTR => continue,
+            Some(code) if code == libc::EAGAIN || code == libc::EWOULDBLOCK => return true,
+            _ => return false,
+        }
+    }
+}
+
+fn io_to_err(e: std::io::Error) -> Error {
+    match e.raw_os_error() {
+        Some(code) => Error::Io(code),
+        None => Error::transport(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::response_closes_after_body;
+
+    #[test]
+    fn body_reuse_requires_known_fully_consumed_body() {
+        assert!(body_response_reusable(1, None, Some(4096), 4096, 0, 4096));
+        assert!(body_response_reusable(
+            1,
+            Some("keep-alive"),
+            Some(100),
+            100,
+            10,
+            100
+        ));
+        assert!(!body_response_reusable(
+            1,
+            Some("keep-alive, close"),
+            Some(4096),
+            4096,
+            0,
+            4096
+        ));
+        assert!(!body_response_reusable(1, None, None, 4096, 0, 4096));
+        assert!(!body_response_reusable(1, None, Some(8192), 4096, 0, 4096));
+        assert!(!body_response_reusable(
+            1,
+            None,
+            Some(4096),
+            4096,
+            4097,
+            4096
+        ));
+    }
+
+    #[test]
+    fn head_reuse_rejects_close_and_extra_bytes() {
+        assert!(head_response_reusable(1, None, 42, 42));
+        assert!(head_response_reusable(1, Some("keep-alive"), 42, 42));
+        assert!(!head_response_reusable(1, Some("close"), 42, 42));
+        assert!(!head_response_reusable(1, None, 42, 43));
+    }
+
+    #[test]
+    fn response_reuse_follows_http_version_rules() {
+        assert!(body_response_reusable(1, None, Some(1), 1, 0, 1));
+        assert!(!body_response_reusable(1, Some("close"), Some(1), 1, 0, 1));
+        assert!(!body_response_reusable(0, None, Some(1), 1, 0, 1));
+        assert!(body_response_reusable(
+            0,
+            Some("keep-alive"),
+            Some(1),
+            1,
+            0,
+            1
+        ));
+    }
+
+    #[test]
+    fn close_delimited_bodies_require_close_semantics() {
+        assert!(!response_closes_after_body(1, None));
+        assert!(response_closes_after_body(1, Some("close")));
+        assert!(response_closes_after_body(0, None));
+        assert!(!response_closes_after_body(0, Some("keep-alive")));
+    }
+}

--- a/cmd/unbounded-storage/src/backend/http.rs
+++ b/cmd/unbounded-storage/src/backend/http.rs
@@ -10,11 +10,10 @@
 //! zero-copy in the destination pages (the kernel decrypts in place).
 //! The record-aware recv path lives in [`crate::tls`].
 //!
-//! This is the cold path, so it is deliberately simple: one TCP
-//! connection per fetch (`Connection: close`, no pooling), and one heap
-//! copy of the received body into the registered backing. The hot
-//! serving path is zero-copy elsewhere; here correctness and legibility
-//! win over avoiding the ingest copy.
+//! Origin connections are kept alive when the response has a known,
+//! fully-consumed body and the peer did not ask to close the stream. Idle
+//! sockets stay ring-local so the shard ring and worker-local RPC rings
+//! never share fds.
 //!
 //! ## Address resolution and the `Host` header
 //!
@@ -27,28 +26,28 @@
 //!
 //! ## Future optimizations (not in v1)
 //!
-//! - Connection pooling / keep-alive bounded by `http_concurrency` to
-//!   amortize the TCP+`connect` handshake across fetches.
 //! - Conditional revalidation via ETag. Per the content-addressed
 //!   design the ETag should fold into the stripe key's identity (a new
 //!   ETag yields a new key), rather than being tracked as separate
 //!   per-stripe metadata.
 
 use std::future::Future;
-use std::os::fd::RawFd;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use ::http::header::{CONNECTION, HOST, RANGE};
+use ::http::header::{HOST, RANGE};
 
 use crate::bufferpool::{BulkRef, Error, PageRef, PageStream};
-use crate::http::{Method, ResponseHead, StatusCode, serialize_request};
+use crate::http::{Method, StatusCode, response_closes_after_body, serialize_request};
 use crate::ring::{NetHandle, SockAddr};
 use crate::storage::{ObjectMetadata, StripeReq};
 use crate::tls::TlsContext;
 
 use super::Backend;
+use super::conn::{
+    OriginConnPool, body_response_reusable, head_response_reusable, send_request_read_head,
+};
 use super::limiter::FetchLimiter;
 use super::origin_ring::OriginRing;
 
@@ -79,6 +78,7 @@ pub struct HttpBackend {
     page_size: usize,
     backing_base: *mut u8,
     limiter: FetchLimiter,
+    conns: OriginConnPool,
 }
 
 // SAFETY: mirrors `crate::memory::Backing`. `HttpBackend` is
@@ -116,6 +116,7 @@ impl HttpBackend {
             page_size,
             backing_base,
             limiter: FetchLimiter::new(http_concurrency),
+            conns: OriginConnPool::new(http_concurrency),
         }
     }
 
@@ -191,6 +192,7 @@ impl HttpBackend {
         let origin_addr = self.origin;
         let backing_base = self.backing_base;
         let page_size = self.page_size;
+        let conns = self.conns.clone();
 
         // A metadata entry is not a byte range of the object; it is a
         // synthetic one-page cache entry whose payload is the object's
@@ -218,6 +220,7 @@ impl HttpBackend {
                         backing_base,
                         page_size,
                         self.limiter.clone(),
+                        conns,
                     ),
                 ),
             ));
@@ -241,6 +244,7 @@ impl HttpBackend {
                 len,
                 fetch(
                     handle,
+                    conns,
                     origin_addr,
                     host,
                     sni_host,
@@ -371,6 +375,7 @@ impl PageStream for HttpFetchStream<'_> {
 #[allow(clippy::too_many_arguments)]
 async fn fetch(
     handle: NetHandle,
+    conns: OriginConnPool,
     origin: SockAddr,
     host: String,
     sni_host: String,
@@ -396,53 +401,33 @@ async fn fetch(
         return Err(Error::from("http backend: zero-length fetch requested"));
     }
 
-    // Bound concurrent origin dials to `http_concurrency`. The permit is
+    // Bound concurrent origin work to `http_concurrency`. The permit is
     // held for the whole fetch and returned to the pool on drop.
     let _permit = limiter.acquire().await;
-    let conn = TcpConn::open()?;
-    // The ring's op futures self-pump (each polls its own ring's
-    // `progress()`), so this fetch drives the ring entirely on the
-    // current thread. For the RPC-handler backend that is an
-    // `fabric-rpc-worker` thread with its OWN worker-local ring, so it
-    // never races the shard thread's ring. SAFETY: SockAddr is owned by
-    // the backend for the fetch's lifetime; the ring copies it into its
-    // own slot.
-    handle.connect(conn.fd, origin).await.map_err(io_to_err)?;
-
-    // Drive the TLS handshake (and enable kTLS) before any request bytes
-    // when this is an `https://` backend. `is_tls` then switches the
-    // record-aware recv path on for every read on this socket.
-    let is_tls = crate::tls::maybe_handshake(&tls, &handle, conn.fd, &sni_host).await?;
-
     let request = format_get_request(&path, &host, start, start + len - 1)?;
-    handle.send(conn.fd, request).await.map_err(io_to_err)?;
+    let (conn, head) = send_request_read_head(
+        &conns,
+        &handle,
+        origin,
+        &tls,
+        &sni_host,
+        request,
+        None,
+        "http backend: malformed origin response head",
+        "http backend: connection closed before response headers complete",
+        "http backend: response head exceeds limit",
+    )
+    .await?;
+    let fd = conn.fd();
+    let is_tls = conn.is_tls();
+    let status = head.status;
+    let version_minor = head.version_minor;
+    let header_end = head.header_end;
+    let content_length = head.content_length;
+    let content_range_start = head.content_range_start;
+    let connection = head.connection;
+    let buf = head.buf;
 
-    // Accumulate until the full header block has arrived. The origin
-    // sends headers then body on the same stream.
-    let mut buf: Vec<u8> = Vec::new();
-    let (status, header_end, content_length, content_range_start) = loop {
-        if let Some(h) = ResponseHead::parse(&buf)
-            .map_err(|_| Error::from("http backend: malformed origin response head"))?
-        {
-            break (
-                h.status,
-                h.header_end,
-                h.content_length(),
-                h.content_range_start(),
-            );
-        }
-        let chunk = crate::tls::recv_chunk(&handle, conn.fd, is_tls).await?;
-        if chunk.is_empty() {
-            return Err(Error::from(
-                "http backend: connection closed before response headers complete",
-            ));
-        }
-        buf.extend_from_slice(&chunk);
-    };
-
-    if status != StatusCode::OK && status != StatusCode::PARTIAL_CONTENT {
-        return Err(Error::from("http backend: origin returned non-2xx status"));
-    }
     check_origin_status(status, start)?;
 
     // An origin that answers a different slice than we asked for would
@@ -463,7 +448,13 @@ async fn fetch(
     // length, so the padding is never handed to a client. A connection
     // that closes before the advertised length is a genuine truncation.
     let body_start = header_end;
-    let body_len_mode = expected_body_len(status, content_length, len)?;
+    let body_len_mode = expected_body_len(
+        status,
+        version_minor,
+        connection.as_deref(),
+        content_length,
+        len,
+    )?;
 
     // `body_cap` is the most body bytes we will accept into the pages.
     // For a known Content-Length it is that length (already validated by
@@ -511,8 +502,7 @@ async fn fetch(
         // Pool reserves for this fetch across every await here; the
         // backend is shard-pinned so no other thread touches it. The
         // destination stays reserved until this future resolves.
-        let n_recv =
-            crate::tls::recv_fixed(&handle, conn.fd, is_tls, page_byte_off, recv_len).await?;
+        let n_recv = crate::tls::recv_fixed(&handle, fd, is_tls, page_byte_off, recv_len).await?;
         if n_recv == 0 {
             // EOF. With a known length this is a truncation; for the
             // close-delimited case it is the normal end of the body.
@@ -529,6 +519,16 @@ async fn fetch(
     // served reads to the object length, so this padding is never
     // returned to a client.
     zero_fill_pages_from(&dsts, filled, backing_base, page_size)?;
+    if body_response_reusable(
+        version_minor,
+        connection.as_deref(),
+        content_length,
+        body_cap,
+        leading.len(),
+        filled,
+    ) {
+        conns.put(&handle, conn);
+    }
     Ok(())
 }
 
@@ -552,6 +552,7 @@ async fn fetch_metadata(
     backing_base: *mut u8,
     page_size: usize,
     limiter: FetchLimiter,
+    conns: OriginConnPool,
 ) -> Result<(), Error> {
     let capacity: usize = dsts.iter().map(|p| p.len as usize).sum();
     if capacity < 8 {
@@ -560,44 +561,33 @@ async fn fetch_metadata(
         ));
     }
 
-    // Bound concurrent origin dials to `http_concurrency` (see `fetch`).
+    // Bound concurrent origin work to `http_concurrency` (see `fetch`).
     let _permit = limiter.acquire().await;
-    let conn = TcpConn::open()?;
-    // See `fetch` for why driving the ring on the current thread is
-    // sound (the op futures self-pump on their own thread's ring).
-    handle.connect(conn.fd, origin).await.map_err(io_to_err)?;
-
-    // See `fetch`: handshake (and kTLS enable) before the request, then
-    // `is_tls` switches the record-aware recv path on.
-    let is_tls = crate::tls::maybe_handshake(&tls, &handle, conn.fd, &sni_host).await?;
-
     let request = format_head_request(&path, &host)?;
-    handle.send(conn.fd, request).await.map_err(io_to_err)?;
-
-    // Accumulate until the full header block has arrived, capping the
-    // header buffer so a pathological origin cannot grow it unbounded.
     const MAX_HEAD: usize = 64 * 1024;
-    let mut buf: Vec<u8> = Vec::new();
-    let (status, content_length) = loop {
-        if let Some(h) = ResponseHead::parse(&buf)
-            .map_err(|_| Error::from("http backend: malformed origin response head"))?
-        {
-            break (h.status, h.content_length());
-        }
-        if buf.len() >= MAX_HEAD {
-            return Err(Error::from(
-                "http backend: metadata HEAD response head exceeds 64 KiB",
-            ));
-        }
-        let chunk = crate::tls::recv_chunk(&handle, conn.fd, is_tls).await?;
-        if chunk.is_empty() {
-            return Err(Error::from(
-                "http backend: connection closed before metadata HEAD headers complete",
-            ));
-        }
-        buf.extend_from_slice(&chunk);
-    };
+    let (conn, head) = send_request_read_head(
+        &conns,
+        &handle,
+        origin,
+        &tls,
+        &sni_host,
+        request,
+        Some(MAX_HEAD),
+        "http backend: malformed origin response head",
+        "http backend: connection closed before metadata HEAD headers complete",
+        "http backend: metadata HEAD response head exceeds 64 KiB",
+    )
+    .await?;
+    let status = head.status;
+    let version_minor = head.version_minor;
+    let header_end = head.header_end;
+    let content_length = head.content_length;
+    let connection = head.connection;
+    let buf = head.buf;
 
+    if status == StatusCode::NOT_FOUND {
+        return Err(Error::OriginNotFound);
+    }
     if status != StatusCode::OK {
         return Err(Error::from(
             "http backend: metadata HEAD returned non-200 status",
@@ -608,12 +598,15 @@ async fn fetch_metadata(
 
     let body = ObjectMetadata::new(length).encode()?;
     copy_body_into_pages(&body, &dsts, backing_base, page_size)?;
+    if head_response_reusable(version_minor, connection.as_deref(), header_end, buf.len()) {
+        conns.put(&handle, conn);
+    }
     Ok(())
 }
 
 /// Determine how many body bytes to read for this response, or `None`
-/// when the origin advertised no `Content-Length` and the caller must
-/// read until the `Connection: close` stream ends.
+/// when the origin advertised no `Content-Length` but its connection
+/// semantics still guarantee EOF will delimit the body.
 ///
 /// A `206` returns at most the bytes we asked for, so a `Content-Length`
 /// exceeding `len` is a protocol violation. A `200` (accepted only at
@@ -621,10 +614,17 @@ async fn fetch_metadata(
 /// page; we only want the first `len` bytes of it.
 fn expected_body_len(
     status: StatusCode,
+    version_minor: u8,
+    connection: Option<&str>,
     content_length: Option<u64>,
     len: u64,
 ) -> Result<Option<u64>, Error> {
     let Some(cl) = content_length else {
+        if !response_closes_after_body(version_minor, connection) {
+            return Err(Error::from(
+                "http backend: origin response missing Content-Length on keep-alive connection",
+            ));
+        }
         return Ok(None);
     };
     let n = if status == StatusCode::PARTIAL_CONTENT {
@@ -642,12 +642,20 @@ fn expected_body_len(
 
 /// Validate the origin's response status against the requested offset.
 ///
-/// `206` (Partial Content) is always fine. A `200` means the origin
-/// ignored our `Range` and is streaming the whole object from byte 0;
-/// that is only usable when we asked from offset 0, otherwise the body
+/// `404` maps to [`Error::OriginNotFound`] so frontends can return a
+/// not-found response instead of treating it as an opaque transport
+/// failure. `206` (Partial Content) is always fine. A `200` means the
+/// origin ignored our `Range` and is streaming the whole object from byte
+/// 0; that is only usable when we asked from offset 0, otherwise the body
 /// would not begin at `start` and copying it would silently corrupt the
-/// stripe. Non-2xx is rejected by the caller before this is reached.
+/// stripe. Other statuses are rejected as origin protocol failures.
 fn check_origin_status(status: StatusCode, start: u64) -> Result<(), Error> {
+    if status == StatusCode::NOT_FOUND {
+        return Err(Error::OriginNotFound);
+    }
+    if status != StatusCode::OK && status != StatusCode::PARTIAL_CONTENT {
+        return Err(Error::from("http backend: origin returned non-2xx status"));
+    }
     if status == StatusCode::OK && start != 0 {
         return Err(Error::from(
             "http backend: origin ignored Range (200) for a non-zero offset",
@@ -826,15 +834,13 @@ fn absolute_range(stripe_idx: u64, stripe_size: u64, src_offset: u64, src_len: u
 }
 
 /// Format a ranged HTTP/1.1 GET request. `start`/`end` are inclusive
-/// byte offsets for the `Range` header. `Connection: close` keeps v1
-/// simple (one connection per fetch).
+/// byte offsets for the `Range` header.
 fn format_get_request(path: &str, host: &str, start: u64, end: u64) -> Result<Vec<u8>, Error> {
     let req = ::http::Request::builder()
         .method(Method::GET)
         .uri(path)
         .header(HOST, host)
         .header(RANGE, format!("bytes={start}-{end}"))
-        .header(CONNECTION, "close")
         .body(())
         .map_err(|_| Error::from("http backend: failed to build origin GET request"))?;
     Ok(serialize_request(&req))
@@ -849,7 +855,6 @@ fn format_head_request(path: &str, host: &str) -> Result<Vec<u8>, Error> {
         .method(Method::HEAD)
         .uri(path)
         .header(HOST, host)
-        .header(CONNECTION, "close")
         .body(())
         .map_err(|_| Error::from("http backend: failed to build origin HEAD request"))?;
     Ok(serialize_request(&req))
@@ -859,34 +864,6 @@ fn io_to_err(e: std::io::Error) -> Error {
     match e.raw_os_error() {
         Some(code) => Error::Io(code),
         None => Error::transport(e),
-    }
-}
-
-/// RAII wrapper around a libc TCP socket fd. The ring never creates
-/// fds; the backend opens the socket with `libc::socket` and closes it
-/// on drop (one connection per fetch in v1).
-struct TcpConn {
-    fd: RawFd,
-}
-
-impl TcpConn {
-    fn open() -> Result<Self, Error> {
-        // SAFETY: socket() with valid AF/type/protocol constants.
-        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
-        if fd < 0 {
-            return Err(io_to_err(std::io::Error::last_os_error()));
-        }
-        Ok(Self { fd })
-    }
-}
-
-impl Drop for TcpConn {
-    fn drop(&mut self) {
-        // SAFETY: fd was returned by socket() and is not used after
-        // this; closing it releases the kernel resource.
-        unsafe {
-            libc::close(self.fd);
-        }
     }
 }
 
@@ -919,7 +896,7 @@ mod tests {
         );
         assert!(s.contains("host: 10.0.0.1:8080\r\n"), "got: {s}");
         assert!(s.contains("range: bytes=0-4095\r\n"), "got: {s}");
-        assert!(s.contains("connection: close\r\n"), "got: {s}");
+        assert!(!s.contains("connection:"), "got: {s}");
         assert!(s.ends_with("\r\n\r\n"), "got: {s}");
     }
 
@@ -933,6 +910,18 @@ mod tests {
 
     #[test]
     fn check_origin_status_rules() {
+        assert!(matches!(
+            check_origin_status(StatusCode::NOT_FOUND, 0),
+            Err(Error::OriginNotFound)
+        ));
+        assert!(matches!(
+            check_origin_status(StatusCode::NOT_FOUND, 4096),
+            Err(Error::OriginNotFound)
+        ));
+        assert!(matches!(
+            check_origin_status(StatusCode::INTERNAL_SERVER_ERROR, 0),
+            Err(Error::Transport(_))
+        ));
         // 206 is always acceptable, at any offset.
         assert!(check_origin_status(StatusCode::PARTIAL_CONTENT, 0).is_ok());
         assert!(check_origin_status(StatusCode::PARTIAL_CONTENT, 4096).is_ok());
@@ -948,7 +937,7 @@ mod tests {
     fn expected_body_len_206_uses_content_length() {
         // Short tail: origin had fewer bytes than the page we asked for.
         assert_eq!(
-            expected_body_len(StatusCode::PARTIAL_CONTENT, Some(1000), 4096).unwrap(),
+            expected_body_len(StatusCode::PARTIAL_CONTENT, 1, None, Some(1000), 4096).unwrap(),
             Some(1000)
         );
     }
@@ -956,14 +945,14 @@ mod tests {
     #[test]
     fn expected_body_len_206_rejects_overlong_content_length() {
         // A 206 must not return more than we asked for.
-        assert!(expected_body_len(StatusCode::PARTIAL_CONTENT, Some(5000), 4096).is_err());
+        assert!(expected_body_len(StatusCode::PARTIAL_CONTENT, 1, None, Some(5000), 4096).is_err());
     }
 
     #[test]
     fn expected_body_len_200_caps_at_requested_len() {
         // Whole-object 200 stream: we only want the first page.
         assert_eq!(
-            expected_body_len(StatusCode::OK, Some(1_000_000), 4096).unwrap(),
+            expected_body_len(StatusCode::OK, 1, None, Some(1_000_000), 4096).unwrap(),
             Some(4096)
         );
     }
@@ -972,14 +961,27 @@ mod tests {
     fn expected_body_len_200_short_object() {
         // Object shorter than a page: read the 500 bytes, zero-fill rest.
         assert_eq!(
-            expected_body_len(StatusCode::OK, Some(500), 4096).unwrap(),
+            expected_body_len(StatusCode::OK, 1, None, Some(500), 4096).unwrap(),
             Some(500)
         );
     }
 
     #[test]
     fn expected_body_len_absent_content_length_reads_to_close() {
-        assert_eq!(expected_body_len(StatusCode::OK, None, 4096).unwrap(), None);
+        assert_eq!(
+            expected_body_len(StatusCode::OK, 1, Some("close"), None, 4096).unwrap(),
+            None
+        );
+        assert_eq!(
+            expected_body_len(StatusCode::OK, 0, None, None, 4096).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn expected_body_len_absent_content_length_rejects_keep_alive() {
+        assert!(expected_body_len(StatusCode::OK, 1, None, None, 4096).is_err());
+        assert!(expected_body_len(StatusCode::OK, 0, Some("keep-alive"), None, 4096).is_err());
     }
 
     #[test]
@@ -1084,7 +1086,7 @@ mod tests {
         let s = std::str::from_utf8(&req).unwrap();
         assert!(s.starts_with("HEAD /o HTTP/1.1\r\n"), "got: {s}");
         assert!(s.contains("host: h:1\r\n"), "got: {s}");
-        assert!(s.contains("connection: close\r\n"), "got: {s}");
+        assert!(!s.contains("connection:"), "got: {s}");
         assert!(s.ends_with("\r\n\r\n"), "got: {s}");
         assert!(!s.contains("range:"), "got: {s}");
     }

--- a/cmd/unbounded-storage/src/backend/mod.rs
+++ b/cmd/unbounded-storage/src/backend/mod.rs
@@ -8,6 +8,9 @@ mod null;
 pub mod url;
 
 #[cfg(target_os = "linux")]
+mod conn;
+
+#[cfg(target_os = "linux")]
 mod http;
 
 #[cfg(target_os = "linux")]

--- a/cmd/unbounded-storage/src/backend/s3.rs
+++ b/cmd/unbounded-storage/src/backend/s3.rs
@@ -13,9 +13,8 @@
 //! lives in [`crate::tls`]. The `Host:` header and SNI/cert hostname are
 //! carried as owned strings parsed from the configured endpoint URL.
 //!
-//! It mirrors the HTTP backend's fetch/length structure and shares its
-//! cold-path simplicity (one TCP connection per fetch, one heap copy of
-//! the body into the registered backing). It diverges in two ways:
+//! It mirrors the HTTP backend's fetch/length structure and connection
+//! reuse rules. It diverges in two ways:
 //!
 //! - It carries the origin **hostname** (not just a resolved IPv4) so the
 //!   `Host:` header uses the real virtual-host name the bucket policy
@@ -27,20 +26,22 @@
 //!   missing object from a transport failure.
 
 use std::future::Future;
-use std::os::fd::RawFd;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use ::http::header::{CONNECTION, HOST, RANGE};
+use ::http::header::{HOST, RANGE};
 
 use crate::bufferpool::{BulkRef, Error, PageRef, PageStream};
-use crate::http::{Method, ResponseHead, StatusCode, serialize_request};
+use crate::http::{Method, StatusCode, response_closes_after_body, serialize_request};
 use crate::ring::{NetHandle, SockAddr};
 use crate::storage::{ObjectMetadata, StripeReq};
 use crate::tls::TlsContext;
 
 use super::Backend;
+use super::conn::{
+    OriginConnPool, body_response_reusable, head_response_reusable, send_request_read_head,
+};
 use super::limiter::FetchLimiter;
 use super::origin_ring::OriginRing;
 
@@ -73,6 +74,7 @@ pub struct S3Backend {
     page_size: usize,
     backing_base: *mut u8,
     limiter: FetchLimiter,
+    conns: OriginConnPool,
 }
 
 // SAFETY: mirrors `HttpBackend`'s justification. `S3Backend` is
@@ -111,6 +113,7 @@ impl S3Backend {
             page_size,
             backing_base,
             limiter: FetchLimiter::new(http_concurrency),
+            conns: OriginConnPool::new(http_concurrency),
         }
     }
 
@@ -158,6 +161,7 @@ impl S3Backend {
         let host = self.host.clone();
         let sni_host = self.sni_host.clone();
         let tls = self.tls.clone();
+        let conns = self.conns.clone();
 
         // A metadata entry is not a byte range of the object; it is a
         // synthetic one-page cache entry whose payload is the object's
@@ -185,6 +189,7 @@ impl S3Backend {
                         backing_base,
                         page_size,
                         self.limiter.clone(),
+                        conns,
                     ),
                 ),
             ));
@@ -208,6 +213,7 @@ impl S3Backend {
                 len,
                 fetch(
                     handle,
+                    conns,
                     origin_addr,
                     host,
                     sni_host,
@@ -329,6 +335,7 @@ impl PageStream for S3FetchStream<'_> {
 #[allow(clippy::too_many_arguments)]
 async fn fetch(
     handle: NetHandle,
+    conns: OriginConnPool,
     origin: SockAddr,
     host: String,
     sni_host: String,
@@ -354,40 +361,32 @@ async fn fetch(
         return Err(Error::from("s3 backend: zero-length fetch requested"));
     }
 
-    // Bound concurrent origin dials to `http_concurrency`. The permit is
+    // Bound concurrent origin work to `http_concurrency`. The permit is
     // held for the whole fetch and returned to the pool on drop.
     let _permit = limiter.acquire().await;
-    let conn = TcpConn::open()?;
-    // See `HttpBackend::fetch` for why driving the ring on the current
-    // thread is sound (the op futures self-pump on their own thread's
-    // ring).
-    handle.connect(conn.fd, origin).await.map_err(io_to_err)?;
-
-    let is_tls = crate::tls::maybe_handshake(&tls, &handle, conn.fd, &sni_host).await?;
-
     let request = format_get_request(&path, &host, start, start + len - 1)?;
-    handle.send(conn.fd, request).await.map_err(io_to_err)?;
-
-    let mut buf: Vec<u8> = Vec::new();
-    let (status, header_end, content_length, content_range_start) = loop {
-        if let Some(h) = ResponseHead::parse(&buf)
-            .map_err(|_| Error::from("s3 backend: malformed origin response head"))?
-        {
-            break (
-                h.status,
-                h.header_end,
-                h.content_length(),
-                h.content_range_start(),
-            );
-        }
-        let chunk = crate::tls::recv_chunk(&handle, conn.fd, is_tls).await?;
-        if chunk.is_empty() {
-            return Err(Error::from(
-                "s3 backend: connection closed before response headers complete",
-            ));
-        }
-        buf.extend_from_slice(&chunk);
-    };
+    let (conn, head) = send_request_read_head(
+        &conns,
+        &handle,
+        origin,
+        &tls,
+        &sni_host,
+        request,
+        None,
+        "s3 backend: malformed origin response head",
+        "s3 backend: connection closed before response headers complete",
+        "s3 backend: response head exceeds limit",
+    )
+    .await?;
+    let fd = conn.fd();
+    let is_tls = conn.is_tls();
+    let status = head.status;
+    let version_minor = head.version_minor;
+    let header_end = head.header_end;
+    let content_length = head.content_length;
+    let content_range_start = head.content_range_start;
+    let connection = head.connection;
+    let buf = head.buf;
 
     check_origin_status(status, start)?;
 
@@ -409,7 +408,13 @@ async fn fetch(
     // length, so the padding is never handed to a client. A connection
     // that closes before the advertised length is a genuine truncation.
     let body_start = header_end;
-    let body_len_mode = expected_body_len(status, content_length, len)?;
+    let body_len_mode = expected_body_len(
+        status,
+        version_minor,
+        connection.as_deref(),
+        content_length,
+        len,
+    )?;
 
     // `body_cap` is the most body bytes we will accept into the pages.
     // For a known Content-Length it is that length (already validated by
@@ -457,8 +462,7 @@ async fn fetch(
         // Pool reserves for this fetch across every await here; the
         // backend is shard-pinned so no other thread touches it. The
         // destination stays reserved until this future resolves.
-        let n_recv =
-            crate::tls::recv_fixed(&handle, conn.fd, is_tls, page_byte_off, recv_len).await?;
+        let n_recv = crate::tls::recv_fixed(&handle, fd, is_tls, page_byte_off, recv_len).await?;
         if n_recv == 0 {
             // EOF. With a known length this is a truncation; for the
             // close-delimited case it is the normal end of the body.
@@ -475,6 +479,16 @@ async fn fetch(
     // served reads to the object length, so this padding is never
     // returned to a client.
     zero_fill_pages_from(&dsts, filled, backing_base, page_size)?;
+    if body_response_reusable(
+        version_minor,
+        connection.as_deref(),
+        content_length,
+        body_cap,
+        leading.len(),
+        filled,
+    ) {
+        conns.put(&handle, conn);
+    }
     Ok(())
 }
 
@@ -493,6 +507,7 @@ async fn fetch_metadata(
     backing_base: *mut u8,
     page_size: usize,
     limiter: FetchLimiter,
+    conns: OriginConnPool,
 ) -> Result<(), Error> {
     let capacity: usize = dsts.iter().map(|p| p.len as usize).sum();
     if capacity < 8 {
@@ -501,40 +516,29 @@ async fn fetch_metadata(
         ));
     }
 
-    // Bound concurrent origin dials to `http_concurrency` (see `fetch`).
+    // Bound concurrent origin work to `http_concurrency` (see `fetch`).
     let _permit = limiter.acquire().await;
-    let conn = TcpConn::open()?;
-    // See `S3Backend::fetch` for why driving the ring on the current
-    // thread is sound (the op futures self-pump on their own thread's
-    // ring).
-    handle.connect(conn.fd, origin).await.map_err(io_to_err)?;
-
-    let is_tls = crate::tls::maybe_handshake(&tls, &handle, conn.fd, &sni_host).await?;
-
     let request = format_head_request(&path, &host)?;
-    handle.send(conn.fd, request).await.map_err(io_to_err)?;
-
     const MAX_HEAD: usize = 64 * 1024;
-    let mut buf: Vec<u8> = Vec::new();
-    let (status, content_length) = loop {
-        if let Some(h) = ResponseHead::parse(&buf)
-            .map_err(|_| Error::from("s3 backend: malformed origin response head"))?
-        {
-            break (h.status, h.content_length());
-        }
-        if buf.len() >= MAX_HEAD {
-            return Err(Error::from(
-                "s3 backend: metadata HEAD response head exceeds 64 KiB",
-            ));
-        }
-        let chunk = crate::tls::recv_chunk(&handle, conn.fd, is_tls).await?;
-        if chunk.is_empty() {
-            return Err(Error::from(
-                "s3 backend: connection closed before metadata HEAD headers complete",
-            ));
-        }
-        buf.extend_from_slice(&chunk);
-    };
+    let (conn, head) = send_request_read_head(
+        &conns,
+        &handle,
+        origin,
+        &tls,
+        &sni_host,
+        request,
+        Some(MAX_HEAD),
+        "s3 backend: malformed origin response head",
+        "s3 backend: connection closed before metadata HEAD headers complete",
+        "s3 backend: metadata HEAD response head exceeds 64 KiB",
+    )
+    .await?;
+    let status = head.status;
+    let version_minor = head.version_minor;
+    let header_end = head.header_end;
+    let content_length = head.content_length;
+    let connection = head.connection;
+    let buf = head.buf;
 
     if status == StatusCode::NOT_FOUND {
         return Err(Error::OriginNotFound);
@@ -549,18 +553,28 @@ async fn fetch_metadata(
 
     let body = ObjectMetadata::new(length).encode()?;
     copy_body_into_pages(&body, &dsts, backing_base, page_size)?;
+    if head_response_reusable(version_minor, connection.as_deref(), header_end, buf.len()) {
+        conns.put(&handle, conn);
+    }
     Ok(())
 }
 
 /// Determine how many body bytes to read for this response, or `None`
-/// when the origin advertised no `Content-Length` and the caller must
-/// read until the `Connection: close` stream ends.
+/// when the origin advertised no `Content-Length` but its connection
+/// semantics still guarantee EOF will delimit the body.
 fn expected_body_len(
     status: StatusCode,
+    version_minor: u8,
+    connection: Option<&str>,
     content_length: Option<u64>,
     len: u64,
 ) -> Result<Option<u64>, Error> {
     let Some(cl) = content_length else {
+        if !response_closes_after_body(version_minor, connection) {
+            return Err(Error::from(
+                "s3 backend: origin response missing Content-Length on keep-alive connection",
+            ));
+        }
         return Ok(None);
     };
     let n = if status == StatusCode::PARTIAL_CONTENT {
@@ -767,7 +781,6 @@ fn format_get_request(path: &str, host: &str, start: u64, end: u64) -> Result<Ve
         .uri(path)
         .header(HOST, host)
         .header(RANGE, format!("bytes={start}-{end}"))
-        .header(CONNECTION, "close")
         .body(())
         .map_err(|_| Error::from("s3 backend: failed to build origin GET request"))?;
     Ok(serialize_request(&req))
@@ -780,7 +793,6 @@ fn format_head_request(path: &str, host: &str) -> Result<Vec<u8>, Error> {
         .method(Method::HEAD)
         .uri(path)
         .header(HOST, host)
-        .header(CONNECTION, "close")
         .body(())
         .map_err(|_| Error::from("s3 backend: failed to build origin HEAD request"))?;
     Ok(serialize_request(&req))
@@ -790,34 +802,6 @@ fn io_to_err(e: std::io::Error) -> Error {
     match e.raw_os_error() {
         Some(code) => Error::Io(code),
         None => Error::transport(e),
-    }
-}
-
-/// RAII wrapper around a libc TCP socket fd. The ring never creates
-/// fds; the backend opens the socket with `libc::socket` and closes it
-/// on drop (one connection per fetch in v1).
-struct TcpConn {
-    fd: RawFd,
-}
-
-impl TcpConn {
-    fn open() -> Result<Self, Error> {
-        // SAFETY: socket() with valid AF/type/protocol constants.
-        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
-        if fd < 0 {
-            return Err(io_to_err(std::io::Error::last_os_error()));
-        }
-        Ok(Self { fd })
-    }
-}
-
-impl Drop for TcpConn {
-    fn drop(&mut self) {
-        // SAFETY: fd was returned by socket() and is not used after
-        // this; closing it releases the kernel resource.
-        unsafe {
-            libc::close(self.fd);
-        }
     }
 }
 
@@ -862,7 +846,7 @@ mod tests {
         assert!(s.starts_with("GET /bucket/key HTTP/1.1\r\n"), "got: {s}");
         assert!(s.contains("host: s3.example.com\r\n"), "got: {s}");
         assert!(s.contains("range: bytes=0-4095\r\n"), "got: {s}");
-        assert!(s.contains("connection: close\r\n"), "got: {s}");
+        assert!(!s.contains("connection:"), "got: {s}");
         assert!(!s.contains("x-amz-date"), "got: {s}");
         assert!(!s.contains("authorization"), "got: {s}");
         assert!(s.ends_with("\r\n\r\n"), "got: {s}");
@@ -877,6 +861,20 @@ mod tests {
         assert!(!s.contains("range:"), "got: {s}");
         assert!(!s.contains("x-amz-date"), "got: {s}");
         assert!(s.ends_with("\r\n\r\n"), "got: {s}");
+    }
+
+    #[test]
+    fn expected_body_len_absent_content_length_requires_close() {
+        assert_eq!(
+            expected_body_len(StatusCode::OK, 1, Some("close"), None, 4096).unwrap(),
+            None
+        );
+        assert_eq!(
+            expected_body_len(StatusCode::OK, 0, None, None, 4096).unwrap(),
+            None
+        );
+        assert!(expected_body_len(StatusCode::OK, 1, None, None, 4096).is_err());
+        assert!(expected_body_len(StatusCode::OK, 0, Some("keep-alive"), None, 4096).is_err());
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/config/diff.rs
+++ b/cmd/unbounded-storage/src/config/diff.rs
@@ -209,6 +209,7 @@ mod tests {
             source: "b".to_string(),
             config: Some(frontend_spec::Config::Http(HttpFrontendConfig {
                 addr: "0.0.0.0:9000".to_string(),
+                max_requests_per_connection: None,
             })),
         });
         let d = ConfigDiff::between(&a, &b);

--- a/cmd/unbounded-storage/src/config/graph.rs
+++ b/cmd/unbounded-storage/src/config/graph.rs
@@ -373,6 +373,7 @@ mod tests {
             source: source.to_string(),
             config: Some(frontend_spec::Config::Http(HttpFrontendConfig {
                 addr: format!("127.0.0.1:{}", 9000 + id.len()),
+                max_requests_per_connection: None,
             })),
         }
     }

--- a/cmd/unbounded-storage/src/config/load.rs
+++ b/cmd/unbounded-storage/src/config/load.rs
@@ -92,6 +92,7 @@ pub enum ConfigError {
         frontend_name: String,
         addr: String,
     },
+    ZeroFrontendMaxRequestsPerConnection(String),
     MissingPeerConfig(u64),
     MissingDiskConfig,
     InvalidMetricsAddr {
@@ -221,6 +222,10 @@ impl fmt::Display for ConfigError {
                     "frontend {frontend_name:?}: duplicate addr address {addr:?}"
                 )
             }
+            ConfigError::ZeroFrontendMaxRequestsPerConnection(frontend_name) => write!(
+                f,
+                "frontend {frontend_name:?}: max_requests_per_connection must be greater than zero"
+            ),
             ConfigError::MissingPeerConfig(peer_id) => {
                 write!(f, "peer {peer_id}: config must set one peer transport")
             }
@@ -377,6 +382,11 @@ fn validate(cfg: &Config) -> Result<(), ConfigError> {
         match fr.config.as_ref() {
             Some(frontend_spec::Config::Http(cfg)) => {
                 validate_frontend_addr(&fr.name, &cfg.addr, &mut seen_addrs)?;
+                if cfg.max_requests_per_connection == Some(0) {
+                    return Err(ConfigError::ZeroFrontendMaxRequestsPerConnection(
+                        fr.name.clone(),
+                    ));
+                }
             }
             Some(frontend_spec::Config::S3(cfg)) => {
                 validate_frontend_addr(&fr.name, &cfg.addr, &mut seen_addrs)?;
@@ -1292,6 +1302,31 @@ addr = "not-an-addr"
             Err(ConfigError::InvalidFrontendAddr { frontend_name, .. }) if frontend_name == "f" => {
             }
             other => panic!("expected InvalidFrontendAddr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_zero_frontend_request_cap() {
+        let s = r#"
+[[backends]]
+name = "b"
+
+[backends.config.http]
+url = "https://e"
+
+[[frontends]]
+name = "f"
+source = "b"
+
+[frontends.config.http]
+addr = "127.0.0.1:9000"
+max_requests_per_connection = 0
+"#;
+        let f = write_cfg(s);
+        match load(f.path()) {
+            Err(ConfigError::ZeroFrontendMaxRequestsPerConnection(frontend_name))
+                if frontend_name == "f" => {}
+            other => panic!("expected ZeroFrontendMaxRequestsPerConnection, got {other:?}"),
         }
     }
 

--- a/cmd/unbounded-storage/src/config/reconcile.rs
+++ b/cmd/unbounded-storage/src/config/reconcile.rs
@@ -1049,6 +1049,7 @@ mod tests {
             source: backend_id.to_string(),
             config: Some(frontend_spec::Config::Http(HttpFrontendConfig {
                 addr: "0.0.0.0:9000".to_string(),
+                max_requests_per_connection: None,
             })),
         }
     }

--- a/cmd/unbounded-storage/src/config/schema.rs
+++ b/cmd/unbounded-storage/src/config/schema.rs
@@ -23,6 +23,7 @@ include!(concat!(env!("OUT_DIR"), "/unbounded.storage.config.rs"));
 
 const DEFAULT_STRIPE_SIZE_BYTES: u64 = 4 * 1024 * 1024;
 const DEFAULT_HTTP_CONCURRENCY: u32 = 64;
+pub const DEFAULT_HTTP_FRONTEND_MAX_REQUESTS_PER_CONNECTION: u32 = 1024;
 const DEFAULT_FAKE_OBJECT_SIZE_BYTES: u64 = 1024 * 1024;
 
 impl Config {
@@ -37,6 +38,10 @@ impl Config {
 
         for backend in &mut self.backends {
             backend.apply_defaults();
+        }
+
+        for frontend in &mut self.frontends {
+            frontend.apply_defaults();
         }
 
         let startup = self.startup.get_or_insert_with(StartupCfg::default);
@@ -229,6 +234,13 @@ impl DiskSpec {
 }
 
 impl FrontendSpec {
+    fn apply_defaults(&mut self) {
+        if let Some(frontend_spec::Config::Http(cfg)) = self.config.as_mut() {
+            cfg.max_requests_per_connection
+                .get_or_insert(DEFAULT_HTTP_FRONTEND_MAX_REQUESTS_PER_CONNECTION);
+        }
+    }
+
     pub fn kind_name(&self) -> &'static str {
         match self.config {
             Some(frontend_spec::Config::Http(_)) => "http",
@@ -243,6 +255,15 @@ impl FrontendSpec {
             Some(frontend_spec::Config::Http(cfg)) => Some(cfg.addr.as_str()),
             Some(frontend_spec::Config::S3(cfg)) => Some(cfg.addr.as_str()),
             Some(frontend_spec::Config::Loadgen(_)) | None => None,
+        }
+    }
+
+    pub fn max_requests_per_connection(&self) -> Option<u32> {
+        match self.config.as_ref() {
+            Some(frontend_spec::Config::Http(cfg)) => cfg.max_requests_per_connection,
+            Some(frontend_spec::Config::S3(_)) | Some(frontend_spec::Config::Loadgen(_)) | None => {
+                None
+            }
         }
     }
 }
@@ -515,6 +536,7 @@ source = "primary-http"
 
 [frontends.config.http]
 addr = "0.0.0.0:9000"
+max_requests_per_connection = 256
 "#;
         let mut c: Config = toml::from_str(s).unwrap();
         c.apply_defaults();
@@ -536,6 +558,7 @@ addr = "0.0.0.0:9000"
         let f = &c.frontends[0];
         assert_eq!(f.name, "workload-http");
         assert_eq!(f.addr(), Some("0.0.0.0:9000"));
+        assert_eq!(f.max_requests_per_connection(), Some(256));
         assert_eq!(f.source, "primary-http");
     }
 
@@ -579,6 +602,24 @@ url = "https://example.com"
             }
             other => panic!("expected http backend config, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn http_frontend_optional_fields_default() {
+        let s = r#"
+[[frontends]]
+name = "f"
+source = "b"
+
+[frontends.config.http]
+addr = "0.0.0.0:9000"
+"#;
+        let mut c: Config = toml::from_str(s).unwrap();
+        c.apply_defaults();
+        assert_eq!(
+            c.frontends[0].max_requests_per_connection(),
+            Some(DEFAULT_HTTP_FRONTEND_MAX_REQUESTS_PER_CONNECTION)
+        );
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/fabric/rpc.rs
+++ b/cmd/unbounded-storage/src/fabric/rpc.rs
@@ -171,9 +171,47 @@ pub(crate) struct PageAck {
     pub page_idx: u32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) enum ErrorAckCode {
+    Generic,
+    OriginNotFound,
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct ErrorAck {
+    pub code: ErrorAckCode,
     pub message: String,
+}
+
+impl ErrorAck {
+    pub(crate) fn generic(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorAckCode::Generic,
+            message: message.into(),
+        }
+    }
+
+    fn for_handler_error(error: &(dyn std::error::Error + 'static)) -> Self {
+        Self {
+            code: classify_handler_error(error),
+            message: error.to_string(),
+        }
+    }
+}
+
+fn classify_handler_error(error: &(dyn std::error::Error + 'static)) -> ErrorAckCode {
+    let mut current = Some(error);
+    while let Some(err) = current {
+        if matches!(
+            err.downcast_ref::<crate::bufferpool::Error>(),
+            Some(crate::bufferpool::Error::OriginNotFound)
+        ) {
+            return ErrorAckCode::OriginNotFound;
+        }
+        current = err.source();
+    }
+
+    ErrorAckCode::Generic
 }
 
 /// Per-server shared state held by the responder and each worker.
@@ -401,7 +439,7 @@ fn run_worker<R, H>(
                 &shared,
                 ep,
                 header.request_id,
-                "local backing not registered",
+                ErrorAck::generic("local backing not registered"),
             );
 
             if let Some(mut l) = log.take() {
@@ -547,7 +585,12 @@ where
     loop {
         if shared.shutdown.load(Ordering::Acquire) {
             drain_inflight(shared, &mut inflight);
-            let _ = send_error_ack(shared, ep, header.request_id, "server shutting down");
+            let _ = send_error_ack(
+                shared,
+                ep,
+                header.request_id,
+                ErrorAck::generic("server shutting down"),
+            );
             return ServeOutcome {
                 written: next_idx,
                 result: Err("server shutting down".to_string()),
@@ -567,7 +610,12 @@ where
                             drain_inflight(shared, &mut inflight);
                             let msg = format!("write_page: {e}");
                             if !shared.shutdown.load(Ordering::Acquire) {
-                                let _ = send_error_ack(shared, ep, header.request_id, &msg);
+                                let _ = send_error_ack(
+                                    shared,
+                                    ep,
+                                    header.request_id,
+                                    ErrorAck::generic(msg.clone()),
+                                );
                             }
                             return ServeOutcome {
                                 written: next_idx,
@@ -581,10 +629,16 @@ where
                     // so the NIC is no longer reading backing memory when
                     // the handler stream (and any scratch page) is dropped.
                     drain_inflight(shared, &mut inflight);
-                    let _ = send_error_ack(shared, ep, header.request_id, &format!("{e}"));
+                    let msg = format!("{e}");
+                    let _ = send_error_ack(
+                        shared,
+                        ep,
+                        header.request_id,
+                        ErrorAck::for_handler_error(&e),
+                    );
                     return ServeOutcome {
                         written: next_idx,
-                        result: Err(format!("{e}")),
+                        result: Err(msg),
                     };
                 }
                 std::task::Poll::Ready(None) => {
@@ -621,7 +675,12 @@ where
             drain_inflight(shared, &mut inflight);
             let msg = format!("write_page: {e}");
             if !shared.shutdown.load(Ordering::Acquire) {
-                let _ = send_error_ack(shared, ep, header.request_id, &msg);
+                let _ = send_error_ack(
+                    shared,
+                    ep,
+                    header.request_id,
+                    ErrorAck::generic(msg.clone()),
+                );
             }
             return ServeOutcome {
                 written: next_idx,
@@ -814,7 +873,12 @@ where
 
     loop {
         if shared.shutdown.load(Ordering::Acquire) {
-            let _ = send_error_ack(shared, ep, header.request_id, "server shutting down");
+            let _ = send_error_ack(
+                shared,
+                ep,
+                header.request_id,
+                ErrorAck::generic("server shutting down"),
+            );
             return ServeOutcome {
                 written: next_idx,
                 result: Err("server shutting down".to_string()),
@@ -826,7 +890,12 @@ where
                 if let Err(e) = write_page(shared, local_mr, ep, header, next_idx, page) {
                     let msg = format!("write_page: {e}");
                     if !shared.shutdown.load(Ordering::Acquire) {
-                        let _ = send_error_ack(shared, ep, header.request_id, &msg);
+                        let _ = send_error_ack(
+                            shared,
+                            ep,
+                            header.request_id,
+                            ErrorAck::generic(msg.clone()),
+                        );
                     }
                     return ServeOutcome {
                         written: next_idx,
@@ -836,10 +905,16 @@ where
                 next_idx = next_idx.saturating_add(1);
             }
             std::task::Poll::Ready(Some(Err(e))) => {
-                let _ = send_error_ack(shared, ep, header.request_id, &format!("{e}"));
+                let msg = format!("{e}");
+                let _ = send_error_ack(
+                    shared,
+                    ep,
+                    header.request_id,
+                    ErrorAck::for_handler_error(&e),
+                );
                 return ServeOutcome {
                     written: next_idx,
-                    result: Err(format!("{e}")),
+                    result: Err(msg),
                 };
             }
             std::task::Poll::Ready(None) => {
@@ -1041,12 +1116,9 @@ fn send_error_ack(
     shared: &Arc<ServerShared>,
     ep: EpPtr,
     request_id: u32,
-    msg: &str,
+    ack: ErrorAck,
 ) -> FabResult<()> {
-    let payload = bincode::serialize(&ErrorAck {
-        message: msg.to_string(),
-    })
-    .map_err(|_| FabricError::Pkg("bincode(ErrorAck)", 0))?;
+    let payload = bincode::serialize(&ack).map_err(|_| FabricError::Pkg("bincode(ErrorAck)", 0))?;
     submit_small_send(shared, ep, MsgKind::ErrorAck, request_id, &payload)
 }
 
@@ -1100,10 +1172,8 @@ fn enqueue_small_send(
 /// not awaited. Dropping the future is safe (the slot handler frees the
 /// send buffer when the completion is reaped).
 fn reject_overloaded(shared: &Arc<ServerShared>, ep: EpPtr, request_id: u32) -> FabResult<()> {
-    let payload = bincode::serialize(&ErrorAck {
-        message: "server overloaded".to_string(),
-    })
-    .map_err(|_| FabricError::Pkg("bincode(ErrorAck)", 0))?;
+    let payload = bincode::serialize(&ErrorAck::generic("server overloaded"))
+        .map_err(|_| FabricError::Pkg("bincode(ErrorAck)", 0))?;
     let _fut = enqueue_small_send(
         shared,
         ep,

--- a/cmd/unbounded-storage/src/fabric/transport.rs
+++ b/cmd/unbounded-storage/src/fabric/transport.rs
@@ -58,7 +58,7 @@ use super::dispatch::{AckSink, InboundDispatch};
 use super::error::{FabricError, Result as FabResult};
 use super::fabric::Fabric;
 use super::ffi;
-use super::rpc::{ErrorAck, PageAck, RequestHeader};
+use super::rpc::{ErrorAck, ErrorAckCode, PageAck, RequestHeader};
 use super::wire::{MsgHeader, MsgKind};
 
 /// Selects a peer for a given request. Returns `Option` so the
@@ -499,15 +499,14 @@ impl<'a, R> PageStream for FabricBulkStream<'a, R> {
                                     return Poll::Ready(None);
                                 }
                                 *emitted_error = true;
-                                let msg = bincode::deserialize::<ErrorAck>(&payload)
-                                    .map(|e| e.message)
-                                    .unwrap_or_else(|_| "server error (undecodable)".into());
+                                let ack = bincode::deserialize::<ErrorAck>(&payload)
+                                    .unwrap_or_else(|_| {
+                                        ErrorAck::generic("server error (undecodable)")
+                                    });
                                 if let Some(mut l) = log.take() {
-                                    l.finish_err(&msg);
+                                    l.finish_err(&ack.message);
                                 }
-                                return Poll::Ready(Some(Err(PoolError::transport(ServerError(
-                                    msg,
-                                )))));
+                                return Poll::Ready(Some(Err(error_ack_to_pool_error(ack))));
                             }
                             // A REQUEST is never routed to a client ack
                             // sink; ignore any stray delivery.
@@ -571,6 +570,13 @@ impl std::fmt::Display for ServerError {
 }
 
 impl std::error::Error for ServerError {}
+
+fn error_ack_to_pool_error(ack: ErrorAck) -> PoolError {
+    match ack.code {
+        ErrorAckCode::Generic => PoolError::transport(ServerError(ack.message)),
+        ErrorAckCode::OriginNotFound => PoolError::OriginNotFound,
+    }
+}
 
 /// Register the ack sink and submit the framed request. Returns the
 /// shared state the stream drains. On any failure the dispatch entry is
@@ -771,6 +777,21 @@ mod tests {
         });
     }
 
+    fn push_error_ack(stream: &mut FabricBulkStream<'_, ()>, code: ErrorAckCode, message: &str) {
+        let StreamState::Active { shared, .. } = &stream.state else {
+            panic!("expected active stream");
+        };
+        let payload = bincode::serialize(&ErrorAck {
+            code,
+            message: message.to_string(),
+        })
+        .expect("serialize error ack");
+        shared.push(RecvCompletion {
+            kind: MsgKind::ErrorAck,
+            payload,
+        });
+    }
+
     fn push_page_landed(stream: &mut FabricBulkStream<'_, ()>, ordinal: u32) {
         let StreamState::Active { shared, .. } = &stream.state else {
             panic!("expected active stream");
@@ -877,6 +898,71 @@ mod tests {
             stream.as_mut().poll_next(&mut cx),
             Poll::Ready(None)
         ));
+    }
+
+    #[test]
+    fn error_ack_origin_not_found_preserves_pool_error() {
+        let dsts = [PageRef {
+            page_idx: 0,
+            offset: 0,
+            len: 4096,
+        }];
+        let mut stream = active_stream(&dsts, vec![false]);
+        push_error_ack(&mut stream, ErrorAckCode::OriginNotFound, "origin missing");
+
+        assert!(matches!(
+            poll_once(&mut stream),
+            Poll::Ready(Some(Err(PoolError::OriginNotFound)))
+        ));
+        assert!(matches!(poll_once(&mut stream), Poll::Ready(None)));
+    }
+
+    #[test]
+    fn error_ack_generic_origin_not_found_suffix_remains_transport_error() {
+        let dsts = [PageRef {
+            page_idx: 0,
+            offset: 0,
+            len: 4096,
+        }];
+        let mut stream = active_stream(&dsts, vec![false]);
+        push_error_ack(
+            &mut stream,
+            ErrorAckCode::Generic,
+            "unrelated failure: origin object not found",
+        );
+
+        match poll_once(&mut stream) {
+            Poll::Ready(Some(Err(PoolError::Transport(err)))) => {
+                assert!(
+                    err.to_string().contains("unrelated failure"),
+                    "unexpected error: {err}",
+                );
+            }
+            other => panic!("expected transport error, got {other:?}"),
+        }
+        assert!(matches!(poll_once(&mut stream), Poll::Ready(None)));
+    }
+
+    #[test]
+    fn error_ack_other_message_remains_transport_error() {
+        let dsts = [PageRef {
+            page_idx: 0,
+            offset: 0,
+            len: 4096,
+        }];
+        let mut stream = active_stream(&dsts, vec![false]);
+        push_error_ack(&mut stream, ErrorAckCode::Generic, "backend exploded");
+
+        match poll_once(&mut stream) {
+            Poll::Ready(Some(Err(PoolError::Transport(err)))) => {
+                assert!(
+                    err.to_string().contains("backend exploded"),
+                    "unexpected error: {err}",
+                );
+            }
+            other => panic!("expected transport error, got {other:?}"),
+        }
+        assert!(matches!(poll_once(&mut stream), Poll::Ready(None)));
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/frontend/http_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/http_serve.rs
@@ -36,11 +36,12 @@ use std::os::fd::RawFd;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
+use std::time::{Duration, Instant};
 
 use ::http::header::{ACCEPT_RANGES, CONNECTION, CONTENT_LENGTH, CONTENT_RANGE};
 use ::http::{Response, StatusCode};
 
-use crate::bufferpool::{BufferPool, ReadStream, StripeKey, StripePlan};
+use crate::bufferpool::{BufferPool, Error as PoolError, ReadStream, StripeKey, StripePlan};
 use crate::config::{FrontendSpec, frontend_spec};
 use crate::fanout::{FanoutTable, FetchChannel, FetchReply, Owner};
 use crate::frontend::FrontendError;
@@ -50,7 +51,8 @@ use crate::frontend::range::{
 use crate::frontend::serve_metrics::{ConnGuard, ReqOutcome};
 use crate::http::{
     FdGuard, HttpRequest, MAX_HEADER_BYTES, Method, ParseError, RECV_CHUNK, bind_listener,
-    send_all, serialize_response_head, split_query,
+    connection_header_value, request_allows_keep_alive, send_all, serialize_response_head,
+    split_query,
 };
 use crate::ring::NetHandle;
 use crate::runtime::noop_waker;
@@ -67,6 +69,9 @@ pub struct HttpFrontend {
     id: String,
     addr: SocketAddr,
 }
+
+const MAX_FRONTEND_CONNS: usize = 4096;
+const KEEP_ALIVE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl HttpFrontend {
     /// Construct from a [`FrontendSpec`], validating the config type and
@@ -204,6 +209,14 @@ impl<P: BufferPool<Req = StripeReq> + 'static> HttpDriver<P> {
                 Poll::Ready(res) => {
                     busy = true;
                     if let Ok(fd) = res {
+                        if self.conns.len() >= MAX_FRONTEND_CONNS {
+                            // SAFETY: this driver owns newly accepted fds.
+                            unsafe {
+                                libc::close(fd);
+                            }
+                            self.accept_fut = Box::pin(self.handle.accept(self.listen_fd));
+                            continue;
+                        }
                         let serve = serve_connection(
                             Rc::clone(&self.pool),
                             self.handle.clone(),
@@ -278,34 +291,60 @@ async fn serve_connection<P: BufferPool<Req = StripeReq>>(
 ) {
     let _fd = FdGuard(conn_fd);
     let _conn = ConnGuard::new();
-    let mut log = crate::obs::ReqLog::new("frontend.http");
-    let start = std::time::Instant::now();
-    let mut outcome = ReqOutcome::default();
-    let result = serve_request(
-        &pool,
-        &handle,
-        conn_fd,
-        &backend_id,
-        cache_id.as_deref(),
-        neighborhood_id.as_deref(),
-        stripe_size,
-        page_size,
-        &fanout,
-        bypass,
-        &mut log,
-        &mut outcome,
-    )
-    .await;
-    outcome.record(&frontend_id, start.elapsed().as_secs_f64());
-    match result {
-        Ok(()) => log.finish_ok(),
-        Err(()) => log.finish_err("connection error"),
+    let mut buf: Vec<u8> = Vec::new();
+    let mut deadline = None;
+    loop {
+        let mut log = crate::obs::ReqLog::new("frontend.http");
+        let start = std::time::Instant::now();
+        let mut outcome = ReqOutcome::default();
+        let result = serve_request(
+            &pool,
+            &handle,
+            conn_fd,
+            &backend_id,
+            cache_id.as_deref(),
+            neighborhood_id.as_deref(),
+            stripe_size,
+            page_size,
+            &fanout,
+            bypass,
+            &mut buf,
+            deadline,
+            &mut log,
+            &mut outcome,
+        )
+        .await;
+        match result {
+            Ok(ServeStep::Closed) => break,
+            Ok(ServeStep::Close) => {
+                outcome.record(&frontend_id, start.elapsed().as_secs_f64());
+                log.finish_ok();
+                break;
+            }
+            Ok(ServeStep::KeepAlive) => {
+                outcome.record(&frontend_id, start.elapsed().as_secs_f64());
+                log.finish_ok();
+                deadline = Some(Instant::now() + KEEP_ALIVE_IDLE_TIMEOUT);
+            }
+            Err(()) => {
+                outcome.record(&frontend_id, start.elapsed().as_secs_f64());
+                log.finish_err("connection error");
+                break;
+            }
+        }
     }
+}
+
+enum ServeStep {
+    KeepAlive,
+    Close,
+    Closed,
 }
 
 /// The fallible serve body. Returns `Err(())` on any I/O, parse, or
 /// pool error; the caller closes the fd regardless. Error responses
-/// (400/405/416) are best-effort sends followed by `Ok(())`.
+/// (400/405/416) are best-effort sends followed by a close/keep-alive
+/// step based on the parsed request.
 async fn serve_request<P: BufferPool<Req = StripeReq>>(
     pool: &Rc<P>,
     handle: &NetHandle,
@@ -317,33 +356,45 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
     page_size: usize,
     fanout: &Rc<FanoutTable>,
     bypass: bool,
+    buf: &mut Vec<u8>,
+    idle_deadline: Option<Instant>,
     log: &mut crate::obs::ReqLog,
     outcome: &mut ReqOutcome,
-) -> Result<(), ()> {
+) -> Result<ServeStep, ()> {
     // 1. Read until the request head is complete (or the cap is hit).
-    let mut buf: Vec<u8> = Vec::new();
-    loop {
+    let req = loop {
         match HttpRequest::parse(&buf) {
-            Ok(_) => break,
+            Ok(req) => break req,
             Err(ParseError::Incomplete) => {
-                if buf.len() > MAX_HEADER_BYTES {
+                if buf.len() >= MAX_HEADER_BYTES {
                     return Err(());
                 }
-                let chunk = handle.recv(conn_fd, RECV_CHUNK).await.map_err(|_| ())?;
+                let chunk = recv_with_deadline(handle, conn_fd, RECV_CHUNK, idle_deadline)
+                    .await
+                    .map_err(|_| ())?;
                 if chunk.is_empty() {
-                    return Err(());
+                    return if buf.is_empty() {
+                        Ok(ServeStep::Closed)
+                    } else {
+                        Err(())
+                    };
                 }
                 buf.extend_from_slice(&chunk);
             }
             Err(_) => {
-                let _ = send_all(handle, conn_fd, status_line_response(400)).await;
+                send_all(handle, conn_fd, status_line_response(400, false)).await?;
                 log.field("status", 400);
                 outcome.status = 400;
-                return Ok(());
+                buf.clear();
+                return Ok(ServeStep::Close);
             }
         }
+    };
+    if req.header_end > MAX_HEADER_BYTES {
+        return Err(());
     }
-    let req = HttpRequest::parse(&buf).map_err(|_| ())?;
+    let keep_alive = request_allows_keep_alive(&req);
+    let header_end = req.header_end;
 
     // 2. Only GET and HEAD are served. HEAD resolves length and builds
     // the same head as GET but never streams a body.
@@ -351,10 +402,11 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
         Method::GET => false,
         Method::HEAD => true,
         _ => {
-            let _ = send_all(handle, conn_fd, status_line_response(405)).await;
+            send_all(handle, conn_fd, status_line_response(405, keep_alive)).await?;
             log.field("status", 405);
             outcome.status = 405;
-            return Ok(());
+            finish_request(buf, header_end);
+            return Ok(next_step(keep_alive));
         }
     };
     outcome.method = if is_head { "HEAD" } else { "GET" };
@@ -369,10 +421,11 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
         Some(v) => match ByteRange::parse(v) {
             Ok(r) => Some(r),
             Err(_) => {
-                let _ = send_all(handle, conn_fd, status_line_response(400)).await;
+                send_all(handle, conn_fd, status_line_response(400, keep_alive)).await?;
                 log.field("status", 400);
                 outcome.status = 400;
-                return Ok(());
+                finish_request(buf, header_end);
+                return Ok(next_step(keep_alive));
             }
         },
         None => None,
@@ -382,7 +435,7 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
     // metadata entry through the pool. The HTTP backend fills it from
     // an origin HEAD on a miss; local-disk and peer hits skip the
     // origin entirely.
-    let len = read_object_length(
+    let len = match read_object_length(
         pool,
         backend_id,
         cache_id,
@@ -392,7 +445,17 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
         bypass,
     )
     .await
-    .map_err(|_| ())?;
+    {
+        LenResult::Len(len) => len,
+        LenResult::NotFound => {
+            let _ = send_all(handle, conn_fd, status_line_response(404, keep_alive)).await;
+            log.field("status", 404);
+            outcome.status = 404;
+            finish_request(buf, header_end);
+            return Ok(next_step(keep_alive));
+        }
+        LenResult::Other => return Err(()),
+    };
 
     // 6. Resolve the requested range against the length.
     let resolved = match range {
@@ -400,25 +463,32 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
         Some(br) => match br.resolve(len) {
             Ok(r) => r,
             Err(RangeError::Unsatisfiable { object_len }) => {
-                let _ = send_all(handle, conn_fd, unsatisfiable_response(object_len)).await;
+                send_all(
+                    handle,
+                    conn_fd,
+                    unsatisfiable_response(object_len, keep_alive),
+                )
+                .await?;
                 log.field("status", 416);
                 outcome.status = 416;
-                return Ok(());
+                finish_request(buf, header_end);
+                return Ok(next_step(keep_alive));
             }
             Err(_) => {
-                let _ = send_all(handle, conn_fd, status_line_response(400)).await;
+                send_all(handle, conn_fd, status_line_response(400, keep_alive)).await?;
                 log.field("status", 400);
                 outcome.status = 400;
-                return Ok(());
+                finish_request(buf, header_end);
+                return Ok(next_step(keep_alive));
             }
         },
     };
 
     // 7. Response head: 206 if the client sent a Range, else 200.
     let head = if range.is_some() {
-        partial_head(resolved, len)
+        partial_head(resolved, len, keep_alive)
     } else {
-        full_head(len)
+        full_head(len, keep_alive)
     };
     outcome.status = if range.is_some() { 206 } else { 200 };
     // HEAD carries no body, so no body bytes are streamed to the client;
@@ -431,7 +501,8 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
     // 7b. HEAD carries no body: the head (with Content-Length /
     // Content-Range) is the entire response.
     if is_head {
-        return Ok(());
+        finish_request(buf, header_end);
+        return Ok(next_step(keep_alive));
     }
 
     // 8. Stream the body, fanning each stripe out to its content-address
@@ -450,7 +521,9 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
         stripe_size,
         bypass,
     )
-    .await
+    .await?;
+    finish_request(buf, header_end);
+    Ok(next_step(keep_alive))
 }
 
 /// Type-erased cross-shard fetch future. Holds the channel round-trip to
@@ -795,7 +868,7 @@ async fn read_object_length<P: BufferPool<Req = StripeReq>>(
     path: &str,
     page_size: usize,
     bypass: bool,
-) -> Result<u64, ()> {
+) -> LenResult {
     let origin_ref = OriginRef::metadata_entry(backend_id, path);
     let req = StripeReq::new(origin_ref.stripe_key())
         .with_origin(origin_ref)
@@ -804,19 +877,78 @@ async fn read_object_length<P: BufferPool<Req = StripeReq>>(
             neighborhood_id.map(ToOwned::to_owned),
         )
         .with_bypass(bypass);
-    let mut rs: ReadStream = pool.read(&req, 0, page_size as u64).await.map_err(|_| ())?;
-    let page = rs.next_page().await.ok_or(())?.map_err(|_| ())?;
-    let meta = ObjectMetadata::decode(page.as_slice()).map_err(|_| ())?;
-    Ok(meta.length)
+    let mut rs: ReadStream = match pool.read(&req, 0, page_size as u64).await {
+        Ok(rs) => rs,
+        Err(e) => return classify_len_error(e),
+    };
+    let page = match rs.next_page().await {
+        Some(Ok(page)) => page,
+        Some(Err(e)) => return classify_len_error(e),
+        None => return LenResult::Other,
+    };
+    match ObjectMetadata::decode(page.as_slice()) {
+        Ok(meta) => LenResult::Len(meta.length),
+        Err(e) => classify_len_error(e),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum LenResult {
+    Len(u64),
+    NotFound,
+    Other,
+}
+
+fn classify_len_error(err: PoolError) -> LenResult {
+    match err {
+        PoolError::OriginNotFound => LenResult::NotFound,
+        _ => LenResult::Other,
+    }
+}
+
+async fn recv_with_deadline(
+    handle: &NetHandle,
+    conn_fd: RawFd,
+    max_len: usize,
+    deadline: Option<Instant>,
+) -> Result<Vec<u8>, ()> {
+    let mut fut = Box::pin(handle.recv(conn_fd, max_len));
+    poll_fn(|cx| {
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Poll::Ready(Err(()));
+        }
+        match fut.as_mut().poll(cx) {
+            Poll::Ready(res) => Poll::Ready(res.map_err(|_| ())),
+            Poll::Pending => {
+                if deadline.is_some() {
+                    cx.waker().wake_by_ref();
+                }
+                Poll::Pending
+            }
+        }
+    })
+    .await
+}
+
+fn finish_request(buf: &mut Vec<u8>, header_end: usize) {
+    buf.drain(..header_end);
+}
+
+fn next_step(keep_alive: bool) -> ServeStep {
+    if keep_alive {
+        ServeStep::KeepAlive
+    } else {
+        ServeStep::Close
+    }
 }
 
 /// Format the `200 OK` head for serving a whole object.
-fn full_head(len: u64) -> Vec<u8> {
+fn full_head(len: u64, keep_alive: bool) -> Vec<u8> {
     let resp = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_LENGTH, len.to_string())
         .header(ACCEPT_RANGES, "bytes")
-        .header(CONNECTION, "close")
+        .header(CONNECTION, connection_header_value(keep_alive))
         .body(())
         .expect("valid full-object response head");
     serialize_response_head(&resp)
@@ -824,7 +956,7 @@ fn full_head(len: u64) -> Vec<u8> {
 
 /// Format the `206 Partial Content` head for a resolved byte range.
 /// `END` in `Content-Range` is inclusive (`resolved.end - 1`).
-fn partial_head(resolved: ResolvedRange, total: u64) -> Vec<u8> {
+fn partial_head(resolved: ResolvedRange, total: u64, keep_alive: bool) -> Vec<u8> {
     let start = resolved.start;
     let end_incl = resolved.end - 1;
     let clen = resolved.len();
@@ -833,7 +965,7 @@ fn partial_head(resolved: ResolvedRange, total: u64) -> Vec<u8> {
         .header(CONTENT_RANGE, format!("bytes {start}-{end_incl}/{total}"))
         .header(CONTENT_LENGTH, clen.to_string())
         .header(ACCEPT_RANGES, "bytes")
-        .header(CONNECTION, "close")
+        .header(CONNECTION, connection_header_value(keep_alive))
         .body(())
         .expect("valid partial-content response head");
     serialize_response_head(&resp)
@@ -841,12 +973,12 @@ fn partial_head(resolved: ResolvedRange, total: u64) -> Vec<u8> {
 
 /// Format a `416 Range Not Satisfiable` head with `Content-Range: bytes
 /// */LEN`.
-fn unsatisfiable_response(total: u64) -> Vec<u8> {
+fn unsatisfiable_response(total: u64, keep_alive: bool) -> Vec<u8> {
     let resp = Response::builder()
         .status(StatusCode::RANGE_NOT_SATISFIABLE)
         .header(CONTENT_RANGE, format!("bytes */{total}"))
         .header(CONTENT_LENGTH, "0")
-        .header(CONNECTION, "close")
+        .header(CONNECTION, connection_header_value(keep_alive))
         .body(())
         .expect("valid unsatisfiable-range response head");
     serialize_response_head(&resp)
@@ -854,12 +986,12 @@ fn unsatisfiable_response(total: u64) -> Vec<u8> {
 
 /// Format a bodyless status-line response (`Content-Length: 0`) for the
 /// simple error statuses this frontend emits.
-fn status_line_response(status: u16) -> Vec<u8> {
+fn status_line_response(status: u16, keep_alive: bool) -> Vec<u8> {
     let status = StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     let resp = Response::builder()
         .status(status)
         .header(CONTENT_LENGTH, "0")
-        .header(CONNECTION, "close")
+        .header(CONNECTION, connection_header_value(keep_alive))
         .body(())
         .expect("valid status-line response head");
     serialize_response_head(&resp)
@@ -872,6 +1004,7 @@ mod tests {
     use crate::config::HttpFrontendConfig;
     use crate::fanout::NumaShardTable;
     use crate::frontend::range::StripeSlice;
+    use crate::http::{request_is_bodyless, request_wants_keep_alive};
     use crate::storage::disks::CacheDirectorySet;
     use std::cell::RefCell;
 
@@ -897,19 +1030,19 @@ mod tests {
 
     #[test]
     fn full_head_exact_bytes() {
-        let head = full_head(4096);
+        let head = full_head(4096, true);
         let s = std::str::from_utf8(&head).unwrap();
         assert!(s.starts_with("HTTP/1.1 200 OK\r\n"), "got: {s}");
         assert!(s.contains("content-length: 4096\r\n"), "got: {s}");
         assert!(s.contains("accept-ranges: bytes\r\n"), "got: {s}");
-        assert!(s.contains("connection: close\r\n"), "got: {s}");
+        assert!(s.contains("connection: keep-alive\r\n"), "got: {s}");
         assert!(s.ends_with("\r\n\r\n"), "got: {s}");
     }
 
     #[test]
     fn partial_head_exact_bytes_inclusive_end() {
         // Resolved [0, 100) of a 1000-byte object -> bytes 0-99/1000.
-        let head = partial_head(ResolvedRange { start: 0, end: 100 }, 1000);
+        let head = partial_head(ResolvedRange { start: 0, end: 100 }, 1000, true);
         let s = std::str::from_utf8(&head).unwrap();
         assert!(
             s.starts_with("HTTP/1.1 206 Partial Content\r\n"),
@@ -918,7 +1051,7 @@ mod tests {
         assert!(s.contains("content-range: bytes 0-99/1000\r\n"), "got: {s}");
         assert!(s.contains("content-length: 100\r\n"), "got: {s}");
         assert!(s.contains("accept-ranges: bytes\r\n"), "got: {s}");
-        assert!(s.contains("connection: close\r\n"), "got: {s}");
+        assert!(s.contains("connection: keep-alive\r\n"), "got: {s}");
         assert!(s.ends_with("\r\n\r\n"), "got: {s}");
     }
 
@@ -931,15 +1064,17 @@ mod tests {
                 end: 100,
             },
             100,
+            false,
         );
         let s = std::str::from_utf8(&head).unwrap();
         assert!(s.contains("content-range: bytes 70-99/100\r\n"), "got: {s}");
         assert!(s.contains("content-length: 30\r\n"), "got: {s}");
+        assert!(s.contains("connection: close\r\n"), "got: {s}");
     }
 
     #[test]
     fn unsatisfiable_response_exact_bytes() {
-        let head = unsatisfiable_response(100);
+        let head = unsatisfiable_response(100, false);
         let s = std::str::from_utf8(&head).unwrap();
         assert!(
             s.starts_with("HTTP/1.1 416 Range Not Satisfiable\r\n"),
@@ -953,7 +1088,7 @@ mod tests {
 
     #[test]
     fn status_405_and_400_exact_bytes() {
-        let r405 = status_line_response(405);
+        let r405 = status_line_response(405, false);
         let s405 = std::str::from_utf8(&r405).unwrap();
         assert!(
             s405.starts_with("HTTP/1.1 405 Method Not Allowed\r\n"),
@@ -963,7 +1098,7 @@ mod tests {
         assert!(s405.contains("connection: close\r\n"), "got: {s405}");
         assert!(s405.ends_with("\r\n\r\n"), "got: {s405}");
 
-        let r400 = status_line_response(400);
+        let r400 = status_line_response(400, false);
         let s400 = std::str::from_utf8(&r400).unwrap();
         assert!(
             s400.starts_with("HTTP/1.1 400 Bad Request\r\n"),
@@ -972,6 +1107,65 @@ mod tests {
         assert!(s400.contains("content-length: 0\r\n"), "got: {s400}");
         assert!(s400.contains("connection: close\r\n"), "got: {s400}");
         assert!(s400.ends_with("\r\n\r\n"), "got: {s400}");
+    }
+
+    #[test]
+    fn status_404_exact_bytes() {
+        let r404 = status_line_response(404, false);
+        let s404 = std::str::from_utf8(&r404).unwrap();
+        assert!(
+            s404.starts_with("HTTP/1.1 404 Not Found\r\n"),
+            "got: {s404}"
+        );
+        assert!(s404.contains("content-length: 0\r\n"), "got: {s404}");
+        assert!(s404.contains("connection: close\r\n"), "got: {s404}");
+        assert!(s404.ends_with("\r\n\r\n"), "got: {s404}");
+    }
+
+    #[test]
+    fn request_keep_alive_follows_http_connection_rules() {
+        let req = HttpRequest::parse(b"GET / HTTP/1.1\r\n\r\n").unwrap();
+        assert!(request_wants_keep_alive(&req));
+
+        let req = HttpRequest::parse(b"GET / HTTP/1.1\r\nConnection: close\r\n\r\n").unwrap();
+        assert!(!request_wants_keep_alive(&req));
+
+        let req = HttpRequest::parse(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+        assert!(!request_wants_keep_alive(&req));
+
+        let req = HttpRequest::parse(b"GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n").unwrap();
+        assert!(request_wants_keep_alive(&req));
+    }
+
+    #[test]
+    fn request_has_body_detects_unsupported_body_headers() {
+        let req = HttpRequest::parse(b"GET / HTTP/1.1\r\n\r\n").unwrap();
+        assert!(request_is_bodyless(&req));
+
+        let req = HttpRequest::parse(b"GET / HTTP/1.1\r\nContent-Length: 0\r\n\r\n").unwrap();
+        assert!(request_is_bodyless(&req));
+
+        let req = HttpRequest::parse(b"GET / HTTP/1.1\r\nContent-Length: 1\r\n\r\n").unwrap();
+        assert!(!request_is_bodyless(&req));
+
+        let req =
+            HttpRequest::parse(b"GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n").unwrap();
+        assert!(!request_is_bodyless(&req));
+    }
+
+    #[test]
+    fn duplicate_body_headers_disable_keep_alive() {
+        let req = HttpRequest::parse(
+            b"GET / HTTP/1.1\r\nContent-Length: 0\r\nContent-Length: 10\r\n\r\n",
+        )
+        .unwrap();
+        assert!(!request_is_bodyless(&req));
+
+        let req = HttpRequest::parse(
+            b"GET / HTTP/1.1\r\nConnection: keep-alive\r\nConnection: close\r\n\r\n",
+        )
+        .unwrap();
+        assert!(!request_wants_keep_alive(&req));
     }
 
     #[test]
@@ -1077,7 +1271,9 @@ mod tests {
     /// constructor is crate-internal to bufferpool): it always errors.
     /// Sufficient to wire an [`HttpDriver`] for accept-loop tests, where
     /// the serve path is not exercised against a real pool.
-    struct MockPool;
+    struct MockPool {
+        err: Error,
+    }
 
     impl BufferPool for MockPool {
         type Req = StripeReq;
@@ -1088,7 +1284,7 @@ mod tests {
             _offset: u64,
             _len: u64,
         ) -> Result<ReadStream<'p>, Error> {
-            Err(Error::from("mock pool has no data"))
+            Err(self.err.clone())
         }
 
         fn read_windowed<'p>(
@@ -1098,7 +1294,7 @@ mod tests {
             _len: u64,
             _window: usize,
         ) -> Result<WindowedRead<'p>, Error> {
-            Err(Error::from("mock pool has no data"))
+            Err(self.err.clone())
         }
 
         fn read_pipelined<'p>(
@@ -1106,8 +1302,47 @@ mod tests {
             _stripes: Vec<StripePlan<StripeReq>>,
             _window: usize,
         ) -> Result<PipelinedRead<'p>, Error> {
-            Err(Error::from("mock pool has no data"))
+            Err(self.err.clone())
         }
+    }
+
+    fn block_on<F: Future>(fut: F) -> F::Output {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = Box::pin(fut);
+        for _ in 0..1_000_000 {
+            match fut.as_mut().poll(&mut cx) {
+                Poll::Ready(v) => return v,
+                Poll::Pending => std::thread::yield_now(),
+            }
+        }
+        panic!("future did not complete");
+    }
+
+    #[test]
+    fn read_object_length_maps_origin_not_found_to_len_result() {
+        let pool = Rc::new(MockPool {
+            err: Error::OriginNotFound,
+        });
+
+        let result = block_on(read_object_length(
+            &pool, "primary", None, None, "/missing", 4096, false,
+        ));
+
+        assert_eq!(result, LenResult::NotFound);
+    }
+
+    #[test]
+    fn read_object_length_maps_other_errors_to_other() {
+        let pool = Rc::new(MockPool {
+            err: Error::from("mock pool has no data"),
+        });
+
+        let result = block_on(read_object_length(
+            &pool, "primary", None, None, "/broken", 4096, false,
+        ));
+
+        assert_eq!(result, LenResult::Other);
     }
 
     #[test]
@@ -1129,7 +1364,9 @@ mod tests {
             }
         };
         let mut driver = HttpDriver::new(
-            Rc::new(MockPool),
+            Rc::new(MockPool {
+                err: Error::from("mock pool has no data"),
+            }),
             handle,
             listen_fd,
             Rc::from("primary"),

--- a/cmd/unbounded-storage/src/frontend/http_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/http_serve.rs
@@ -42,6 +42,7 @@ use ::http::header::{ACCEPT_RANGES, CONNECTION, CONTENT_LENGTH, CONTENT_RANGE};
 use ::http::{Response, StatusCode};
 
 use crate::bufferpool::{BufferPool, Error as PoolError, ReadStream, StripeKey, StripePlan};
+use crate::config::schema::DEFAULT_HTTP_FRONTEND_MAX_REQUESTS_PER_CONNECTION;
 use crate::config::{FrontendSpec, frontend_spec};
 use crate::fanout::{FanoutTable, FetchChannel, FetchReply, Owner};
 use crate::frontend::FrontendError;
@@ -68,6 +69,7 @@ use crate::storage::{ObjectMetadata, OriginRef, StripeReq};
 pub struct HttpFrontend {
     id: String,
     addr: SocketAddr,
+    max_requests_per_connection: usize,
 }
 
 const MAX_FRONTEND_CONNS: usize = 4096;
@@ -85,9 +87,18 @@ impl HttpFrontend {
             .addr
             .parse::<SocketAddr>()
             .map_err(|_| FrontendError::BadBind(cfg.addr.clone()))?;
+        let max_requests_per_connection = cfg
+            .max_requests_per_connection
+            .unwrap_or(DEFAULT_HTTP_FRONTEND_MAX_REQUESTS_PER_CONNECTION);
+        if max_requests_per_connection == 0 {
+            return Err(FrontendError::BadConfig(
+                "max_requests_per_connection must be greater than zero",
+            ));
+        }
         Ok(Self {
             id: spec.name.clone(),
             addr,
+            max_requests_per_connection: max_requests_per_connection as usize,
         })
     }
 
@@ -99,6 +110,12 @@ impl HttpFrontend {
     /// The configured listen address.
     pub fn bind(&self) -> SocketAddr {
         self.addr
+    }
+
+    /// Maximum requests served before the frontend closes a keep-alive
+    /// connection and lets the client reconnect through `SO_REUSEPORT`.
+    pub fn max_requests_per_connection(&self) -> usize {
+        self.max_requests_per_connection
     }
 
     /// Create, bind, and listen the per-shard accept socket with
@@ -135,6 +152,7 @@ pub struct HttpDriver<P: BufferPool<Req = StripeReq> + 'static> {
     page_size: usize,
     fanout: Rc<FanoutTable>,
     bypass: bool,
+    max_requests_per_connection: usize,
     accept_fut: Pin<Box<dyn Future<Output = std::io::Result<RawFd>>>>,
     conns: Vec<Pin<Box<dyn Future<Output = ()>>>>,
     waker: Waker,
@@ -160,6 +178,7 @@ impl<P: BufferPool<Req = StripeReq> + 'static> HttpDriver<P> {
         page_size: usize,
         fanout: Rc<FanoutTable>,
         bypass: bool,
+        max_requests_per_connection: usize,
     ) -> Self {
         let accept_fut = Box::pin(handle.accept(listen_fd));
         Self {
@@ -174,6 +193,7 @@ impl<P: BufferPool<Req = StripeReq> + 'static> HttpDriver<P> {
             page_size,
             fanout,
             bypass,
+            max_requests_per_connection,
             accept_fut,
             conns: Vec::new(),
             waker: noop_waker(),
@@ -229,6 +249,7 @@ impl<P: BufferPool<Req = StripeReq> + 'static> HttpDriver<P> {
                             self.page_size,
                             Rc::clone(&self.fanout),
                             self.bypass,
+                            self.max_requests_per_connection,
                         );
                         self.conns.push(Box::pin(serve));
                     }
@@ -288,11 +309,13 @@ async fn serve_connection<P: BufferPool<Req = StripeReq>>(
     page_size: usize,
     fanout: Rc<FanoutTable>,
     bypass: bool,
+    max_requests_per_connection: usize,
 ) {
     let _fd = FdGuard(conn_fd);
     let _conn = ConnGuard::new();
     let mut buf: Vec<u8> = Vec::new();
     let mut deadline = None;
+    let mut requests_served = 0usize;
     loop {
         let mut log = crate::obs::ReqLog::new("frontend.http");
         let start = std::time::Instant::now();
@@ -310,6 +333,7 @@ async fn serve_connection<P: BufferPool<Req = StripeReq>>(
             bypass,
             &mut buf,
             deadline,
+            requests_served.saturating_add(1) < max_requests_per_connection,
             &mut log,
             &mut outcome,
         )
@@ -322,6 +346,7 @@ async fn serve_connection<P: BufferPool<Req = StripeReq>>(
                 break;
             }
             Ok(ServeStep::KeepAlive) => {
+                requests_served = requests_served.saturating_add(1);
                 outcome.record(&frontend_id, start.elapsed().as_secs_f64());
                 log.finish_ok();
                 deadline = Some(Instant::now() + KEEP_ALIVE_IDLE_TIMEOUT);
@@ -358,6 +383,7 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
     bypass: bool,
     buf: &mut Vec<u8>,
     idle_deadline: Option<Instant>,
+    allow_keep_alive_after_response: bool,
     log: &mut crate::obs::ReqLog,
     outcome: &mut ReqOutcome,
 ) -> Result<ServeStep, ()> {
@@ -393,7 +419,7 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
     if req.header_end > MAX_HEADER_BYTES {
         return Err(());
     }
-    let keep_alive = request_allows_keep_alive(&req);
+    let keep_alive = request_allows_keep_alive(&req) && allow_keep_alive_after_response;
     let header_end = req.header_end;
 
     // 2. Only GET and HEAD are served. HEAD resolves length and builds
@@ -1014,6 +1040,7 @@ mod tests {
             source: "primary".to_string(),
             config: Some(frontend_spec::Config::Http(HttpFrontendConfig {
                 addr: addr.to_string(),
+                max_requests_per_connection: None,
             })),
         }
     }
@@ -1026,6 +1053,32 @@ mod tests {
 
         let bad = HttpFrontend::from_spec(&spec("f", "not-an-addr"));
         assert!(matches!(bad, Err(FrontendError::BadBind(_))));
+    }
+
+    #[test]
+    fn from_spec_defaults_and_validates_request_cap() {
+        let f = HttpFrontend::from_spec(&spec("workload", "0.0.0.0:9000")).unwrap();
+        assert_eq!(
+            f.max_requests_per_connection(),
+            DEFAULT_HTTP_FRONTEND_MAX_REQUESTS_PER_CONNECTION as usize
+        );
+
+        let mut capped = spec("workload", "0.0.0.0:9000");
+        let Some(frontend_spec::Config::Http(cfg)) = capped.config.as_mut() else {
+            panic!("expected http config");
+        };
+        cfg.max_requests_per_connection = Some(7);
+        let f = HttpFrontend::from_spec(&capped).unwrap();
+        assert_eq!(f.max_requests_per_connection(), 7);
+
+        let Some(frontend_spec::Config::Http(cfg)) = capped.config.as_mut() else {
+            panic!("expected http config");
+        };
+        cfg.max_requests_per_connection = Some(0);
+        assert!(matches!(
+            HttpFrontend::from_spec(&capped),
+            Err(FrontendError::BadConfig(_))
+        ));
     }
 
     #[test]
@@ -1382,6 +1435,7 @@ mod tests {
                 CacheDirectorySet::new(),
             )),
             false,
+            DEFAULT_HTTP_FRONTEND_MAX_REQUESTS_PER_CONNECTION as usize,
         );
         // No client has connected: accept is pending, no conns, so the
         // engine reports no work and stays idle.

--- a/cmd/unbounded-storage/src/frontend/loadgen_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/loadgen_serve.rs
@@ -360,6 +360,7 @@ mod tests {
         let mut spec = loadgen_spec();
         spec.config = Some(frontend_spec::Config::Http(HttpFrontendConfig {
             addr: "127.0.0.1:9000".to_string(),
+            max_requests_per_connection: None,
         }));
         assert!(LoadgenFrontend::from_spec(&spec).is_err());
     }

--- a/cmd/unbounded-storage/src/frontend/mod.rs
+++ b/cmd/unbounded-storage/src/frontend/mod.rs
@@ -71,6 +71,8 @@ pub enum FrontendError {
     UnsupportedKind(&'static str),
     /// The listener address in the spec could not be parsed/bound.
     BadBind(String),
+    /// A frontend-specific config value is invalid.
+    BadConfig(&'static str),
 }
 
 impl std::fmt::Display for FrontendError {
@@ -78,6 +80,7 @@ impl std::fmt::Display for FrontendError {
         match self {
             FrontendError::UnsupportedKind(k) => write!(f, "unsupported frontend kind: {k}"),
             FrontendError::BadBind(b) => write!(f, "bad frontend addr: {b}"),
+            FrontendError::BadConfig(msg) => write!(f, "bad frontend config: {msg}"),
         }
     }
 }

--- a/cmd/unbounded-storage/src/frontend/s3_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/s3_serve.rs
@@ -738,6 +738,7 @@ mod tests {
         let mut s = spec("f", "127.0.0.1:9000");
         s.config = Some(frontend_spec::Config::Http(HttpFrontendConfig {
             addr: "127.0.0.1:9000".to_string(),
+            max_requests_per_connection: None,
         }));
         assert!(matches!(
             S3Frontend::from_spec(&s),

--- a/cmd/unbounded-storage/src/http/connection.rs
+++ b/cmd/unbounded-storage/src/http/connection.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! HTTP connection lifetime policy shared by frontends and backends.
+
+use super::headers::{any_header_value_has_token, header_count, header_value_has_token};
+use super::request::HttpRequest;
+
+/// Whether a request's HTTP version and `Connection` headers ask for a
+/// persistent connection.
+pub fn request_wants_keep_alive(req: &HttpRequest<'_>) -> bool {
+    if req.version_minor == 0 {
+        any_header_value_has_token(&req.headers, "connection", "keep-alive")
+    } else {
+        !any_header_value_has_token(&req.headers, "connection", "close")
+    }
+}
+
+/// Whether a request has no body bytes the frontend would need to drain
+/// before parsing the next request on the same connection.
+pub fn request_is_bodyless(req: &HttpRequest<'_>) -> bool {
+    if header_count(&req.headers, "transfer-encoding") > 0 {
+        return false;
+    }
+
+    match header_count(&req.headers, "content-length") {
+        0 => true,
+        1 => {
+            req.header("content-length")
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                == Some(0)
+        }
+        _ => false,
+    }
+}
+
+/// Whether the frontend can safely keep a client connection alive after
+/// serving this request.
+pub fn request_allows_keep_alive(req: &HttpRequest<'_>) -> bool {
+    request_wants_keep_alive(req) && request_is_bodyless(req)
+}
+
+/// Canonical `Connection` response header value for a keep-alive decision.
+pub fn connection_header_value(keep_alive: bool) -> &'static str {
+    if keep_alive { "keep-alive" } else { "close" }
+}
+
+/// Whether an origin response keeps the TCP connection reusable after
+/// its body has been fully consumed.
+pub fn response_keep_alive(version_minor: u8, connection: Option<&str>) -> bool {
+    if version_minor == 0 {
+        connection.is_some_and(|value| header_value_has_token(value, "keep-alive"))
+    } else {
+        !connection.is_some_and(|value| header_value_has_token(value, "close"))
+    }
+}
+
+/// Whether EOF is the expected delimiter after the response body.
+pub fn response_closes_after_body(version_minor: u8, connection: Option<&str>) -> bool {
+    !response_keep_alive(version_minor, connection)
+}

--- a/cmd/unbounded-storage/src/http/headers.rs
+++ b/cmd/unbounded-storage/src/http/headers.rs
@@ -66,6 +66,30 @@ pub(crate) fn header<'a>(headers: &[Header<'a>], name: &str) -> Option<&'a str> 
         .map(|h| h.value)
 }
 
+/// Count headers matching `name` case-insensitively.
+pub(crate) fn header_count(headers: &[Header<'_>], name: &str) -> usize {
+    headers
+        .iter()
+        .filter(|h| h.name.eq_ignore_ascii_case(name))
+        .count()
+}
+
+/// True when any matching header value contains `token`.
+pub(crate) fn any_header_value_has_token(headers: &[Header<'_>], name: &str, token: &str) -> bool {
+    headers
+        .iter()
+        .filter(|h| h.name.eq_ignore_ascii_case(name))
+        .any(|h| header_value_has_token(h.value, token))
+}
+
+/// Return whether a comma-separated header value contains `token`, using
+/// HTTP's case-insensitive token matching rules.
+pub(crate) fn header_value_has_token(value: &str, token: &str) -> bool {
+    value
+        .split(',')
+        .any(|part| part.trim().eq_ignore_ascii_case(token))
+}
+
 /// Parse a `Content-Length` header value (case-insensitive name) into a
 /// byte count, or `None` if absent or unparseable.
 pub(crate) fn content_length(headers: &[Header]) -> Option<u64> {
@@ -125,6 +149,14 @@ mod tests {
         );
         assert_eq!(content_length(&headers(&[("content-length", "x")])), None);
         assert_eq!(content_length(&headers(&[("Content-Type", "x")])), None);
+    }
+
+    #[test]
+    fn header_value_token_matching_is_case_insensitive() {
+        assert!(header_value_has_token("keep-alive, Close", "close"));
+        assert!(header_value_has_token(" keep-alive ", "KEEP-ALIVE"));
+        assert!(!header_value_has_token("keep-alive", "close"));
+        assert!(!header_value_has_token("upgrade", "up"));
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/http/mod.rs
+++ b/cmd/unbounded-storage/src/http/mod.rs
@@ -24,11 +24,16 @@
 //! borrowed header views (zero-copy on the hot path); the serializers
 //! build an owned `Vec<u8>` from an [`http::Request`]/[`http::Response`].
 
+mod connection;
 mod headers;
 mod request;
 mod response;
 mod server;
 
+pub use connection::{
+    connection_header_value, request_allows_keep_alive, request_is_bodyless,
+    request_wants_keep_alive, response_closes_after_body, response_keep_alive,
+};
 pub use headers::{Header, ParseError};
 pub use request::{HttpRequest, serialize_request};
 pub use response::{ResponseHead, serialize_response_head};

--- a/cmd/unbounded-storage/src/http/request.rs
+++ b/cmd/unbounded-storage/src/http/request.rs
@@ -27,6 +27,9 @@ pub struct HttpRequest<'a> {
     pub target: &'a str,
     /// Minor version: `1` for `HTTP/1.1`, `0` for `HTTP/1.0`.
     pub version_minor: u8,
+    /// Byte offset just past the terminating `\r\n\r\n`, i.e. where a
+    /// request body or the next pipelined request begins.
+    pub header_end: usize,
     /// Headers are kept as borrowed, zero-copy slices into the source
     /// buffer rather than an owned [`http::HeaderMap`]. This is a
     /// deliberate choice: the frontend parses one request per buffer on
@@ -49,11 +52,11 @@ impl<'a> HttpRequest<'a> {
         let mut header_storage = [httparse::EMPTY_HEADER; MAX_HEADERS];
         let mut req = httparse::Request::new(&mut header_storage);
 
-        match req.parse(buf) {
-            Ok(httparse::Status::Complete(_)) => {}
+        let header_end = match req.parse(buf) {
+            Ok(httparse::Status::Complete(n)) => n,
             Ok(httparse::Status::Partial) => return Err(ParseError::Incomplete),
             Err(e) => return Err(headers::map_httparse_error(e)),
-        }
+        };
 
         let method = Method::from_bytes(req.method.unwrap().as_bytes())
             .map_err(|_| ParseError::BadRequestLine)?;
@@ -66,6 +69,7 @@ impl<'a> HttpRequest<'a> {
             method,
             target,
             version_minor,
+            header_end,
             headers,
         })
     }
@@ -119,6 +123,10 @@ mod tests {
         assert_eq!(r.method, Method::GET);
         assert_eq!(r.target, "/bucket/key");
         assert_eq!(r.version_minor, 1);
+        assert_eq!(
+            r.header_end,
+            "GET /bucket/key HTTP/1.1\r\nHost: example.com\r\nRange: bytes=0-10\r\n\r\n".len()
+        );
         assert_eq!(r.header("host"), Some("example.com"));
         assert_eq!(r.header("range"), Some("bytes=0-10"));
     }
@@ -209,6 +217,10 @@ mod tests {
         // A body after the header block is not consumed by the parser.
         let r = req("GET / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello").unwrap();
         assert_eq!(r.header("content-length"), Some("5"));
+        assert_eq!(
+            r.header_end,
+            "GET / HTTP/1.1\r\nContent-Length: 5\r\n\r\n".len()
+        );
         assert_eq!(r.headers.len(), 1);
     }
 

--- a/cmd/unbounded-storage/src/http/response.rs
+++ b/cmd/unbounded-storage/src/http/response.rs
@@ -22,6 +22,8 @@ pub use ::http::StatusCode;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResponseHead<'a> {
     pub status: StatusCode,
+    /// Minor version: `1` for `HTTP/1.1`, `0` for `HTTP/1.0`.
+    pub version_minor: u8,
     /// Byte offset just past the terminating `\r\n\r\n`, i.e. where the
     /// body begins in the source buffer.
     pub header_end: usize,
@@ -44,6 +46,7 @@ impl<'a> ResponseHead<'a> {
                 let headers = headers::collect_headers(resp.headers)?;
                 Ok(Some(ResponseHead {
                     status,
+                    version_minor: resp.version.ok_or(ParseError::BadStatusLine)?,
                     header_end: n,
                     headers,
                 }))
@@ -103,6 +106,7 @@ mod tests {
         let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 1024\r\nContent-Type: x\r\n\r\nBODY";
         let head = ResponseHead::parse(raw).unwrap().expect("complete head");
         assert_eq!(head.status, StatusCode::OK);
+        assert_eq!(head.version_minor, 1);
         assert_eq!(head.content_length(), Some(1024));
         assert_eq!(&raw[head.header_end..], b"BODY");
     }

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -1322,6 +1322,7 @@ impl FrontendBuildCtx {
                     self.page_size,
                     self.fanout.clone(),
                     binding.bypass_cache,
+                    frontend.max_requests_per_connection(),
                 )))
             }
             Some(frontend_spec::Config::S3(_)) => {

--- a/cmd/unbounded-storage/src/p2p/handler.rs
+++ b/cmd/unbounded-storage/src/p2p/handler.rs
@@ -90,7 +90,16 @@ impl std::fmt::Display for RecursiveHandlerError {
     }
 }
 
-impl std::error::Error for RecursiveHandlerError {}
+impl std::error::Error for RecursiveHandlerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RecursiveHandlerError::BlockStore(e)
+            | RecursiveHandlerError::Backend(e)
+            | RecursiveHandlerError::Forward(e) => Some(e),
+            RecursiveHandlerError::NoScratchPage | RecursiveHandlerError::HopLimitExceeded => None,
+        }
+    }
+}
 
 /// Recursive handler resolving stripe reads by routing through the
 /// finger table.

--- a/cmd/unbounded-storage/src/ring/network.rs
+++ b/cmd/unbounded-storage/src/ring/network.rs
@@ -447,6 +447,12 @@ impl NetHandle {
         Rc::as_ptr(&self.ring) as usize
     }
 
+    /// Address identity of the underlying ring allocation for components
+    /// that must keep resources ring-local across reused handles.
+    pub(crate) fn ring_key(&self) -> usize {
+        Rc::as_ptr(&self.ring) as usize
+    }
+
     /// `'static` counterpart of [`NetworkRing::accept`].
     pub fn accept(&self, listen_fd: RawFd) -> impl Future<Output = io::Result<RawFd>> + 'static {
         let ring = Rc::clone(&self.ring);

--- a/cmd/unbounded-storage/tests/dst.rs
+++ b/cmd/unbounded-storage/tests/dst.rs
@@ -5,6 +5,7 @@ mod bufferpool;
 mod fabric;
 mod fanout;
 mod framework;
+mod http_keepalive;
 mod lifecycle;
 mod p2p;
 mod page_channel;

--- a/cmd/unbounded-storage/tests/http_keepalive/mod.rs
+++ b/cmd/unbounded-storage/tests/http_keepalive/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! HTTP keep-alive DST: drives a deterministic in-memory connection
+//! model through the shared HTTP parser and connection lifetime policy.
+
+pub mod tests;
+pub mod workload;

--- a/cmd/unbounded-storage/tests/http_keepalive/tests.proptest-regressions
+++ b/cmd/unbounded-storage/tests/http_keepalive/tests.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc efa553ff1cce3f2946ce84c8ca814529499f7a933b9b9763a810b21898a00c6b # shrinks to seed = 0, w = Workload { requests: [RequestSpec { method: Get, version: Http11, connection: None, body: None }, RequestSpec { method: Get, version: Http11, connection: None, body: None }, RequestSpec { method: Get, version: Http11, connection: None, body: None }], chunk_sizes: [1], max_send_delay: 0, max_requests_per_connection: 1 }

--- a/cmd/unbounded-storage/tests/http_keepalive/tests.rs
+++ b/cmd/unbounded-storage/tests/http_keepalive/tests.rs
@@ -31,11 +31,17 @@ proptest! {
     /// matching the keep-alive decision made for that request.
     #[test]
     fn invariant_response_connection_matches_decision(seed in any::<u64>(), w in workload_strategy()) {
+        let max_requests_per_connection = w.max_requests_per_connection;
         let report = run_workload(seed, w).expect("run completed");
         for served in &report.served {
             let expected = if served.keep_alive { "keep-alive" } else { "close" };
             prop_assert_eq!(served.response_connection.as_str(), expected);
-            prop_assert_eq!(served.keep_alive, served.wants_keep_alive && served.bodyless);
+            prop_assert_eq!(
+                served.keep_alive,
+                served.wants_keep_alive
+                    && served.bodyless
+                    && served.request_index.saturating_add(1) < max_requests_per_connection
+            );
         }
     }
 }
@@ -59,6 +65,7 @@ fn smoke_pipelined_http11_requests_share_connection() {
         ],
         chunk_sizes: vec![u8::MAX],
         max_send_delay: 0,
+        max_requests_per_connection: 1024,
     };
     let report = run_workload(0, w).expect("run completed");
     assert_eq!(report.served.len(), 2);
@@ -87,6 +94,7 @@ fn smoke_body_header_closes_before_pipelined_request() {
         ],
         chunk_sizes: vec![u8::MAX],
         max_send_delay: 0,
+        max_requests_per_connection: 1024,
     };
     let all_bytes = request_bytes(&w.requests);
     let first_len = w.requests[0].to_bytes().len();
@@ -95,6 +103,44 @@ fn smoke_body_header_closes_before_pipelined_request() {
     assert!(!report.served[0].keep_alive);
     assert_eq!(report.stopped_with, StopReason::ServerClosed);
     assert_eq!(report.leftover, all_bytes[first_len - 1..].to_vec());
+}
+
+#[test]
+fn smoke_request_cap_closes_after_bound() {
+    let w = Workload {
+        requests: vec![
+            RequestSpec {
+                method: RequestMethod::Get,
+                version: HttpVersion::Http11,
+                connection: ConnectionSpec::None,
+                body: BodySpec::None,
+            },
+            RequestSpec {
+                method: RequestMethod::Head,
+                version: HttpVersion::Http11,
+                connection: ConnectionSpec::None,
+                body: BodySpec::None,
+            },
+            RequestSpec {
+                method: RequestMethod::Get,
+                version: HttpVersion::Http11,
+                connection: ConnectionSpec::None,
+                body: BodySpec::None,
+            },
+        ],
+        chunk_sizes: vec![u8::MAX],
+        max_send_delay: 0,
+        max_requests_per_connection: 2,
+    };
+    let all_bytes = request_bytes(&w.requests);
+    let first_two_len = w.requests[0].to_bytes().len() + w.requests[1].to_bytes().len();
+    let report = run_workload(0, w).expect("run completed");
+    assert_eq!(report.served.len(), 2);
+    assert!(report.served[0].keep_alive);
+    assert!(!report.served[1].keep_alive);
+    assert_eq!(report.served[1].response_connection, "close");
+    assert_eq!(report.stopped_with, StopReason::ServerClosed);
+    assert_eq!(report.leftover, all_bytes[first_two_len..].to_vec());
 }
 
 fn assert_served_prefix(report: &RunReport, expected: &[bool]) -> Result<(), TestCaseError> {

--- a/cmd/unbounded-storage/tests/http_keepalive/tests.rs
+++ b/cmd/unbounded-storage/tests/http_keepalive/tests.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! HTTP keep-alive DST property tests.
+
+use proptest::prelude::*;
+
+use crate::http_keepalive::workload::{
+    BodySpec, ConnectionSpec, HttpVersion, RequestMethod, RequestSpec, RunReport, StopReason,
+    Workload, expected_keep_alive_prefix, request_bytes, run_workload, workload_strategy,
+};
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        ..ProptestConfig::default()
+    })]
+
+    /// Invariant: the model serves exactly the prefix permitted by the
+    /// shared keep-alive policy. A non-reusable request closes the
+    /// connection and prevents later pipelined bytes from being parsed as
+    /// another request.
+    #[test]
+    fn invariant_serves_keep_alive_prefix(seed in any::<u64>(), w in workload_strategy()) {
+        let expected = expected_keep_alive_prefix(&w);
+        let report = run_workload(seed, w).expect("run completed");
+        assert_served_prefix(&report, &expected)?;
+    }
+
+    /// Invariant: every serialized response carries a `Connection` header
+    /// matching the keep-alive decision made for that request.
+    #[test]
+    fn invariant_response_connection_matches_decision(seed in any::<u64>(), w in workload_strategy()) {
+        let report = run_workload(seed, w).expect("run completed");
+        for served in &report.served {
+            let expected = if served.keep_alive { "keep-alive" } else { "close" };
+            prop_assert_eq!(served.response_connection.as_str(), expected);
+            prop_assert_eq!(served.keep_alive, served.wants_keep_alive && served.bodyless);
+        }
+    }
+}
+
+#[test]
+fn smoke_pipelined_http11_requests_share_connection() {
+    let w = Workload {
+        requests: vec![
+            RequestSpec {
+                method: RequestMethod::Get,
+                version: HttpVersion::Http11,
+                connection: ConnectionSpec::None,
+                body: BodySpec::None,
+            },
+            RequestSpec {
+                method: RequestMethod::Head,
+                version: HttpVersion::Http11,
+                connection: ConnectionSpec::Close,
+                body: BodySpec::None,
+            },
+        ],
+        chunk_sizes: vec![u8::MAX],
+        max_send_delay: 0,
+    };
+    let report = run_workload(0, w).expect("run completed");
+    assert_eq!(report.served.len(), 2);
+    assert!(report.served[0].keep_alive);
+    assert!(!report.served[1].keep_alive);
+    assert_eq!(report.stopped_with, StopReason::ServerClosed);
+    assert!(report.leftover.is_empty());
+}
+
+#[test]
+fn smoke_body_header_closes_before_pipelined_request() {
+    let w = Workload {
+        requests: vec![
+            RequestSpec {
+                method: RequestMethod::Get,
+                version: HttpVersion::Http11,
+                connection: ConnectionSpec::KeepAlive,
+                body: BodySpec::ContentLengthNonZero,
+            },
+            RequestSpec {
+                method: RequestMethod::Get,
+                version: HttpVersion::Http11,
+                connection: ConnectionSpec::None,
+                body: BodySpec::None,
+            },
+        ],
+        chunk_sizes: vec![u8::MAX],
+        max_send_delay: 0,
+    };
+    let all_bytes = request_bytes(&w.requests);
+    let first_len = w.requests[0].to_bytes().len();
+    let report = run_workload(0, w).expect("run completed");
+    assert_eq!(report.served.len(), 1);
+    assert!(!report.served[0].keep_alive);
+    assert_eq!(report.stopped_with, StopReason::ServerClosed);
+    assert_eq!(report.leftover, all_bytes[first_len - 1..].to_vec());
+}
+
+fn assert_served_prefix(report: &RunReport, expected: &[bool]) -> Result<(), TestCaseError> {
+    prop_assert_eq!(report.served.len(), expected.len());
+    for (idx, (served, keep_alive)) in report.served.iter().zip(expected).enumerate() {
+        prop_assert_eq!(served.request_index, idx);
+        prop_assert_eq!(served.keep_alive, *keep_alive);
+    }
+    if expected.last().copied() == Some(false) {
+        prop_assert_eq!(report.stopped_with, StopReason::ServerClosed);
+    } else {
+        prop_assert_eq!(report.stopped_with, StopReason::ClientClosed);
+    }
+    prop_assert!(report.steps > 0);
+    Ok(())
+}

--- a/cmd/unbounded-storage/tests/http_keepalive/workload.rs
+++ b/cmd/unbounded-storage/tests/http_keepalive/workload.rs
@@ -1,0 +1,374 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Workload model and runner for HTTP keep-alive connection semantics.
+//!
+//! The runner intentionally models only the transport-independent part of
+//! the frontend: incremental request-head parsing, the keep-alive decision,
+//! header-drain behavior that preserves pipelined bytes, and response
+//! `Connection` header serialization. Real sockets and io_uring progress
+//! remain covered by the storage smoke/integration paths.
+
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use ::http::header::{CONNECTION, CONTENT_LENGTH};
+use proptest::collection::vec;
+use proptest::prelude::*;
+use unbounded_storage::http::{
+    HttpRequest, ParseError, ResponseHead, StatusCode, connection_header_value,
+    request_allows_keep_alive, request_is_bodyless, request_wants_keep_alive,
+    serialize_response_head,
+};
+
+use crate::framework::executor::{Executor, RunError, yield_n, yield_once};
+
+#[derive(Clone, Debug)]
+pub struct Workload {
+    pub requests: Vec<RequestSpec>,
+    pub chunk_sizes: Vec<u8>,
+    pub max_send_delay: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestSpec {
+    pub method: RequestMethod,
+    pub version: HttpVersion,
+    pub connection: ConnectionSpec,
+    pub body: BodySpec,
+}
+
+#[derive(Clone, Debug)]
+pub enum RequestMethod {
+    Get,
+    Head,
+}
+
+#[derive(Clone, Debug)]
+pub enum HttpVersion {
+    Http10,
+    Http11,
+}
+
+#[derive(Clone, Debug)]
+pub enum ConnectionSpec {
+    None,
+    KeepAlive,
+    Close,
+    KeepAliveThenClose,
+}
+
+#[derive(Clone, Debug)]
+pub enum BodySpec {
+    None,
+    ContentLengthZero,
+    ContentLengthNonZero,
+    DuplicateContentLength,
+    TransferEncoding,
+}
+
+#[derive(Debug)]
+pub struct RunReport {
+    pub served: Vec<ServedRequest>,
+    pub stopped_with: StopReason,
+    pub leftover: Vec<u8>,
+    pub steps: u64,
+}
+
+#[derive(Debug)]
+pub struct ServedRequest {
+    pub request_index: usize,
+    pub wants_keep_alive: bool,
+    pub bodyless: bool,
+    pub keep_alive: bool,
+    pub response_connection: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopReason {
+    ClientClosed,
+    ServerClosed,
+    ParseError,
+}
+
+pub fn workload_strategy() -> impl Strategy<Value = Workload> {
+    (
+        vec(request_strategy(), 1..=8),
+        vec(1u8..=48, 1..=24),
+        prop_oneof![1 => Just(0u32), 9 => 1u32..=4],
+    )
+        .prop_map(|(requests, chunk_sizes, max_send_delay)| Workload {
+            requests,
+            chunk_sizes,
+            max_send_delay,
+        })
+}
+
+fn request_strategy() -> impl Strategy<Value = RequestSpec> {
+    (
+        prop_oneof![Just(RequestMethod::Get), Just(RequestMethod::Head)],
+        prop_oneof![1 => Just(HttpVersion::Http10), 4 => Just(HttpVersion::Http11)],
+        prop_oneof![
+            4 => Just(ConnectionSpec::None),
+            3 => Just(ConnectionSpec::KeepAlive),
+            2 => Just(ConnectionSpec::Close),
+            1 => Just(ConnectionSpec::KeepAliveThenClose),
+        ],
+        prop_oneof![
+            5 => Just(BodySpec::None),
+            3 => Just(BodySpec::ContentLengthZero),
+            1 => Just(BodySpec::ContentLengthNonZero),
+            1 => Just(BodySpec::DuplicateContentLength),
+            1 => Just(BodySpec::TransferEncoding),
+        ],
+    )
+        .prop_map(|(method, version, connection, body)| RequestSpec {
+            method,
+            version,
+            connection,
+            body,
+        })
+}
+
+pub fn run_workload(seed: u64, w: Workload) -> Result<RunReport, RunError> {
+    let chunks = chunk_request_bytes(&w);
+    let inbound = Rc::new(RefCell::new(VecDeque::<Vec<u8>>::new()));
+    let client_done = Rc::new(Cell::new(false));
+    let report = Rc::new(RefCell::new(None));
+
+    let mut exec = Executor::new(seed);
+    spawn_client(
+        &mut exec,
+        chunks,
+        inbound.clone(),
+        client_done.clone(),
+        w.max_send_delay,
+    );
+    spawn_server(
+        &mut exec,
+        inbound,
+        client_done,
+        report.clone(),
+        w.requests.len(),
+    );
+
+    let step_budget = 512 + w.requests.len() as u64 * 256 + w.chunk_sizes.len() as u64 * 16;
+    exec.run(step_budget)?;
+
+    let mut report = report.borrow_mut().take().expect("server produced report");
+    report.steps = exec.last_steps();
+    Ok(report)
+}
+
+pub fn expected_keep_alive_prefix(w: &Workload) -> Vec<bool> {
+    let mut out = Vec::new();
+    for req in &w.requests {
+        let bytes = req.to_bytes();
+        let parsed = HttpRequest::parse(&bytes).expect("generated request parses");
+        let keep_alive = request_allows_keep_alive(&parsed);
+        out.push(keep_alive);
+        if !keep_alive {
+            break;
+        }
+    }
+    out
+}
+
+pub fn request_bytes(reqs: &[RequestSpec]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for req in reqs {
+        out.extend_from_slice(&req.to_bytes());
+    }
+    out
+}
+
+fn spawn_client(
+    exec: &mut Executor,
+    chunks: Vec<Vec<u8>>,
+    inbound: Rc<RefCell<VecDeque<Vec<u8>>>>,
+    client_done: Rc<Cell<bool>>,
+    max_send_delay: u32,
+) {
+    exec.spawn(async move {
+        for chunk in chunks {
+            let delay = if max_send_delay == 0 {
+                0
+            } else {
+                crate::framework::executor::with_sim(|s| {
+                    use rand::Rng;
+                    s.rng.gen_range(0..=max_send_delay)
+                })
+            };
+            yield_n(delay).await;
+            inbound.borrow_mut().push_back(chunk);
+            yield_once().await;
+        }
+        client_done.set(true);
+    });
+}
+
+fn spawn_server(
+    exec: &mut Executor,
+    inbound: Rc<RefCell<VecDeque<Vec<u8>>>>,
+    client_done: Rc<Cell<bool>>,
+    report: Rc<RefCell<Option<RunReport>>>,
+    request_count: usize,
+) {
+    exec.spawn(async move {
+        let mut buf = Vec::new();
+        let mut served = Vec::new();
+        let mut stop = StopReason::ClientClosed;
+
+        loop {
+            if served.len() >= request_count {
+                break;
+            }
+
+            match HttpRequest::parse(&buf) {
+                Ok(req) => {
+                    let request_index = served.len();
+                    let wants_keep_alive = request_wants_keep_alive(&req);
+                    let bodyless = request_is_bodyless(&req);
+                    let keep_alive = request_allows_keep_alive(&req);
+                    let header_end = req.header_end;
+                    let response_connection = response_connection_value(keep_alive);
+
+                    served.push(ServedRequest {
+                        request_index,
+                        wants_keep_alive,
+                        bodyless,
+                        keep_alive,
+                        response_connection,
+                    });
+                    buf.drain(..header_end);
+
+                    if !keep_alive {
+                        stop = StopReason::ServerClosed;
+                        break;
+                    }
+                    yield_once().await;
+                }
+                Err(ParseError::Incomplete) => {
+                    if let Some(chunk) = inbound.borrow_mut().pop_front() {
+                        buf.extend_from_slice(&chunk);
+                    } else if client_done.get() {
+                        stop = StopReason::ClientClosed;
+                        break;
+                    } else {
+                        yield_once().await;
+                    }
+                }
+                Err(_) => {
+                    stop = StopReason::ParseError;
+                    break;
+                }
+            }
+        }
+
+        *report.borrow_mut() = Some(RunReport {
+            served,
+            stopped_with: stop,
+            leftover: buf,
+            steps: 0,
+        });
+    });
+}
+
+fn response_connection_value(keep_alive: bool) -> String {
+    let resp = ::http::Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_LENGTH, "0")
+        .header(CONNECTION, connection_header_value(keep_alive))
+        .body(())
+        .expect("valid response");
+    let bytes = serialize_response_head(&resp);
+    let head = ResponseHead::parse(&bytes)
+        .expect("response parses")
+        .expect("response head complete");
+    head.header("connection")
+        .expect("connection header present")
+        .to_string()
+}
+
+fn chunk_request_bytes(w: &Workload) -> Vec<Vec<u8>> {
+    let bytes = request_bytes(&w.requests);
+    let mut chunks = Vec::new();
+    let mut pos = 0usize;
+    let mut idx = 0usize;
+    while pos < bytes.len() {
+        let requested = w.chunk_sizes[idx % w.chunk_sizes.len()].max(1) as usize;
+        let end = pos.saturating_add(requested).min(bytes.len());
+        chunks.push(bytes[pos..end].to_vec());
+        pos = end;
+        idx += 1;
+    }
+    chunks
+}
+
+impl RequestSpec {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = format!(
+            "{} /object/{} {}\r\n",
+            self.method.as_str(),
+            self.path_suffix(),
+            self.version.as_str()
+        )
+        .into_bytes();
+
+        match self.connection {
+            ConnectionSpec::None => {}
+            ConnectionSpec::KeepAlive => out.extend_from_slice(b"Connection: keep-alive\r\n"),
+            ConnectionSpec::Close => out.extend_from_slice(b"Connection: close\r\n"),
+            ConnectionSpec::KeepAliveThenClose => {
+                out.extend_from_slice(b"Connection: keep-alive\r\n");
+                out.extend_from_slice(b"Connection: close\r\n");
+            }
+        }
+
+        match self.body {
+            BodySpec::None => {}
+            BodySpec::ContentLengthZero => out.extend_from_slice(b"Content-Length: 0\r\n"),
+            BodySpec::ContentLengthNonZero => out.extend_from_slice(b"Content-Length: 1\r\n"),
+            BodySpec::DuplicateContentLength => {
+                out.extend_from_slice(b"Content-Length: 0\r\n");
+                out.extend_from_slice(b"Content-Length: 1\r\n");
+            }
+            BodySpec::TransferEncoding => out.extend_from_slice(b"Transfer-Encoding: chunked\r\n"),
+        }
+
+        out.extend_from_slice(b"\r\n");
+        if matches!(self.body, BodySpec::ContentLengthNonZero) {
+            out.extend_from_slice(b"x");
+        }
+        out
+    }
+
+    fn path_suffix(&self) -> &'static str {
+        match self.body {
+            BodySpec::None => "none",
+            BodySpec::ContentLengthZero => "cl0",
+            BodySpec::ContentLengthNonZero => "cl1",
+            BodySpec::DuplicateContentLength => "dupe-cl",
+            BodySpec::TransferEncoding => "te",
+        }
+    }
+}
+
+impl RequestMethod {
+    fn as_str(&self) -> &'static str {
+        match self {
+            RequestMethod::Get => "GET",
+            RequestMethod::Head => "HEAD",
+        }
+    }
+}
+
+impl HttpVersion {
+    fn as_str(&self) -> &'static str {
+        match self {
+            HttpVersion::Http10 => "HTTP/1.0",
+            HttpVersion::Http11 => "HTTP/1.1",
+        }
+    }
+}

--- a/cmd/unbounded-storage/tests/http_keepalive/workload.rs
+++ b/cmd/unbounded-storage/tests/http_keepalive/workload.rs
@@ -29,6 +29,7 @@ pub struct Workload {
     pub requests: Vec<RequestSpec>,
     pub chunk_sizes: Vec<u8>,
     pub max_send_delay: u32,
+    pub max_requests_per_connection: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -97,12 +98,16 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
         vec(request_strategy(), 1..=8),
         vec(1u8..=48, 1..=24),
         prop_oneof![1 => Just(0u32), 9 => 1u32..=4],
+        1usize..=8,
     )
-        .prop_map(|(requests, chunk_sizes, max_send_delay)| Workload {
-            requests,
-            chunk_sizes,
-            max_send_delay,
-        })
+        .prop_map(
+            |(requests, chunk_sizes, max_send_delay, max_requests_per_connection)| Workload {
+                requests,
+                chunk_sizes,
+                max_send_delay,
+                max_requests_per_connection,
+            },
+        )
 }
 
 fn request_strategy() -> impl Strategy<Value = RequestSpec> {
@@ -151,6 +156,7 @@ pub fn run_workload(seed: u64, w: Workload) -> Result<RunReport, RunError> {
         client_done,
         report.clone(),
         w.requests.len(),
+        w.max_requests_per_connection,
     );
 
     let step_budget = 512 + w.requests.len() as u64 * 256 + w.chunk_sizes.len() as u64 * 16;
@@ -166,7 +172,8 @@ pub fn expected_keep_alive_prefix(w: &Workload) -> Vec<bool> {
     for req in &w.requests {
         let bytes = req.to_bytes();
         let parsed = HttpRequest::parse(&bytes).expect("generated request parses");
-        let keep_alive = request_allows_keep_alive(&parsed);
+        let keep_alive = request_allows_keep_alive(&parsed)
+            && out.len().saturating_add(1) < w.max_requests_per_connection;
         out.push(keep_alive);
         if !keep_alive {
             break;
@@ -214,6 +221,7 @@ fn spawn_server(
     client_done: Rc<Cell<bool>>,
     report: Rc<RefCell<Option<RunReport>>>,
     request_count: usize,
+    max_requests_per_connection: usize,
 ) {
     exec.spawn(async move {
         let mut buf = Vec::new();
@@ -230,7 +238,8 @@ fn spawn_server(
                     let request_index = served.len();
                     let wants_keep_alive = request_wants_keep_alive(&req);
                     let bodyless = request_is_bodyless(&req);
-                    let keep_alive = request_allows_keep_alive(&req);
+                    let keep_alive = request_allows_keep_alive(&req)
+                        && served.len().saturating_add(1) < max_requests_per_connection;
                     let header_end = req.header_end;
                     let response_connection = response_connection_value(keep_alive);
 

--- a/cmd/unbounded-storage/tests/lifecycle/workload.rs
+++ b/cmd/unbounded-storage/tests/lifecycle/workload.rs
@@ -925,6 +925,7 @@ fn frontend_specs(generation: usize, count: u8) -> Vec<FrontendSpec> {
             source: "cache-0".to_string(),
             config: Some(frontend_spec::Config::Http(HttpFrontendConfig {
                 addr: format!("127.0.0.1:{}", 10_000 + generation as u16 * 16 + i as u16),
+                max_requests_per_connection: None,
             })),
         })
         .collect()

--- a/cmd/unbounded-storage/tests/lifecycle/workload.rs
+++ b/cmd/unbounded-storage/tests/lifecycle/workload.rs
@@ -251,11 +251,7 @@ struct SimApplyTarget {
 }
 
 impl ConfigApplyTarget for SimApplyTarget {
-    fn apply_in_place(
-        &mut self,
-        new: &Arc<Config>,
-        diff: &ConfigDiff,
-    ) -> Result<(), ApplyError> {
+    fn apply_in_place(&mut self, new: &Arc<Config>, diff: &ConfigDiff) -> Result<(), ApplyError> {
         let projection = runtime_projection(new)
             .map_err(|e| ApplyError::Target(format!("config projection failed: {e}")))?;
 


### PR DESCRIPTION
Adds support for the standard keepalive header to avoid frequent reconnections from frontends and backends.