### PR TITLE
storage: cache internal btree nodes

### DIFF
--- a/cmd/unbounded-storage/src/storage/btree/cow.rs
+++ b/cmd/unbounded-storage/src/storage/btree/cow.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! CoW B+tree primitives: bulk-loading, path-copy commits, and
-//! root-anchored lookup.
+//! CoW B+tree primitives: bulk-loading, path-copy commits,
+//! internal-node caching, and root-anchored lookup.
 //!
 //! The mutator side has two write modes:
 //!
@@ -23,14 +23,15 @@
 //! them is no longer reachable from any live snapshot - see the
 //! generation-tracker documentation in `super`.
 //!
-//! The lookup side does *not* hold the in-memory map: it walks
-//! the on-disk tree starting from the
-//! [`RootSnapshot`](super::RootSnapshot) currently published via
-//! [`arc_swap::ArcSwap`]. That keeps lookups honest - they
-//! exercise the exact disk path a fresh process would.
+//! Lookups use the immutable internal-node cache attached to each
+//! published [`RootSnapshot`](super::RootSnapshot) to descend to a
+//! leaf, then read that leaf from disk. This removes upper-level
+//! metadata I/O without caching every leaf entry in memory.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::future::Future;
+use std::mem::size_of;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -56,13 +57,135 @@ type WriteFut<'f> = Pin<Box<dyn Future<Output = Result<(), Error>> + 'f>>;
 /// times fanout.
 const MAX_TRAVERSAL_NODES: u64 = 1 << 24;
 
-/// Walk the tree rooted at `root_lba` for `key`. Returns `None`
-/// for any miss, including structural corruption / checksum
-/// mismatches (the design's silent-miss policy).
+/// Immutable decoded cache of internal B+tree nodes reachable from
+/// a published root. Leaf pages are deliberately excluded so lookup
+/// memory scales with the upper levels only.
+#[derive(Default)]
+pub struct InternalNodeCache {
+    nodes: HashMap<Lba, CachedInternalNode>,
+    bytes: usize,
+}
+
+struct CachedInternalNode {
+    keys: Box<[PageKey]>,
+    children: Box<[Lba]>,
+}
+
+impl InternalNodeCache {
+    pub fn bytes(&self) -> usize {
+        self.bytes
+    }
+
+    fn get(&self, lba: Lba) -> Option<&CachedInternalNode> {
+        self.nodes.get(&lba)
+    }
+}
+
+/// Build a cache for every internal node reachable from `root_lba`.
+/// The traversal first discovers the tree height by following the
+/// leftmost spine, then reads only levels above the leaves. That keeps
+/// cache construction proportional to internal-node count, not leaf
+/// count.
+pub async fn build_internal_cache<B: BlockDevice>(
+    device: &B,
+    scratch: &Rc<ScratchPool>,
+    root_lba: Lba,
+    strict: bool,
+) -> Result<Arc<InternalNodeCache>, Error> {
+    let depth = internal_depth(device, scratch, root_lba, strict).await?;
+    if depth == 0 {
+        return Ok(Arc::new(InternalNodeCache::default()));
+    }
+
+    let mut nodes = HashMap::new();
+    let mut bytes = 0usize;
+    let mut stack = vec![(root_lba, depth)];
+    let mut buf = scratch.acquire().await;
+    let mut visited = 0u64;
+
+    while let Some((node_lba, remaining_depth)) = stack.pop() {
+        visited += 1;
+        if visited > MAX_TRAVERSAL_NODES {
+            return Err(Error::Corrupt);
+        }
+        match device.read(node_lba, buf.as_mut_slice()).await {
+            Ok(()) => {}
+            Err(e) if strict => return Err(e),
+            Err(_) => continue,
+        }
+
+        match page::decode(buf.as_slice()) {
+            Decoded::Internal { keys, children, .. } if keys.len() == children.len() => {
+                if remaining_depth > 1 {
+                    for &child in &children {
+                        stack.push((child, remaining_depth - 1));
+                    }
+                }
+                bytes += size_of::<CachedInternalNode>()
+                    + keys.len() * size_of::<PageKey>()
+                    + children.len() * size_of::<Lba>();
+                nodes.insert(
+                    node_lba,
+                    CachedInternalNode {
+                        keys: keys.into_boxed_slice(),
+                        children: children.into_boxed_slice(),
+                    },
+                );
+            }
+            Decoded::Internal { .. } | Decoded::Empty | Decoded::Meta { .. } if strict => {
+                return Err(Error::Corrupt);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(Arc::new(InternalNodeCache { nodes, bytes }))
+}
+
+async fn internal_depth<B: BlockDevice>(
+    device: &B,
+    scratch: &Rc<ScratchPool>,
+    root_lba: Lba,
+    strict: bool,
+) -> Result<usize, Error> {
+    if !root_lba.is_valid() {
+        return Ok(0);
+    }
+
+    let mut cur = root_lba;
+    let mut depth = 0usize;
+    let mut buf = scratch.acquire().await;
+    for _ in 0..32 {
+        match device.read(cur, buf.as_mut_slice()).await {
+            Ok(()) => {}
+            Err(e) if strict => return Err(e),
+            Err(_) => return Ok(depth),
+        }
+        match page::decode(buf.as_slice()) {
+            Decoded::Internal { children, .. } if !children.is_empty() => {
+                depth += 1;
+                cur = children[0];
+            }
+            Decoded::Leaf { .. } => return Ok(depth),
+            Decoded::Internal { .. } | Decoded::Empty | Decoded::Meta { .. } if strict => {
+                return Err(Error::Corrupt);
+            }
+            _ => return Ok(depth),
+        }
+    }
+
+    Err(Error::Corrupt)
+}
+
+/// Walk the tree rooted at `root_lba` for `key`, using cached
+/// internal nodes when present and reading only the terminal leaf
+/// in the common case. Returns `None` for any miss, including
+/// structural corruption / checksum mismatches.
 pub async fn lookup<B: BlockDevice>(
     device: &B,
     scratch: &Rc<ScratchPool>,
     root_lba: Lba,
+    internal_cache: &InternalNodeCache,
     key: &PageKey,
 ) -> Result<Option<LeafEntry>, Error> {
     if !root_lba.is_valid() {
@@ -70,9 +193,17 @@ pub async fn lookup<B: BlockDevice>(
     }
     let mut cur = root_lba;
     let mut buf = scratch.acquire().await;
-    // Bound the descent by the worst-case depth so a cycle in
-    // corrupted-but-checksum-valid pages can't loop forever.
     for _ in 0..32 {
+        if let Some(node) = internal_cache.get(cur) {
+            let idx = match node.keys.binary_search(key) {
+                Ok(i) => i,
+                Err(0) => return Ok(None),
+                Err(i) => i - 1,
+            };
+            cur = node.children[idx];
+            continue;
+        }
+
         match device.read(cur, buf.as_mut_slice()).await {
             Ok(()) => {}
             Err(_) => return Ok(None),
@@ -80,9 +211,6 @@ pub async fn lookup<B: BlockDevice>(
         match page::decode(buf.as_slice()) {
             Decoded::Empty => return Ok(None),
             Decoded::Leaf { entries, .. } => {
-                // Linear scan; leaves are at most ~72 entries on
-                // 4 KiB pages so the binary-search win is tiny
-                // and the linear version is much easier to read.
                 for (k, v) in entries {
                     if &k == key {
                         return Ok(Some(v));

--- a/cmd/unbounded-storage/src/storage/btree/mod.rs
+++ b/cmd/unbounded-storage/src/storage/btree/mod.rs
@@ -422,11 +422,15 @@ impl<B: BlockDevice> BTreeIndex<B> {
     /// Look up `key` by using the current snapshot's internal-node
     /// cache, then reading the terminal leaf from disk.
     pub async fn lookup(&self, key: &PageKey) -> Result<Option<LeafEntry>, Error> {
-        let (root_lba, internal_cache) = {
-            let snap = self.root.load();
-            (snap.root_lba, snap.internal_cache.clone())
-        };
-        cow::lookup(&*self.device, &self.scratch, root_lba, &internal_cache, key).await
+        let snap = self.root.load();
+        cow::lookup(
+            &*self.device,
+            &self.scratch,
+            snap.root_lba,
+            &snap.internal_cache,
+            key,
+        )
+        .await
     }
 
     /// Apply a batch of mutations atomically. Must be called by

--- a/cmd/unbounded-storage/src/storage/btree/mod.rs
+++ b/cmd/unbounded-storage/src/storage/btree/mod.rs
@@ -83,6 +83,7 @@ pub struct RootSnapshot {
     tracker: Rc<RefCell<AliveTracker>>,
     pending: Rc<RefCell<PendingFree>>,
     allocator: Arc<Allocator>,
+    internal_cache: Arc<cow::InternalNodeCache>,
 }
 
 impl RootSnapshot {
@@ -92,6 +93,7 @@ impl RootSnapshot {
         tracker: Rc<RefCell<AliveTracker>>,
         pending: Rc<RefCell<PendingFree>>,
         allocator: Arc<Allocator>,
+        internal_cache: Arc<cow::InternalNodeCache>,
     ) -> Arc<Self> {
         Arc::new(Self {
             root_lba,
@@ -99,7 +101,12 @@ impl RootSnapshot {
             tracker,
             pending,
             allocator,
+            internal_cache,
         })
+    }
+
+    fn lookup_cache_bytes(&self) -> usize {
+        self.internal_cache.bytes()
     }
 }
 
@@ -316,12 +323,16 @@ impl<B: BlockDevice> BTreeIndex<B> {
         let pending = Rc::new(RefCell::new(PendingFree::default()));
         alive.borrow_mut().alive.insert(state.txn_id);
 
+        let internal_cache =
+            cow::build_internal_cache(&**device, scratch, state.root_lba, false).await?;
+
         let snapshot = RootSnapshot::new(
             state.root_lba,
             state.txn_id,
             alive.clone(),
             pending.clone(),
             allocator.clone(),
+            internal_cache,
         );
 
         Ok(Some(Self {
@@ -382,12 +393,15 @@ impl<B: BlockDevice> BTreeIndex<B> {
         let pending = Rc::new(RefCell::new(PendingFree::default()));
         alive.borrow_mut().alive.insert(txn_id);
 
+        let internal_cache = cow::build_internal_cache(&*device, &scratch, root_lba, true).await?;
+
         let snapshot = RootSnapshot::new(
             root_lba,
             txn_id,
             alive.clone(),
             pending.clone(),
             allocator.clone(),
+            internal_cache,
         );
 
         Ok(Self {
@@ -405,11 +419,14 @@ impl<B: BlockDevice> BTreeIndex<B> {
         })
     }
 
-    /// Look up `key`. Disk errors and structural corruption
-    /// surface as `Ok(None)` per the design's silent-miss policy.
+    /// Look up `key` by using the current snapshot's internal-node
+    /// cache, then reading the terminal leaf from disk.
     pub async fn lookup(&self, key: &PageKey) -> Result<Option<LeafEntry>, Error> {
-        let snap = self.root.load();
-        cow::lookup(&*self.device, &self.scratch, snap.root_lba, key).await
+        let (root_lba, internal_cache) = {
+            let snap = self.root.load();
+            (snap.root_lba, snap.internal_cache.clone())
+        };
+        cow::lookup(&*self.device, &self.scratch, root_lba, &internal_cache, key).await
     }
 
     /// Apply a batch of mutations atomically. Must be called by
@@ -459,6 +476,17 @@ impl<B: BlockDevice> BTreeIndex<B> {
             sorted_ops,
         )
         .await?;
+
+        let internal_cache =
+            match cow::build_internal_cache(&*self.device, &self.scratch, result.new_root, true)
+                .await
+            {
+                Ok(cache) => cache,
+                Err(e) => {
+                    cow::free_all(&self.allocator, &result.new_pages);
+                    return Err(e);
+                }
+            };
 
         let active = self.active_meta.get();
         // apply_path_copy above has already marked the new pages
@@ -512,6 +540,7 @@ impl<B: BlockDevice> BTreeIndex<B> {
             self.alive.clone(),
             self.pending.clone(),
             self.allocator.clone(),
+            internal_cache,
         );
         self.root.store(snapshot);
         Ok(())
@@ -532,10 +561,16 @@ impl<B: BlockDevice> BTreeIndex<B> {
         }
     }
 
-    /// Number of live entries in the in-memory mirror. Exposed
-    /// for diagnostics and tests; lookups never use this.
+    /// Number of live entries in the in-memory mirror. Exposed for
+    /// diagnostics and tests.
     pub fn live_entries(&self) -> usize {
         self.mutator.borrow().entries.len()
+    }
+
+    /// Heap footprint of the immutable lookup cache owned by the
+    /// currently published snapshot.
+    pub fn lookup_cache_bytes(&self) -> usize {
+        self.root.load().lookup_cache_bytes()
     }
 
     /// Largest LBA ever allocated on the underlying allocator. Exposed for diagnostics and tests.

--- a/cmd/unbounded-storage/src/storage/engine.rs
+++ b/cmd/unbounded-storage/src/storage/engine.rs
@@ -231,6 +231,7 @@ pub struct EngineSnapshot {
     pub checksum_misses: u64,
     pub resident_pages: usize,
     pub btree_entries: usize,
+    pub btree_lookup_cache_bytes: usize,
     /// Length of the deferred-reclaim queue: LBAs that were
     /// displaced (overwrite or eviction) while their old page
     /// was still pinned and that have not yet been returned to
@@ -317,6 +318,7 @@ impl<B: BlockDevice> StorageEngine<B> {
             checksum_misses: m.checksum_misses,
             resident_pages: self.lru.len(),
             btree_entries: self.btree.live_entries(),
+            btree_lookup_cache_bytes: self.btree.lookup_cache_bytes(),
             pending_free_len: self.pending_free.lock().unwrap().len(),
         }
     }
@@ -618,6 +620,45 @@ impl<B: BlockDevice> StorageEngine<B> {
         self.metric(|m| m.hits += 1);
         crate::metrics::storage_lookup(crate::metrics::Lookup::Hit);
         Ok(true)
+    }
+
+    /// Benchmark/tooling hook: populate the B-tree metadata without
+    /// writing payload pages. The entries become valid for metadata
+    /// lookup benchmarks only; callers must not read the payload LBAs
+    /// unless they wrote matching data separately.
+    pub async fn seed_metadata_for_bench(
+        &self,
+        entries: &[(StripeKey, u64, Lba, crate::storage::types::Checksum, u32)],
+    ) -> Result<(), crate::storage::types::Error> {
+        let mut mutations = Vec::with_capacity(entries.len());
+        for &(stripe, stripe_off, lba, data_checksum, byte_len) in entries {
+            let n_pages = self.n_pages(byte_len);
+            let _ = self.allocator.mark_range_in_use(lba, n_pages);
+            mutations.push(Mutation::Insert {
+                key: Self::page_key(&stripe, stripe_off, self.cfg.page_size_bytes),
+                value: LeafEntry {
+                    lba,
+                    data_checksum,
+                    byte_len,
+                },
+            });
+        }
+
+        self.btree.apply_batch(mutations).await?;
+        self.publish_usage_gauges();
+        Ok(())
+    }
+
+    /// Benchmark/tooling hook: perform only the B-tree metadata lookup
+    /// for `(key, stripe_off)`, without reading or checksumming the
+    /// payload page.
+    pub async fn lookup_metadata_for_bench(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+    ) -> Result<bool, crate::storage::types::Error> {
+        let pk = Self::page_key(&key, stripe_off, self.cfg.page_size_bytes);
+        Ok(self.btree.lookup(&pk).await?.is_some())
     }
 
     /// Write the contents of `src` to `(key, stripe_off)`. The

--- a/cmd/unbounded-storage/src/storage/engine.rs
+++ b/cmd/unbounded-storage/src/storage/engine.rs
@@ -622,45 +622,6 @@ impl<B: BlockDevice> StorageEngine<B> {
         Ok(true)
     }
 
-    /// Benchmark/tooling hook: populate the B-tree metadata without
-    /// writing payload pages. The entries become valid for metadata
-    /// lookup benchmarks only; callers must not read the payload LBAs
-    /// unless they wrote matching data separately.
-    pub async fn seed_metadata_for_bench(
-        &self,
-        entries: &[(StripeKey, u64, Lba, crate::storage::types::Checksum, u32)],
-    ) -> Result<(), crate::storage::types::Error> {
-        let mut mutations = Vec::with_capacity(entries.len());
-        for &(stripe, stripe_off, lba, data_checksum, byte_len) in entries {
-            let n_pages = self.n_pages(byte_len);
-            let _ = self.allocator.mark_range_in_use(lba, n_pages);
-            mutations.push(Mutation::Insert {
-                key: Self::page_key(&stripe, stripe_off, self.cfg.page_size_bytes),
-                value: LeafEntry {
-                    lba,
-                    data_checksum,
-                    byte_len,
-                },
-            });
-        }
-
-        self.btree.apply_batch(mutations).await?;
-        self.publish_usage_gauges();
-        Ok(())
-    }
-
-    /// Benchmark/tooling hook: perform only the B-tree metadata lookup
-    /// for `(key, stripe_off)`, without reading or checksumming the
-    /// payload page.
-    pub async fn lookup_metadata_for_bench(
-        &self,
-        key: StripeKey,
-        stripe_off: u64,
-    ) -> Result<bool, crate::storage::types::Error> {
-        let pk = Self::page_key(&key, stripe_off, self.cfg.page_size_bytes);
-        Ok(self.btree.lookup(&pk).await?.is_some())
-    }
-
     /// Write the contents of `src` to `(key, stripe_off)`. The
     /// caller owns the slice and guarantees it is valid for reads
     /// for the duration of the returned future.

--- a/cmd/unbounded-storage/tests/lifecycle/workload.rs
+++ b/cmd/unbounded-storage/tests/lifecycle/workload.rs
@@ -251,11 +251,7 @@ struct SimApplyTarget {
 }
 
 impl ConfigApplyTarget for SimApplyTarget {
-    fn apply_in_place(
-        &mut self,
-        new: &Arc<Config>,
-        diff: &ConfigDiff,
-    ) -> Result<(), ApplyError> {
+    fn apply_in_place(&mut self, new: &Arc<Config>, diff: &ConfigDiff) -> Result<(), ApplyError> {
         let projection = runtime_projection(new)
             .map_err(|e| ApplyError::Target(format!("config projection failed: {e}")))?;
 

--- a/cmd/unbounded-storage/tests/storage/mocks.rs
+++ b/cmd/unbounded-storage/tests/storage/mocks.rs
@@ -10,14 +10,14 @@
 //! (delay bound, fault rate) live on a local `MockSimConfig` held
 //! behind an `Rc`, never on the framework's [`SimState`].
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use rand::Rng;
 use unbounded_storage::storage::blockdev::{BlockDevice, MockDevice, MockDeviceConfig};
 use unbounded_storage::storage::types::{Error, Lba};
 
-use crate::framework::executor::{with_sim, yield_n};
+use crate::framework::executor::{with_sim, yield_n, yield_once};
 
 /// Storage-DST simulation knobs. Mirrors the bufferpool DST's
 /// `MockSimConfig` so the two harnesses read the same way side by
@@ -76,6 +76,7 @@ pub struct SimBlockDevice {
     corruptions_injected: Cell<u64>,
     inflight: Cell<u32>,
     max_inflight: Cell<u32>,
+    read_pause: RefCell<Option<Rc<ReadPause>>>,
 }
 
 impl SimBlockDevice {
@@ -89,6 +90,7 @@ impl SimBlockDevice {
             corruptions_injected: Cell::new(0),
             inflight: Cell::new(0),
             max_inflight: Cell::new(0),
+            read_pause: RefCell::new(None),
         }
     }
 
@@ -122,6 +124,50 @@ impl SimBlockDevice {
     pub fn poke(&self, lba: Lba, src: &[u8]) {
         self.inner.poke(lba, src);
     }
+
+    pub fn pause_next_read(&self, lba: Lba) -> Rc<ReadPause> {
+        let pause = Rc::new(ReadPause::new(lba));
+        *self.read_pause.borrow_mut() = Some(pause.clone());
+        pause
+    }
+}
+
+pub struct ReadPause {
+    lba: Lba,
+    armed: Cell<bool>,
+    paused: Cell<bool>,
+    released: Cell<bool>,
+}
+
+impl ReadPause {
+    fn new(lba: Lba) -> Self {
+        Self {
+            lba,
+            armed: Cell::new(true),
+            paused: Cell::new(false),
+            released: Cell::new(false),
+        }
+    }
+
+    pub fn paused(&self) -> bool {
+        self.paused.get()
+    }
+
+    pub fn release(&self) {
+        self.released.set(true);
+    }
+
+    fn try_pause(&self, lba: Lba) -> bool {
+        if self.lba != lba || !self.armed.replace(false) {
+            return false;
+        }
+        self.paused.set(true);
+        true
+    }
+
+    fn released(&self) -> bool {
+        self.released.get()
+    }
 }
 
 impl BlockDevice for SimBlockDevice {
@@ -146,6 +192,14 @@ impl BlockDevice for SimBlockDevice {
         let fault = draw_fault(&self.cfg);
         let _guard = InflightGuard::enter(self);
         yield_n(delay).await;
+        let pause = self.read_pause.borrow().as_ref().cloned();
+        if let Some(pause) = pause {
+            if pause.try_pause(lba) {
+                while !pause.released() {
+                    yield_once().await;
+                }
+            }
+        }
         self.reads.set(self.reads.get() + 1);
         if fault {
             self.io_errors.set(self.io_errors.get() + 1);

--- a/cmd/unbounded-storage/tests/storage/mod.rs
+++ b/cmd/unbounded-storage/tests/storage/mod.rs
@@ -12,5 +12,6 @@
 pub mod mocks;
 pub mod oracle;
 pub mod recovery;
+pub mod snapshot;
 pub mod tests;
 pub mod workload;

--- a/cmd/unbounded-storage/tests/storage/recovery.rs
+++ b/cmd/unbounded-storage/tests/storage/recovery.rs
@@ -426,7 +426,9 @@ fn torn_btree_leaf_reports_miss() {
 
                 // Now read every key back. Each read either misses or
                 // hits with the EXACT bytes we wrote; nothing else is
-                // acceptable.
+                // acceptable. The internal-node cache can route to the
+                // leaf without disk I/O, but the leaf itself remains
+                // disk-backed and must fail closed after corruption.
                 let mut results: Vec<(bool, Vec<u8>)> = Vec::new();
                 let read_base = writes_for_task.len();
                 for (i, (k, off, _)) in writes_for_task.iter().enumerate() {

--- a/cmd/unbounded-storage/tests/storage/snapshot.rs
+++ b/cmd/unbounded-storage/tests/storage/snapshot.rs
@@ -1,0 +1,362 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Scripted snapshot-lifetime scenarios for the storage engine.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use unbounded_storage::bufferpool::{BlockStore, PageRef, StripeKey};
+use unbounded_storage::memory::Backing;
+use unbounded_storage::storage::blockdev::{BlockDevice, MockDeviceConfig};
+use unbounded_storage::storage::types::{Checksum, Lba, PageKey};
+use unbounded_storage::storage::{EngineConfig, StorageEngine};
+
+use crate::framework::executor::{Executor, yield_once};
+use crate::storage::mocks::{MockSimConfig, SimBlockDevice};
+
+const PAGE_SIZE: usize = 4096;
+const PAGE_TYPE_OFFSET: usize = 0;
+const PAGE_TYPE_LEAF: u8 = 1;
+const NENTRIES_OFFSET: usize = 2;
+const TXN_ID_RANGE: std::ops::Range<usize> = 8..16;
+const HEADER_LEN: usize = 32;
+const KEY_LEN: usize = 36;
+const LEAF_ENTRY_LEN: usize = 56;
+
+fn backing(base: *mut u8, page_size: usize, page_count: usize) -> Backing {
+    Backing {
+        base,
+        page_size,
+        page_count,
+        keepalive: std::sync::Arc::new(()),
+    }
+}
+
+fn engine_cfg() -> EngineConfig {
+    EngineConfig {
+        page_size_bytes: PAGE_SIZE,
+        btree_page_bytes: PAGE_SIZE,
+        ..EngineConfig::default()
+    }
+}
+
+fn payload(key_idx: u8, off_idx: u8, seed: u8) -> Vec<u8> {
+    let mut out = vec![0u8; PAGE_SIZE];
+    let mix = key_idx.wrapping_mul(31) ^ off_idx.wrapping_mul(17) ^ seed;
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = (i as u8).wrapping_add(mix);
+    }
+    out
+}
+
+fn stripe(i: u8) -> StripeKey {
+    let mut s = [0u8; 32];
+    s[0] = i;
+    StripeKey(s)
+}
+
+fn page_key(key: StripeKey, offset: u64) -> PageKey {
+    PageKey::new(key.0, (offset / PAGE_SIZE as u64) as u32)
+}
+
+struct Pool {
+    buf: Box<[u8]>,
+}
+
+impl Pool {
+    fn new(page_count: usize) -> Self {
+        Self {
+            buf: vec![0u8; page_count * PAGE_SIZE].into_boxed_slice(),
+        }
+    }
+
+    fn base(&mut self) -> *mut u8 {
+        self.buf.as_mut_ptr()
+    }
+}
+
+async fn admit_one<B>(
+    eng: &StorageEngine<B>,
+    pool_base: *mut u8,
+    pool_slot: usize,
+    key: StripeKey,
+    offset: u64,
+    bytes: &[u8],
+) where
+    B: BlockDevice,
+{
+    unsafe {
+        let p = pool_base.add(pool_slot * PAGE_SIZE);
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), p, PAGE_SIZE);
+    }
+    let page = PageRef {
+        page_idx: pool_slot as u32,
+        offset: 0,
+        len: PAGE_SIZE as u32,
+    };
+    eng.write_page(&key, offset, page).await.unwrap();
+    eng.write_page(&key, offset, page).await.unwrap();
+}
+
+fn find_leaf_lba_for_key(device: &SimBlockDevice, key: PageKey) -> Option<u64> {
+    let mut buf = vec![0u8; PAGE_SIZE];
+    let mut best: Option<(u64, u64)> = None;
+    let max_entries = (PAGE_SIZE - HEADER_LEN) / LEAF_ENTRY_LEN;
+
+    for lba in 2..device.capacity_pages() {
+        device.peek(Lba(lba), &mut buf);
+        if buf[PAGE_TYPE_OFFSET] != PAGE_TYPE_LEAF {
+            continue;
+        }
+        let nentries =
+            u16::from_le_bytes([buf[NENTRIES_OFFSET], buf[NENTRIES_OFFSET + 1]]) as usize;
+        if nentries > max_entries {
+            continue;
+        }
+        let contains_key = (0..nentries).any(|i| {
+            let base = HEADER_LEN + i * LEAF_ENTRY_LEN;
+            PageKey::decode(&buf[base..base + KEY_LEN]) == Some(key)
+        });
+        if !contains_key {
+            continue;
+        }
+        let txn = u64::from_le_bytes(buf[TXN_ID_RANGE].try_into().unwrap());
+        if best.map(|(_, best_txn)| txn > best_txn).unwrap_or(true) {
+            best = Some((lba, txn));
+        }
+    }
+
+    best.map(|(lba, _)| lba)
+}
+
+#[test]
+fn lookup_pins_snapshot_until_leaf_read_finishes() {
+    const ENTRIES: usize = 80;
+    const TARGET: u8 = 0;
+    const REWRITE: u8 = 1;
+    const OTHER_LEAF: u8 = 79;
+    const READ_SLOT: usize = ENTRIES;
+    const WRITE_SLOT: usize = ENTRIES + 1;
+
+    let sim_cfg = MockSimConfig::new();
+    sim_cfg.max_io_delay.set(0);
+    sim_cfg.io_fault_rate.set(0);
+    sim_cfg.read_corrupt_rate.set(0);
+    let device = Arc::new(SimBlockDevice::new(
+        MockDeviceConfig {
+            page_size: PAGE_SIZE,
+            capacity_pages: 512,
+            ..Default::default()
+        },
+        sim_cfg,
+    ));
+
+    let mut pool = Pool::new(ENTRIES + 2);
+    let pool_base = pool.base() as usize;
+    let expected = payload(TARGET, 0, 10);
+
+    type Engine = StorageEngine<SimBlockDevice>;
+    enum Stage {
+        Pending,
+        Failed,
+        Ready(Arc<Engine>),
+    }
+
+    let stage: Rc<RefCell<Stage>> = Rc::new(RefCell::new(Stage::Pending));
+    let phase = Rc::new(Cell::new(0u8));
+    let reader_done = Rc::new(Cell::new(false));
+    let writer_done = Rc::new(Cell::new(false));
+    let result: Rc<RefCell<Option<(bool, Vec<u8>)>>> = Rc::new(RefCell::new(None));
+    let mut exec = Executor::new(0x5107_BA11);
+
+    {
+        let stage = stage.clone();
+        let device = device.clone();
+        exec.spawn(Box::pin(async move {
+            let eng = match StorageEngine::open(device, engine_cfg()).await {
+                Ok(e) => Arc::new(e),
+                Err(_) => {
+                    *stage.borrow_mut() = Stage::Failed;
+                    return;
+                }
+            };
+            if eng
+                .register_pages(&backing(pool_base as *mut u8, PAGE_SIZE, ENTRIES + 2))
+                .is_err()
+            {
+                *stage.borrow_mut() = Stage::Failed;
+                return;
+            }
+            *stage.borrow_mut() = Stage::Ready(eng);
+        }));
+    }
+
+    {
+        let stage = stage.clone();
+        exec.spawn(Box::pin(async move {
+            let eng = loop {
+                match &*stage.borrow() {
+                    Stage::Pending => {}
+                    Stage::Failed => return,
+                    Stage::Ready(e) => break e.clone(),
+                }
+                yield_once().await;
+            };
+            eng.run_mutator().await;
+        }));
+    }
+
+    {
+        let stage = stage.clone();
+        let phase = phase.clone();
+        let reader_done = reader_done.clone();
+        let result = result.clone();
+        exec.spawn(Box::pin(async move {
+            let eng = loop {
+                match &*stage.borrow() {
+                    Stage::Pending => {}
+                    Stage::Failed => {
+                        reader_done.set(true);
+                        return;
+                    }
+                    Stage::Ready(e) => break e.clone(),
+                }
+                yield_once().await;
+            };
+            while phase.get() < 1 {
+                yield_once().await;
+            }
+            unsafe {
+                let p = (pool_base as *mut u8).add(READ_SLOT * PAGE_SIZE);
+                std::ptr::write_bytes(p, 0, PAGE_SIZE);
+            }
+            let dst = PageRef {
+                page_idx: READ_SLOT as u32,
+                offset: 0,
+                len: PAGE_SIZE as u32,
+            };
+            let hit = eng.read_page(&stripe(TARGET), 0, dst).await.unwrap();
+            let bytes = if hit {
+                let p = unsafe { (pool_base as *const u8).add(READ_SLOT * PAGE_SIZE) };
+                unsafe { std::slice::from_raw_parts(p, PAGE_SIZE) }.to_vec()
+            } else {
+                Vec::new()
+            };
+            *result.borrow_mut() = Some((hit, bytes));
+            reader_done.set(true);
+        }));
+    }
+
+    {
+        let stage = stage.clone();
+        let phase = phase.clone();
+        let writer_done = writer_done.clone();
+        exec.spawn(Box::pin(async move {
+            let eng = loop {
+                match &*stage.borrow() {
+                    Stage::Pending => {}
+                    Stage::Failed => {
+                        writer_done.set(true);
+                        return;
+                    }
+                    Stage::Ready(e) => break e.clone(),
+                }
+                yield_once().await;
+            };
+            while phase.get() < 2 {
+                yield_once().await;
+            }
+            eng.seed_metadata_for_bench(&[(
+                stripe(REWRITE),
+                0,
+                Lba(400),
+                Checksum::ZERO,
+                PAGE_SIZE as u32,
+            )])
+            .await
+            .unwrap();
+            eng.seed_metadata_for_bench(&[(
+                stripe(OTHER_LEAF),
+                0,
+                Lba(401),
+                Checksum::ZERO,
+                PAGE_SIZE as u32,
+            )])
+            .await
+            .unwrap();
+            writer_done.set(true);
+        }));
+    }
+
+    {
+        let stage = stage.clone();
+        let phase = phase.clone();
+        let reader_done = reader_done.clone();
+        let writer_done = writer_done.clone();
+        let device = device.clone();
+        exec.spawn(Box::pin(async move {
+            let eng = loop {
+                match &*stage.borrow() {
+                    Stage::Pending => {}
+                    Stage::Failed => return,
+                    Stage::Ready(e) => break e.clone(),
+                }
+                yield_once().await;
+            };
+
+            for i in 0..ENTRIES {
+                let bytes = payload(i as u8, 0, 10);
+                admit_one(&eng, pool_base as *mut u8, i, stripe(i as u8), 0, &bytes).await;
+            }
+            assert!(
+                eng.snapshot().btree_lookup_cache_bytes > 0,
+                "test requires an internal-node cache",
+            );
+
+            let target_leaf = find_leaf_lba_for_key(&device, page_key(stripe(TARGET), 0))
+                .expect("target key lives in a leaf");
+            let rewrite_leaf = find_leaf_lba_for_key(&device, page_key(stripe(REWRITE), 0))
+                .expect("rewrite key lives in a leaf");
+            let other_leaf = find_leaf_lba_for_key(&device, page_key(stripe(OTHER_LEAF), 0))
+                .expect("other key lives in a leaf");
+            assert_eq!(
+                target_leaf, rewrite_leaf,
+                "rewrite must retire the leaf containing the target key",
+            );
+            assert_ne!(
+                target_leaf, other_leaf,
+                "second metadata commit must rewrite a different leaf",
+            );
+
+            let pause = device.pause_next_read(Lba(target_leaf));
+            phase.set(1);
+            while !pause.paused() {
+                yield_once().await;
+            }
+            phase.set(2);
+            while !writer_done.get() {
+                yield_once().await;
+            }
+            pause.release();
+            while !reader_done.get() {
+                yield_once().await;
+            }
+            eng.close_mutator();
+        }));
+    }
+
+    exec.run(1_000_000)
+        .expect("executor finished without deadlock or budget exhaustion");
+
+    let (hit, bytes) = result.borrow().clone().expect("reader populated result");
+    assert!(
+        hit,
+        "lookup lost the target key while its snapshot leaf was reclaimed and reused",
+    );
+    assert_eq!(
+        bytes, expected,
+        "lookup returned bytes from a different snapshot generation",
+    );
+}

--- a/cmd/unbounded-storage/tests/storage/snapshot.rs
+++ b/cmd/unbounded-storage/tests/storage/snapshot.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use unbounded_storage::bufferpool::{BlockStore, PageRef, StripeKey};
 use unbounded_storage::memory::Backing;
 use unbounded_storage::storage::blockdev::{BlockDevice, MockDeviceConfig};
-use unbounded_storage::storage::types::{Checksum, Lba, PageKey};
+use unbounded_storage::storage::types::{Lba, PageKey};
 use unbounded_storage::storage::{EngineConfig, StorageEngine};
 
 use crate::framework::executor::{Executor, yield_once};
@@ -268,24 +268,24 @@ fn lookup_pins_snapshot_until_leaf_read_finishes() {
             while phase.get() < 2 {
                 yield_once().await;
             }
-            eng.seed_metadata_for_bench(&[(
+            admit_one(
+                &eng,
+                pool_base as *mut u8,
+                WRITE_SLOT,
                 stripe(REWRITE),
                 0,
-                Lba(400),
-                Checksum::ZERO,
-                PAGE_SIZE as u32,
-            )])
-            .await
-            .unwrap();
-            eng.seed_metadata_for_bench(&[(
+                &payload(REWRITE, 0, 20),
+            )
+            .await;
+            admit_one(
+                &eng,
+                pool_base as *mut u8,
+                WRITE_SLOT,
                 stripe(OTHER_LEAF),
                 0,
-                Lba(401),
-                Checksum::ZERO,
-                PAGE_SIZE as u32,
-            )])
-            .await
-            .unwrap();
+                &payload(OTHER_LEAF, 0, 30),
+            )
+            .await;
             writer_done.set(true);
         }));
     }

--- a/cmd/unbounded-storage/tests/storage/tests.rs
+++ b/cmd/unbounded-storage/tests/storage/tests.rs
@@ -601,45 +601,39 @@ fn smoke() {
 /// proving the `SimBlockDevice` inflight counter actually
 /// observes overlap when overlap is geometrically forced.
 ///
-/// Several clients each issue many reads against distinct
-/// keys with a generous `max_io_delay`. Reads are not
-/// singleflight-gated and (unlike writes) do not funnel
-/// through the mutator, so the executor can interleave
-/// device reads from independent client tasks freely; with
-/// per-op `yield_n(delay)` and the executor's random task
-/// pick, at least one engine must see two device ops in
-/// flight at once. If this test ever observes peak == 1,
+/// Several clients each admit one distinct key and then issue many
+/// reads for that key with a generous `max_io_delay`. Reads are not
+/// singleflight-gated and (unlike writes) do not funnel through the
+/// mutator, so the executor can interleave device reads from
+/// independent client tasks freely; with per-op `yield_n(delay)` and
+/// the executor's random task pick, at least one engine must see two
+/// device ops in flight at once. If this test ever observes peak == 1,
 /// `SimBlockDevice` has stopped yielding through `await` or
 /// the engine has acquired a global I/O lock that defeats
 /// the per-disk concurrency the rest of the harness assumes.
 #[test]
 fn smoke_concurrent_reads_overlap() {
-    // 4 clients, each reads 6 distinct keys (each pre-written
-    // twice so admission promotes them). Reads cannot be
-    // collapsed, so the device sees ~24 independent ops, more
-    // than enough for at least one overlap under the executor's
-    // random pick.
+    // Each client first writes one distinct key twice so admission
+    // promotes it, then repeatedly reads that key. The per-client
+    // prefix avoids relying on a separate primer client completing
+    // before readers start; after the prefixes, reads cannot be
+    // collapsed and are numerous enough to force overlap under the
+    // deterministic executor.
     let mut clients = Vec::new();
-    let key_count = 6u8;
-    // One client up front double-writes every key to prime
-    // admission. Subsequent clients then read in parallel.
-    let mut primer = Vec::new();
+    let key_count = 16u8;
     for k in 0..key_count {
-        primer.push(Op::Write {
-            key_idx: k,
-            off_idx: 0,
-            payload_seed: k,
-        });
-        primer.push(Op::Write {
-            key_idx: k,
-            off_idx: 0,
-            payload_seed: k,
-        });
-    }
-    clients.push(ClientSpec { ops: primer });
-    for _ in 0..4 {
         let mut ops = Vec::new();
-        for k in 0..key_count {
+        ops.push(Op::Write {
+            key_idx: k,
+            off_idx: 0,
+            payload_seed: k,
+        });
+        ops.push(Op::Write {
+            key_idx: k,
+            off_idx: 0,
+            payload_seed: k,
+        });
+        for _ in 0..16 {
             ops.push(Op::Read {
                 key_idx: k,
                 off_idx: 0,
@@ -649,8 +643,8 @@ fn smoke_concurrent_reads_overlap() {
     }
     let w = Workload {
         page_size: 4096,
-        device_pages: 64,
-        max_io_delay: 8,
+        device_pages: 256,
+        max_io_delay: 32,
         io_fault_rate: 0,
         read_corrupt_rate: 0,
         key_count,
@@ -668,8 +662,8 @@ fn smoke_concurrent_reads_overlap() {
         .unwrap_or(0);
     assert!(
         peak >= 2,
-        "engine never saw overlapping device ops despite 4 concurrent readers over 6 \
-         primed keys with max_io_delay=8: per-disk peaks={:?}, device_reads={}, \
+        "engine never saw overlapping device ops despite 16 concurrent readers over 16 \
+         admitted keys with max_io_delay=32: per-disk peaks={:?}, device_reads={}, \
          device_writes={}",
         report.max_inflight_per_disk,
         report.device_reads,


### PR DESCRIPTION
Very fast nvme disks are bottlenecked by metadata btree seek iops. Caching the entire tree gets expensive for large disks - caching only a subset of the "hot" internal nodes of the tree gets us enough iops back.