### PR TITLE
storage: prioritized cache eviction

### DIFF
--- a/api/unbounded-storage/config.pb.go
+++ b/api/unbounded-storage/config.pb.go
@@ -545,7 +545,9 @@ type CacheSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Backend source used for miss fills. Cache name is the only logical keyspace prefix.
-	Source        string `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	Source string `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	// Higher priority cache pages are evicted after lower priority pages. Defaults to 0.
+	Priority      int32 `protobuf:"varint,3,opt,name=priority,proto3" json:"priority,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -592,6 +594,13 @@ func (x *CacheSpec) GetSource() string {
 		return x.Source
 	}
 	return ""
+}
+
+func (x *CacheSpec) GetPriority() int32 {
+	if x != nil {
+		return x.Priority
+	}
+	return 0
 }
 
 type StartupCfg struct {
@@ -2333,10 +2342,11 @@ const file_config_proto_rawDesc = "" +
 	"\x04addr\x18\x01 \x01(\tR\x04addr\":\n" +
 	"\x0eRdmaPeerConfig\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\tR\x04addr\x12\x14\n" +
-	"\x05addrs\x18\x02 \x03(\tR\x05addrs\"7\n" +
+	"\x05addrs\x18\x02 \x03(\tR\x05addrs\"S\n" +
 	"\tCacheSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
-	"\x06source\x18\x02 \x01(\tR\x06source\"\x89\x02\n" +
+	"\x06source\x18\x02 \x01(\tR\x06source\x12\x1a\n" +
+	"\bpriority\x18\x03 \x01(\x05R\bpriority\"\x89\x02\n" +
 	"\n" +
 	"StartupCfg\x12;\n" +
 	"\x06memory\x18\x01 \x01(\v2#.unbounded.storage.config.MemoryCfgR\x06memory\x12;\n" +

--- a/api/unbounded-storage/config.proto
+++ b/api/unbounded-storage/config.proto
@@ -114,6 +114,8 @@ message CacheSpec {
   string name = 1;
   // Backend source used for miss fills. Cache name is the only logical keyspace prefix.
   string source = 2;
+  // Higher priority cache pages are evicted after lower priority pages. Defaults to 0.
+  int32 priority = 3;
 }
 
 message StartupCfg {

--- a/cmd/unbounded-storage/src/bufferpool/mod.rs
+++ b/cmd/unbounded-storage/src/bufferpool/mod.rs
@@ -24,5 +24,5 @@ pub use pipeline::{PipelinedRead, StripePlan};
 pub use pool::Pool;
 pub use stream::{OwnedPageFuture, PageGuard, ReadStream};
 pub use traits::{BlockStore, BufferPool, PageCachePolicy, PageStream, Req, Transport};
-pub use types::{BulkRef, Error, PageRef, PoolConfig, StripeKey, TraceCtx};
+pub use types::{BulkRef, Error, PageRef, PoolConfig, StripeFetchKey, StripeKey, TraceCtx};
 pub use window::WindowedRead;

--- a/cmd/unbounded-storage/src/bufferpool/pool.rs
+++ b/cmd/unbounded-storage/src/bufferpool/pool.rs
@@ -14,7 +14,7 @@ use crate::bufferpool::inflight::{PageSlot, SlotState, StripeFetch};
 use crate::bufferpool::pipeline::{PipelinedRead, StripePlan};
 use crate::bufferpool::stream::{LocalBoxFuture, ReadStream, StaticBoxFuture, StreamSrc};
 use crate::bufferpool::traits::{BlockStore, BufferPool, PageCachePolicy, Req, Transport};
-use crate::bufferpool::types::{BulkRef, Error, PageRef, PoolConfig, StripeKey};
+use crate::bufferpool::types::{BulkRef, Error, PageRef, PoolConfig, StripeFetchKey, StripeKey};
 use crate::bufferpool::window::WindowedRead;
 use crate::memory::Backing;
 
@@ -41,9 +41,9 @@ where
     pub(super) backing: Backing,
     pub(super) page_size: usize,
     pub(super) free: Rc<FreeList>,
-    pub(super) inflight: RefCell<HashMap<StripeKey, Rc<RefCell<StripeFetch>>>>,
-    pub(super) cache_lru: RefCell<VecDeque<(StripeKey, u64, u64)>>,
-    pub(super) cache_lru_tokens: RefCell<HashMap<(StripeKey, u64), u64>>,
+    pub(super) inflight: RefCell<HashMap<StripeFetchKey, Rc<RefCell<StripeFetch>>>>,
+    pub(super) cache_lru: RefCell<VecDeque<(StripeFetchKey, u64, u64)>>,
+    pub(super) cache_lru_tokens: RefCell<HashMap<(StripeFetchKey, u64), u64>>,
     pub(super) next_cache_lru_token: Cell<u64>,
     pub(super) cached_pages: Cell<usize>,
     pub(super) page_cache_drain_epoch: Cell<u64>,
@@ -305,10 +305,14 @@ where
         self.inner.stream_count.set(cur + 1);
 
         let key = req.key();
+        let fetch_key = StripeFetchKey {
+            stripe: key,
+            cache_id: req.cache_id().cloned(),
+        };
         let fetch = {
             let mut inflight = self.inner.inflight.borrow_mut();
             inflight
-                .entry(key)
+                .entry(fetch_key.clone())
                 .or_insert_with(|| Rc::new(RefCell::new(StripeFetch::new())))
                 .clone()
         };
@@ -324,6 +328,7 @@ where
             self.inner.clone(),
             Rc::new(req.clone()),
             key,
+            fetch_key,
             fetch,
             Rc::new(page_cache_policy),
             self.inner.page_cache_drain_epoch.get(),
@@ -373,6 +378,7 @@ where
     /// this source.
     req: Rc<R>,
     key: StripeKey,
+    fetch_key: StripeFetchKey,
     fetch: Rc<RefCell<StripeFetch>>,
     page_cache_policy: Rc<PageCachePolicy>,
     page_cache_drain_epoch: u64,
@@ -404,6 +410,7 @@ where
         inner: Rc<PoolInner<T, S, R>>,
         req: Rc<R>,
         key: StripeKey,
+        fetch_key: StripeFetchKey,
         fetch: Rc<RefCell<StripeFetch>>,
         page_cache_policy: Rc<PageCachePolicy>,
         page_cache_drain_epoch: u64,
@@ -413,6 +420,7 @@ where
             inner,
             req,
             key,
+            fetch_key,
             fetch,
             page_cache_policy,
             page_cache_drain_epoch,
@@ -458,6 +466,7 @@ where
             self.inner.clone(),
             self.fetch.clone(),
             self.key,
+            self.fetch_key.clone(),
             self.req.clone(),
             self.page_cache_policy.clone(),
             self.page_cache_drain_epoch,
@@ -471,7 +480,7 @@ where
         try_fetch_ready_page(
             &self.inner,
             &self.fetch,
-            self.key,
+            &self.fetch_key,
             page_no,
             self.page_cache_policy.as_ref(),
             self.page_cache_drain_epoch,
@@ -479,7 +488,7 @@ where
     }
 
     fn release_guard(&self, page_no: u64) {
-        release_guard(&self.inner, self.key, &self.fetch, page_no);
+        release_guard(&self.inner, &self.fetch_key, &self.fetch, page_no);
     }
 
     fn decrement_stream(&self) {
@@ -496,7 +505,7 @@ where
     }
 
     fn decrement_owned_future_stream(&self) {
-        decrement_stream(&self.inner, self.key, &self.fetch);
+        decrement_stream(&self.inner, &self.fetch_key, &self.fetch);
     }
 
     fn try_reserve_prefetch(&self, max: usize) -> bool {
@@ -546,7 +555,7 @@ where
 
 fn release_guard<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     fetch: &Rc<RefCell<StripeFetch>>,
     page_no: u64,
 ) where
@@ -568,7 +577,7 @@ fn release_guard<T, S, R>(
 // ---------------------------------------------------------------------------
 
 /// RAII bump of `slot.consumer_holds`. Construction increments;
-/// drop decrements and runs `recycle_if_terminal`. Used by parked
+/// drop decrements and runs `retire_recyclable_slot`. Used by parked
 /// subscribers and the leader during I/O+tee to keep the slot
 /// pinned across `.await` points. On success the hold is
 /// transferred to the caller via [`ConsumerHold::forget`] and
@@ -583,7 +592,7 @@ where
     inner: Rc<PoolInner<T, S, R>>,
     fetch: Rc<RefCell<StripeFetch>>,
     slot: Rc<PageSlot>,
-    key: StripeKey,
+    key: StripeFetchKey,
     page_no: u64,
     active: bool,
 }
@@ -598,7 +607,7 @@ where
         inner: Rc<PoolInner<T, S, R>>,
         fetch: Rc<RefCell<StripeFetch>>,
         slot: Rc<PageSlot>,
-        key: StripeKey,
+        key: StripeFetchKey,
         page_no: u64,
     ) -> Self {
         slot.consumer_holds.set(slot.consumer_holds.get() + 1);
@@ -632,7 +641,13 @@ where
         }
         let prev = self.slot.consumer_holds.get();
         self.slot.consumer_holds.set(prev.saturating_sub(1));
-        retire_recyclable_slot(&self.inner, self.key, &self.fetch, &self.slot, self.page_no);
+        retire_recyclable_slot(
+            &self.inner,
+            &self.key,
+            &self.fetch,
+            &self.slot,
+            self.page_no,
+        );
     }
 }
 
@@ -641,7 +656,7 @@ where
 /// already owed a page; errors release their backing page immediately.
 fn retire_recyclable_slot<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     fetch: &Rc<RefCell<StripeFetch>>,
     slot: &Rc<PageSlot>,
     page_no: u64,
@@ -662,7 +677,6 @@ fn retire_recyclable_slot<T, S, R>(
             _ => RetireState::Other,
         }
     };
-
     match state {
         RetireState::Ready if slot.page_cache_enabled.get() && !inner.free.has_waiters() => {
             cache_ready_slot(inner, key, fetch, slot, page_no)
@@ -685,7 +699,7 @@ enum RetireState {
 
 fn decrement_stream<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     fetch: &Rc<RefCell<StripeFetch>>,
 ) where
     T: Transport<R>,
@@ -731,13 +745,13 @@ fn decrement_stream<T, S, R>(
         f.stream_refcount == 0 && f.pages.is_empty()
     };
     if should_remove {
-        inner.inflight.borrow_mut().remove(&key);
+        inner.inflight.borrow_mut().remove(key);
     }
 }
 
 fn cache_ready_slot<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     fetch: &Rc<RefCell<StripeFetch>>,
     slot: &Rc<PageSlot>,
     page_no: u64,
@@ -760,11 +774,11 @@ fn cache_ready_slot<T, S, R>(
         inner
             .cache_lru_tokens
             .borrow_mut()
-            .insert((key, page_no), token);
+            .insert((key.clone(), page_no), token);
         inner
             .cache_lru
             .borrow_mut()
-            .push_back((key, page_no, token));
+            .push_back((key.clone(), page_no, token));
         inner.cached_pages.set(inner.cached_pages.get() + 1);
         crate::metrics::bufferpool_cached_delta(1);
         compact_cache_lru_if_sparse(inner);
@@ -773,7 +787,7 @@ fn cache_ready_slot<T, S, R>(
 
 fn remove_slot_page<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     fetch: &Rc<RefCell<StripeFetch>>,
     slot: &Rc<PageSlot>,
     page_no: u64,
@@ -795,7 +809,7 @@ where
 
 fn remove_cache_lru_entry<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     page_no: u64,
     slot: &PageSlot,
 ) where
@@ -811,7 +825,7 @@ fn remove_cache_lru_entry<T, S, R>(
 
 fn remove_cache_accounting<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     page_no: u64,
 ) -> bool
 where
@@ -822,7 +836,7 @@ where
     if inner
         .cache_lru_tokens
         .borrow_mut()
-        .remove(&(key, page_no))
+        .remove(&(key.clone(), page_no))
         .is_none()
     {
         return false;
@@ -847,7 +861,7 @@ where
     }
     let tokens = inner.cache_lru_tokens.borrow();
     let mut lru = inner.cache_lru.borrow_mut();
-    lru.retain(|(key, page_no, token)| tokens.get(&(*key, *page_no)) == Some(token));
+    lru.retain(|(key, page_no, token)| tokens.get(&(key.clone(), *page_no)) == Some(token));
 }
 
 fn evict_oldest_cached<T, S, R>(inner: &Rc<PoolInner<T, S, R>>) -> Option<u32>
@@ -858,18 +872,18 @@ where
 {
     loop {
         let (key, page_no, token) = inner.cache_lru.borrow_mut().pop_front()?;
-        if inner.cache_lru_tokens.borrow().get(&(key, page_no)) != Some(&token) {
+        if inner.cache_lru_tokens.borrow().get(&(key.clone(), page_no)) != Some(&token) {
             continue;
         }
         let fetch = inner.inflight.borrow().get(&key).cloned();
         let Some(fetch) = fetch else {
-            remove_cache_accounting(inner, key, page_no);
+            remove_cache_accounting(inner, &key, page_no);
             continue;
         };
         let pi = {
             let mut f = fetch.borrow_mut();
             let Some(slot) = f.pages.get(&page_no).cloned() else {
-                remove_cache_accounting(inner, key, page_no);
+                remove_cache_accounting(inner, &key, page_no);
                 continue;
             };
             if !slot.cached.get()
@@ -877,15 +891,15 @@ where
                 || !matches!(*slot.state.borrow(), SlotState::Ready)
             {
                 slot.cached.set(false);
-                remove_cache_accounting(inner, key, page_no);
+                remove_cache_accounting(inner, &key, page_no);
                 continue;
             }
             slot.cached.set(false);
-            remove_cache_accounting(inner, key, page_no);
+            remove_cache_accounting(inner, &key, page_no);
             let pi = f.pages.remove(&page_no).and_then(|s| s.page_idx.take());
             pi
         };
-        remove_empty_stripe(inner, key, &fetch);
+        remove_empty_stripe(inner, &key, &fetch);
         if pi.is_some() {
             crate::metrics::bufferpool_page_cache_evicted();
             return pi;
@@ -895,7 +909,7 @@ where
 
 fn remove_empty_stripe<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     fetch: &Rc<RefCell<StripeFetch>>,
 ) where
     T: Transport<R>,
@@ -907,13 +921,13 @@ fn remove_empty_stripe<T, S, R>(
         f.stream_refcount == 0 && f.pages.is_empty()
     };
     if should_remove {
-        inner.inflight.borrow_mut().remove(&key);
+        inner.inflight.borrow_mut().remove(key);
     }
 }
 
 fn reset_cached_ready_slot_for_bypass<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
-    key: StripeKey,
+    key: &StripeFetchKey,
     page_no: u64,
     slot: &PageSlot,
 ) -> bool
@@ -936,7 +950,7 @@ where
 fn try_fetch_ready_page<T, S, R>(
     inner: &Rc<PoolInner<T, S, R>>,
     fetch: &Rc<RefCell<StripeFetch>>,
-    key: StripeKey,
+    fetch_key: &StripeFetchKey,
     page_no: u64,
     page_cache_policy: &PageCachePolicy,
     page_cache_drain_epoch: u64,
@@ -946,6 +960,7 @@ where
     S: BlockStore,
     R: Req,
 {
+    let key = fetch_key.stripe;
     let slot = fetch.borrow().pages.get(&page_no).cloned()?;
     let stripe_off = match page_no.checked_mul(inner.page_size as u64) {
         Some(off) => off,
@@ -969,7 +984,8 @@ where
 
     match action {
         Action::Ready => {
-            if !page_cache_enabled && reset_cached_ready_slot_for_bypass(inner, key, page_no, &slot)
+            if !page_cache_enabled
+                && reset_cached_ready_slot_for_bypass(inner, fetch_key, page_no, &slot)
             {
                 return None;
             }
@@ -981,8 +997,15 @@ where
                 .page_idx
                 .get()
                 .expect("page_idx must be set when slot is Ready");
-            remove_cache_lru_entry(inner, key, page_no, &slot);
-            ConsumerHold::new(inner.clone(), fetch.clone(), slot, key, page_no).forget();
+            remove_cache_lru_entry(inner, fetch_key, page_no, &slot);
+            ConsumerHold::new(
+                inner.clone(),
+                fetch.clone(),
+                slot,
+                fetch_key.clone(),
+                page_no,
+            )
+            .forget();
             Some(Ok(pi))
         }
         Action::Error(e) => Some(Err(e)),
@@ -1042,6 +1065,7 @@ async fn fetch_page<T, S, R>(
     inner: Rc<PoolInner<T, S, R>>,
     fetch: Rc<RefCell<StripeFetch>>,
     key: StripeKey,
+    fetch_key: StripeFetchKey,
     req: Rc<R>,
     page_cache_policy: Rc<PageCachePolicy>,
     page_cache_drain_epoch: u64,
@@ -1100,7 +1124,7 @@ where
         match action {
             Action::Ready => {
                 if !page_cache_enabled
-                    && reset_cached_ready_slot_for_bypass(&inner, key, page_no, &slot)
+                    && reset_cached_ready_slot_for_bypass(&inner, &fetch_key, page_no, &slot)
                 {
                     continue;
                 }
@@ -1111,12 +1135,18 @@ where
                 if page_cache_enabled && slot.cached.get() {
                     crate::metrics::bufferpool_request(crate::metrics::Lookup::Hit);
                 }
-                remove_cache_lru_entry(&inner, key, page_no, &slot);
+                remove_cache_lru_entry(&inner, &fetch_key, page_no, &slot);
                 // Bump and immediately transfer to the caller; the
                 // returned `PageGuard` balances it via
                 // `StreamSrc::release_guard`.
-                ConsumerHold::new(inner.clone(), fetch.clone(), slot.clone(), key, page_no)
-                    .forget();
+                ConsumerHold::new(
+                    inner.clone(),
+                    fetch.clone(),
+                    slot.clone(),
+                    fetch_key.clone(),
+                    page_no,
+                )
+                .forget();
                 return Ok(pi);
             }
             Action::Error(e) => return Err(e),
@@ -1126,8 +1156,13 @@ where
                 // leader's `PageGuard` drop cannot recycle the slot
                 // between wake and re-poll. The hold is transferred
                 // to us on `Ready`, dropped on `Error`/`Retry`.
-                let park =
-                    ParkOnSlot::new(inner.clone(), fetch.clone(), slot.clone(), key, page_no);
+                let park = ParkOnSlot::new(
+                    inner.clone(),
+                    fetch.clone(),
+                    slot.clone(),
+                    fetch_key.clone(),
+                    page_no,
+                );
                 match park.await {
                     ParkOutcome::Ready(hold) => {
                         let pi = slot
@@ -1147,8 +1182,13 @@ where
                 // declared first drop last, so `leader_guard` flips
                 // state and wakes parked subscribers before
                 // `leader_hold` drops and possibly recycles.
-                let leader_hold =
-                    ConsumerHold::new(inner.clone(), fetch.clone(), slot.clone(), key, page_no);
+                let leader_hold = ConsumerHold::new(
+                    inner.clone(),
+                    fetch.clone(),
+                    slot.clone(),
+                    fetch_key.clone(),
+                    page_no,
+                );
                 let mut leader_guard = LeaderGuard {
                     slot: &slot,
                     free: &inner.free,
@@ -1415,7 +1455,7 @@ where
     inner: Rc<PoolInner<T, S, R>>,
     fetch: Rc<RefCell<StripeFetch>>,
     slot: Rc<PageSlot>,
-    key: StripeKey,
+    key: StripeFetchKey,
     page_no: u64,
     /// `Some` once we have registered our waker and pre-bumped
     /// `consumer_holds`. Taken out and either transferred to the
@@ -1450,7 +1490,7 @@ where
         inner: Rc<PoolInner<T, S, R>>,
         fetch: Rc<RefCell<StripeFetch>>,
         slot: Rc<PageSlot>,
-        key: StripeKey,
+        key: StripeFetchKey,
         page_no: u64,
     ) -> Self {
         Self {
@@ -1485,7 +1525,7 @@ where
                 this.inner.clone(),
                 this.fetch.clone(),
                 this.slot.clone(),
-                this.key,
+                this.key.clone(),
                 this.page_no,
             ));
         }

--- a/cmd/unbounded-storage/src/bufferpool/tests.rs
+++ b/cmd/unbounded-storage/src/bufferpool/tests.rs
@@ -747,13 +747,13 @@ fn disabled_leader_policy_controls_coalesced_retention() {
     store.set_page_cache_enabled_for(Some("enabled"), true);
 
     let disabled_leader = TestReq::with_cache_id(k, "disabled");
-    let enabled_coalescer = TestReq::with_cache_id(k, "enabled");
+    let enabled_reader = TestReq::with_cache_id(k, "enabled");
     let f1 = async {
         let mut s = pool.read(&disabled_leader, 0, P as u64).await.unwrap();
         s.next_page().await.unwrap().unwrap().as_slice().to_vec()
     };
     let f2 = async {
-        let mut s = pool.read(&enabled_coalescer, 0, P as u64).await.unwrap();
+        let mut s = pool.read(&enabled_reader, 0, P as u64).await.unwrap();
         s.next_page().await.unwrap().unwrap().as_slice().to_vec()
     };
 
@@ -761,9 +761,13 @@ fn disabled_leader_policy_controls_coalesced_retention() {
 
     assert_eq!(b1, stripe);
     assert_eq!(b2, stripe);
-    assert_eq!(transport.calls(), 1, "reads coalesced behind one leader");
-    assert_eq!(pool.cached_pages(), 0, "leader policy controls retention");
-    assert_quiescent(&pool, 4, "coalesced disabled leader policy");
+    assert_eq!(transport.calls(), 2, "different caches do not coalesce");
+    assert_eq!(
+        pool.cached_pages(),
+        1,
+        "enabled cache retains independently"
+    );
+    assert_quiescent(&pool, 4, "cache-scoped policy");
 }
 
 #[test]
@@ -1002,6 +1006,35 @@ fn single_flight_coalesces_concurrent_reads() {
     assert_eq!(b2, stripe);
     assert_eq!(transport.calls(), 1, "single-flight coalesced");
     assert_quiescent(&pool, 4, "single-flight");
+}
+
+#[test]
+fn single_flight_is_scoped_by_cache_id() {
+    const P: usize = 4096;
+    let (pool, transport, _store) = make_pool_v2(P, 4);
+    let k = key(0xDE);
+    let mut stripe = vec![0u8; P];
+    for (i, b) in stripe.iter_mut().enumerate() {
+        *b = (i & 0xff) as u8;
+    }
+    transport.put_stripe(k, stripe.clone());
+    transport.set_pend_polls(2);
+
+    let req1 = TestReq::with_cache_id(k, "cache-a");
+    let req2 = TestReq::with_cache_id(k, "cache-b");
+    let f1 = async {
+        let mut s = pool.read(&req1, 0, P as u64).await.unwrap();
+        s.next_page().await.unwrap().unwrap().as_slice().to_vec()
+    };
+    let f2 = async {
+        let mut s = pool.read(&req2, 0, P as u64).await.unwrap();
+        s.next_page().await.unwrap().unwrap().as_slice().to_vec()
+    };
+    let (b1, b2) = block_on_two(f1, f2);
+    assert_eq!(b1, stripe);
+    assert_eq!(b2, stripe);
+    assert_eq!(transport.calls(), 2, "different caches do not coalesce");
+    assert_quiescent(&pool, 4, "cache-scoped single-flight");
 }
 
 #[test]

--- a/cmd/unbounded-storage/src/bufferpool/types.rs
+++ b/cmd/unbounded-storage/src/bufferpool/types.rs
@@ -23,6 +23,15 @@ pub struct PageRef {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StripeKey(pub [u8; 32]);
 
+/// Single-flight scope for an active stripe. Requests in different
+/// cache namespaces may carry different eviction policy, so they must
+/// not collapse onto the same blockstore lookup or writeback.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct StripeFetchKey {
+    pub stripe: StripeKey,
+    pub cache_id: Option<String>,
+}
+
 /// A byte range within a peer-side stripe, passed to
 /// `Transport::bulk_get`. `len` is bounded by `page_size`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/cmd/unbounded-storage/src/config/diff.rs
+++ b/cmd/unbounded-storage/src/config/diff.rs
@@ -211,6 +211,7 @@ mod tests {
         b.caches.push(CacheSpec {
             name: "c".to_string(),
             source: "n".to_string(),
+            priority: 0,
         });
         let d = ConfigDiff::between(&a, &b);
         assert!(d.caches_changed);

--- a/cmd/unbounded-storage/src/config/graph.rs
+++ b/cmd/unbounded-storage/src/config/graph.rs
@@ -33,6 +33,7 @@ pub struct RuntimeMesh {
 pub struct RuntimeCache {
     pub id: String,
     pub backend_id: String,
+    pub priority: i32,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -160,6 +161,7 @@ pub fn runtime_projection(config: &Config) -> Result<RuntimeGraph, String> {
                 RuntimeCache {
                     id: cache.name.clone(),
                     backend_id: cache.source.clone(),
+                    priority: cache.priority,
                 },
             )
         })
@@ -276,6 +278,7 @@ mod tests {
         CacheSpec {
             name: id.to_string(),
             source: source.to_string(),
+            priority: 0,
         }
     }
 
@@ -324,6 +327,21 @@ mod tests {
         assert_binding(&graph, "direct", "b", None, true);
         assert_binding(&graph, "cache", "b", Some("c-backend"), false);
         assert_eq!(graph.caches.len(), 1);
+        assert_eq!(graph.caches["c-backend"].priority, 0);
+    }
+
+    #[test]
+    fn runtime_projection_carries_cache_priority() {
+        let mut cfg = Config::default();
+        cfg.backends.push(backend("b"));
+        let mut c = cache("c", "b");
+        c.priority = 42;
+        cfg.caches.push(c);
+
+        let graph = runtime_projection(&cfg).unwrap();
+
+        assert_eq!(graph.caches["c"].backend_id, "b");
+        assert_eq!(graph.caches["c"].priority, 42);
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/config/schema.rs
+++ b/cmd/unbounded-storage/src/config/schema.rs
@@ -623,7 +623,27 @@ addr = "0.0.0.0:9000"
         let mut c: Config = toml::from_str(s).unwrap();
         c.apply_defaults();
         assert_eq!(c.caches[0].name, "cache");
+        assert_eq!(c.caches[0].priority, 0);
         assert_eq!(c.frontends[0].source, "cache");
+    }
+
+    #[test]
+    fn cache_priority_round_trips() {
+        let s = r#"
+[[caches]]
+name = "high"
+source = "origin"
+priority = 7
+
+[[caches]]
+name = "low"
+source = "origin"
+priority = -3
+"#;
+        let mut c: Config = toml::from_str(s).unwrap();
+        c.apply_defaults();
+        assert_eq!(c.caches[0].priority, 7);
+        assert_eq!(c.caches[1].priority, -3);
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -1199,10 +1199,14 @@ fn reconcile_cache_disks(
     cache_directories: &CacheDirectorySet,
     projection: &config::RuntimeGraph,
 ) {
-    let mut cache_ids: Vec<String> = projection.caches.keys().cloned().collect();
-    cache_ids.sort();
+    let mut caches: Vec<(String, i32)> = projection
+        .caches
+        .values()
+        .map(|cache| (cache.id.clone(), cache.priority))
+        .collect();
+    caches.sort_by(|a, b| a.0.cmp(&b.0));
     disk_registry.reconcile_ids([SHARED_DISK_REGISTRY_ID.to_string()]);
-    cache_directories.reconcile(cache_ids.iter().cloned());
+    cache_directories.reconcile(caches.iter().cloned());
 
     let disks = config::runtime_disks(projection);
     let report = disk_registry.reconcile_cache(SHARED_DISK_REGISTRY_ID, &disks);
@@ -1217,7 +1221,7 @@ fn reconcile_cache_disks(
     }
 
     let channels = disk_registry.channels_snapshot(SHARED_DISK_REGISTRY_ID);
-    for cache_id in cache_ids {
+    for (cache_id, _) in caches {
         cache_directories.apply_channels(&cache_id, channels.clone());
     }
 }

--- a/cmd/unbounded-storage/src/storage/disks/shard_view.rs
+++ b/cmd/unbounded-storage/src/storage/disks/shard_view.rs
@@ -26,7 +26,7 @@
 //! reads and writes return [`Error::Transport`] - the data path is
 //! offline by definition.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -46,7 +46,13 @@ pub struct LiveShardLocalStore {
 
 /// Hot-swappable set of cache directories keyed by cache id.
 pub struct CacheDirectorySet {
-    directories: Mutex<HashMap<String, Arc<DiskChannelDirectory>>>,
+    directories: Mutex<HashMap<String, CacheDirectoryEntry>>,
+}
+
+#[derive(Clone)]
+struct CacheDirectoryEntry {
+    directory: Arc<DiskChannelDirectory>,
+    priority: i32,
 }
 
 /// Chain-aware `BlockStore` dispatcher. Requests without a cache id
@@ -104,27 +110,52 @@ impl CacheDirectorySet {
         })
     }
 
-    pub fn reconcile<I>(&self, cache_ids: I)
+    pub fn reconcile<I, S>(&self, caches: I)
     where
         I: IntoIterator,
-        I::Item: Into<String>,
+        I::Item: Into<(S, i32)>,
+        S: Into<String>,
     {
-        let desired: HashSet<String> = cache_ids.into_iter().map(Into::into).collect();
+        let desired: HashMap<String, i32> = caches
+            .into_iter()
+            .map(|cache| {
+                let (id, priority) = cache.into();
+                (id.into(), priority)
+            })
+            .collect();
         let mut guard = self.directories.lock().unwrap();
-        for directory in guard
+        for entry in guard
             .iter()
-            .filter_map(|(id, directory)| (!desired.contains(id)).then_some(directory))
+            .filter_map(|(id, entry)| (!desired.contains_key(id)).then_some(entry))
         {
-            directory.apply_channels(Vec::new());
+            entry.directory.apply_channels(Vec::new());
         }
-        guard.retain(|id, _| desired.contains(id));
-        for id in desired {
-            guard.entry(id).or_insert_with(DiskChannelDirectory::new);
+        guard.retain(|id, _| desired.contains_key(id));
+        for (id, priority) in desired {
+            guard
+                .entry(id)
+                .and_modify(|entry| entry.priority = priority)
+                .or_insert_with(|| CacheDirectoryEntry {
+                    directory: DiskChannelDirectory::new(),
+                    priority,
+                });
         }
     }
 
     pub fn get(&self, cache_id: &str) -> Option<Arc<DiskChannelDirectory>> {
-        self.directories.lock().unwrap().get(cache_id).cloned()
+        self.directories
+            .lock()
+            .unwrap()
+            .get(cache_id)
+            .map(|entry| entry.directory.clone())
+    }
+
+    pub fn priority(&self, cache_id: &str) -> Option<i32> {
+        self.directories
+            .lock()
+            .unwrap()
+            .get(cache_id)
+            .map(|entry| entry.priority)
     }
 
     pub fn get_or_create(&self, cache_id: &str) -> Arc<DiskChannelDirectory> {
@@ -132,7 +163,11 @@ impl CacheDirectorySet {
             .lock()
             .unwrap()
             .entry(cache_id.to_string())
-            .or_insert_with(DiskChannelDirectory::new)
+            .or_insert_with(|| CacheDirectoryEntry {
+                directory: DiskChannelDirectory::new(),
+                priority: 0,
+            })
+            .directory
             .clone()
     }
 
@@ -295,6 +330,30 @@ impl LiveShardLocalStore {
         };
         Ok((p, page.len as usize))
     }
+
+    async fn write_page_with_priority<R: Req + ?Sized>(
+        &self,
+        req: &R,
+        stripe_off: u64,
+        page: PageRef,
+        priority: i32,
+    ) -> Result<(), Error> {
+        let key = req.key();
+        let Some(channels) = self.current_or_replay() else {
+            return Err(Error::from("no disks open"));
+        };
+        let (p, len) = self.resolve(page)?;
+        // NOTE: see `read_page`. `disk_for`'s `channels.len()` divisor
+        // means changing the set of open disks repartitions placement;
+        // stripes written under a different open-disk count become
+        // unreachable. Changing the open-disk set is NOT data-preserving.
+        let idx = disk_for(&key, stripe_off, channels.len());
+        let slice = std::ptr::slice_from_raw_parts(p.cast_const(), len);
+        // SAFETY: see `read_page` above.
+        channels[idx]
+            .write_page_with_priority(key, stripe_off, slice, priority)
+            .await
+    }
 }
 
 impl BlockStore for LiveShardLocalStore {
@@ -336,20 +395,7 @@ impl BlockStore for LiveShardLocalStore {
         stripe_off: u64,
         page: PageRef,
     ) -> Result<(), Error> {
-        let key = req.key();
-        let Some(channels) = self.current_or_replay() else {
-            return Err(Error::from("no disks open"));
-        };
-        let (p, len) = self.resolve(page)?;
-        // NOTE: see `read_page`. `disk_for`'s `channels.len()` divisor
-        // means changing the set of open disks repartitions placement;
-        // stripes written under a different open-disk count become
-        // unreachable. Changing the open-disk set is NOT data-preserving.
-        let idx = disk_for(&key, stripe_off, channels.channels.len());
-        let slice = std::ptr::slice_from_raw_parts(p.cast_const(), len);
-        // SAFETY: see `read_page` above.
-        channels.channels[idx]
-            .write_page(key, stripe_off, slice)
+        self.write_page_with_priority(req, stripe_off, page, 0)
             .await
     }
 }
@@ -434,8 +480,9 @@ impl BlockStore for ChainLocalStore {
         if directory.current().is_none() {
             return Ok(());
         }
+        let priority = self.directories.priority(cache_id).unwrap_or(0);
         self.store_for(cache_id)
-            .write_page(req, stripe_off, page)
+            .write_page_with_priority(req, stripe_off, page, priority)
             .await
     }
 }

--- a/cmd/unbounded-storage/src/storage/disks/shard_view.rs
+++ b/cmd/unbounded-storage/src/storage/disks/shard_view.rs
@@ -343,19 +343,19 @@ impl LiveShardLocalStore {
             return Err(Error::from("no disks open"));
         };
         let (p, len) = self.resolve(dst)?;
-        // NOTE: `disk_for` routes by `channels.len()`. Changing the set
+        // NOTE: `disk_for` routes by `channels.channels.len()`. Changing the set
         // of open disks (add/remove via reconcile or hot-swap) changes
         // that divisor, so a stripe persisted under a different open-disk
         // count hashes to a different disk and becomes UNREACHABLE. The
         // directory generation bump only invalidates the buffer cache,
         // not on-disk placement: changing the open-disk set is NOT a
         // data-preserving operation.
-        let idx = disk_for(&key, stripe_off, channels.len());
+        let idx = disk_for(&key, stripe_off, channels.channels.len());
         let slice = std::ptr::slice_from_raw_parts_mut(p, len);
         // SAFETY: `resolve` produced an in-bounds pointer into the
         // shard's pinned backing; the pool guarantees the page is not
         // aliased for the duration of this future.
-        channels[idx]
+        channels.channels[idx]
             .read_page_with_priority(key, stripe_off, slice, priority)
             .await
     }
@@ -372,14 +372,14 @@ impl LiveShardLocalStore {
             return Err(Error::from("no disks open"));
         };
         let (p, len) = self.resolve(page)?;
-        // NOTE: see `read_page`. `disk_for`'s `channels.len()` divisor
+        // NOTE: see `read_page`. `disk_for`'s `channels.channels.len()` divisor
         // means changing the set of open disks repartitions placement;
         // stripes written under a different open-disk count become
         // unreachable. Changing the open-disk set is NOT data-preserving.
-        let idx = disk_for(&key, stripe_off, channels.len());
+        let idx = disk_for(&key, stripe_off, channels.channels.len());
         let slice = std::ptr::slice_from_raw_parts(p.cast_const(), len);
         // SAFETY: see `read_page` above.
-        channels[idx]
+        channels.channels[idx]
             .write_page_with_priority(key, stripe_off, slice, priority)
             .await
     }
@@ -808,7 +808,7 @@ mod tests {
     #[test]
     fn cache_id_readd_rebinds_chain_store_to_new_directory() {
         let dirs = CacheDirectorySet::new();
-        dirs.reconcile(["cache-a"]);
+        dirs.reconcile([("cache-a", 0)]);
         let core1 = Core::spawn();
         dirs.apply_channels(
             "cache-a",
@@ -820,8 +820,8 @@ mod tests {
         view.register_pages(&backing).unwrap();
         let first = view.store_for("cache-a");
 
-        dirs.reconcile(std::iter::empty::<&str>());
-        dirs.reconcile(["cache-a"]);
+        dirs.reconcile(std::iter::empty::<(&str, i32)>());
+        dirs.reconcile([("cache-a", 0)]);
         let core2 = Core::spawn();
         dirs.apply_channels(
             "cache-a",
@@ -847,7 +847,7 @@ mod tests {
     #[test]
     fn page_cache_policy_lookup_does_not_create_live_store() {
         let dirs = CacheDirectorySet::new();
-        dirs.reconcile(["cache-a"]);
+        dirs.reconcile([("cache-a", 0)]);
         let (channel, _rx) = PageChannel::new();
         dirs.apply_channels("cache-a", vec![(PathBuf::from("/a"), channel, None, false)]);
 
@@ -864,7 +864,7 @@ mod tests {
     #[test]
     fn no_cache_id_disables_page_cache_policy() {
         let dirs = CacheDirectorySet::new();
-        dirs.reconcile(["cache-a"]);
+        dirs.reconcile([("cache-a", 0)]);
         let (channel, _rx) = PageChannel::new();
         dirs.apply_channels("cache-a", vec![(PathBuf::from("/a"), channel, None, true)]);
 
@@ -882,7 +882,13 @@ mod tests {
     fn chain_store_rejects_second_backing() {
         let t = DiskChannelDirectory::new();
         let view = ChainLocalStore::new(Arc::new(CacheDirectorySet {
-            directories: Mutex::new(HashMap::from([("cache-a".to_string(), t)])),
+            directories: Mutex::new(HashMap::from([(
+                "cache-a".to_string(),
+                CacheDirectoryEntry {
+                    directory: t,
+                    priority: 0,
+                },
+            )])),
         }));
         let (_b1, backing1) = make_backing(4);
         view.register_pages(&backing1).unwrap();

--- a/cmd/unbounded-storage/src/storage/disks/shard_view.rs
+++ b/cmd/unbounded-storage/src/storage/disks/shard_view.rs
@@ -331,6 +331,35 @@ impl LiveShardLocalStore {
         Ok((p, page.len as usize))
     }
 
+    async fn read_page_with_priority<R: Req + ?Sized>(
+        &self,
+        req: &R,
+        stripe_off: u64,
+        dst: PageRef,
+        priority: i32,
+    ) -> Result<bool, Error> {
+        let key = req.key();
+        let Some(channels) = self.current_or_replay() else {
+            return Err(Error::from("no disks open"));
+        };
+        let (p, len) = self.resolve(dst)?;
+        // NOTE: `disk_for` routes by `channels.len()`. Changing the set
+        // of open disks (add/remove via reconcile or hot-swap) changes
+        // that divisor, so a stripe persisted under a different open-disk
+        // count hashes to a different disk and becomes UNREACHABLE. The
+        // directory generation bump only invalidates the buffer cache,
+        // not on-disk placement: changing the open-disk set is NOT a
+        // data-preserving operation.
+        let idx = disk_for(&key, stripe_off, channels.len());
+        let slice = std::ptr::slice_from_raw_parts_mut(p, len);
+        // SAFETY: `resolve` produced an in-bounds pointer into the
+        // shard's pinned backing; the pool guarantees the page is not
+        // aliased for the duration of this future.
+        channels[idx]
+            .read_page_with_priority(key, stripe_off, slice, priority)
+            .await
+    }
+
     async fn write_page_with_priority<R: Req + ?Sized>(
         &self,
         req: &R,
@@ -367,26 +396,7 @@ impl BlockStore for LiveShardLocalStore {
         stripe_off: u64,
         dst: PageRef,
     ) -> Result<bool, Error> {
-        let key = req.key();
-        let Some(channels) = self.current_or_replay() else {
-            return Err(Error::from("no disks open"));
-        };
-        let (p, len) = self.resolve(dst)?;
-        // NOTE: `disk_for` routes by `channels.len()`. Changing the set
-        // of open disks (add/remove via reconcile or hot-swap) changes
-        // that divisor, so a stripe persisted under a different open-disk
-        // count hashes to a different disk and becomes UNREACHABLE. The
-        // directory generation bump only invalidates the buffer cache,
-        // not on-disk placement: changing the open-disk set is NOT a
-        // data-preserving operation.
-        let idx = disk_for(&key, stripe_off, channels.channels.len());
-        let slice = std::ptr::slice_from_raw_parts_mut(p, len);
-        // SAFETY: `resolve` produced an in-bounds pointer into the
-        // shard's pinned backing; the pool guarantees the page is not
-        // aliased for the duration of this future.
-        channels.channels[idx]
-            .read_page(key, stripe_off, slice)
-            .await
+        self.read_page_with_priority(req, stripe_off, dst, 0).await
     }
 
     async fn write_page<R: Req + ?Sized>(
@@ -460,8 +470,9 @@ impl BlockStore for ChainLocalStore {
         if directory.current().is_none() {
             return Ok(false);
         }
+        let priority = self.directories.priority(cache_id).unwrap_or(0);
         self.store_for(cache_id)
-            .read_page(req, stripe_off, dst)
+            .read_page_with_priority(req, stripe_off, dst, priority)
             .await
     }
 

--- a/cmd/unbounded-storage/src/storage/engine.rs
+++ b/cmd/unbounded-storage/src/storage/engine.rs
@@ -605,8 +605,8 @@ impl<B: BlockDevice> StorageEngine<B> {
         }
     }
 
-    /// Read `(key, stripe_off)` into `dst` and promote any resident
-    /// hit to at least `priority` for eviction ordering.
+    /// Read `(key, stripe_off)` into `dst` and classify any resident
+    /// hit at `priority` for eviction ordering.
     ///
     /// SAFETY: same contract as [`Self::read_page_into`].
     pub async unsafe fn read_page_into_with_priority(
@@ -1243,7 +1243,7 @@ mod tests {
     }
 
     #[test]
-    fn priority_read_promotes_resident_page() {
+    fn priority_read_reclassifies_resident_page() {
         let (eng, _buf) = engine(64);
         let eng_body = eng.clone();
         let mutator = eng.clone().run_mutator();
@@ -1288,7 +1288,7 @@ mod tests {
     }
 
     #[test]
-    fn lower_priority_read_does_not_demote_resident_page() {
+    fn lower_priority_read_reclassifies_resident_page() {
         let (eng, _buf) = engine(64);
         let eng_body = eng.clone();
         let mutator = eng.clone().run_mutator();
@@ -1325,7 +1325,7 @@ mod tests {
 
             let entries = eng_body.lru_entries_for_test();
             assert_eq!(entries.len(), 1);
-            assert_eq!(entries[0].priority, 10);
+            assert_eq!(entries[0].priority, -10);
             eng_body.close_mutator();
         };
         block_on_pair(body, mutator.as_mut());

--- a/cmd/unbounded-storage/src/storage/engine.rs
+++ b/cmd/unbounded-storage/src/storage/engine.rs
@@ -440,11 +440,11 @@ impl<B: BlockDevice> StorageEngine<B> {
             // references them. Re-admit so they remain tracked
             // and are reconsidered on a later sweep.
             let mut victims: Vec<Lba> = Vec::with_capacity(candidates.len());
-            for lba in candidates {
-                if self.refcount.pin_count(lba.0).unwrap_or(0) == 0 {
-                    victims.push(lba);
+            for candidate in candidates {
+                if self.refcount.pin_count(candidate.lba.0).unwrap_or(0) == 0 {
+                    victims.push(candidate.lba);
                 } else {
-                    self.lru.admit(lba);
+                    self.lru.admit(candidate.lba, candidate.priority);
                 }
             }
             if victims.is_empty() {
@@ -546,7 +546,10 @@ impl<B: BlockDevice> bufferpool::BlockStore for StorageEngine<B> {
         // SAFETY: see register_pages contract.
         let src_buf: *const [u8] = unsafe { self.slice_from_ref(page) };
         // SAFETY: see comment above.
-        unsafe { self.write_page_from(req.key(), stripe_off, src_buf).await }
+        unsafe {
+            self.write_page_from_with_priority(req.key(), stripe_off, src_buf, 0)
+                .await
+        }
     }
 }
 
@@ -664,6 +667,23 @@ impl<B: BlockDevice> StorageEngine<B> {
         stripe_off: u64,
         src: *const [u8],
     ) -> Result<(), bufferpool::Error> {
+        unsafe {
+            self.write_page_from_with_priority(key, stripe_off, src, 0)
+                .await
+        }
+    }
+
+    /// Write the contents of `src` to `(key, stripe_off)` and record
+    /// the page's cache priority for eviction ordering.
+    ///
+    /// SAFETY: same contract as [`Self::write_page_from`].
+    pub async unsafe fn write_page_from_with_priority(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        src: *const [u8],
+        priority: i32,
+    ) -> Result<(), bufferpool::Error> {
         let pk = Self::page_key(&key, stripe_off, self.cfg.page_size_bytes);
 
         if !self.cfg.bypass_admission && !self.admission.should_admit(&pk) {
@@ -779,7 +799,7 @@ impl<B: BlockDevice> StorageEngine<B> {
             let mut rev = self.reverse.lock().unwrap();
             rev.insert(lba.0, (pk, src_buf.len() as u32));
         }
-        self.lru.admit(lba);
+        self.lru.admit(lba, priority);
         self.metric(|m| m.admitted += 1);
         leader.publish(entry);
 

--- a/cmd/unbounded-storage/src/storage/engine.rs
+++ b/cmd/unbounded-storage/src/storage/engine.rs
@@ -256,6 +256,13 @@ pub struct EngineSnapshot {
     pub pending_free_len: usize,
 }
 
+#[cfg(test)]
+#[derive(Debug, Eq, PartialEq)]
+struct LruEntrySnapshot {
+    lba: Lba,
+    priority: i32,
+}
+
 impl<B: BlockDevice> StorageEngine<B> {
     pub async fn open(
         device: Arc<B>,
@@ -338,6 +345,15 @@ impl<B: BlockDevice> StorageEngine<B> {
             btree_lookup_cache_bytes: self.btree.lookup_cache_bytes(),
             pending_free_len: self.pending_free.lock().unwrap().len(),
         }
+    }
+
+    #[cfg(test)]
+    fn lru_entries_for_test(&self) -> Vec<LruEntrySnapshot> {
+        self.lru
+            .entries_for_test()
+            .into_iter()
+            .map(|(lba, priority)| LruEntrySnapshot { lba, priority })
+            .collect()
     }
 
     fn page_key(stripe: &StripeKey, stripe_off: u64, page_bytes: usize) -> PageKey {
@@ -583,6 +599,23 @@ impl<B: BlockDevice> StorageEngine<B> {
         stripe_off: u64,
         dst: *mut [u8],
     ) -> Result<bool, bufferpool::Error> {
+        unsafe {
+            self.read_page_into_with_priority(key, stripe_off, dst, 0)
+                .await
+        }
+    }
+
+    /// Read `(key, stripe_off)` into `dst` and promote any resident
+    /// hit to at least `priority` for eviction ordering.
+    ///
+    /// SAFETY: same contract as [`Self::read_page_into`].
+    pub async unsafe fn read_page_into_with_priority(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        dst: *mut [u8],
+        priority: i32,
+    ) -> Result<bool, bufferpool::Error> {
         let pk = Self::page_key(&key, stripe_off, self.cfg.page_size_bytes);
 
         let entry = match self.lookup_entry(&pk).await {
@@ -636,7 +669,7 @@ impl<B: BlockDevice> StorageEngine<B> {
             return Ok(false);
         }
 
-        self.lru.touch(entry.lba);
+        self.lru.touch_with_priority(entry.lba, priority);
         self.admission.record_frequency(&pk);
         self.metric(|m| m.hits += 1);
         crate::metrics::storage_lookup(crate::metrics::Lookup::Hit);
@@ -1029,9 +1062,11 @@ mod tests {
             capacity_pages: capacity,
             ..Default::default()
         }));
-        let mut cfg = EngineConfig::default();
-        cfg.page_size_bytes = 4096; // collapse cache page == device block for tests
-        cfg.btree_page_bytes = 4096;
+        let cfg = EngineConfig {
+            page_size_bytes: 4096, // collapse cache page == device block for tests
+            btree_page_bytes: 4096,
+            ..Default::default()
+        };
         let eng = Arc::new(block_on(StorageEngine::open(device, cfg)).unwrap());
         // 64 pool pages of 4 KiB each.
         let buf: Box<[u8]> = vec![0u8; 4096 * 64].into_boxed_slice();
@@ -1203,6 +1238,95 @@ mod tests {
             assert!(eng_body.snapshot().checksum_misses >= 1);
             eng_body.close_mutator();
             let _ = buf;
+        };
+        block_on_pair(body, mutator.as_mut());
+    }
+
+    #[test]
+    fn priority_read_promotes_resident_page() {
+        let (eng, _buf) = engine(64);
+        let eng_body = eng.clone();
+        let mutator = eng.clone().run_mutator();
+        let mut mutator = pin!(mutator);
+        let body = async move {
+            let src = PageRef {
+                page_idx: 0,
+                offset: 0,
+                len: 4096,
+            };
+            let dst = PageRef {
+                page_idx: 1,
+                offset: 0,
+                len: 4096,
+            };
+            unsafe {
+                let src_buf = eng_body.slice_from_ref(src);
+                eng_body
+                    .write_page_from_with_priority(stripe(7), 0, src_buf, -10)
+                    .await
+                    .unwrap();
+                eng_body
+                    .write_page_from_with_priority(stripe(7), 0, src_buf, -10)
+                    .await
+                    .unwrap();
+                assert_eq!(eng_body.lru_entries_for_test()[0].priority, -10);
+
+                let read_slice = eng_body.slice_mut_from_ref(dst);
+                let hit = eng_body
+                    .read_page_into_with_priority(stripe(7), 0, read_slice, 10)
+                    .await
+                    .unwrap();
+                assert!(hit);
+            }
+
+            let entries = eng_body.lru_entries_for_test();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].priority, 10);
+            eng_body.close_mutator();
+        };
+        block_on_pair(body, mutator.as_mut());
+    }
+
+    #[test]
+    fn lower_priority_read_does_not_demote_resident_page() {
+        let (eng, _buf) = engine(64);
+        let eng_body = eng.clone();
+        let mutator = eng.clone().run_mutator();
+        let mut mutator = pin!(mutator);
+        let body = async move {
+            let src = PageRef {
+                page_idx: 0,
+                offset: 0,
+                len: 4096,
+            };
+            let dst = PageRef {
+                page_idx: 1,
+                offset: 0,
+                len: 4096,
+            };
+            unsafe {
+                let src_buf = eng_body.slice_from_ref(src);
+                eng_body
+                    .write_page_from_with_priority(stripe(8), 0, src_buf, 10)
+                    .await
+                    .unwrap();
+                eng_body
+                    .write_page_from_with_priority(stripe(8), 0, src_buf, 10)
+                    .await
+                    .unwrap();
+
+                let read_slice = eng_body.slice_mut_from_ref(dst);
+                let hit = eng_body
+                    .read_page_into_with_priority(stripe(8), 0, read_slice, -10)
+                    .await
+                    .unwrap();
+                assert!(hit);
+            }
+
+            let entries = eng_body.lru_entries_for_test();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].priority, 10);
+            eng_body.close_mutator();
         };
         block_on_pair(body, mutator.as_mut());
     }

--- a/cmd/unbounded-storage/src/storage/local.rs
+++ b/cmd/unbounded-storage/src/storage/local.rs
@@ -178,10 +178,27 @@ impl<B: BlockDevice + 'static> LocalStorage<B> {
         stripe_off: u64,
         src: *const [u8],
     ) -> Result<(), Error> {
+        unsafe {
+            self.write_page_from_with_priority(key, stripe_off, src, 0)
+                .await
+        }
+    }
+
+    /// Route a raw-slice write to the disk that owns the page and
+    /// record the page's cache priority for eviction ordering.
+    ///
+    /// SAFETY: see [`StorageEngine::write_page_from`].
+    pub async unsafe fn write_page_from_with_priority(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        src: *const [u8],
+        priority: i32,
+    ) -> Result<(), Error> {
         let idx = self.disk_for(key, stripe_off);
         unsafe {
             self.engines[idx]
-                .write_page_from(key, stripe_off, src)
+                .write_page_from_with_priority(key, stripe_off, src, priority)
                 .await
         }
     }

--- a/cmd/unbounded-storage/src/storage/local.rs
+++ b/cmd/unbounded-storage/src/storage/local.rs
@@ -172,7 +172,7 @@ impl<B: BlockDevice + 'static> LocalStorage<B> {
     }
 
     /// Route a raw-slice read to the disk that owns the page and
-    /// promote any resident hit to at least `priority` for eviction.
+    /// classify any resident hit at `priority` for eviction.
     ///
     /// SAFETY: see [`StorageEngine::read_page_into`].
     pub async unsafe fn read_page_into_with_priority(

--- a/cmd/unbounded-storage/src/storage/local.rs
+++ b/cmd/unbounded-storage/src/storage/local.rs
@@ -165,8 +165,29 @@ impl<B: BlockDevice + 'static> LocalStorage<B> {
         stripe_off: u64,
         dst: *mut [u8],
     ) -> Result<bool, Error> {
+        unsafe {
+            self.read_page_into_with_priority(key, stripe_off, dst, 0)
+                .await
+        }
+    }
+
+    /// Route a raw-slice read to the disk that owns the page and
+    /// promote any resident hit to at least `priority` for eviction.
+    ///
+    /// SAFETY: see [`StorageEngine::read_page_into`].
+    pub async unsafe fn read_page_into_with_priority(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        dst: *mut [u8],
+        priority: i32,
+    ) -> Result<bool, Error> {
         let idx = self.disk_for(key, stripe_off);
-        unsafe { self.engines[idx].read_page_into(key, stripe_off, dst).await }
+        unsafe {
+            self.engines[idx]
+                .read_page_into_with_priority(key, stripe_off, dst, priority)
+                .await
+        }
     }
 
     /// Route a raw-slice write to the disk that owns the page.

--- a/cmd/unbounded-storage/src/storage/lru/mod.rs
+++ b/cmd/unbounded-storage/src/storage/lru/mod.rs
@@ -67,6 +67,16 @@ impl SieveLru {
         self.len() == 0
     }
 
+    #[cfg(test)]
+    pub(crate) fn entries_for_test(&self) -> Vec<(Lba, i32)> {
+        let inner = self.inner.lock().unwrap();
+        inner
+            .buckets
+            .iter()
+            .flat_map(|(&priority, bucket)| bucket.iter().map(move |&lba| (lba, priority)))
+            .collect()
+    }
+
     /// Returns true once the populated fraction crosses the
     /// configured high watermark. Callers (the eviction worker)
     /// use this to decide when to run a sweep.
@@ -84,6 +94,36 @@ impl SieveLru {
 
     pub fn touch(&self, lba: Lba) {
         let _ = self.refcount.mark_referenced(lba.0);
+    }
+
+    pub fn touch_with_priority(&self, lba: Lba, priority: i32) {
+        self.promote(lba, priority);
+        self.touch(lba);
+    }
+
+    /// Raise `lba` to `priority` if it is currently resident in a
+    /// lower-priority bucket. Priority is monotonic for a resident page:
+    /// a low-priority cache read must not undo protection established by
+    /// an earlier high-priority cache access to the same content.
+    pub fn promote(&self, lba: Lba, priority: i32) {
+        let mut inner = self.inner.lock().unwrap();
+        let Some((current, pos)) = inner.buckets.iter().find_map(|(&priority, q)| {
+            q.iter()
+                .position(|&candidate| candidate == lba)
+                .map(|pos| (priority, pos))
+        }) else {
+            return;
+        };
+        if current >= priority {
+            return;
+        }
+        if let Some(q) = inner.buckets.get_mut(&current) {
+            q.remove(pos);
+            if inner.buckets.get(&current).is_some_and(VecDeque::is_empty) {
+                inner.buckets.remove(&current);
+            }
+            inner.buckets.entry(priority).or_default().push_front(lba);
+        }
     }
 
     /// Sweep the hand looking for up to `target` evictable
@@ -265,6 +305,42 @@ mod tests {
         let v = l.sweep(1);
         assert_eq!(lbas(&v), vec![Lba(3)]);
         assert_eq!(l.len(), 1);
+    }
+
+    #[test]
+    fn higher_priority_touch_promotes_resident_page() {
+        let l = lru(16);
+        l.admit(Lba(2), -10);
+        l.admit(Lba(3), 0);
+
+        l.touch_with_priority(Lba(2), 10);
+        let v = l.sweep(2);
+
+        assert_eq!(lbas(&v), vec![Lba(3), Lba(2)]);
+        assert_eq!(
+            v.iter()
+                .map(|candidate| candidate.priority)
+                .collect::<Vec<_>>(),
+            vec![0, 10]
+        );
+    }
+
+    #[test]
+    fn lower_priority_touch_does_not_demote_resident_page() {
+        let l = lru(16);
+        l.admit(Lba(2), 10);
+        l.admit(Lba(3), 0);
+
+        l.touch_with_priority(Lba(2), -10);
+        let v = l.sweep(2);
+
+        assert_eq!(lbas(&v), vec![Lba(3), Lba(2)]);
+        assert_eq!(
+            v.iter()
+                .map(|candidate| candidate.priority)
+                .collect::<Vec<_>>(),
+            vec![0, 10]
+        );
     }
 
     fn lbas(victims: &[EvictionCandidate]) -> Vec<Lba> {

--- a/cmd/unbounded-storage/src/storage/lru/mod.rs
+++ b/cmd/unbounded-storage/src/storage/lru/mod.rs
@@ -97,15 +97,12 @@ impl SieveLru {
     }
 
     pub fn touch_with_priority(&self, lba: Lba, priority: i32) {
-        self.promote(lba, priority);
+        self.reclassify(lba, priority);
         self.touch(lba);
     }
 
-    /// Raise `lba` to `priority` if it is currently resident in a
-    /// lower-priority bucket. Priority is monotonic for a resident page:
-    /// a low-priority cache read must not undo protection established by
-    /// an earlier high-priority cache access to the same content.
-    pub fn promote(&self, lba: Lba, priority: i32) {
+    /// Move `lba` to the current access priority if it is resident.
+    pub fn reclassify(&self, lba: Lba, priority: i32) {
         let mut inner = self.inner.lock().unwrap();
         let Some((current, pos)) = inner.buckets.iter().find_map(|(&priority, q)| {
             q.iter()
@@ -114,7 +111,7 @@ impl SieveLru {
         }) else {
             return;
         };
-        if current >= priority {
+        if current == priority {
             return;
         }
         if let Some(q) = inner.buckets.get_mut(&current) {
@@ -308,7 +305,7 @@ mod tests {
     }
 
     #[test]
-    fn higher_priority_touch_promotes_resident_page() {
+    fn higher_priority_touch_reclassifies_resident_page() {
         let l = lru(16);
         l.admit(Lba(2), -10);
         l.admit(Lba(3), 0);
@@ -326,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn lower_priority_touch_does_not_demote_resident_page() {
+    fn lower_priority_touch_reclassifies_resident_page() {
         let l = lru(16);
         l.admit(Lba(2), 10);
         l.admit(Lba(3), 0);
@@ -339,7 +336,7 @@ mod tests {
             v.iter()
                 .map(|candidate| candidate.priority)
                 .collect::<Vec<_>>(),
-            vec![0, 10]
+            vec![0, -10]
         );
     }
 

--- a/cmd/unbounded-storage/src/storage/lru/mod.rs
+++ b/cmd/unbounded-storage/src/storage/lru/mod.rs
@@ -3,11 +3,12 @@
 
 //! SIEVE eviction policy.
 //!
-//! Per-disk cache pages are tracked in a single FIFO queue. Each
-//! page's "referenced" bit lives on the shared
+//! Per-disk cache pages are tracked in FIFO queues bucketed by cache
+//! priority. Each page's "referenced" bit lives on the shared
 //! [`RefcountTable`](crate::storage::refcount::RefcountTable),
 //! colocated with its pin count. On every access the engine
-//! sets the bit; the SIEVE hand sweeps from the tail and:
+//! sets the bit; the SIEVE hand sweeps from lower-priority buckets
+//! first and from each bucket's tail:
 //!
 //! - if the page is pinned, skip it without touching the bit
 //!   (it's in flight; future eviction passes will revisit);
@@ -16,10 +17,12 @@
 //! - otherwise evict the page.
 //!
 //! Compared to a textbook clock, SIEVE only rotates entries
-//! that the hand visits, which keeps the queue's tail
-//! biased toward genuinely cold pages.
+//! that the hand visits, which keeps each bucket's tail
+//! biased toward genuinely cold pages. Priority does not add an LBA
+//! index on the write/allocation path; it is recorded only with the
+//! resident LRU entry and consulted during eviction.
 
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use crate::storage::refcount::RefcountTable;
@@ -27,15 +30,27 @@ use crate::storage::types::Lba;
 
 pub struct SieveLru {
     capacity: u64,
-    queue: Mutex<VecDeque<Lba>>,
+    inner: Mutex<Inner>,
     refcount: Arc<RefcountTable>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EvictionCandidate {
+    pub lba: Lba,
+    pub priority: i32,
+}
+
+#[derive(Default)]
+struct Inner {
+    buckets: BTreeMap<i32, VecDeque<Lba>>,
+    len: usize,
 }
 
 impl SieveLru {
     pub fn new(capacity: u64, refcount: Arc<RefcountTable>) -> Self {
         Self {
             capacity,
-            queue: Mutex::new(VecDeque::new()),
+            inner: Mutex::new(Inner::default()),
             refcount,
         }
     }
@@ -45,7 +60,7 @@ impl SieveLru {
     }
 
     pub fn len(&self) -> usize {
-        self.queue.lock().unwrap().len()
+        self.inner.lock().unwrap().len
     }
 
     pub fn is_empty(&self) -> bool {
@@ -61,8 +76,10 @@ impl SieveLru {
         len / cap >= fraction
     }
 
-    pub fn admit(&self, lba: Lba) {
-        self.queue.lock().unwrap().push_front(lba);
+    pub fn admit(&self, lba: Lba, priority: i32) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.buckets.entry(priority).or_default().push_front(lba);
+        inner.len += 1;
     }
 
     pub fn touch(&self, lba: Lba) {
@@ -70,29 +87,54 @@ impl SieveLru {
     }
 
     /// Sweep the hand looking for up to `target` evictable
-    /// pages. Pinned pages are skipped (left in place); pages
-    /// whose referenced bit is set get demoted (bit cleared,
-    /// rotated to the head); cold pages are returned as
-    /// victims. The sweep gives up after seeing twice the
-    /// queue's length to avoid an unbounded loop when every
-    /// resident page is pinned.
-    pub fn sweep(&self, target: usize) -> Vec<Lba> {
+    /// pages. Lower-priority buckets are searched before higher-
+    /// priority buckets. Pinned pages are skipped (left in place);
+    /// pages whose referenced bit is set get demoted (bit cleared,
+    /// rotated to the head); cold pages are returned as victims.
+    /// The sweep gives up after seeing twice the resident length to
+    /// avoid an unbounded loop when every resident page is pinned.
+    pub fn sweep(&self, target: usize) -> Vec<EvictionCandidate> {
         let mut victims = Vec::with_capacity(target.min(64));
-        let mut q = self.queue.lock().unwrap();
-        let mut budget = q.len() * 2;
-        while victims.len() < target && budget > 0 {
-            budget -= 1;
-            let Some(lba) = q.pop_back() else { break };
-            if self.refcount.is_pinned(lba.0).unwrap_or(false) {
-                q.push_front(lba);
-                continue;
+        let mut inner = self.inner.lock().unwrap();
+        let mut budget = inner.len * 2;
+        while victims.len() < target && budget > 0 && inner.len > 0 {
+            let priorities: Vec<i32> = inner.buckets.keys().copied().collect();
+            let mut made_progress = false;
+            for priority in priorities {
+                if victims.len() >= target || budget == 0 {
+                    break;
+                }
+                let bucket_len = inner.buckets.get(&priority).map_or(0, VecDeque::len);
+                for _ in 0..bucket_len {
+                    if victims.len() >= target || budget == 0 {
+                        break;
+                    }
+                    let Some(lba) = inner
+                        .buckets
+                        .get_mut(&priority)
+                        .and_then(VecDeque::pop_back)
+                    else {
+                        break;
+                    };
+                    budget -= 1;
+                    made_progress = true;
+                    if self.refcount.is_pinned(lba.0).unwrap_or(false) {
+                        inner.buckets.entry(priority).or_default().push_front(lba);
+                    } else if self.refcount.is_referenced(lba.0).unwrap_or(false) {
+                        let _ = self.refcount.clear_referenced(lba.0);
+                        inner.buckets.entry(priority).or_default().push_front(lba);
+                    } else {
+                        inner.len -= 1;
+                        victims.push(EvictionCandidate { lba, priority });
+                    }
+                    if inner.buckets.get(&priority).is_some_and(VecDeque::is_empty) {
+                        inner.buckets.remove(&priority);
+                    }
+                }
             }
-            if self.refcount.is_referenced(lba.0).unwrap_or(false) {
-                let _ = self.refcount.clear_referenced(lba.0);
-                q.push_front(lba);
-                continue;
+            if !made_progress {
+                break;
             }
-            victims.push(lba);
         }
         victims
     }
@@ -101,9 +143,26 @@ impl SieveLru {
     /// external invalidation removes a page (e.g., the engine
     /// observed bitrot).
     pub fn forget(&self, lba: Lba) {
-        let mut q = self.queue.lock().unwrap();
-        if let Some(pos) = q.iter().position(|&x| x == lba) {
-            q.remove(pos);
+        let mut inner = self.inner.lock().unwrap();
+        let priorities: Vec<i32> = inner.buckets.keys().copied().collect();
+        for priority in priorities {
+            let removed = if let Some(q) = inner.buckets.get_mut(&priority) {
+                if let Some(pos) = q.iter().position(|&x| x == lba) {
+                    q.remove(pos);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if removed {
+                inner.len -= 1;
+                if inner.buckets.get(&priority).is_some_and(VecDeque::is_empty) {
+                    inner.buckets.remove(&priority);
+                }
+                break;
+            }
         }
     }
 }
@@ -121,10 +180,10 @@ mod tests {
     fn admit_then_sweep_returns_cold_pages_in_lru_order() {
         let l = lru(16);
         for i in 2..6 {
-            l.admit(Lba(i));
+            l.admit(Lba(i), 0);
         }
         let v = l.sweep(2);
-        assert_eq!(v, vec![Lba(2), Lba(3)]);
+        assert_eq!(lbas(&v), vec![Lba(2), Lba(3)]);
         assert_eq!(l.len(), 2);
     }
 
@@ -132,15 +191,15 @@ mod tests {
     fn touched_pages_survive_first_sweep() {
         let l = lru(16);
         for i in 2..6 {
-            l.admit(Lba(i));
+            l.admit(Lba(i), 0);
         }
         l.touch(Lba(2));
         // Hand reaches Lba(2) first; bit set => clear+rotate.
         let v = l.sweep(1);
-        assert_eq!(v, vec![Lba(3)]);
+        assert_eq!(lbas(&v), vec![Lba(3)]);
         // Sweep again: now Lba(2) has bit cleared and gets evicted next.
         let v = l.sweep(1);
-        assert_eq!(v, vec![Lba(4)]);
+        assert_eq!(lbas(&v), vec![Lba(4)]);
     }
 
     #[test]
@@ -148,11 +207,11 @@ mod tests {
         let l = lru(16);
         let rc = l.refcount.clone();
         for i in 2..6 {
-            l.admit(Lba(i));
+            l.admit(Lba(i), 0);
         }
         let _g = rc.pin(2).unwrap();
         let v = l.sweep(3);
-        assert_eq!(v, vec![Lba(3), Lba(4), Lba(5)]);
+        assert_eq!(lbas(&v), vec![Lba(3), Lba(4), Lba(5)]);
         // Lba(2) is still in the queue (skipped, re-enqueued).
         assert_eq!(l.len(), 1);
     }
@@ -162,7 +221,7 @@ mod tests {
         let l = lru(10);
         assert!(!l.watermark_exceeded(0.9));
         for i in 2..11 {
-            l.admit(Lba(i));
+            l.admit(Lba(i), 0);
         }
         assert!(l.watermark_exceeded(0.9));
     }
@@ -170,10 +229,45 @@ mod tests {
     #[test]
     fn forget_removes_lba() {
         let l = lru(8);
-        l.admit(Lba(2));
-        l.admit(Lba(3));
+        l.admit(Lba(2), 0);
+        l.admit(Lba(3), 0);
         l.forget(Lba(2));
         assert_eq!(l.len(), 1);
-        assert_eq!(l.sweep(2), vec![Lba(3)]);
+        assert_eq!(lbas(&l.sweep(2)), vec![Lba(3)]);
+    }
+
+    #[test]
+    fn higher_priority_pages_are_evicted_last() {
+        let l = lru(16);
+        l.admit(Lba(2), 10);
+        l.admit(Lba(3), -1);
+        l.admit(Lba(4), 0);
+        l.admit(Lba(5), -1);
+
+        let v = l.sweep(3);
+        assert_eq!(lbas(&v), vec![Lba(3), Lba(5), Lba(4)]);
+        assert_eq!(
+            v.iter().map(|c| c.priority).collect::<Vec<_>>(),
+            vec![-1, -1, 0]
+        );
+        assert_eq!(l.len(), 1);
+        assert_eq!(lbas(&l.sweep(1)), vec![Lba(2)]);
+    }
+
+    #[test]
+    fn sweep_falls_through_when_lower_priority_pages_are_not_cold() {
+        let l = lru(16);
+        let rc = l.refcount.clone();
+        l.admit(Lba(2), -10);
+        l.admit(Lba(3), 5);
+        let _g = rc.pin(2).unwrap();
+
+        let v = l.sweep(1);
+        assert_eq!(lbas(&v), vec![Lba(3)]);
+        assert_eq!(l.len(), 1);
+    }
+
+    fn lbas(victims: &[EvictionCandidate]) -> Vec<Lba> {
+        victims.iter().map(|candidate| candidate.lba).collect()
     }
 }

--- a/cmd/unbounded-storage/src/storage/page_channel.rs
+++ b/cmd/unbounded-storage/src/storage/page_channel.rs
@@ -95,8 +95,8 @@ impl PageChannel {
         self.read_page_with_priority(key, stripe_off, dst, 0).await
     }
 
-    /// Read `(key, stripe_off)` into `dst` and promote any resident
-    /// hit to at least `priority` for eviction ordering.
+    /// Read `(key, stripe_off)` into `dst` and classify any resident
+    /// hit at `priority` for eviction ordering.
     ///
     /// SAFETY: `dst` must point to a writable region that lives
     /// until the returned future resolves and is pinned for DMA.

--- a/cmd/unbounded-storage/src/storage/page_channel.rs
+++ b/cmd/unbounded-storage/src/storage/page_channel.rs
@@ -92,6 +92,21 @@ impl PageChannel {
         stripe_off: u64,
         dst: *mut [u8],
     ) -> Result<bool, Error> {
+        self.read_page_with_priority(key, stripe_off, dst, 0).await
+    }
+
+    /// Read `(key, stripe_off)` into `dst` and promote any resident
+    /// hit to at least `priority` for eviction ordering.
+    ///
+    /// SAFETY: `dst` must point to a writable region that lives
+    /// until the returned future resolves and is pinned for DMA.
+    pub async fn read_page_with_priority(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        dst: *mut [u8],
+        priority: i32,
+    ) -> Result<bool, Error> {
         let len = dst.len();
         let ptr = NonNull::new(dst.cast::<u8>()).ok_or(Error::Io(libc::EINVAL))?;
         let reply = ReplySlot::new();
@@ -101,6 +116,7 @@ impl PageChannel {
                 stripe_off,
                 dst: SendPtr(ptr),
                 len,
+                priority,
                 reply: reply.clone(),
             })
             .map_err(|_| Error::Io(libc::EPIPE))?;
@@ -207,6 +223,7 @@ pub enum PageCommand {
         stripe_off: u64,
         dst: SendPtr,
         len: usize,
+        priority: i32,
         reply: Arc<ReplySlot<bool>>,
     },
     WritePage {
@@ -275,6 +292,7 @@ impl<B: BlockDevice + 'static> PageService<B> {
                     stripe_off,
                     dst,
                     len,
+                    priority,
                     reply,
                 }) => {
                     let engine = self.engine.clone();
@@ -284,7 +302,11 @@ impl<B: BlockDevice + 'static> PageService<B> {
                             // `dst` valid until `reply` is set (see
                             // module docs).
                             let slice = std::ptr::slice_from_raw_parts_mut(dst.0.as_ptr(), len);
-                            unsafe { engine.read_page_into(key, stripe_off, slice).await }
+                            unsafe {
+                                engine
+                                    .read_page_into_with_priority(key, stripe_off, slice, priority)
+                                    .await
+                            }
                         });
                     self.in_flight.push(Inflight::Read { fut, reply });
                 }

--- a/cmd/unbounded-storage/src/storage/page_channel.rs
+++ b/cmd/unbounded-storage/src/storage/page_channel.rs
@@ -117,6 +117,21 @@ impl PageChannel {
         stripe_off: u64,
         src: *const [u8],
     ) -> Result<(), Error> {
+        self.write_page_with_priority(key, stripe_off, src, 0).await
+    }
+
+    /// Write `src` to `(key, stripe_off)` and attach the cache
+    /// priority used by eviction.
+    ///
+    /// SAFETY: `src` must point to a readable region that lives
+    /// until the returned future resolves and is pinned for DMA.
+    pub async fn write_page_with_priority(
+        &self,
+        key: StripeKey,
+        stripe_off: u64,
+        src: *const [u8],
+        priority: i32,
+    ) -> Result<(), Error> {
         let len = src.len();
         let ptr = NonNull::new(src.cast::<u8>().cast_mut()).ok_or(Error::Io(libc::EINVAL))?;
         let reply = ReplySlot::new();
@@ -126,6 +141,7 @@ impl PageChannel {
                 stripe_off,
                 src: SendPtr(ptr),
                 len,
+                priority,
                 reply: reply.clone(),
             })
             .map_err(|_| Error::Io(libc::EPIPE))?;
@@ -198,6 +214,7 @@ pub enum PageCommand {
         stripe_off: u64,
         src: SendPtr,
         len: usize,
+        priority: i32,
         reply: Arc<ReplySlot<()>>,
     },
     RegisterBuffer {
@@ -276,6 +293,7 @@ impl<B: BlockDevice + 'static> PageService<B> {
                     stripe_off,
                     src,
                     len,
+                    priority,
                     reply,
                 }) => {
                     let engine = self.engine.clone();
@@ -285,7 +303,11 @@ impl<B: BlockDevice + 'static> PageService<B> {
                             // service treats this region as immutable.
                             let slice =
                                 std::ptr::slice_from_raw_parts(src.0.as_ptr().cast_const(), len);
-                            unsafe { engine.write_page_from(key, stripe_off, slice).await }
+                            unsafe {
+                                engine
+                                    .write_page_from_with_priority(key, stripe_off, slice, priority)
+                                    .await
+                            }
                         });
                     self.in_flight.push(Inflight::Write { fut, reply });
                 }

--- a/cmd/unbounded-storage/tests/lifecycle/workload.rs
+++ b/cmd/unbounded-storage/tests/lifecycle/workload.rs
@@ -869,6 +869,7 @@ fn config_for_generation(version: u64, disks: Vec<DiskSpec>) -> Config {
     cfg.caches = vec![CacheSpec {
         name: "cache-0".to_string(),
         source: "backend-0".to_string(),
+        priority: 0,
     }];
     cfg.disks = disks;
     cfg.frontends = frontend_specs(0, 1);

--- a/cmd/unbounded-storage/tests/storage/tests.rs
+++ b/cmd/unbounded-storage/tests/storage/tests.rs
@@ -37,7 +37,13 @@ proptest! {
         let oracle = Oracle::new();
         for c in &w.clients {
             for op in &c.ops {
-                if let Op::Write { key_idx, off_idx, payload_seed } = op {
+                if let Op::Write {
+                    key_idx,
+                    off_idx,
+                    payload_seed,
+                    ..
+                } = op
+                {
                     oracle.record_write(
                         w.key(*key_idx),
                         w.offset(*off_idx),
@@ -86,7 +92,13 @@ proptest! {
         let oracle = Oracle::new();
         for c in &w.clients {
             for op in &c.ops {
-                if let Op::Write { key_idx, off_idx, payload_seed } = op {
+                if let Op::Write {
+                    key_idx,
+                    off_idx,
+                    payload_seed,
+                    ..
+                } = op
+                {
                     oracle.record_write(
                         w.key(*key_idx),
                         w.offset(*off_idx),
@@ -115,7 +127,13 @@ proptest! {
         let oracle = Oracle::new();
         for c in &w.clients {
             for op in &c.ops {
-                if let Op::Write { key_idx, off_idx, payload_seed } = op {
+                if let Op::Write {
+                    key_idx,
+                    off_idx,
+                    payload_seed,
+                    ..
+                } = op
+                {
                     oracle.record_write(
                         w.key(*key_idx),
                         w.offset(*off_idx),
@@ -264,7 +282,13 @@ proptest! {
         let oracle = Oracle::new();
         for c in &w.clients {
             for op in &c.ops {
-                if let Op::Write { key_idx, off_idx, payload_seed } = op {
+                if let Op::Write {
+                    key_idx,
+                    off_idx,
+                    payload_seed,
+                    ..
+                } = op
+                {
                     oracle.record_write(
                         w.key(*key_idx),
                         w.offset(*off_idx),
@@ -538,6 +562,7 @@ fn smoke() {
         max_io_delay: 2,
         io_fault_rate: 0,
         read_corrupt_rate: 0,
+        priorities: vec![0],
         key_count: 2,
         offset_count: 2,
         clients: vec![
@@ -547,11 +572,13 @@ fn smoke() {
                         key_idx: 0,
                         off_idx: 0,
                         payload_seed: 1,
+                        priority_idx: 0,
                     },
                     Op::Write {
                         key_idx: 0,
                         off_idx: 0,
                         payload_seed: 1,
+                        priority_idx: 0,
                     },
                     Op::Read {
                         key_idx: 0,
@@ -565,11 +592,13 @@ fn smoke() {
                         key_idx: 1,
                         off_idx: 1,
                         payload_seed: 9,
+                        priority_idx: 0,
                     },
                     Op::Write {
                         key_idx: 1,
                         off_idx: 1,
                         payload_seed: 9,
+                        priority_idx: 0,
                     },
                     Op::Read {
                         key_idx: 1,
@@ -593,6 +622,62 @@ fn smoke() {
         hits >= 1,
         "expected at least one hit after double-write: {:?}",
         report.outcomes
+    );
+}
+
+/// Priority smoke: varied-priority writes drive eviction under
+/// concurrent clients. Completion is the liveness assertion: any
+/// priority-bucket lock inversion, unbounded sweep, or mutator
+/// contention shows up as `RunError::Deadlock` or budget exhaustion.
+#[test]
+fn smoke_priority_eviction_contention() {
+    let mut clients = Vec::new();
+    let key_count = 96u8;
+    for cid in 0..6u8 {
+        let mut ops = Vec::new();
+        for k in (cid..key_count).step_by(6) {
+            let priority_idx = k % 3;
+            ops.push(Op::Write {
+                key_idx: k,
+                off_idx: 0,
+                payload_seed: k.wrapping_mul(3),
+                priority_idx,
+            });
+            ops.push(Op::Write {
+                key_idx: k,
+                off_idx: 0,
+                payload_seed: k.wrapping_mul(3),
+                priority_idx,
+            });
+        }
+        clients.push(ClientSpec { ops });
+    }
+
+    let w = Workload {
+        page_size: 4096,
+        device_pages: 40,
+        max_io_delay: 8,
+        io_fault_rate: 0,
+        read_corrupt_rate: 0,
+        priorities: vec![-5, 0, 5],
+        key_count,
+        offset_count: 1,
+        clients,
+        restart_after: false,
+        num_disks: 1,
+    };
+    let report = run_workload(0x51EED, w).expect("priority eviction smoke run");
+    assert!(
+        report.evictions > 0,
+        "priority smoke did not exercise eviction: admitted={}, resident_pages={}, device_pages={}",
+        report.admitted,
+        report.resident_pages,
+        report.device_pages,
+    );
+    assert_eq!(
+        report.mutator_pending_per_disk,
+        vec![0],
+        "mutator backlog remained after priority eviction smoke"
     );
 }
 
@@ -627,11 +712,13 @@ fn smoke_concurrent_reads_overlap() {
             key_idx: k,
             off_idx: 0,
             payload_seed: k,
+            priority_idx: 0,
         });
         ops.push(Op::Write {
             key_idx: k,
             off_idx: 0,
             payload_seed: k,
+            priority_idx: 0,
         });
         for _ in 0..16 {
             ops.push(Op::Read {
@@ -647,6 +734,7 @@ fn smoke_concurrent_reads_overlap() {
         max_io_delay: 32,
         io_fault_rate: 0,
         read_corrupt_rate: 0,
+        priorities: vec![0],
         key_count,
         offset_count: 1,
         clients,

--- a/cmd/unbounded-storage/tests/storage/workload.rs
+++ b/cmd/unbounded-storage/tests/storage/workload.rs
@@ -71,6 +71,10 @@ pub struct Workload {
     /// must convert this into a miss; we never want a `ReadHit`
     /// that returns corrupted bytes.
     pub read_corrupt_rate: u32,
+    /// Cache priorities assigned to writes. Priorities only affect
+    /// eviction order; they should not change admission, allocation,
+    /// or read correctness.
+    pub priorities: Vec<i32>,
     /// Distinct stripe keys the workload may reference.
     pub key_count: u8,
     /// Distinct page offsets within each stripe.
@@ -101,6 +105,7 @@ pub enum Op {
         key_idx: u8,
         off_idx: u8,
         payload_seed: u8,
+        priority_idx: u8,
     },
     Read {
         key_idx: u8,
@@ -132,6 +137,14 @@ impl Workload {
         }
         out
     }
+
+    pub fn priority(&self, idx: u8) -> i32 {
+        if self.priorities.is_empty() {
+            0
+        } else {
+            self.priorities[idx as usize % self.priorities.len()]
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +171,10 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
         9 => Just(0u32),
         1 => 1u32..=20,
     ];
+    let priorities = prop_oneof![
+        3 => Just(vec![0]),
+        2 => vec(-3i32..=3, 1..=4),
+    ];
     let key_count = 1u8..=3;
     let offset_count = 1u8..=3;
     // Two clients is the minimum that can produce in-flight
@@ -183,6 +200,7 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
         max_io_delay,
         io_fault_rate,
         read_corrupt_rate,
+        priorities,
         key_count,
         offset_count,
         clients,
@@ -195,6 +213,7 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
                 max_io_delay,
                 io_fault_rate,
                 read_corrupt_rate,
+                priorities,
                 key_count,
                 offset_count,
                 clients,
@@ -208,6 +227,7 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
                     max_io_delay,
                     io_fault_rate,
                     read_corrupt_rate,
+                    priorities,
                     key_count,
                     offset_count,
                     clients,
@@ -259,8 +279,14 @@ fn op_strategy() -> impl Strategy<Value = Op> {
     // requires a second touch before anything lands; a read-heavy
     // mix would barely exercise the data path.
     prop_oneof![
-        6 => (any::<u8>(), any::<u8>(), any::<u8>())
-            .prop_map(|(k, o, s)| Op::Write { key_idx: k, off_idx: o, payload_seed: s }),
+        6 => (any::<u8>(), any::<u8>(), any::<u8>(), any::<u8>()).prop_map(|(k, o, s, p)| {
+            Op::Write {
+                key_idx: k,
+                off_idx: o,
+                payload_seed: s,
+                priority_idx: p,
+            }
+        }),
         4 => (any::<u8>(), any::<u8>())
             .prop_map(|(k, o)| Op::Read { key_idx: k, off_idx: o }),
     ]
@@ -675,11 +701,13 @@ pub fn run_workload(seed: u64, w: Workload) -> Result<RunReport, RunError> {
                         key_idx,
                         off_idx,
                         payload_seed,
+                        priority_idx,
                     } => {
                         let key = w.key(*key_idx);
                         let offset = w.offset(*off_idx);
                         let bytes = w.payload(*key_idx, *off_idx, *payload_seed);
                         let byte_len = bytes.len();
+                        let priority = w.priority(*priority_idx);
                         // SAFETY: each op owns a unique pool slot,
                         // so no other task writes here concurrently.
                         // We always wipe the full slot first so any
@@ -694,13 +722,18 @@ pub fn run_workload(seed: u64, w: Workload) -> Result<RunReport, RunError> {
                             std::ptr::write_bytes(p, 0, page_size);
                             std::ptr::copy_nonoverlapping(bytes.as_ptr(), p, byte_len);
                         }
-                        let page = PageRef {
-                            page_idx: pool_slot as u32,
-                            offset: 0,
-                            len: byte_len as u32,
-                        };
                         oracle.record_write(key, offset, bytes);
-                        match local.write_page(&key, offset, page).await {
+                        let slice = std::ptr::slice_from_raw_parts(
+                            (pool_base_v as *const u8).wrapping_add(pool_slot * page_size),
+                            byte_len,
+                        );
+                        // SAFETY: each write op owns a unique initialized pool slot for the
+                        // duration of this await, and `slice` covers exactly `byte_len` bytes.
+                        match unsafe {
+                            local
+                                .write_page_from_with_priority(key, offset, slice, priority)
+                                .await
+                        } {
                             Ok(()) => outcomes.borrow_mut().push(Outcome::WriteOk),
                             Err(e) => outcomes
                                 .borrow_mut()


### PR DESCRIPTION
## Summary
- Add cache priority configuration and runtime projection support
- Prefer lower-priority cache pages during eviction and reclassify resident pages on reads
- Scope inflight bufferpool fetches by cache identity

## Validation
- make unbounded-storage-test
- GitHub Actions are expected to rerun after the latest rebase