### PR TITLE
storage: use o_direct for file-backed disks

### DIFF
--- a/cmd/unbounded-storage/src/storage/blockdev/uring.rs
+++ b/cmd/unbounded-storage/src/storage/blockdev/uring.rs
@@ -117,10 +117,7 @@ impl std::fmt::Display for OpenError {
 fn open_file(path: &Path, o_direct: bool) -> Result<File, Error> {
     let cpath =
         CString::new(path.as_os_str().as_encoded_bytes()).map_err(|_| Error::Io(libc::EINVAL))?;
-    let mut flags = libc::O_RDWR | libc::O_CLOEXEC;
-    if o_direct {
-        flags |= libc::O_DIRECT;
-    }
+    let flags = open_flags(o_direct);
     // SAFETY: cpath is null-terminated and outlives the call.
     let fd = unsafe { libc::open(cpath.as_ptr(), flags) };
     if fd < 0 {
@@ -132,6 +129,14 @@ fn open_file(path: &Path, o_direct: bool) -> Result<File, Error> {
     }
     // SAFETY: fd is freshly opened by us and not aliased elsewhere.
     Ok(unsafe { File::from_raw_fd(fd as RawFd) })
+}
+
+fn open_flags(o_direct: bool) -> libc::c_int {
+    let mut flags = libc::O_RDWR | libc::O_CLOEXEC;
+    if o_direct {
+        flags |= libc::O_DIRECT;
+    }
+    flags
 }
 
 /// Create `path` if absent and size it to exactly `size_bytes`.
@@ -285,5 +290,11 @@ mod tests {
             std::fs::metadata(&path.0).unwrap().len(),
             (12 * PAGE) as u64
         );
+    }
+
+    #[test]
+    fn open_flags_include_o_direct_when_requested() {
+        assert_eq!(open_flags(false) & libc::O_DIRECT, 0);
+        assert_eq!(open_flags(true) & libc::O_DIRECT, libc::O_DIRECT);
     }
 }

--- a/cmd/unbounded-storage/src/storage/disks/uring.rs
+++ b/cmd/unbounded-storage/src/storage/disks/uring.rs
@@ -75,6 +75,11 @@ pub struct UringDiskTarget {
     runtime: std::sync::Arc<PinnedRuntime>,
 }
 
+struct DiskOpenMode {
+    ring_cfg: StorageRingConfig,
+    o_direct: bool,
+}
+
 impl UringDiskTarget {
     pub fn new(runtime: std::sync::Arc<PinnedRuntime>) -> Self {
         Self { runtime }
@@ -117,22 +122,15 @@ impl DiskTarget for UringDiskTarget {
         // against a 4 KiB btree page): using the cache page size here makes
         // every 4 KiB btree/meta I/O fail EINVAL and skews all byte offsets.
         let page_size = device_page_size(&engine_cfg);
-        let mut ring_cfg = StorageRingConfig::default();
-        if let Some(qd) = spec.queue_depth {
-            ring_cfg.queue_depth = qd;
-        }
+        let open_mode = disk_open_mode(spec);
 
-        // A file-backed disk runs buffered I/O on a regular file, so the
-        // hardware-only ring flags (IOPOLL, and the O_DIRECT it implies,
-        // plus SINGLE_ISSUER/DEFER_TASKRUN) must be stripped; this mirrors
-        // StorageRingConfig::test_local. The backing file is created and
+        // A file-backed disk still uses O_DIRECT so the daemon bypasses
+        // the host page cache, but regular files do not support the
+        // polled block-device ring mode. The backing file is created and
         // sized here, on the supervisor thread, before the storage core
-        // opens it (capacity comes from the file length). Size validity is
-        // guaranteed by config validation.
+        // opens it (capacity comes from the file length). Size validity
+        // is guaranteed by config validation.
         if spec.is_file() {
-            ring_cfg.iopoll = false;
-            ring_cfg.single_issuer = false;
-            ring_cfg.defer_taskrun = false;
             let size = spec
                 .file_size()
                 .expect("file disk size is validated at config load");
@@ -151,7 +149,7 @@ impl DiskTarget for UringDiskTarget {
         let (ready_tx, ready_rx) = mpsc::sync_channel::<Result<PageChannel, String>>(1);
 
         let body = move || {
-            run_storage_core(path, ring_cfg, page_size, engine_cfg, stop_thr, ready_tx);
+            run_storage_core(path, open_mode, page_size, engine_cfg, stop_thr, ready_tx);
         };
 
         // Route thread spawning + pinning through the shared runtime.
@@ -188,7 +186,7 @@ impl DiskTarget for UringDiskTarget {
 /// [`PageService`], and `ring.progress()` interleaved until shutdown.
 fn run_storage_core(
     path: PathBuf,
-    ring_cfg: StorageRingConfig,
+    open_mode: DiskOpenMode,
     page_size: usize,
     engine_cfg: EngineConfig,
     stop: Arc<AtomicBool>,
@@ -205,7 +203,7 @@ fn run_storage_core(
         // Held for the storage core's lifetime: the ring addresses this
         // fd by its registered Fixed index, so it must outlive the ring.
         file: _disk_file,
-    } = match UringDevice::open(&path, ring_cfg, ring_cfg.iopoll, page_size) {
+    } = match UringDevice::open(&path, open_mode.ring_cfg, open_mode.o_direct, page_size) {
         Ok(d) => d,
         Err(e) => {
             let _ = ready_tx.send(Err(e.to_string()));
@@ -395,6 +393,24 @@ fn run_core_loop<B, R>(
             break;
         }
         idle();
+    }
+}
+
+fn disk_open_mode(spec: &DiskSpec) -> DiskOpenMode {
+    let mut ring_cfg = StorageRingConfig::default();
+    if let Some(qd) = spec.queue_depth {
+        ring_cfg.queue_depth = qd;
+    }
+
+    if spec.is_file() {
+        ring_cfg.iopoll = false;
+        ring_cfg.single_issuer = false;
+        ring_cfg.defer_taskrun = false;
+    }
+
+    DiskOpenMode {
+        ring_cfg,
+        o_direct: true,
     }
 }
 
@@ -668,6 +684,52 @@ mod tests {
         spec_cfg.page_size_bytes = 8 * 1024 * 1024;
         spec_cfg.btree_page_bytes = 4096;
         assert_eq!(device_page_size(&spec_cfg), 4096);
+    }
+
+    #[test]
+    fn file_disks_use_direct_io_without_iopoll() {
+        let spec = DiskSpec {
+            queue_depth: Some(32),
+            page_size_bytes: None,
+            skip_recovery_scan: false,
+            config: Some(crate::config::schema::disk_spec::Config::File(
+                crate::config::schema::FileDiskConfig {
+                    path: "/tmp/unbounded-storage-test-disk".to_string(),
+                    size: Some(64 * 4096),
+                },
+            )),
+        };
+
+        let mode = disk_open_mode(&spec);
+
+        assert!(mode.o_direct, "file disks must bypass the host page cache");
+        assert!(!mode.ring_cfg.iopoll, "regular files cannot use IOPOLL");
+        assert!(!mode.ring_cfg.single_issuer);
+        assert!(!mode.ring_cfg.defer_taskrun);
+        assert_eq!(mode.ring_cfg.queue_depth, 32);
+    }
+
+    #[test]
+    fn block_disks_keep_default_direct_iopoll_mode() {
+        let spec = DiskSpec {
+            queue_depth: Some(64),
+            page_size_bytes: None,
+            skip_recovery_scan: false,
+            config: Some(crate::config::schema::disk_spec::Config::Block(
+                crate::config::schema::BlockDiskConfig {
+                    numa: None,
+                    path: "/dev/nvme0n1".to_string(),
+                },
+            )),
+        };
+
+        let mode = disk_open_mode(&spec);
+
+        assert!(mode.o_direct);
+        assert!(mode.ring_cfg.iopoll);
+        assert!(mode.ring_cfg.single_issuer);
+        assert!(mode.ring_cfg.defer_taskrun);
+        assert_eq!(mode.ring_cfg.queue_depth, 64);
     }
 
     /// Regression for BUG 2: a `ring.progress()` error in STEADY STATE


### PR DESCRIPTION
The btree store is designed for O_DIRECT so it can manage its own cache and avoid the extra copy incurred by the linux page cache. Currently block devices use direct IO but file-backed disks do not.