### PR TITLE
agent: expose RDMA-CM devices to nodes

### DIFF
--- a/cmd/agent/internal/daemon/nodeoperator.go
+++ b/cmd/agent/internal/daemon/nodeoperator.go
@@ -172,6 +172,7 @@ func (nspawnNodeOperator) RestartNode(ctx context.Context, log *slog.Logger, act
 	log.Info("restarting active node", "machine", active.Name)
 
 	err = phases.Serial(log,
+		rootfs.EnsureNSpawnWorkspace(log, gs.RootFS),
 		nodestop.StopNode(log, active.Name),
 		nodestart.StartNode(log, gs.NodeStart),
 		nodestart.WaitForKubelet(log, active.Name),

--- a/pkg/agent/goalstates/hostdevices.go
+++ b/pkg/agent/goalstates/hostdevices.go
@@ -221,7 +221,7 @@ func loadRDMACMModules() {
 	}
 }
 
-func rdmaCMDeviceNumber(path string) (int, int, bool) {
+func rdmaCMDeviceNumber(path string) (uint32, uint32, bool) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, 0, false
@@ -232,29 +232,29 @@ func rdmaCMDeviceNumber(path string) (int, int, bool) {
 		return 0, 0, false
 	}
 
-	major, err := strconv.Atoi(parts[0])
+	major, err := strconv.ParseUint(parts[0], 10, 32)
 	if err != nil {
 		return 0, 0, false
 	}
 
-	minor, err := strconv.Atoi(parts[1])
+	minor, err := strconv.ParseUint(parts[1], 10, 32)
 	if err != nil {
 		return 0, 0, false
 	}
 
-	return major, minor, true
+	return uint32(major), uint32(minor), true
 }
 
 type mknodFunc func(path string, mode uint32, dev int) error
 
-func createRDMACMDeviceNode(infinibandDir string, major, minor int, mknod mknodFunc) string {
+func createRDMACMDeviceNode(infinibandDir string, major, minor uint32, mknod mknodFunc) string {
 	if err := os.MkdirAll(infinibandDir, 0o755); err != nil {
 		return ""
 	}
 
 	nodePath := filepath.Join(infinibandDir, "rdma_cm")
 
-	dev := int(unix.Mkdev(uint32(major), uint32(minor)))
+	dev := int(unix.Mkdev(major, minor))
 	if err := mknod(nodePath, unix.S_IFCHR|0o666, dev); err != nil && !os.IsExist(err) {
 		return ""
 	}

--- a/pkg/agent/goalstates/hostdevices.go
+++ b/pkg/agent/goalstates/hostdevices.go
@@ -216,7 +216,9 @@ func loadRDMACMModules() {
 		return
 	}
 
-	_ = exec.Command(modprobe, "rdma_cm").Run()
+	if err := exec.Command(modprobe, "rdma_cm").Run(); err != nil {
+		return
+	}
 }
 
 func rdmaCMDeviceNumber(path string) (int, int, bool) {
@@ -251,6 +253,7 @@ func createRDMACMDeviceNode(infinibandDir string, major, minor int, mknod mknodF
 	}
 
 	nodePath := filepath.Join(infinibandDir, "rdma_cm")
+
 	dev := int(unix.Mkdev(uint32(major), uint32(minor)))
 	if err := mknod(nodePath, unix.S_IFCHR|0o666, dev); err != nil && !os.IsExist(err) {
 		return ""

--- a/pkg/agent/goalstates/hostdevices.go
+++ b/pkg/agent/goalstates/hostdevices.go
@@ -5,9 +5,13 @@ package goalstates
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -19,6 +23,10 @@ const (
 	// infinibandDir holds InfiniBand/RDMA HCA character devices
 	// (e.g. uverbs0, umad0, issm0, rdma_cm).
 	infinibandDir = "/dev/infiniband"
+	// rdmaCMMiscDevPath is the kernel-published major:minor for the RDMA-CM
+	// misc device. systemd-nspawn needs the corresponding /dev/infiniband/rdma_cm
+	// node bind-mounted for libfabric's verbs/RDMA-CM path.
+	rdmaCMMiscDevPath = "/sys/class/misc/rdma_cm/dev"
 )
 
 // excludedBlockDevicePrefixes lists /sys/class/block entry name prefixes that
@@ -83,7 +91,7 @@ func DiscoverHostDevices() HostDevices {
 	}
 
 	devices.Block = discoverBlockDevicePaths(sysClassBlockDir, devDir)
-	devices.Infiniband = discoverInfinibandDevicePaths(infinibandDir)
+	devices.Infiniband = discoverInfinibandDevicePaths(infinibandDir, rdmaCMMiscDevPath, true)
 
 	return devices
 }
@@ -154,7 +162,11 @@ func isExcludedBlockDevice(name string) bool {
 // devices under infinibandDir and returns their device node paths in sorted
 // order. Returns nil (not an error) when the directory is absent, which is the
 // common case on hosts without RDMA hardware.
-func discoverInfinibandDevicePaths(infinibandDir string) []string {
+func discoverInfinibandDevicePaths(infinibandDir, rdmaCMMiscDevPath string, loadRDMACM bool) []string {
+	if loadRDMACM {
+		ensureRDMACMDevice(infinibandDir, rdmaCMMiscDevPath)
+	}
+
 	entries, err := os.ReadDir(infinibandDir)
 	if err != nil {
 		return nil
@@ -173,4 +185,80 @@ func discoverInfinibandDevicePaths(infinibandDir string) []string {
 	sort.Strings(paths)
 
 	return paths
+}
+
+func ensureRDMACMDevice(infinibandDir, miscDevPath string) string {
+	nodePath := filepath.Join(infinibandDir, "rdma_cm")
+	if _, err := os.Stat(nodePath); err == nil {
+		return nodePath
+	}
+
+	major, minor, ok := rdmaCMDeviceNumber(miscDevPath)
+	if !ok {
+		loadRDMACMModules()
+
+		major, minor, ok = rdmaCMDeviceNumber(miscDevPath)
+		if !ok {
+			return ""
+		}
+	}
+
+	return createRDMACMDeviceNode(infinibandDir, major, minor, unix.Mknod)
+}
+
+func loadRDMACMModules() {
+	modprobe, err := exec.LookPath("modprobe")
+	if err != nil {
+		return
+	}
+
+	if err := exec.Command(modprobe, "rdma_ucm").Run(); err == nil {
+		return
+	}
+
+	_ = exec.Command(modprobe, "rdma_cm").Run()
+}
+
+func rdmaCMDeviceNumber(path string) (int, int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	parts := strings.Split(strings.TrimSpace(string(data)), ":")
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return major, minor, true
+}
+
+type mknodFunc func(path string, mode uint32, dev int) error
+
+func createRDMACMDeviceNode(infinibandDir string, major, minor int, mknod mknodFunc) string {
+	if err := os.MkdirAll(infinibandDir, 0o755); err != nil {
+		return ""
+	}
+
+	nodePath := filepath.Join(infinibandDir, "rdma_cm")
+	dev := int(unix.Mkdev(uint32(major), uint32(minor)))
+	if err := mknod(nodePath, unix.S_IFCHR|0o666, dev); err != nil && !os.IsExist(err) {
+		return ""
+	}
+
+	if _, err := os.Stat(nodePath); err != nil {
+		return ""
+	}
+
+	return nodePath
 }

--- a/pkg/agent/goalstates/hostdevices_test.go
+++ b/pkg/agent/goalstates/hostdevices_test.go
@@ -115,7 +115,7 @@ func TestDiscoverInfinibandDevicePaths(t *testing.T) {
 	// A subdirectory must be skipped.
 	require.NoError(t, os.Mkdir(filepath.Join(ibDir, "subdir"), 0o755))
 
-	got := discoverInfinibandDevicePaths(ibDir)
+	got := discoverInfinibandDevicePaths(ibDir, filepath.Join(t.TempDir(), "missing"), false)
 
 	want := []string{
 		filepath.Join(ibDir, "rdma_cm"),
@@ -128,7 +128,61 @@ func TestDiscoverInfinibandDevicePaths(t *testing.T) {
 func TestDiscoverInfinibandDevicePaths_MissingDir(t *testing.T) {
 	t.Parallel()
 
-	require.Nil(t, discoverInfinibandDevicePaths("/nonexistent/dev/infiniband"))
+	require.Nil(t, discoverInfinibandDevicePaths("/nonexistent/dev/infiniband", filepath.Join(t.TempDir(), "missing"), false))
+}
+
+func TestRDMACMDeviceNumber(t *testing.T) {
+	t.Parallel()
+
+	devFile := filepath.Join(t.TempDir(), "dev")
+	require.NoError(t, os.WriteFile(devFile, []byte("10:263\n"), 0o644))
+
+	major, minor, ok := rdmaCMDeviceNumber(devFile)
+	require.True(t, ok)
+	require.Equal(t, 10, major)
+	require.Equal(t, 263, minor)
+}
+
+func TestRDMACMDeviceNumberInvalid(t *testing.T) {
+	t.Parallel()
+
+	devFile := filepath.Join(t.TempDir(), "dev")
+	require.NoError(t, os.WriteFile(devFile, []byte("not-a-device\n"), 0o644))
+
+	_, _, ok := rdmaCMDeviceNumber(devFile)
+	require.False(t, ok)
+}
+
+func TestCreateRDMACMDeviceNode(t *testing.T) {
+	t.Parallel()
+
+	ibDir := filepath.Join(t.TempDir(), "infiniband")
+
+	got := createRDMACMDeviceNode(ibDir, 10, 263, func(path string, mode uint32, dev int) error {
+		require.Equal(t, filepath.Join(ibDir, "rdma_cm"), path)
+		require.NotZero(t, mode&0o666)
+		require.NotZero(t, dev)
+
+		f, err := os.Create(path)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		return nil
+	})
+
+	require.Equal(t, filepath.Join(ibDir, "rdma_cm"), got)
+}
+
+func TestEnsureRDMACMDeviceExisting(t *testing.T) {
+	t.Parallel()
+
+	ibDir := t.TempDir()
+	path := filepath.Join(ibDir, "rdma_cm")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.Equal(t, path, ensureRDMACMDevice(ibDir, filepath.Join(t.TempDir(), "missing")))
 }
 
 func TestHostDevices_Paths_MergesDedupesSorts(t *testing.T) {

--- a/pkg/agent/goalstates/hostdevices_test.go
+++ b/pkg/agent/goalstates/hostdevices_test.go
@@ -139,8 +139,8 @@ func TestRDMACMDeviceNumber(t *testing.T) {
 
 	major, minor, ok := rdmaCMDeviceNumber(devFile)
 	require.True(t, ok)
-	require.Equal(t, 10, major)
-	require.Equal(t, 263, minor)
+	require.Equal(t, uint32(10), major)
+	require.Equal(t, uint32(263), minor)
 }
 
 func TestRDMACMDeviceNumberInvalid(t *testing.T) {
@@ -148,6 +148,16 @@ func TestRDMACMDeviceNumberInvalid(t *testing.T) {
 
 	devFile := filepath.Join(t.TempDir(), "dev")
 	require.NoError(t, os.WriteFile(devFile, []byte("not-a-device\n"), 0o644))
+
+	_, _, ok := rdmaCMDeviceNumber(devFile)
+	require.False(t, ok)
+}
+
+func TestRDMACMDeviceNumberRejectsOverflow(t *testing.T) {
+	t.Parallel()
+
+	devFile := filepath.Join(t.TempDir(), "dev")
+	require.NoError(t, os.WriteFile(devFile, []byte("4294967296:0\n"), 0o644))
 
 	_, _, ok := rdmaCMDeviceNumber(devFile)
 	require.False(t, ok)


### PR DESCRIPTION
- expose RDMA-CM devices to nspawn containers
- load the RDMA CM kernel modules before device discovery
- add host device tests for RDMA-CM discovery and rendering