### PR TITLE
agent: expose AMD GPU devices in nspawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For a deeper dive, see the [Project Overview](https://azure.github.io/unbounded/
 - **Cloud API provisioning** — Auto-provision instances from Nebius, CoreWeave, OCI, Azure, AWS, and others via Karpenter in response to unschedulable pods.
 - **Bare-metal PXE boot** — PXE-boot servers with integrated DHCP, TFTP, HTTP, Redfish BMC power management, and TPM 2.0 attestation.
 - **Works with any conformant Kubernetes** — AKS, EKS, GKE, kubeadm, k3s, and more. Bring your own cluster or use the quickstart script.
-- **GPU support** — Automatic detection and configuration of NVIDIA GPUs on provisioned nodes.
+- **GPU support** — Automatic detection and exposure of NVIDIA and AMD GPUs on provisioned nodes.
 
 ## Components
 
@@ -129,7 +129,7 @@ Full documentation is available at **[azure.github.io/unbounded](https://azure.g
 |---|---|
 | **Concepts** | [Project Overview](https://azure.github.io/unbounded/concepts/overview/) · [Networking](https://azure.github.io/unbounded/concepts/networking/) · [Bare Metal](https://azure.github.io/unbounded/concepts/bare-metal/) |
 | **Guides** | [Getting Started](https://azure.github.io/unbounded/guides/getting-started/) · [Existing Cluster](https://azure.github.io/unbounded/guides/existing-cluster/) · [SSH Provisioning](https://azure.github.io/unbounded/guides/ssh/) · [Cloud API](https://azure.github.io/unbounded/guides/cloud-api/) · [PXE Boot](https://azure.github.io/unbounded/guides/pxe/) · [Agent](https://azure.github.io/unbounded/guides/agent/) |
-| **Reference** | [Architecture](https://azure.github.io/unbounded/reference/architecture/) · [CLI](https://azure.github.io/unbounded/reference/cli/) · [Machine CRD](https://azure.github.io/unbounded/reference/machina-crd/) · [GPU / NVIDIA](https://azure.github.io/unbounded/reference/gpu/nvidia/) |
+| **Reference** | [Architecture](https://azure.github.io/unbounded/reference/architecture/) · [CLI](https://azure.github.io/unbounded/reference/cli/) · [Machine CRD](https://azure.github.io/unbounded/reference/machina-crd/) · [GPU / NVIDIA](https://azure.github.io/unbounded/reference/gpu/nvidia/) · [GPU / AMD](https://azure.github.io/unbounded/reference/gpu/amd/) |
 
 ## Repository Structure
 

--- a/docs/content/guides/agent.md
+++ b/docs/content/guides/agent.md
@@ -20,7 +20,7 @@ in sequence:
    kernel parameters for Kubernetes networking, and disables services that
    conflict with kubelet (Docker, swap).
 2. **Rootfs preparation** (`rootfs`) -- detects host settings such as CPU
-   architecture and NVIDIA GPU devices, creates a
+   architecture and GPU devices, creates a
    [systemd-nspawn]({{< relref "reference/agent/nspawn" >}}) machine rootfs
    (from an OCI image), and downloads containerd, runc, CNI
    plugins, and Kubernetes binaries.
@@ -334,15 +334,19 @@ my-node    Ready    <none>   20s   v1.33.1   192.168.100.10   <none>        Ubun
 
 ## GPU Support
 
-When NVIDIA GPUs are detected on the host, the agent automatically:
+When GPUs are detected on the host, the agent automatically exposes the host
+paths needed by Kubernetes device plugins:
 
-- Bind-mounts GPU devices and driver libraries into the nspawn machine.
-- Generates a CDI spec and registers the NVIDIA container runtime with
+- For NVIDIA GPUs, bind-mounts GPU devices and driver libraries into the nspawn
+  machine, generates a CDI spec, and registers the NVIDIA container runtime with
   containerd.
+- For AMD GPUs, bind-mounts `/dev/kfd` and DRM device nodes and exposes AMD
+  sysfs paths read-only so the AMD Kubernetes device plugin can detect GPUs
+  inside nspawn.
 
-No additional configuration is required. Both `amd64` and `arm64`
-architectures are supported. See the
-[GPU reference]({{< relref "reference/gpu" >}}) for details.
+The agent does not deploy GPU device plugins. Install the vendor device plugin
+for Kubernetes resource advertisement. See the [GPU reference]({{< relref "reference/gpu" >}})
+for details.
 
 ## Troubleshooting
 
@@ -357,8 +361,9 @@ kubelet logs inside the nspawn machine:
 machinectl shell <machine-name> /bin/journalctl -u kubelet
 ```
 
-**GPU not detected** -- Confirm that the NVIDIA driver is installed on the host
-and that GPU devices are visible under `/dev/nvidia*`.
+**GPU not detected** -- Confirm that the vendor driver is installed and loaded
+on the host. For NVIDIA, check `/dev/nvidia*`. For AMD, check `/dev/kfd`,
+`/dev/dri/card*`, and `/dev/dri/renderD*`.
 
 ## See Also
 

--- a/docs/content/reference/agent/nspawn.md
+++ b/docs/content/reference/agent/nspawn.md
@@ -96,11 +96,16 @@ the template runs with `--settings=override`. As a result, the generated
 network namespace. Host interfaces, host firewall and routing rules, and
 loopback listeners are therefore visible from inside the nspawn machine.
 
-When NVIDIA GPUs are detected on the host, the agent automatically bind-mounts
-the GPU device nodes (e.g. `/dev/nvidia0`, `/dev/nvidiactl`) and the host's
-driver libraries into the container, and grants the necessary cgroup device
-permissions. See [NVIDIA GPU Support]({{< relref "reference/gpu/nvidia" >}}) for
-the full GPU pipeline.
+When GPUs are detected on the host, the agent automatically exposes the host
+paths needed by the corresponding Kubernetes device plugin:
+
+- **NVIDIA GPUs.** Bind-mounts GPU device nodes and host driver libraries,
+  grants cgroup device permissions, generates a CDI spec, and configures the
+  NVIDIA container runtime. See [NVIDIA GPU Support]({{< relref "reference/gpu/nvidia" >}}).
+- **AMD GPUs.** Bind-mounts `/dev/kfd` and DRM device nodes, grants cgroup
+  device permissions, and exposes AMD sysfs paths read-only so the AMD
+  Kubernetes device plugin can discover GPUs inside nspawn. See
+  [AMD GPU Support]({{< relref "reference/gpu/amd" >}}).
 
 When the KVM character device (`/dev/kvm`) is present on the host, the agent
 automatically bind-mounts it into the container so that workloads inside the

--- a/docs/content/reference/gpu/amd.md
+++ b/docs/content/reference/gpu/amd.md
@@ -1,0 +1,88 @@
+---
+title: "AMD GPU Support"
+weight: 2
+description: "How the unbounded-agent exposes AMD GPUs so the AMD Kubernetes device plugin can discover them."
+---
+
+The unbounded-agent detects AMD GPUs on the host and exposes the device nodes
+and sysfs paths required by the AMD Kubernetes device plugin inside the
+`systemd-nspawn` machine. Kubernetes resource advertisement is still handled by
+a user-deployed AMD device plugin.
+
+## Prerequisites
+
+Before the agent can expose AMD GPUs, the host must have the AMDGPU/KFD driver
+loaded and the expected device nodes present:
+
+- `/dev/kfd`
+- `/dev/dri/card*`
+- `/dev/dri/renderD*`
+
+The AMD Kubernetes device plugin must also be deployed in the cluster. The agent
+does not install the plugin, configure ROCm userspace libraries, or create a
+custom containerd runtime for AMD GPUs.
+
+## How It Works
+
+AMD GPU support is intentionally limited to making host hardware visible inside
+the nspawn machine so the AMD device plugin can do the Kubernetes-level
+registration:
+
+1. **Device discovery.** The agent checks for `/dev/kfd`. When present, it also
+   collects `/dev/dri/card*` and `/dev/dri/renderD*` device nodes.
+2. **nspawn device exposure.** The agent writes `Bind=` entries for the
+   discovered AMD device nodes and matching `DeviceAllow=<path> rwm` entries in
+   the systemd service override.
+3. **sysfs exposure.** The agent bind-mounts AMD-related sysfs paths read-only
+   into the nspawn machine so the AMD device plugin can inspect the amdgpu
+   driver and KFD topology.
+4. **Kubernetes advertisement.** After kubelet starts, the AMD Kubernetes device
+   plugin detects the exposed devices and registers AMD GPU resources on the
+   node.
+
+## Exposed Host Paths
+
+When `/dev/kfd` exists, the agent exposes these device nodes when present:
+
+- `/dev/kfd`
+- `/dev/dri/card*`
+- `/dev/dri/renderD*`
+
+The agent also exposes these sysfs paths read-only when present:
+
+- `/sys/module/amdgpu`
+- `/sys/class/kfd`
+- `/sys/class/drm`
+- `/sys/devices`
+
+These sysfs mounts are required because the AMD device plugin reads paths such
+as `/sys/module/amdgpu/drivers/pci:amdgpu/...` and
+`/sys/class/kfd/kfd/topology/...` during discovery.
+
+## Troubleshooting
+
+### Device plugin exits with `amdgpu driver unavailable`
+
+If the AMD device plugin logs an error like this:
+
+```text
+amdgpu driver unavailable. exiting with exit code 2. error: stat /sys/module/amdgpu/drivers/: no such file or directory
+```
+
+the nspawn machine was likely started without the AMD sysfs bind mounts. Verify
+that the host has the AMD driver loaded and restart or recreate the nspawn
+machine after the agent has rendered the updated `.nspawn` configuration.
+
+On the host, check:
+
+```bash
+ls -ld /sys/module/amdgpu /sys/class/kfd /sys/class/drm
+ls -l /dev/kfd /dev/dri/card* /dev/dri/renderD*
+```
+
+Inside the nspawn machine, check:
+
+```bash
+machinectl shell <machine-name> /bin/ls -ld /sys/module/amdgpu /sys/class/kfd /sys/class/drm
+machinectl shell <machine-name> /bin/ls -l /dev/kfd /dev/dri/card* /dev/dri/renderD*
+```

--- a/pkg/agent/goalstates/amd.go
+++ b/pkg/agent/goalstates/amd.go
@@ -10,9 +10,7 @@ import (
 	"strings"
 )
 
-const (
-	amdKFDDevicePath = "/dev/kfd"
-)
+const amdKFDDevicePath = "/dev/kfd"
 
 // AMDHost aggregates AMD GPU host state discovered at agent startup.
 type AMDHost struct {

--- a/pkg/agent/goalstates/amd.go
+++ b/pkg/agent/goalstates/amd.go
@@ -68,6 +68,12 @@ func discoverAMDDevicesAt(kfdPath, driPath string) []string {
 			}
 
 			name := e.Name()
+			// TODO: Narrow DRM discovery to AMD-owned nodes by checking
+			// /sys/class/drm/<name>/device/vendor == 0x1002. Today we expose all DRM
+			// card/render nodes when /dev/kfd exists so the AMD device plugin can
+			// discover GPUs in nspawn. That is broader than necessary on mixed-GPU
+			// hosts, but avoids accidentally missing non-standard AMD layouts until
+			// we validate sysfs filtering behavior across target hardware.
 			if strings.HasPrefix(name, "card") || strings.HasPrefix(name, "renderD") {
 				devices = append(devices, filepath.Join(driPath, name))
 			}

--- a/pkg/agent/goalstates/amd.go
+++ b/pkg/agent/goalstates/amd.go
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package goalstates
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const (
+	amdKFDDevicePath = "/dev/kfd"
+)
+
+// AMDHost aggregates AMD GPU host state discovered at agent startup.
+type AMDHost struct {
+	// GPUDevicePaths lists AMD GPU device paths discovered on the host
+	// (e.g. /dev/kfd, /dev/dri/card*, /dev/dri/renderD*). When non-empty the
+	// nspawn configuration will bind-mount these devices and grant cgroup access
+	// so the AMD Kubernetes device plugin can detect GPUs inside the machine.
+	GPUDevicePaths []string
+}
+
+// ResolveAMDHost probes the host for AMD GPU device nodes. Returns an empty
+// struct when the host does not have AMD GPUs or the driver is not loaded.
+func ResolveAMDHost() AMDHost {
+	return AMDHost{GPUDevicePaths: discoverAMDDevices()}
+}
+
+// discoverAMDDevices scans for AMD GPU device nodes and returns them as a
+// sorted slice. AMD ROCm workloads and the AMD Kubernetes device plugin require
+// /dev/kfd plus the corresponding DRM card/render nodes under /dev/dri.
+func discoverAMDDevices() []string {
+	return discoverAMDDevicesAt(amdKFDDevicePath, driDir)
+}
+
+func discoverAMDDevicesAt(kfdPath, driPath string) []string {
+	if _, err := os.Stat(kfdPath); err != nil {
+		return nil
+	}
+
+	devices := []string{kfdPath}
+
+	driEntries, err := os.ReadDir(driPath)
+	if err == nil {
+		for _, e := range driEntries {
+			if e.IsDir() {
+				continue
+			}
+
+			name := e.Name()
+			if strings.HasPrefix(name, "card") || strings.HasPrefix(name, "renderD") {
+				devices = append(devices, filepath.Join(driPath, name))
+			}
+		}
+	}
+
+	slices.Sort(devices)
+
+	return devices
+}

--- a/pkg/agent/goalstates/amd.go
+++ b/pkg/agent/goalstates/amd.go
@@ -12,6 +12,13 @@ import (
 
 const amdKFDDevicePath = "/dev/kfd"
 
+var amdSysFSPaths = []string{
+	"/sys/module/amdgpu",
+	"/sys/class/kfd",
+	"/sys/class/drm",
+	"/sys/devices",
+}
+
 // AMDHost aggregates AMD GPU host state discovered at agent startup.
 type AMDHost struct {
 	// GPUDevicePaths lists AMD GPU device paths discovered on the host
@@ -19,12 +26,24 @@ type AMDHost struct {
 	// nspawn configuration will bind-mount these devices and grant cgroup access
 	// so the AMD Kubernetes device plugin can detect GPUs inside the machine.
 	GPUDevicePaths []string
+
+	// SysFSPaths lists host sysfs paths the AMD Kubernetes device plugin reads
+	// to discover AMD GPUs and KFD topology inside the nspawn machine.
+	SysFSPaths []string
 }
 
 // ResolveAMDHost probes the host for AMD GPU device nodes. Returns an empty
 // struct when the host does not have AMD GPUs or the driver is not loaded.
 func ResolveAMDHost() AMDHost {
-	return AMDHost{GPUDevicePaths: discoverAMDDevices()}
+	devices := discoverAMDDevices()
+	if len(devices) == 0 {
+		return AMDHost{}
+	}
+
+	return AMDHost{
+		GPUDevicePaths: devices,
+		SysFSPaths:     discoverAMDSysFSPaths(amdSysFSPaths),
+	}
 }
 
 // discoverAMDDevices scans for AMD GPU device nodes and returns them as a
@@ -58,4 +77,18 @@ func discoverAMDDevicesAt(kfdPath, driPath string) []string {
 	slices.Sort(devices)
 
 	return devices
+}
+
+func discoverAMDSysFSPaths(paths []string) []string {
+	var existing []string
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+
+		existing = append(existing, path)
+	}
+
+	return existing
 }

--- a/pkg/agent/goalstates/amd_test.go
+++ b/pkg/agent/goalstates/amd_test.go
@@ -52,3 +52,14 @@ func TestDiscoverAMDDevices_NoKFD(t *testing.T) {
 
 	require.Nil(t, discoverAMDDevicesAt(filepath.Join(devDir, "kfd"), driDir))
 }
+
+func TestDiscoverAMDSysFSPaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "module", "amdgpu")
+	missing := filepath.Join(dir, "class", "kfd")
+	require.NoError(t, os.MkdirAll(existing, 0o755))
+
+	require.Equal(t, []string{existing}, discoverAMDSysFSPaths([]string{existing, missing}))
+}

--- a/pkg/agent/goalstates/amd_test.go
+++ b/pkg/agent/goalstates/amd_test.go
@@ -59,6 +59,7 @@ func TestDiscoverAMDSysFSPaths(t *testing.T) {
 	dir := t.TempDir()
 	existing := filepath.Join(dir, "module", "amdgpu")
 	missing := filepath.Join(dir, "class", "kfd")
+
 	require.NoError(t, os.MkdirAll(existing, 0o755))
 
 	require.Equal(t, []string{existing}, discoverAMDSysFSPaths([]string{existing, missing}))

--- a/pkg/agent/goalstates/amd_test.go
+++ b/pkg/agent/goalstates/amd_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package goalstates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverAMDDevices(t *testing.T) {
+	t.Parallel()
+
+	devDir := t.TempDir()
+	driDir := filepath.Join(devDir, "dri")
+	require.NoError(t, os.Mkdir(driDir, 0o755))
+
+	for _, path := range []string{
+		filepath.Join(devDir, "kfd"),
+		filepath.Join(driDir, "card0"),
+		filepath.Join(driDir, "renderD128"),
+		filepath.Join(driDir, "by-path"),
+	} {
+		f, err := os.Create(path)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	got := discoverAMDDevicesAt(filepath.Join(devDir, "kfd"), driDir)
+
+	want := []string{
+		filepath.Join(devDir, "dri", "card0"),
+		filepath.Join(devDir, "dri", "renderD128"),
+		filepath.Join(devDir, "kfd"),
+	}
+	require.Equal(t, want, got)
+}
+
+func TestDiscoverAMDDevices_NoKFD(t *testing.T) {
+	t.Parallel()
+
+	devDir := t.TempDir()
+	driDir := filepath.Join(devDir, "dri")
+	require.NoError(t, os.Mkdir(driDir, 0o755))
+
+	f, err := os.Create(filepath.Join(driDir, "renderD128"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.Nil(t, discoverAMDDevicesAt(filepath.Join(devDir, "kfd"), driDir))
+}

--- a/pkg/agent/goalstates/resolve.go
+++ b/pkg/agent/goalstates/resolve.go
@@ -44,6 +44,8 @@ func ResolveMachine(log *slog.Logger, cfg *config.AgentConfig, machineName strin
 		return nil, fmt.Errorf("resolve nvidia host: %w", err)
 	}
 
+	amd := ResolveAMDHost()
+
 	ociImage := ResolveOCIImage(log, cfg.OCIImage, len(nvidia.GPUDevicePaths) > 0)
 
 	kubelet, err := resolveKubelet(cfg)
@@ -87,6 +89,7 @@ func ResolveMachine(log *slog.Logger, cfg *config.AgentConfig, machineName strin
 		Downloads:         downloads,
 		OCIImage:          ociImage,
 		Nvidia:            nvidia,
+		AMD:               amd,
 		HostDevices:       DiscoverHostDevices(),
 	}
 

--- a/pkg/agent/goalstates/rootfs.go
+++ b/pkg/agent/goalstates/rootfs.go
@@ -34,6 +34,9 @@ type RootFS struct {
 	// container. Empty on non-GPU hosts.
 	Nvidia NvidiaHost
 
+	// AMD holds AMD GPU state discovered on the host. Empty on non-AMD GPU hosts.
+	AMD AMDHost
+
 	// HostDevices holds host device nodes to be bind-mounted into the
 	// nspawn container, grouped by category (KVM, block storage, InfiniBand
 	// HCA). Device nodes are discovered at agent startup. Empty on hosts

--- a/pkg/agent/phases/rootfs/assets/nspawn.conf
+++ b/pkg/agent/phases/rootfs/assets/nspawn.conf
@@ -50,4 +50,7 @@ BindReadOnly={{.HostDir}}:{{.ContainerDir}}
 {{- range .AMDGPUDevicePaths}}
 Bind={{.}}
 {{- end}}
+{{- range .AMDSysFSPaths}}
+BindReadOnly={{.}}
+{{- end}}
 {{- end}}

--- a/pkg/agent/phases/rootfs/assets/nspawn.conf
+++ b/pkg/agent/phases/rootfs/assets/nspawn.conf
@@ -44,3 +44,10 @@ Bind={{.}}
 BindReadOnly={{.HostDir}}:{{.ContainerDir}}
 {{- end}}
 {{- end}}
+{{- if .AMDGPUDevicePaths}}
+# AMD GPU support - bind-mount AMD device nodes into the container so the AMD
+# Kubernetes device plugin can detect GPUs inside nspawn.
+{{- range .AMDGPUDevicePaths}}
+Bind={{.}}
+{{- end}}
+{{- end}}

--- a/pkg/agent/phases/rootfs/assets/service-override.conf
+++ b/pkg/agent/phases/rootfs/assets/service-override.conf
@@ -63,3 +63,12 @@ DeviceAllow={{.}} rwm
 DeviceAllow={{.}} rwm
 {{- end}}
 {{- end}}
+{{- if .AMDGPUDevicePaths}}
+
+# AMD GPU support - allow the container to access AMD device nodes via the
+# cgroup device controller. The AMD Kubernetes device plugin needs these nodes
+# visible and usable inside nspawn.
+{{- range .AMDGPUDevicePaths}}
+DeviceAllow={{.}} rwm
+{{- end}}
+{{- end}}

--- a/pkg/agent/phases/rootfs/nspawn.go
+++ b/pkg/agent/phases/rootfs/nspawn.go
@@ -149,6 +149,7 @@ func pathsExcluding(paths, excluded []string) []string {
 	}
 
 	var out []string
+
 	for _, p := range paths {
 		if !seen[p] {
 			out = append(out, p)

--- a/pkg/agent/phases/rootfs/nspawn.go
+++ b/pkg/agent/phases/rootfs/nspawn.go
@@ -76,6 +76,7 @@ type nspawnTemplateData struct {
 	HostDevicePaths      []string
 	NvidiaGPUDevicePaths []string
 	AMDGPUDevicePaths    []string
+	AMDSysFSPaths        []string
 	NvidiaLibDirMounts   []goalstates.NvidiaLibDirMount
 }
 
@@ -94,6 +95,7 @@ func (e *ensureNSpawnWorkspace) writeNSpawnConfigs() error {
 		HostDevicePaths:      hostDevicePaths,
 		NvidiaGPUDevicePaths: e.goalState.Nvidia.GPUDevicePaths,
 		AMDGPUDevicePaths:    amdGPUDevicePaths,
+		AMDSysFSPaths:        e.goalState.AMD.SysFSPaths,
 		NvidiaLibDirMounts:   e.goalState.Nvidia.LibDirMounts,
 	}
 

--- a/pkg/agent/phases/rootfs/nspawn.go
+++ b/pkg/agent/phases/rootfs/nspawn.go
@@ -75,9 +75,9 @@ type nspawnTemplateData struct {
 	BPFFSMountPath       string
 	HostDevicePaths      []string
 	NvidiaGPUDevicePaths []string
+	NvidiaLibDirMounts   []goalstates.NvidiaLibDirMount
 	AMDGPUDevicePaths    []string
 	AMDSysFSPaths        []string
-	NvidiaLibDirMounts   []goalstates.NvidiaLibDirMount
 }
 
 // writeNSpawnConfigs renders the nspawn and service-override templates with
@@ -94,9 +94,9 @@ func (e *ensureNSpawnWorkspace) writeNSpawnConfigs() error {
 		BPFFSMountPath:       goalstates.BPFFSMountPath(machineName),
 		HostDevicePaths:      hostDevicePaths,
 		NvidiaGPUDevicePaths: e.goalState.Nvidia.GPUDevicePaths,
+		NvidiaLibDirMounts:   e.goalState.Nvidia.LibDirMounts,
 		AMDGPUDevicePaths:    amdGPUDevicePaths,
 		AMDSysFSPaths:        e.goalState.AMD.SysFSPaths,
-		NvidiaLibDirMounts:   e.goalState.Nvidia.LibDirMounts,
 	}
 
 	if len(hostDevicePaths) > 0 {

--- a/pkg/agent/phases/rootfs/nspawn.go
+++ b/pkg/agent/phases/rootfs/nspawn.go
@@ -75,6 +75,7 @@ type nspawnTemplateData struct {
 	BPFFSMountPath       string
 	HostDevicePaths      []string
 	NvidiaGPUDevicePaths []string
+	AMDGPUDevicePaths    []string
 	NvidiaLibDirMounts   []goalstates.NvidiaLibDirMount
 }
 
@@ -86,11 +87,13 @@ func (e *ensureNSpawnWorkspace) writeNSpawnConfigs() error {
 	// directory.
 	machineName := filepath.Base(e.goalState.MachineDir)
 	hostDevicePaths := e.goalState.HostDevices.Paths()
+	amdGPUDevicePaths := pathsExcluding(e.goalState.AMD.GPUDevicePaths, e.goalState.Nvidia.GPUDevicePaths)
 	templateData := nspawnTemplateData{
 		MachineName:          machineName,
 		BPFFSMountPath:       goalstates.BPFFSMountPath(machineName),
 		HostDevicePaths:      hostDevicePaths,
 		NvidiaGPUDevicePaths: e.goalState.Nvidia.GPUDevicePaths,
+		AMDGPUDevicePaths:    amdGPUDevicePaths,
 		NvidiaLibDirMounts:   e.goalState.Nvidia.LibDirMounts,
 	}
 
@@ -105,6 +108,11 @@ func (e *ensureNSpawnWorkspace) writeNSpawnConfigs() error {
 	if len(e.goalState.Nvidia.GPUDevicePaths) > 0 {
 		e.log.Info("GPU devices detected, configuring nspawn bind-mounts",
 			"count", len(e.goalState.Nvidia.GPUDevicePaths))
+	}
+
+	if len(amdGPUDevicePaths) > 0 {
+		e.log.Info("AMD GPU devices detected, configuring nspawn bind-mounts",
+			"count", len(amdGPUDevicePaths))
 	}
 
 	// Render and write the .nspawn configuration file.
@@ -128,4 +136,24 @@ func (e *ensureNSpawnWorkspace) writeNSpawnConfigs() error {
 	}
 
 	return nil
+}
+
+func pathsExcluding(paths, excluded []string) []string {
+	if len(paths) == 0 || len(excluded) == 0 {
+		return paths
+	}
+
+	seen := make(map[string]bool, len(excluded))
+	for _, p := range excluded {
+		seen[p] = true
+	}
+
+	var out []string
+	for _, p := range paths {
+		if !seen[p] {
+			out = append(out, p)
+		}
+	}
+
+	return out
 }

--- a/pkg/agent/phases/rootfs/nspawn_render_test.go
+++ b/pkg/agent/phases/rootfs/nspawn_render_test.go
@@ -88,6 +88,44 @@ func TestServiceOverride_MultipleHostDevices(t *testing.T) {
 	}
 }
 
+func TestServiceOverride_AMDGPUDevices(t *testing.T) {
+	t.Parallel()
+
+	devices := []string{"/dev/dri/card0", "/dev/dri/renderD128", "/dev/kfd"}
+
+	var nspawnBuf bytes.Buffer
+	require.NoError(t, nspawnTemplates.ExecuteTemplate(&nspawnBuf, "nspawn.conf", nspawnTemplateData{
+		BPFFSMountPath:    goalstates.BPFFSMountPath("kube1"),
+		AMDGPUDevicePaths: devices,
+	}))
+
+	var overrideBuf bytes.Buffer
+	require.NoError(t, nspawnTemplates.ExecuteTemplate(&overrideBuf, "service-override.conf", nspawnTemplateData{
+		MachineName:       "kube1",
+		BPFFSMountPath:    goalstates.BPFFSMountPath("kube1"),
+		AMDGPUDevicePaths: devices,
+	}))
+
+	for _, dev := range devices {
+		require.Contains(t, nspawnBuf.String(), "Bind="+dev)
+		require.Contains(t, overrideBuf.String(), "DeviceAllow="+dev+" rwm")
+	}
+
+	require.Contains(t, nspawnBuf.String(), "AMD GPU support")
+	require.Contains(t, overrideBuf.String(), "AMD GPU support")
+}
+
+func TestPathsExcluding(t *testing.T) {
+	t.Parallel()
+
+	got := pathsExcluding(
+		[]string{"/dev/dri/card0", "/dev/dri/renderD128", "/dev/kfd"},
+		[]string{"/dev/dri/card0", "/dev/dri/renderD128"},
+	)
+
+	require.Equal(t, []string{"/dev/kfd"}, got)
+}
+
 func TestServiceOverride_NoHostDevicesNoDeviceAllow(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/agent/phases/rootfs/nspawn_render_test.go
+++ b/pkg/agent/phases/rootfs/nspawn_render_test.go
@@ -97,6 +97,7 @@ func TestServiceOverride_AMDGPUDevices(t *testing.T) {
 	require.NoError(t, nspawnTemplates.ExecuteTemplate(&nspawnBuf, "nspawn.conf", nspawnTemplateData{
 		BPFFSMountPath:    goalstates.BPFFSMountPath("kube1"),
 		AMDGPUDevicePaths: devices,
+		AMDSysFSPaths:     []string{"/sys/module/amdgpu", "/sys/class/kfd"},
 	}))
 
 	var overrideBuf bytes.Buffer
@@ -113,6 +114,8 @@ func TestServiceOverride_AMDGPUDevices(t *testing.T) {
 
 	require.Contains(t, nspawnBuf.String(), "AMD GPU support")
 	require.Contains(t, overrideBuf.String(), "AMD GPU support")
+	require.Contains(t, nspawnBuf.String(), "BindReadOnly=/sys/module/amdgpu")
+	require.Contains(t, nspawnBuf.String(), "BindReadOnly=/sys/class/kfd")
 }
 
 func TestPathsExcluding(t *testing.T) {


### PR DESCRIPTION
## Summary
- discover AMD GPU device nodes on the host
- bind-mount /dev/kfd and DRM card/render nodes into nspawn
- grant matching DeviceAllow access so the AMD Kubernetes device plugin can detect devices inside the machine

## Tests
- go test ./pkg/agent/goalstates ./pkg/agent/phases/rootfs