### PR TITLE
storage: add loadgen dataplane

### DIFF
--- a/api/unbounded-storage/config.pb.go
+++ b/api/unbounded-storage/config.pb.go
@@ -33,18 +33,18 @@ type Config struct {
 	Frontends []*FrontendSpec `protobuf:"bytes,3,rep,name=frontends,proto3" json:"frontends,omitempty"`
 	Backends  []*BackendSpec  `protobuf:"bytes,4,rep,name=backends,proto3" json:"backends,omitempty"`
 	Caches    []*CacheSpec    `protobuf:"bytes,5,rep,name=caches,proto3" json:"caches,omitempty"`
-	Disks     []*DiskSpec     `protobuf:"bytes,7,rep,name=disks,proto3" json:"disks,omitempty"`
+	Disks     []*DiskSpec     `protobuf:"bytes,6,rep,name=disks,proto3" json:"disks,omitempty"`
 	// Number of deterministic finger-table entries to derive per peer. Defaults to 100 when unset.
-	FingersPerNode *uint32 `protobuf:"varint,8,opt,name=fingers_per_node,json=fingersPerNode,proto3,oneof" json:"fingers_per_node,omitempty"`
+	FingersPerNode *uint32 `protobuf:"varint,7,opt,name=fingers_per_node,json=fingersPerNode,proto3,oneof" json:"fingers_per_node,omitempty"`
 	// Name of this process in the `peers` roster. Required when peers or a
 	// routing plan are configured. The internal ring and fabric ids are derived
 	// from this peer name and are startup-fixed.
-	Self string `protobuf:"bytes,9,opt,name=self,proto3" json:"self,omitempty"`
+	Self string `protobuf:"bytes,8,opt,name=self,proto3" json:"self,omitempty"`
 	// Precomputed routing table for this process. When set, `peers` can be
 	// sparse, containing only this process's routing neighbors.
-	RoutingPlan *RoutingPlan `protobuf:"bytes,11,opt,name=routing_plan,json=routingPlan,proto3,oneof" json:"routing_plan,omitempty"`
+	RoutingPlan *RoutingPlan `protobuf:"bytes,9,opt,name=routing_plan,json=routingPlan,proto3,oneof" json:"routing_plan,omitempty"`
 	// Process-wide peer definitions for the globally shared transport mesh.
-	Peers         []*PeerSpec `protobuf:"bytes,12,rep,name=peers,proto3" json:"peers,omitempty"`
+	Peers         []*PeerSpec `protobuf:"bytes,10,rep,name=peers,proto3" json:"peers,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -367,7 +367,7 @@ type RdmaPeerConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Default RDMA fabric address. Provider-native addresses are encoded as
 	// "hex:<fi_getname-bytes>"; RDMA-CM socket addresses are accepted when the
-	// provider reports them. Kept for single-endpoint peers and older writers.
+	// provider reports them.
 	Addr string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
 	// Ordered RDMA fabric addresses for peers that expose multiple fabric units,
 	// such as one endpoint per HCA. The daemon dials the address whose index
@@ -1070,20 +1070,20 @@ type DiskSpec struct {
 	SkipRecoveryScan bool `protobuf:"varint,3,opt,name=skip_recovery_scan,json=skipRecoveryScan,proto3" json:"skip_recovery_scan,omitempty"`
 	// Destructively resets the cache index on open, ignoring any existing on-disk metadata.
 	// Intended only for benchmark cache devices that are safe to reformat between runs.
-	ForceFormat bool `protobuf:"varint,6,opt,name=force_format,json=forceFormat,proto3" json:"force_format,omitempty"`
+	ForceFormat bool `protobuf:"varint,4,opt,name=force_format,json=forceFormat,proto3" json:"force_format,omitempty"`
 	// Admit every write into the cache index instead of requiring the default
 	// second touch. Intended for benchmark warmups that must prefill NVMe devices
 	// with a cold synthetic keyspace.
-	BypassAdmission bool `protobuf:"varint,7,opt,name=bypass_admission,json=bypassAdmission,proto3" json:"bypass_admission,omitempty"`
+	BypassAdmission bool `protobuf:"varint,5,opt,name=bypass_admission,json=bypassAdmission,proto3" json:"bypass_admission,omitempty"`
 	// Serve reads from the committed in-memory index mirror instead of reading
 	// the terminal btree leaf from disk. Intended only for benchmark devices
 	// where recovery/corruption validation has been deliberately traded for
 	// measuring the data-page path.
-	BypassIndexRead bool `protobuf:"varint,8,opt,name=bypass_index_read,json=bypassIndexRead,proto3" json:"bypass_index_read,omitempty"`
+	BypassIndexRead bool `protobuf:"varint,6,opt,name=bypass_index_read,json=bypassIndexRead,proto3" json:"bypass_index_read,omitempty"`
 	// Skip data checksum validation on reads. Intended only for benchmark
 	// devices where cache contents were just populated by the same daemon and
 	// the target is measuring the NVMe data path rather than CPU checksum cost.
-	BypassChecksum bool `protobuf:"varint,9,opt,name=bypass_checksum,json=bypassChecksum,proto3" json:"bypass_checksum,omitempty"`
+	BypassChecksum bool `protobuf:"varint,7,opt,name=bypass_checksum,json=bypassChecksum,proto3" json:"bypass_checksum,omitempty"`
 	// Types that are valid to be assigned to Config:
 	//
 	//	*DiskSpec_Block
@@ -1202,11 +1202,11 @@ type isDiskSpec_Config interface {
 }
 
 type DiskSpec_Block struct {
-	Block *BlockDiskConfig `protobuf:"bytes,4,opt,name=block,proto3,oneof"`
+	Block *BlockDiskConfig `protobuf:"bytes,8,opt,name=block,proto3,oneof"`
 }
 
 type DiskSpec_File struct {
-	File *FileDiskConfig `protobuf:"bytes,5,opt,name=file,proto3,oneof"`
+	File *FileDiskConfig `protobuf:"bytes,9,opt,name=file,proto3,oneof"`
 }
 
 func (*DiskSpec_Block) isDiskSpec_Config() {}
@@ -2108,22 +2108,21 @@ var File_config_proto protoreflect.FileDescriptor
 
 const file_config_proto_rawDesc = "" +
 	"\n" +
-	"\fconfig.proto\x12\x18unbounded.storage.config\"\xfb\x04\n" +
+	"\fconfig.proto\x12\x18unbounded.storage.config\"\xd4\x04\n" +
 	"\x06Config\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x04R\aversion\x12>\n" +
 	"\astartup\x18\x02 \x01(\v2$.unbounded.storage.config.StartupCfgR\astartup\x12D\n" +
 	"\tfrontends\x18\x03 \x03(\v2&.unbounded.storage.config.FrontendSpecR\tfrontends\x12A\n" +
 	"\bbackends\x18\x04 \x03(\v2%.unbounded.storage.config.BackendSpecR\bbackends\x12;\n" +
 	"\x06caches\x18\x05 \x03(\v2#.unbounded.storage.config.CacheSpecR\x06caches\x128\n" +
-	"\x05disks\x18\a \x03(\v2\".unbounded.storage.config.DiskSpecR\x05disks\x12-\n" +
-	"\x10fingers_per_node\x18\b \x01(\rH\x00R\x0efingersPerNode\x88\x01\x01\x12\x12\n" +
-	"\x04self\x18\t \x01(\tR\x04self\x12M\n" +
-	"\frouting_plan\x18\v \x01(\v2%.unbounded.storage.config.RoutingPlanH\x01R\vroutingPlan\x88\x01\x01\x128\n" +
-	"\x05peers\x18\f \x03(\v2\".unbounded.storage.config.PeerSpecR\x05peersB\x13\n" +
+	"\x05disks\x18\x06 \x03(\v2\".unbounded.storage.config.DiskSpecR\x05disks\x12-\n" +
+	"\x10fingers_per_node\x18\a \x01(\rH\x00R\x0efingersPerNode\x88\x01\x01\x12\x12\n" +
+	"\x04self\x18\b \x01(\tR\x04self\x12M\n" +
+	"\frouting_plan\x18\t \x01(\v2%.unbounded.storage.config.RoutingPlanH\x01R\vroutingPlan\x88\x01\x01\x128\n" +
+	"\x05peers\x18\n" +
+	" \x03(\v2\".unbounded.storage.config.PeerSpecR\x05peersB\x13\n" +
 	"\x11_fingers_per_nodeB\x0f\n" +
-	"\r_routing_planJ\x04\b\x06\x10\aJ\x04\b\n" +
-	"\x10\vR\rneighborhoodsR\n" +
-	"local_tags\"\x8f\x01\n" +
+	"\r_routing_plan\"\x8f\x01\n" +
 	"\vRoutingPlan\x12\x18\n" +
 	"\afingers\x18\x01 \x03(\tR\afingers\x12!\n" +
 	"\tsuccessor\x18\x02 \x01(\tH\x00R\tsuccessor\x88\x01\x01\x12%\n" +
@@ -2196,12 +2195,12 @@ const file_config_proto_rawDesc = "" +
 	"queueDepth\x88\x01\x01\x12+\n" +
 	"\x0fpage_size_bytes\x18\x02 \x01(\x04H\x02R\rpageSizeBytes\x88\x01\x01\x12,\n" +
 	"\x12skip_recovery_scan\x18\x03 \x01(\bR\x10skipRecoveryScan\x12!\n" +
-	"\fforce_format\x18\x06 \x01(\bR\vforceFormat\x12)\n" +
-	"\x10bypass_admission\x18\a \x01(\bR\x0fbypassAdmission\x12*\n" +
-	"\x11bypass_index_read\x18\b \x01(\bR\x0fbypassIndexRead\x12'\n" +
-	"\x0fbypass_checksum\x18\t \x01(\bR\x0ebypassChecksum\x12A\n" +
-	"\x05block\x18\x04 \x01(\v2).unbounded.storage.config.BlockDiskConfigH\x00R\x05block\x12>\n" +
-	"\x04file\x18\x05 \x01(\v2(.unbounded.storage.config.FileDiskConfigH\x00R\x04fileB\b\n" +
+	"\fforce_format\x18\x04 \x01(\bR\vforceFormat\x12)\n" +
+	"\x10bypass_admission\x18\x05 \x01(\bR\x0fbypassAdmission\x12*\n" +
+	"\x11bypass_index_read\x18\x06 \x01(\bR\x0fbypassIndexRead\x12'\n" +
+	"\x0fbypass_checksum\x18\a \x01(\bR\x0ebypassChecksum\x12A\n" +
+	"\x05block\x18\b \x01(\v2).unbounded.storage.config.BlockDiskConfigH\x00R\x05block\x12>\n" +
+	"\x04file\x18\t \x01(\v2(.unbounded.storage.config.FileDiskConfigH\x00R\x04fileB\b\n" +
 	"\x06configB\x0e\n" +
 	"\f_queue_depthB\x12\n" +
 	"\x10_page_size_bytes\"G\n" +

--- a/api/unbounded-storage/config.pb.go
+++ b/api/unbounded-storage/config.pb.go
@@ -29,12 +29,22 @@ type Config struct {
 	// Operator-assigned opaque version tracked so operators can confirm which config has been applied. 0 means unversioned.
 	Version uint64 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
 	// Startup options are only read once during initialization.
-	Startup       *StartupCfg         `protobuf:"bytes,2,opt,name=startup,proto3" json:"startup,omitempty"`
-	Frontends     []*FrontendSpec     `protobuf:"bytes,3,rep,name=frontends,proto3" json:"frontends,omitempty"`
-	Backends      []*BackendSpec      `protobuf:"bytes,4,rep,name=backends,proto3" json:"backends,omitempty"`
-	Caches        []*CacheSpec        `protobuf:"bytes,5,rep,name=caches,proto3" json:"caches,omitempty"`
-	Neighborhoods []*NeighborhoodSpec `protobuf:"bytes,6,rep,name=neighborhoods,proto3" json:"neighborhoods,omitempty"`
-	Disks         []*DiskSpec         `protobuf:"bytes,7,rep,name=disks,proto3" json:"disks,omitempty"`
+	Startup   *StartupCfg     `protobuf:"bytes,2,opt,name=startup,proto3" json:"startup,omitempty"`
+	Frontends []*FrontendSpec `protobuf:"bytes,3,rep,name=frontends,proto3" json:"frontends,omitempty"`
+	Backends  []*BackendSpec  `protobuf:"bytes,4,rep,name=backends,proto3" json:"backends,omitempty"`
+	Caches    []*CacheSpec    `protobuf:"bytes,5,rep,name=caches,proto3" json:"caches,omitempty"`
+	Disks     []*DiskSpec     `protobuf:"bytes,7,rep,name=disks,proto3" json:"disks,omitempty"`
+	// Number of deterministic finger-table entries to derive per peer. Defaults to 100 when unset.
+	FingersPerNode *uint32 `protobuf:"varint,8,opt,name=fingers_per_node,json=fingersPerNode,proto3,oneof" json:"fingers_per_node,omitempty"`
+	// Name of this process in the `peers` roster. Required when peers or a
+	// routing plan are configured. The internal ring and fabric ids are derived
+	// from this peer name and are startup-fixed.
+	Self string `protobuf:"bytes,9,opt,name=self,proto3" json:"self,omitempty"`
+	// Precomputed routing table for this process. When set, `peers` can be
+	// sparse, containing only this process's routing neighbors.
+	RoutingPlan *RoutingPlan `protobuf:"bytes,11,opt,name=routing_plan,json=routingPlan,proto3,oneof" json:"routing_plan,omitempty"`
+	// Process-wide peer definitions for the globally shared transport mesh.
+	Peers         []*PeerSpec `protobuf:"bytes,12,rep,name=peers,proto3" json:"peers,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -104,18 +114,364 @@ func (x *Config) GetCaches() []*CacheSpec {
 	return nil
 }
 
-func (x *Config) GetNeighborhoods() []*NeighborhoodSpec {
-	if x != nil {
-		return x.Neighborhoods
-	}
-	return nil
-}
-
 func (x *Config) GetDisks() []*DiskSpec {
 	if x != nil {
 		return x.Disks
 	}
 	return nil
+}
+
+func (x *Config) GetFingersPerNode() uint32 {
+	if x != nil && x.FingersPerNode != nil {
+		return *x.FingersPerNode
+	}
+	return 0
+}
+
+func (x *Config) GetSelf() string {
+	if x != nil {
+		return x.Self
+	}
+	return ""
+}
+
+func (x *Config) GetRoutingPlan() *RoutingPlan {
+	if x != nil {
+		return x.RoutingPlan
+	}
+	return nil
+}
+
+func (x *Config) GetPeers() []*PeerSpec {
+	if x != nil {
+		return x.Peers
+	}
+	return nil
+}
+
+// A precomputed routing table for a single node, produced by a
+// global-view planner. All names reference `PeerSpec.name` values in the
+// `peers` list (each must be present so a fabric connection exists). Ring
+// positions are derived from names, and tags do not affect runtime routing, so
+// only names are carried here.
+type RoutingPlan struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Peer names selected for this routing plan.
+	Fingers []string `protobuf:"bytes,1,rep,name=fingers,proto3" json:"fingers,omitempty"`
+	// Peer name of the nearest-forward neighbor on the ring.
+	Successor *string `protobuf:"bytes,2,opt,name=successor,proto3,oneof" json:"successor,omitempty"`
+	// Peer name of the nearest-backward neighbor on the ring.
+	Predecessor   *string `protobuf:"bytes,3,opt,name=predecessor,proto3,oneof" json:"predecessor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RoutingPlan) Reset() {
+	*x = RoutingPlan{}
+	mi := &file_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RoutingPlan) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RoutingPlan) ProtoMessage() {}
+
+func (x *RoutingPlan) ProtoReflect() protoreflect.Message {
+	mi := &file_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RoutingPlan.ProtoReflect.Descriptor instead.
+func (*RoutingPlan) Descriptor() ([]byte, []int) {
+	return file_config_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RoutingPlan) GetFingers() []string {
+	if x != nil {
+		return x.Fingers
+	}
+	return nil
+}
+
+func (x *RoutingPlan) GetSuccessor() string {
+	if x != nil && x.Successor != nil {
+		return *x.Successor
+	}
+	return ""
+}
+
+func (x *RoutingPlan) GetPredecessor() string {
+	if x != nil && x.Predecessor != nil {
+		return *x.Predecessor
+	}
+	return ""
+}
+
+type PeerSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stable peer name. The process-wide fabric peer id, ring position, and route
+	// references are derived from this name.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Peer tags used by placement-aware planning.
+	Tags []string `protobuf:"bytes,2,rep,name=tags,proto3" json:"tags,omitempty"`
+	// Types that are valid to be assigned to Config:
+	//
+	//	*PeerSpec_Tcp
+	//	*PeerSpec_Rdma
+	Config        isPeerSpec_Config `protobuf_oneof:"config"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PeerSpec) Reset() {
+	*x = PeerSpec{}
+	mi := &file_config_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PeerSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PeerSpec) ProtoMessage() {}
+
+func (x *PeerSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_config_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PeerSpec.ProtoReflect.Descriptor instead.
+func (*PeerSpec) Descriptor() ([]byte, []int) {
+	return file_config_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PeerSpec) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *PeerSpec) GetTags() []string {
+	if x != nil {
+		return x.Tags
+	}
+	return nil
+}
+
+func (x *PeerSpec) GetConfig() isPeerSpec_Config {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (x *PeerSpec) GetTcp() *TcpPeerConfig {
+	if x != nil {
+		if x, ok := x.Config.(*PeerSpec_Tcp); ok {
+			return x.Tcp
+		}
+	}
+	return nil
+}
+
+func (x *PeerSpec) GetRdma() *RdmaPeerConfig {
+	if x != nil {
+		if x, ok := x.Config.(*PeerSpec_Rdma); ok {
+			return x.Rdma
+		}
+	}
+	return nil
+}
+
+type isPeerSpec_Config interface {
+	isPeerSpec_Config()
+}
+
+type PeerSpec_Tcp struct {
+	Tcp *TcpPeerConfig `protobuf:"bytes,3,opt,name=tcp,proto3,oneof"`
+}
+
+type PeerSpec_Rdma struct {
+	Rdma *RdmaPeerConfig `protobuf:"bytes,4,opt,name=rdma,proto3,oneof"`
+}
+
+func (*PeerSpec_Tcp) isPeerSpec_Config() {}
+
+func (*PeerSpec_Rdma) isPeerSpec_Config() {}
+
+type TcpPeerConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// TCP socket address used as this peer's fabric wire address.
+	Addr          string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TcpPeerConfig) Reset() {
+	*x = TcpPeerConfig{}
+	mi := &file_config_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TcpPeerConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TcpPeerConfig) ProtoMessage() {}
+
+func (x *TcpPeerConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_config_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TcpPeerConfig.ProtoReflect.Descriptor instead.
+func (*TcpPeerConfig) Descriptor() ([]byte, []int) {
+	return file_config_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *TcpPeerConfig) GetAddr() string {
+	if x != nil {
+		return x.Addr
+	}
+	return ""
+}
+
+type RdmaPeerConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Default RDMA fabric address. Provider-native addresses are encoded as
+	// "hex:<fi_getname-bytes>"; RDMA-CM socket addresses are accepted when the
+	// provider reports them. Kept for single-endpoint peers and older writers.
+	Addr string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	// Ordered RDMA fabric addresses for peers that expose multiple fabric units,
+	// such as one endpoint per HCA. The daemon dials the address whose index
+	// matches the local fabric unit index, falling back to addr when absent.
+	Addrs         []string `protobuf:"bytes,2,rep,name=addrs,proto3" json:"addrs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RdmaPeerConfig) Reset() {
+	*x = RdmaPeerConfig{}
+	mi := &file_config_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RdmaPeerConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RdmaPeerConfig) ProtoMessage() {}
+
+func (x *RdmaPeerConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_config_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RdmaPeerConfig.ProtoReflect.Descriptor instead.
+func (*RdmaPeerConfig) Descriptor() ([]byte, []int) {
+	return file_config_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *RdmaPeerConfig) GetAddr() string {
+	if x != nil {
+		return x.Addr
+	}
+	return ""
+}
+
+func (x *RdmaPeerConfig) GetAddrs() []string {
+	if x != nil {
+		return x.Addrs
+	}
+	return nil
+}
+
+type CacheSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Backend source used for miss fills. Cache name is the only logical keyspace prefix.
+	Source        string `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CacheSpec) Reset() {
+	*x = CacheSpec{}
+	mi := &file_config_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CacheSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CacheSpec) ProtoMessage() {}
+
+func (x *CacheSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_config_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CacheSpec.ProtoReflect.Descriptor instead.
+func (*CacheSpec) Descriptor() ([]byte, []int) {
+	return file_config_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *CacheSpec) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CacheSpec) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
 }
 
 type StartupCfg struct {
@@ -130,7 +486,7 @@ type StartupCfg struct {
 
 func (x *StartupCfg) Reset() {
 	*x = StartupCfg{}
-	mi := &file_config_proto_msgTypes[1]
+	mi := &file_config_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -142,7 +498,7 @@ func (x *StartupCfg) String() string {
 func (*StartupCfg) ProtoMessage() {}
 
 func (x *StartupCfg) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[1]
+	mi := &file_config_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -155,7 +511,7 @@ func (x *StartupCfg) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartupCfg.ProtoReflect.Descriptor instead.
 func (*StartupCfg) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{1}
+	return file_config_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *StartupCfg) GetMemory() *MemoryCfg {
@@ -196,7 +552,7 @@ type MetricsCfg struct {
 
 func (x *MetricsCfg) Reset() {
 	*x = MetricsCfg{}
-	mi := &file_config_proto_msgTypes[2]
+	mi := &file_config_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -208,7 +564,7 @@ func (x *MetricsCfg) String() string {
 func (*MetricsCfg) ProtoMessage() {}
 
 func (x *MetricsCfg) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[2]
+	mi := &file_config_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -221,7 +577,7 @@ func (x *MetricsCfg) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetricsCfg.ProtoReflect.Descriptor instead.
 func (*MetricsCfg) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{2}
+	return file_config_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *MetricsCfg) GetAddr() string {
@@ -243,7 +599,7 @@ type MemoryCfg struct {
 
 func (x *MemoryCfg) Reset() {
 	*x = MemoryCfg{}
-	mi := &file_config_proto_msgTypes[3]
+	mi := &file_config_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -255,7 +611,7 @@ func (x *MemoryCfg) String() string {
 func (*MemoryCfg) ProtoMessage() {}
 
 func (x *MemoryCfg) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[3]
+	mi := &file_config_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -268,7 +624,7 @@ func (x *MemoryCfg) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MemoryCfg.ProtoReflect.Descriptor instead.
 func (*MemoryCfg) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{3}
+	return file_config_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *MemoryCfg) GetNoHugepages() bool {
@@ -307,7 +663,7 @@ type FabricCfg struct {
 
 func (x *FabricCfg) Reset() {
 	*x = FabricCfg{}
-	mi := &file_config_proto_msgTypes[4]
+	mi := &file_config_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -319,7 +675,7 @@ func (x *FabricCfg) String() string {
 func (*FabricCfg) ProtoMessage() {}
 
 func (x *FabricCfg) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[4]
+	mi := &file_config_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -332,7 +688,7 @@ func (x *FabricCfg) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FabricCfg.ProtoReflect.Descriptor instead.
 func (*FabricCfg) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{4}
+	return file_config_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *FabricCfg) GetBinds() isFabricCfg_Binds {
@@ -428,7 +784,7 @@ type TcpFabricBinds struct {
 
 func (x *TcpFabricBinds) Reset() {
 	*x = TcpFabricBinds{}
-	mi := &file_config_proto_msgTypes[5]
+	mi := &file_config_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -440,7 +796,7 @@ func (x *TcpFabricBinds) String() string {
 func (*TcpFabricBinds) ProtoMessage() {}
 
 func (x *TcpFabricBinds) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[5]
+	mi := &file_config_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -453,7 +809,7 @@ func (x *TcpFabricBinds) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TcpFabricBinds.ProtoReflect.Descriptor instead.
 func (*TcpFabricBinds) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{5}
+	return file_config_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *TcpFabricBinds) GetAddr() string {
@@ -472,7 +828,7 @@ type RdmaFabricBinds struct {
 
 func (x *RdmaFabricBinds) Reset() {
 	*x = RdmaFabricBinds{}
-	mi := &file_config_proto_msgTypes[6]
+	mi := &file_config_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -484,7 +840,7 @@ func (x *RdmaFabricBinds) String() string {
 func (*RdmaFabricBinds) ProtoMessage() {}
 
 func (x *RdmaFabricBinds) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[6]
+	mi := &file_config_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -497,7 +853,7 @@ func (x *RdmaFabricBinds) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RdmaFabricBinds.ProtoReflect.Descriptor instead.
 func (*RdmaFabricBinds) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{6}
+	return file_config_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RdmaFabricBinds) GetBinds() []*RdmaFabricBind {
@@ -519,7 +875,7 @@ type AutoRdmaFabricBinds struct {
 
 func (x *AutoRdmaFabricBinds) Reset() {
 	*x = AutoRdmaFabricBinds{}
-	mi := &file_config_proto_msgTypes[7]
+	mi := &file_config_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -531,7 +887,7 @@ func (x *AutoRdmaFabricBinds) String() string {
 func (*AutoRdmaFabricBinds) ProtoMessage() {}
 
 func (x *AutoRdmaFabricBinds) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[7]
+	mi := &file_config_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -544,7 +900,7 @@ func (x *AutoRdmaFabricBinds) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AutoRdmaFabricBinds.ProtoReflect.Descriptor instead.
 func (*AutoRdmaFabricBinds) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{7}
+	return file_config_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *AutoRdmaFabricBinds) GetHcasPerNumaNode() uint64 {
@@ -564,7 +920,7 @@ type RdmaFabricBind struct {
 
 func (x *RdmaFabricBind) Reset() {
 	*x = RdmaFabricBind{}
-	mi := &file_config_proto_msgTypes[8]
+	mi := &file_config_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -576,7 +932,7 @@ func (x *RdmaFabricBind) String() string {
 func (*RdmaFabricBind) ProtoMessage() {}
 
 func (x *RdmaFabricBind) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[8]
+	mi := &file_config_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -589,7 +945,7 @@ func (x *RdmaFabricBind) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RdmaFabricBind.ProtoReflect.Descriptor instead.
 func (*RdmaFabricBind) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{8}
+	return file_config_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *RdmaFabricBind) GetAddr() string {
@@ -627,7 +983,7 @@ type TopologyCfg struct {
 
 func (x *TopologyCfg) Reset() {
 	*x = TopologyCfg{}
-	mi := &file_config_proto_msgTypes[9]
+	mi := &file_config_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -639,7 +995,7 @@ func (x *TopologyCfg) String() string {
 func (*TopologyCfg) ProtoMessage() {}
 
 func (x *TopologyCfg) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[9]
+	mi := &file_config_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -652,7 +1008,7 @@ func (x *TopologyCfg) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TopologyCfg.ProtoReflect.Descriptor instead.
 func (*TopologyCfg) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{9}
+	return file_config_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TopologyCfg) GetUseSmtSiblings() bool {
@@ -704,419 +1060,6 @@ func (x *TopologyCfg) GetNicWorkers() uint64 {
 	return 0
 }
 
-type NeighborhoodSpec struct {
-	state  protoimpl.MessageState `protogen:"open.v1"`
-	Name   string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Source string                 `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
-	// Number of deterministic finger-table entries to derive per node. Defaults to 100 when unset.
-	FingersPerNode *uint32 `protobuf:"varint,3,opt,name=fingers_per_node,json=fingersPerNode,proto3,oneof" json:"fingers_per_node,omitempty"`
-	// Local node id on the P2P ring and process-wide fabric peer id; required when
-	// peers are configured, shared by every neighborhood when set, and must not
-	// match any peer id.
-	LocalNodeId *uint64 `protobuf:"varint,4,opt,name=local_node_id,json=localNodeId,proto3,oneof" json:"local_node_id,omitempty"`
-	// Local tags used by placement-aware planning.
-	LocalTags []string `protobuf:"bytes,5,rep,name=local_tags,json=localTags,proto3" json:"local_tags,omitempty"`
-	// Precomputed routing table that replaces automatic finger-table derivation when set.
-	// When set, `peers` can be "sparse"; containing only this process's neighbors.
-	RoutingPlan *RoutingPlan `protobuf:"bytes,6,opt,name=routing_plan,json=routingPlan,proto3,oneof" json:"routing_plan,omitempty"`
-	// Peer definitions available to this neighborhood. Peer ids are process-wide
-	// fabric peer ids; repeating an id across neighborhoods requires the same
-	// peer data.
-	Peers         []*PeerSpec `protobuf:"bytes,7,rep,name=peers,proto3" json:"peers,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *NeighborhoodSpec) Reset() {
-	*x = NeighborhoodSpec{}
-	mi := &file_config_proto_msgTypes[10]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *NeighborhoodSpec) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*NeighborhoodSpec) ProtoMessage() {}
-
-func (x *NeighborhoodSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[10]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use NeighborhoodSpec.ProtoReflect.Descriptor instead.
-func (*NeighborhoodSpec) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{10}
-}
-
-func (x *NeighborhoodSpec) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
-func (x *NeighborhoodSpec) GetSource() string {
-	if x != nil {
-		return x.Source
-	}
-	return ""
-}
-
-func (x *NeighborhoodSpec) GetFingersPerNode() uint32 {
-	if x != nil && x.FingersPerNode != nil {
-		return *x.FingersPerNode
-	}
-	return 0
-}
-
-func (x *NeighborhoodSpec) GetLocalNodeId() uint64 {
-	if x != nil && x.LocalNodeId != nil {
-		return *x.LocalNodeId
-	}
-	return 0
-}
-
-func (x *NeighborhoodSpec) GetLocalTags() []string {
-	if x != nil {
-		return x.LocalTags
-	}
-	return nil
-}
-
-func (x *NeighborhoodSpec) GetRoutingPlan() *RoutingPlan {
-	if x != nil {
-		return x.RoutingPlan
-	}
-	return nil
-}
-
-func (x *NeighborhoodSpec) GetPeers() []*PeerSpec {
-	if x != nil {
-		return x.Peers
-	}
-	return nil
-}
-
-// A precomputed routing table for a single node, produced by a
-// global-view planner. All ids reference `PeerSpec.id` values in the
-// `peers` list (each must be present so a fabric connection exists).
-// Ring positions are derived from ids, and tags do not affect runtime
-// routing, so only ids are carried here.
-type RoutingPlan struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Peer ids selected for this routing plan.
-	Fingers []uint64 `protobuf:"varint,1,rep,packed,name=fingers,proto3" json:"fingers,omitempty"`
-	// Peer id of the nearest-forward neighbor on the ring.
-	Successor *uint64 `protobuf:"varint,2,opt,name=successor,proto3,oneof" json:"successor,omitempty"`
-	// Peer id of the nearest-backward neighbor on the ring.
-	Predecessor   *uint64 `protobuf:"varint,3,opt,name=predecessor,proto3,oneof" json:"predecessor,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *RoutingPlan) Reset() {
-	*x = RoutingPlan{}
-	mi := &file_config_proto_msgTypes[11]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RoutingPlan) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RoutingPlan) ProtoMessage() {}
-
-func (x *RoutingPlan) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[11]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use RoutingPlan.ProtoReflect.Descriptor instead.
-func (*RoutingPlan) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{11}
-}
-
-func (x *RoutingPlan) GetFingers() []uint64 {
-	if x != nil {
-		return x.Fingers
-	}
-	return nil
-}
-
-func (x *RoutingPlan) GetSuccessor() uint64 {
-	if x != nil && x.Successor != nil {
-		return *x.Successor
-	}
-	return 0
-}
-
-func (x *RoutingPlan) GetPredecessor() uint64 {
-	if x != nil && x.Predecessor != nil {
-		return *x.Predecessor
-	}
-	return 0
-}
-
-type PeerSpec struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Process-wide fabric peer id, also used for this neighborhood's ring
-	// position and route references.
-	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	// Peer tags used by placement-aware planning.
-	Tags []string `protobuf:"bytes,2,rep,name=tags,proto3" json:"tags,omitempty"`
-	// Types that are valid to be assigned to Config:
-	//
-	//	*PeerSpec_Tcp
-	//	*PeerSpec_Rdma
-	Config        isPeerSpec_Config `protobuf_oneof:"config"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PeerSpec) Reset() {
-	*x = PeerSpec{}
-	mi := &file_config_proto_msgTypes[12]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PeerSpec) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PeerSpec) ProtoMessage() {}
-
-func (x *PeerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[12]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PeerSpec.ProtoReflect.Descriptor instead.
-func (*PeerSpec) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{12}
-}
-
-func (x *PeerSpec) GetId() uint64 {
-	if x != nil {
-		return x.Id
-	}
-	return 0
-}
-
-func (x *PeerSpec) GetTags() []string {
-	if x != nil {
-		return x.Tags
-	}
-	return nil
-}
-
-func (x *PeerSpec) GetConfig() isPeerSpec_Config {
-	if x != nil {
-		return x.Config
-	}
-	return nil
-}
-
-func (x *PeerSpec) GetTcp() *TcpPeerConfig {
-	if x != nil {
-		if x, ok := x.Config.(*PeerSpec_Tcp); ok {
-			return x.Tcp
-		}
-	}
-	return nil
-}
-
-func (x *PeerSpec) GetRdma() *RdmaPeerConfig {
-	if x != nil {
-		if x, ok := x.Config.(*PeerSpec_Rdma); ok {
-			return x.Rdma
-		}
-	}
-	return nil
-}
-
-type isPeerSpec_Config interface {
-	isPeerSpec_Config()
-}
-
-type PeerSpec_Tcp struct {
-	Tcp *TcpPeerConfig `protobuf:"bytes,3,opt,name=tcp,proto3,oneof"`
-}
-
-type PeerSpec_Rdma struct {
-	Rdma *RdmaPeerConfig `protobuf:"bytes,4,opt,name=rdma,proto3,oneof"`
-}
-
-func (*PeerSpec_Tcp) isPeerSpec_Config() {}
-
-func (*PeerSpec_Rdma) isPeerSpec_Config() {}
-
-type TcpPeerConfig struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// TCP socket address used as this peer's fabric wire address.
-	Addr          string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *TcpPeerConfig) Reset() {
-	*x = TcpPeerConfig{}
-	mi := &file_config_proto_msgTypes[13]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TcpPeerConfig) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TcpPeerConfig) ProtoMessage() {}
-
-func (x *TcpPeerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[13]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TcpPeerConfig.ProtoReflect.Descriptor instead.
-func (*TcpPeerConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{13}
-}
-
-func (x *TcpPeerConfig) GetAddr() string {
-	if x != nil {
-		return x.Addr
-	}
-	return ""
-}
-
-type RdmaPeerConfig struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Provider-native RDMA fabric address encoded as "hex:<fi_getname-bytes>".
-	Addr          string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *RdmaPeerConfig) Reset() {
-	*x = RdmaPeerConfig{}
-	mi := &file_config_proto_msgTypes[14]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RdmaPeerConfig) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RdmaPeerConfig) ProtoMessage() {}
-
-func (x *RdmaPeerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[14]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use RdmaPeerConfig.ProtoReflect.Descriptor instead.
-func (*RdmaPeerConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{14}
-}
-
-func (x *RdmaPeerConfig) GetAddr() string {
-	if x != nil {
-		return x.Addr
-	}
-	return ""
-}
-
-type CacheSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Source        string                 `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *CacheSpec) Reset() {
-	*x = CacheSpec{}
-	mi := &file_config_proto_msgTypes[15]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *CacheSpec) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*CacheSpec) ProtoMessage() {}
-
-func (x *CacheSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[15]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use CacheSpec.ProtoReflect.Descriptor instead.
-func (*CacheSpec) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{15}
-}
-
-func (x *CacheSpec) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
-func (x *CacheSpec) GetSource() string {
-	if x != nil {
-		return x.Source
-	}
-	return ""
-}
-
 type DiskSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional io_uring queue depth override for this disk.
@@ -1125,6 +1068,22 @@ type DiskSpec struct {
 	PageSizeBytes *uint64 `protobuf:"varint,2,opt,name=page_size_bytes,json=pageSizeBytes,proto3,oneof" json:"page_size_bytes,omitempty"`
 	// Skips the recovery scan when no metadata page is valid; intended only for fresh or benchmark disks.
 	SkipRecoveryScan bool `protobuf:"varint,3,opt,name=skip_recovery_scan,json=skipRecoveryScan,proto3" json:"skip_recovery_scan,omitempty"`
+	// Destructively resets the cache index on open, ignoring any existing on-disk metadata.
+	// Intended only for benchmark cache devices that are safe to reformat between runs.
+	ForceFormat bool `protobuf:"varint,6,opt,name=force_format,json=forceFormat,proto3" json:"force_format,omitempty"`
+	// Admit every write into the cache index instead of requiring the default
+	// second touch. Intended for benchmark warmups that must prefill NVMe devices
+	// with a cold synthetic keyspace.
+	BypassAdmission bool `protobuf:"varint,7,opt,name=bypass_admission,json=bypassAdmission,proto3" json:"bypass_admission,omitempty"`
+	// Serve reads from the committed in-memory index mirror instead of reading
+	// the terminal btree leaf from disk. Intended only for benchmark devices
+	// where recovery/corruption validation has been deliberately traded for
+	// measuring the data-page path.
+	BypassIndexRead bool `protobuf:"varint,8,opt,name=bypass_index_read,json=bypassIndexRead,proto3" json:"bypass_index_read,omitempty"`
+	// Skip data checksum validation on reads. Intended only for benchmark
+	// devices where cache contents were just populated by the same daemon and
+	// the target is measuring the NVMe data path rather than CPU checksum cost.
+	BypassChecksum bool `protobuf:"varint,9,opt,name=bypass_checksum,json=bypassChecksum,proto3" json:"bypass_checksum,omitempty"`
 	// Types that are valid to be assigned to Config:
 	//
 	//	*DiskSpec_Block
@@ -1136,7 +1095,7 @@ type DiskSpec struct {
 
 func (x *DiskSpec) Reset() {
 	*x = DiskSpec{}
-	mi := &file_config_proto_msgTypes[16]
+	mi := &file_config_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1148,7 +1107,7 @@ func (x *DiskSpec) String() string {
 func (*DiskSpec) ProtoMessage() {}
 
 func (x *DiskSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[16]
+	mi := &file_config_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1161,7 +1120,7 @@ func (x *DiskSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiskSpec.ProtoReflect.Descriptor instead.
 func (*DiskSpec) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{16}
+	return file_config_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *DiskSpec) GetQueueDepth() uint32 {
@@ -1181,6 +1140,34 @@ func (x *DiskSpec) GetPageSizeBytes() uint64 {
 func (x *DiskSpec) GetSkipRecoveryScan() bool {
 	if x != nil {
 		return x.SkipRecoveryScan
+	}
+	return false
+}
+
+func (x *DiskSpec) GetForceFormat() bool {
+	if x != nil {
+		return x.ForceFormat
+	}
+	return false
+}
+
+func (x *DiskSpec) GetBypassAdmission() bool {
+	if x != nil {
+		return x.BypassAdmission
+	}
+	return false
+}
+
+func (x *DiskSpec) GetBypassIndexRead() bool {
+	if x != nil {
+		return x.BypassIndexRead
+	}
+	return false
+}
+
+func (x *DiskSpec) GetBypassChecksum() bool {
+	if x != nil {
+		return x.BypassChecksum
 	}
 	return false
 }
@@ -1238,7 +1225,7 @@ type BlockDiskConfig struct {
 
 func (x *BlockDiskConfig) Reset() {
 	*x = BlockDiskConfig{}
-	mi := &file_config_proto_msgTypes[17]
+	mi := &file_config_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1250,7 +1237,7 @@ func (x *BlockDiskConfig) String() string {
 func (*BlockDiskConfig) ProtoMessage() {}
 
 func (x *BlockDiskConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[17]
+	mi := &file_config_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1263,7 +1250,7 @@ func (x *BlockDiskConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlockDiskConfig.ProtoReflect.Descriptor instead.
 func (*BlockDiskConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{17}
+	return file_config_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *BlockDiskConfig) GetNuma() uint32 {
@@ -1292,7 +1279,7 @@ type FileDiskConfig struct {
 
 func (x *FileDiskConfig) Reset() {
 	*x = FileDiskConfig{}
-	mi := &file_config_proto_msgTypes[18]
+	mi := &file_config_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1304,7 +1291,7 @@ func (x *FileDiskConfig) String() string {
 func (*FileDiskConfig) ProtoMessage() {}
 
 func (x *FileDiskConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[18]
+	mi := &file_config_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1317,7 +1304,7 @@ func (x *FileDiskConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileDiskConfig.ProtoReflect.Descriptor instead.
 func (*FileDiskConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{18}
+	return file_config_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *FileDiskConfig) GetSize() uint64 {
@@ -1350,7 +1337,7 @@ type BackendSpec struct {
 
 func (x *BackendSpec) Reset() {
 	*x = BackendSpec{}
-	mi := &file_config_proto_msgTypes[19]
+	mi := &file_config_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1362,7 +1349,7 @@ func (x *BackendSpec) String() string {
 func (*BackendSpec) ProtoMessage() {}
 
 func (x *BackendSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[19]
+	mi := &file_config_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1375,7 +1362,7 @@ func (x *BackendSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackendSpec.ProtoReflect.Descriptor instead.
 func (*BackendSpec) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{19}
+	return file_config_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *BackendSpec) GetName() string {
@@ -1476,7 +1463,7 @@ type HttpBackendConfig struct {
 
 func (x *HttpBackendConfig) Reset() {
 	*x = HttpBackendConfig{}
-	mi := &file_config_proto_msgTypes[20]
+	mi := &file_config_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1488,7 +1475,7 @@ func (x *HttpBackendConfig) String() string {
 func (*HttpBackendConfig) ProtoMessage() {}
 
 func (x *HttpBackendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[20]
+	mi := &file_config_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1501,7 +1488,7 @@ func (x *HttpBackendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HttpBackendConfig.ProtoReflect.Descriptor instead.
 func (*HttpBackendConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{20}
+	return file_config_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *HttpBackendConfig) GetUrl() string {
@@ -1559,7 +1546,7 @@ type S3BackendConfig struct {
 
 func (x *S3BackendConfig) Reset() {
 	*x = S3BackendConfig{}
-	mi := &file_config_proto_msgTypes[21]
+	mi := &file_config_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1571,7 +1558,7 @@ func (x *S3BackendConfig) String() string {
 func (*S3BackendConfig) ProtoMessage() {}
 
 func (x *S3BackendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[21]
+	mi := &file_config_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1584,7 +1571,7 @@ func (x *S3BackendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use S3BackendConfig.ProtoReflect.Descriptor instead.
 func (*S3BackendConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{21}
+	return file_config_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *S3BackendConfig) GetUrl() string {
@@ -1642,7 +1629,7 @@ type AzureBackendConfig struct {
 
 func (x *AzureBackendConfig) Reset() {
 	*x = AzureBackendConfig{}
-	mi := &file_config_proto_msgTypes[22]
+	mi := &file_config_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1654,7 +1641,7 @@ func (x *AzureBackendConfig) String() string {
 func (*AzureBackendConfig) ProtoMessage() {}
 
 func (x *AzureBackendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[22]
+	mi := &file_config_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1667,7 +1654,7 @@ func (x *AzureBackendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureBackendConfig.ProtoReflect.Descriptor instead.
 func (*AzureBackendConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{22}
+	return file_config_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *AzureBackendConfig) GetUrl() string {
@@ -1710,7 +1697,7 @@ type FakeBackendConfig struct {
 	// Stripe granularity in bytes for synthetic origin references. Defaults to 4 MiB when unset.
 	// Must be a power of two.
 	StripeSizeBytes *uint64 `protobuf:"varint,1,opt,name=stripe_size_bytes,json=stripeSizeBytes,proto3,oneof" json:"stripe_size_bytes,omitempty"`
-	// Size of each synthetic zero-filled object in bytes. Defaults to 1 MiB when unset.
+	// Size of each deterministic synthetic object in bytes. Defaults to 1 MiB when unset.
 	ObjectSizeBytes *uint64 `protobuf:"varint,2,opt,name=object_size_bytes,json=objectSizeBytes,proto3,oneof" json:"object_size_bytes,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
@@ -1718,7 +1705,7 @@ type FakeBackendConfig struct {
 
 func (x *FakeBackendConfig) Reset() {
 	*x = FakeBackendConfig{}
-	mi := &file_config_proto_msgTypes[23]
+	mi := &file_config_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1730,7 +1717,7 @@ func (x *FakeBackendConfig) String() string {
 func (*FakeBackendConfig) ProtoMessage() {}
 
 func (x *FakeBackendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[23]
+	mi := &file_config_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1743,7 +1730,7 @@ func (x *FakeBackendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FakeBackendConfig.ProtoReflect.Descriptor instead.
 func (*FakeBackendConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{23}
+	return file_config_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *FakeBackendConfig) GetStripeSizeBytes() uint64 {
@@ -1776,7 +1763,7 @@ type FrontendSpec struct {
 
 func (x *FrontendSpec) Reset() {
 	*x = FrontendSpec{}
-	mi := &file_config_proto_msgTypes[24]
+	mi := &file_config_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1788,7 +1775,7 @@ func (x *FrontendSpec) String() string {
 func (*FrontendSpec) ProtoMessage() {}
 
 func (x *FrontendSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[24]
+	mi := &file_config_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1801,7 +1788,7 @@ func (x *FrontendSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FrontendSpec.ProtoReflect.Descriptor instead.
 func (*FrontendSpec) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{24}
+	return file_config_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *FrontendSpec) GetName() string {
@@ -1886,7 +1873,7 @@ type HttpFrontendConfig struct {
 
 func (x *HttpFrontendConfig) Reset() {
 	*x = HttpFrontendConfig{}
-	mi := &file_config_proto_msgTypes[25]
+	mi := &file_config_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1898,7 +1885,7 @@ func (x *HttpFrontendConfig) String() string {
 func (*HttpFrontendConfig) ProtoMessage() {}
 
 func (x *HttpFrontendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[25]
+	mi := &file_config_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1911,7 +1898,7 @@ func (x *HttpFrontendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HttpFrontendConfig.ProtoReflect.Descriptor instead.
 func (*HttpFrontendConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{25}
+	return file_config_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *HttpFrontendConfig) GetAddr() string {
@@ -1938,7 +1925,7 @@ type S3FrontendConfig struct {
 
 func (x *S3FrontendConfig) Reset() {
 	*x = S3FrontendConfig{}
-	mi := &file_config_proto_msgTypes[26]
+	mi := &file_config_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1950,7 +1937,7 @@ func (x *S3FrontendConfig) String() string {
 func (*S3FrontendConfig) ProtoMessage() {}
 
 func (x *S3FrontendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[26]
+	mi := &file_config_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1963,7 +1950,7 @@ func (x *S3FrontendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use S3FrontendConfig.ProtoReflect.Descriptor instead.
 func (*S3FrontendConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{26}
+	return file_config_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *S3FrontendConfig) GetAddr() string {
@@ -1977,21 +1964,42 @@ type LoadgenFrontendConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Synthetic read workers per serving shard. Defaults to 1 when unset.
 	Workers *uint32 `protobuf:"varint,1,opt,name=workers,proto3,oneof" json:"workers,omitempty"`
-	// Deterministic object stream seed. Defaults to the loadgen frontend seed when unset.
+	// Deterministic synthetic keyspace and request stream seed.
 	Seed *uint64 `protobuf:"varint,2,opt,name=seed,proto3,oneof" json:"seed,omitempty"`
-	// Number of distinct synthetic object ids to cycle over. Defaults to 1,000,000 when unset.
-	ObjectCount *uint64 `protobuf:"varint,3,opt,name=object_count,json=objectCount,proto3,oneof" json:"object_count,omitempty"`
-	// Bytes to read from the start of each object. When unset, reads the full resolved object length.
+	// Number of distinct synthetic object ids to sample. Defaults to 1,000,000 when unset.
+	KeyspaceObjects *uint64 `protobuf:"varint,3,opt,name=keyspace_objects,json=keyspaceObjects,proto3,oneof" json:"keyspace_objects,omitempty"`
+	// Bytes to read from the start of each object. When unset or zero, reads the full resolved object length.
 	ReadBytes *uint64 `protobuf:"varint,4,opt,name=read_bytes,json=readBytes,proto3,oneof" json:"read_bytes,omitempty"`
-	// Verify every returned body byte is zero. Intended for fake backends.
-	Verify        bool `protobuf:"varint,5,opt,name=verify,proto3" json:"verify,omitempty"`
+	// Verify returned metadata and body bytes against the deterministic synthetic dataset.
+	Verify bool `protobuf:"varint,5,opt,name=verify,proto3" json:"verify,omitempty"`
+	// Optional expected synthetic object size. When set with verify=true, rejects mismatched metadata.
+	ObjectSizeBytes *uint64 `protobuf:"varint,6,opt,name=object_size_bytes,json=objectSizeBytes,proto3,oneof" json:"object_size_bytes,omitempty"`
+	// Zipf exponent for synthetic object rank sampling. Defaults to 1.1 when unset.
+	ZipfExponent *float64 `protobuf:"fixed64,7,opt,name=zipf_exponent,json=zipfExponent,proto3,oneof" json:"zipf_exponent,omitempty"`
+	// When true, workers keep sampling until the first requested stripe routes to
+	// a peer instead of local ownership. This is intended for fabric saturation
+	// benchmarks; the request still uses the normal cache/p2p/storage/origin path.
+	RemoteOnly bool `protobuf:"varint,8,opt,name=remote_only,json=remoteOnly,proto3" json:"remote_only,omitempty"`
+	// When true, loadgen stamps requests so peer handlers synthesize zero-filled
+	// response pages directly from their RPC scratch buffers. This bypasses disk
+	// and origin work while keeping normal peer routing, fabric RPC framing, and
+	// RDMA writes in the benchmark path.
+	FabricOnly bool `protobuf:"varint,9,opt,name=fabric_only,json=fabricOnly,proto3" json:"fabric_only,omitempty"`
+	// When true, workers keep sampling until the first requested stripe is owned
+	// by the local node. This is intended for benchmark warmup phases that prefill
+	// each node's own NVMe-backed cache before a remote-only measurement phase.
+	LocalOnly bool `protobuf:"varint,10,opt,name=local_only,json=localOnly,proto3" json:"local_only,omitempty"`
+	// When true, the initiating bufferpool skips local disk lookup and writeback.
+	// Peer handlers still use their local NVMe-backed cache, so this keeps the
+	// measured path focused on remote NVMe + RDMA instead of requester-side reuse.
+	SkipLocalDisk bool `protobuf:"varint,11,opt,name=skip_local_disk,json=skipLocalDisk,proto3" json:"skip_local_disk,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *LoadgenFrontendConfig) Reset() {
 	*x = LoadgenFrontendConfig{}
-	mi := &file_config_proto_msgTypes[27]
+	mi := &file_config_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2003,7 +2011,7 @@ func (x *LoadgenFrontendConfig) String() string {
 func (*LoadgenFrontendConfig) ProtoMessage() {}
 
 func (x *LoadgenFrontendConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[27]
+	mi := &file_config_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2016,7 +2024,7 @@ func (x *LoadgenFrontendConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadgenFrontendConfig.ProtoReflect.Descriptor instead.
 func (*LoadgenFrontendConfig) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{27}
+	return file_config_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *LoadgenFrontendConfig) GetWorkers() uint32 {
@@ -2033,9 +2041,9 @@ func (x *LoadgenFrontendConfig) GetSeed() uint64 {
 	return 0
 }
 
-func (x *LoadgenFrontendConfig) GetObjectCount() uint64 {
-	if x != nil && x.ObjectCount != nil {
-		return *x.ObjectCount
+func (x *LoadgenFrontendConfig) GetKeyspaceObjects() uint64 {
+	if x != nil && x.KeyspaceObjects != nil {
+		return *x.KeyspaceObjects
 	}
 	return 0
 }
@@ -2054,19 +2062,89 @@ func (x *LoadgenFrontendConfig) GetVerify() bool {
 	return false
 }
 
+func (x *LoadgenFrontendConfig) GetObjectSizeBytes() uint64 {
+	if x != nil && x.ObjectSizeBytes != nil {
+		return *x.ObjectSizeBytes
+	}
+	return 0
+}
+
+func (x *LoadgenFrontendConfig) GetZipfExponent() float64 {
+	if x != nil && x.ZipfExponent != nil {
+		return *x.ZipfExponent
+	}
+	return 0
+}
+
+func (x *LoadgenFrontendConfig) GetRemoteOnly() bool {
+	if x != nil {
+		return x.RemoteOnly
+	}
+	return false
+}
+
+func (x *LoadgenFrontendConfig) GetFabricOnly() bool {
+	if x != nil {
+		return x.FabricOnly
+	}
+	return false
+}
+
+func (x *LoadgenFrontendConfig) GetLocalOnly() bool {
+	if x != nil {
+		return x.LocalOnly
+	}
+	return false
+}
+
+func (x *LoadgenFrontendConfig) GetSkipLocalDisk() bool {
+	if x != nil {
+		return x.SkipLocalDisk
+	}
+	return false
+}
+
 var File_config_proto protoreflect.FileDescriptor
 
 const file_config_proto_rawDesc = "" +
 	"\n" +
-	"\fconfig.proto\x12\x18unbounded.storage.config\"\xb4\x03\n" +
+	"\fconfig.proto\x12\x18unbounded.storage.config\"\xfb\x04\n" +
 	"\x06Config\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x04R\aversion\x12>\n" +
 	"\astartup\x18\x02 \x01(\v2$.unbounded.storage.config.StartupCfgR\astartup\x12D\n" +
 	"\tfrontends\x18\x03 \x03(\v2&.unbounded.storage.config.FrontendSpecR\tfrontends\x12A\n" +
 	"\bbackends\x18\x04 \x03(\v2%.unbounded.storage.config.BackendSpecR\bbackends\x12;\n" +
-	"\x06caches\x18\x05 \x03(\v2#.unbounded.storage.config.CacheSpecR\x06caches\x12P\n" +
-	"\rneighborhoods\x18\x06 \x03(\v2*.unbounded.storage.config.NeighborhoodSpecR\rneighborhoods\x128\n" +
-	"\x05disks\x18\a \x03(\v2\".unbounded.storage.config.DiskSpecR\x05disks\"\x89\x02\n" +
+	"\x06caches\x18\x05 \x03(\v2#.unbounded.storage.config.CacheSpecR\x06caches\x128\n" +
+	"\x05disks\x18\a \x03(\v2\".unbounded.storage.config.DiskSpecR\x05disks\x12-\n" +
+	"\x10fingers_per_node\x18\b \x01(\rH\x00R\x0efingersPerNode\x88\x01\x01\x12\x12\n" +
+	"\x04self\x18\t \x01(\tR\x04self\x12M\n" +
+	"\frouting_plan\x18\v \x01(\v2%.unbounded.storage.config.RoutingPlanH\x01R\vroutingPlan\x88\x01\x01\x128\n" +
+	"\x05peers\x18\f \x03(\v2\".unbounded.storage.config.PeerSpecR\x05peersB\x13\n" +
+	"\x11_fingers_per_nodeB\x0f\n" +
+	"\r_routing_planJ\x04\b\x06\x10\aJ\x04\b\n" +
+	"\x10\vR\rneighborhoodsR\n" +
+	"local_tags\"\x8f\x01\n" +
+	"\vRoutingPlan\x12\x18\n" +
+	"\afingers\x18\x01 \x03(\tR\afingers\x12!\n" +
+	"\tsuccessor\x18\x02 \x01(\tH\x00R\tsuccessor\x88\x01\x01\x12%\n" +
+	"\vpredecessor\x18\x03 \x01(\tH\x01R\vpredecessor\x88\x01\x01B\f\n" +
+	"\n" +
+	"_successorB\x0e\n" +
+	"\f_predecessor\"\xb9\x01\n" +
+	"\bPeerSpec\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04tags\x18\x02 \x03(\tR\x04tags\x12;\n" +
+	"\x03tcp\x18\x03 \x01(\v2'.unbounded.storage.config.TcpPeerConfigH\x00R\x03tcp\x12>\n" +
+	"\x04rdma\x18\x04 \x01(\v2(.unbounded.storage.config.RdmaPeerConfigH\x00R\x04rdmaB\b\n" +
+	"\x06config\"#\n" +
+	"\rTcpPeerConfig\x12\x12\n" +
+	"\x04addr\x18\x01 \x01(\tR\x04addr\":\n" +
+	"\x0eRdmaPeerConfig\x12\x12\n" +
+	"\x04addr\x18\x01 \x01(\tR\x04addr\x12\x14\n" +
+	"\x05addrs\x18\x02 \x03(\tR\x05addrs\"7\n" +
+	"\tCacheSpec\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x06source\x18\x02 \x01(\tR\x06source\"\x89\x02\n" +
 	"\n" +
 	"StartupCfg\x12;\n" +
 	"\x06memory\x18\x01 \x01(\v2#.unbounded.storage.config.MemoryCfgR\x06memory\x12;\n" +
@@ -2112,44 +2190,16 @@ const file_config_proto_rawDesc = "" +
 	"\vnic_workers\x18\a \x01(\x04H\x01R\n" +
 	"nicWorkers\x88\x01\x01B\x10\n" +
 	"\x0e_serving_coresB\x0e\n" +
-	"\f_nic_workers\"\xf6\x02\n" +
-	"\x10NeighborhoodSpec\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
-	"\x06source\x18\x02 \x01(\tR\x06source\x12-\n" +
-	"\x10fingers_per_node\x18\x03 \x01(\rH\x00R\x0efingersPerNode\x88\x01\x01\x12'\n" +
-	"\rlocal_node_id\x18\x04 \x01(\x04H\x01R\vlocalNodeId\x88\x01\x01\x12\x1d\n" +
-	"\n" +
-	"local_tags\x18\x05 \x03(\tR\tlocalTags\x12M\n" +
-	"\frouting_plan\x18\x06 \x01(\v2%.unbounded.storage.config.RoutingPlanH\x02R\vroutingPlan\x88\x01\x01\x128\n" +
-	"\x05peers\x18\a \x03(\v2\".unbounded.storage.config.PeerSpecR\x05peersB\x13\n" +
-	"\x11_fingers_per_nodeB\x10\n" +
-	"\x0e_local_node_idB\x0f\n" +
-	"\r_routing_plan\"\x8f\x01\n" +
-	"\vRoutingPlan\x12\x18\n" +
-	"\afingers\x18\x01 \x03(\x04R\afingers\x12!\n" +
-	"\tsuccessor\x18\x02 \x01(\x04H\x00R\tsuccessor\x88\x01\x01\x12%\n" +
-	"\vpredecessor\x18\x03 \x01(\x04H\x01R\vpredecessor\x88\x01\x01B\f\n" +
-	"\n" +
-	"_successorB\x0e\n" +
-	"\f_predecessor\"\xb5\x01\n" +
-	"\bPeerSpec\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\x04R\x02id\x12\x12\n" +
-	"\x04tags\x18\x02 \x03(\tR\x04tags\x12;\n" +
-	"\x03tcp\x18\x03 \x01(\v2'.unbounded.storage.config.TcpPeerConfigH\x00R\x03tcp\x12>\n" +
-	"\x04rdma\x18\x04 \x01(\v2(.unbounded.storage.config.RdmaPeerConfigH\x00R\x04rdmaB\b\n" +
-	"\x06config\"#\n" +
-	"\rTcpPeerConfig\x12\x12\n" +
-	"\x04addr\x18\x01 \x01(\tR\x04addr\"$\n" +
-	"\x0eRdmaPeerConfig\x12\x12\n" +
-	"\x04addr\x18\x01 \x01(\tR\x04addr\"7\n" +
-	"\tCacheSpec\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
-	"\x06source\x18\x02 \x01(\tR\x06source\"\xbc\x02\n" +
+	"\f_nic_workers\"\xdf\x03\n" +
 	"\bDiskSpec\x12$\n" +
 	"\vqueue_depth\x18\x01 \x01(\rH\x01R\n" +
 	"queueDepth\x88\x01\x01\x12+\n" +
 	"\x0fpage_size_bytes\x18\x02 \x01(\x04H\x02R\rpageSizeBytes\x88\x01\x01\x12,\n" +
-	"\x12skip_recovery_scan\x18\x03 \x01(\bR\x10skipRecoveryScan\x12A\n" +
+	"\x12skip_recovery_scan\x18\x03 \x01(\bR\x10skipRecoveryScan\x12!\n" +
+	"\fforce_format\x18\x06 \x01(\bR\vforceFormat\x12)\n" +
+	"\x10bypass_admission\x18\a \x01(\bR\x0fbypassAdmission\x12*\n" +
+	"\x11bypass_index_read\x18\b \x01(\bR\x0fbypassIndexRead\x12'\n" +
+	"\x0fbypass_checksum\x18\t \x01(\bR\x0ebypassChecksum\x12A\n" +
 	"\x05block\x18\x04 \x01(\v2).unbounded.storage.config.BlockDiskConfigH\x00R\x05block\x12>\n" +
 	"\x04file\x18\x05 \x01(\v2(.unbounded.storage.config.FileDiskConfigH\x00R\x04fileB\b\n" +
 	"\x06configB\x0e\n" +
@@ -2217,19 +2267,31 @@ const file_config_proto_rawDesc = "" +
 	"\x1bmax_requests_per_connection\x18\x02 \x01(\rH\x00R\x18maxRequestsPerConnection\x88\x01\x01B\x1e\n" +
 	"\x1c_max_requests_per_connection\"&\n" +
 	"\x10S3FrontendConfig\x12\x12\n" +
-	"\x04addr\x18\x01 \x01(\tR\x04addr\"\xe8\x01\n" +
+	"\x04addr\x18\x01 \x01(\tR\x04addr\"\x80\x04\n" +
 	"\x15LoadgenFrontendConfig\x12\x1d\n" +
 	"\aworkers\x18\x01 \x01(\rH\x00R\aworkers\x88\x01\x01\x12\x17\n" +
-	"\x04seed\x18\x02 \x01(\x04H\x01R\x04seed\x88\x01\x01\x12&\n" +
-	"\fobject_count\x18\x03 \x01(\x04H\x02R\vobjectCount\x88\x01\x01\x12\"\n" +
+	"\x04seed\x18\x02 \x01(\x04H\x01R\x04seed\x88\x01\x01\x12.\n" +
+	"\x10keyspace_objects\x18\x03 \x01(\x04H\x02R\x0fkeyspaceObjects\x88\x01\x01\x12\"\n" +
 	"\n" +
 	"read_bytes\x18\x04 \x01(\x04H\x03R\treadBytes\x88\x01\x01\x12\x16\n" +
-	"\x06verify\x18\x05 \x01(\bR\x06verifyB\n" +
+	"\x06verify\x18\x05 \x01(\bR\x06verify\x12/\n" +
+	"\x11object_size_bytes\x18\x06 \x01(\x04H\x04R\x0fobjectSizeBytes\x88\x01\x01\x12(\n" +
+	"\rzipf_exponent\x18\a \x01(\x01H\x05R\fzipfExponent\x88\x01\x01\x12\x1f\n" +
+	"\vremote_only\x18\b \x01(\bR\n" +
+	"remoteOnly\x12\x1f\n" +
+	"\vfabric_only\x18\t \x01(\bR\n" +
+	"fabricOnly\x12\x1d\n" +
+	"\n" +
+	"local_only\x18\n" +
+	" \x01(\bR\tlocalOnly\x12&\n" +
+	"\x0fskip_local_disk\x18\v \x01(\bR\rskipLocalDiskB\n" +
 	"\n" +
 	"\b_workersB\a\n" +
-	"\x05_seedB\x0f\n" +
-	"\r_object_countB\r\n" +
-	"\v_read_bytesB@Z>github.com/Azure/unbounded/api/unbounded-storage;storageconfigb\x06proto3"
+	"\x05_seedB\x13\n" +
+	"\x11_keyspace_objectsB\r\n" +
+	"\v_read_bytesB\x14\n" +
+	"\x12_object_size_bytesB\x10\n" +
+	"\x0e_zipf_exponentB@Z>github.com/Azure/unbounded/api/unbounded-storage;storageconfigb\x06proto3"
 
 var (
 	file_config_proto_rawDescOnce sync.Once
@@ -2243,70 +2305,68 @@ func file_config_proto_rawDescGZIP() []byte {
 	return file_config_proto_rawDescData
 }
 
-var file_config_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_config_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_config_proto_goTypes = []any{
 	(*Config)(nil),                // 0: unbounded.storage.config.Config
-	(*StartupCfg)(nil),            // 1: unbounded.storage.config.StartupCfg
-	(*MetricsCfg)(nil),            // 2: unbounded.storage.config.MetricsCfg
-	(*MemoryCfg)(nil),             // 3: unbounded.storage.config.MemoryCfg
-	(*FabricCfg)(nil),             // 4: unbounded.storage.config.FabricCfg
-	(*TcpFabricBinds)(nil),        // 5: unbounded.storage.config.TcpFabricBinds
-	(*RdmaFabricBinds)(nil),       // 6: unbounded.storage.config.RdmaFabricBinds
-	(*AutoRdmaFabricBinds)(nil),   // 7: unbounded.storage.config.AutoRdmaFabricBinds
-	(*RdmaFabricBind)(nil),        // 8: unbounded.storage.config.RdmaFabricBind
-	(*TopologyCfg)(nil),           // 9: unbounded.storage.config.TopologyCfg
-	(*NeighborhoodSpec)(nil),      // 10: unbounded.storage.config.NeighborhoodSpec
-	(*RoutingPlan)(nil),           // 11: unbounded.storage.config.RoutingPlan
-	(*PeerSpec)(nil),              // 12: unbounded.storage.config.PeerSpec
-	(*TcpPeerConfig)(nil),         // 13: unbounded.storage.config.TcpPeerConfig
-	(*RdmaPeerConfig)(nil),        // 14: unbounded.storage.config.RdmaPeerConfig
-	(*CacheSpec)(nil),             // 15: unbounded.storage.config.CacheSpec
-	(*DiskSpec)(nil),              // 16: unbounded.storage.config.DiskSpec
-	(*BlockDiskConfig)(nil),       // 17: unbounded.storage.config.BlockDiskConfig
-	(*FileDiskConfig)(nil),        // 18: unbounded.storage.config.FileDiskConfig
-	(*BackendSpec)(nil),           // 19: unbounded.storage.config.BackendSpec
-	(*HttpBackendConfig)(nil),     // 20: unbounded.storage.config.HttpBackendConfig
-	(*S3BackendConfig)(nil),       // 21: unbounded.storage.config.S3BackendConfig
-	(*AzureBackendConfig)(nil),    // 22: unbounded.storage.config.AzureBackendConfig
-	(*FakeBackendConfig)(nil),     // 23: unbounded.storage.config.FakeBackendConfig
-	(*FrontendSpec)(nil),          // 24: unbounded.storage.config.FrontendSpec
-	(*HttpFrontendConfig)(nil),    // 25: unbounded.storage.config.HttpFrontendConfig
-	(*S3FrontendConfig)(nil),      // 26: unbounded.storage.config.S3FrontendConfig
-	(*LoadgenFrontendConfig)(nil), // 27: unbounded.storage.config.LoadgenFrontendConfig
+	(*RoutingPlan)(nil),           // 1: unbounded.storage.config.RoutingPlan
+	(*PeerSpec)(nil),              // 2: unbounded.storage.config.PeerSpec
+	(*TcpPeerConfig)(nil),         // 3: unbounded.storage.config.TcpPeerConfig
+	(*RdmaPeerConfig)(nil),        // 4: unbounded.storage.config.RdmaPeerConfig
+	(*CacheSpec)(nil),             // 5: unbounded.storage.config.CacheSpec
+	(*StartupCfg)(nil),            // 6: unbounded.storage.config.StartupCfg
+	(*MetricsCfg)(nil),            // 7: unbounded.storage.config.MetricsCfg
+	(*MemoryCfg)(nil),             // 8: unbounded.storage.config.MemoryCfg
+	(*FabricCfg)(nil),             // 9: unbounded.storage.config.FabricCfg
+	(*TcpFabricBinds)(nil),        // 10: unbounded.storage.config.TcpFabricBinds
+	(*RdmaFabricBinds)(nil),       // 11: unbounded.storage.config.RdmaFabricBinds
+	(*AutoRdmaFabricBinds)(nil),   // 12: unbounded.storage.config.AutoRdmaFabricBinds
+	(*RdmaFabricBind)(nil),        // 13: unbounded.storage.config.RdmaFabricBind
+	(*TopologyCfg)(nil),           // 14: unbounded.storage.config.TopologyCfg
+	(*DiskSpec)(nil),              // 15: unbounded.storage.config.DiskSpec
+	(*BlockDiskConfig)(nil),       // 16: unbounded.storage.config.BlockDiskConfig
+	(*FileDiskConfig)(nil),        // 17: unbounded.storage.config.FileDiskConfig
+	(*BackendSpec)(nil),           // 18: unbounded.storage.config.BackendSpec
+	(*HttpBackendConfig)(nil),     // 19: unbounded.storage.config.HttpBackendConfig
+	(*S3BackendConfig)(nil),       // 20: unbounded.storage.config.S3BackendConfig
+	(*AzureBackendConfig)(nil),    // 21: unbounded.storage.config.AzureBackendConfig
+	(*FakeBackendConfig)(nil),     // 22: unbounded.storage.config.FakeBackendConfig
+	(*FrontendSpec)(nil),          // 23: unbounded.storage.config.FrontendSpec
+	(*HttpFrontendConfig)(nil),    // 24: unbounded.storage.config.HttpFrontendConfig
+	(*S3FrontendConfig)(nil),      // 25: unbounded.storage.config.S3FrontendConfig
+	(*LoadgenFrontendConfig)(nil), // 26: unbounded.storage.config.LoadgenFrontendConfig
 }
 var file_config_proto_depIdxs = []int32{
-	1,  // 0: unbounded.storage.config.Config.startup:type_name -> unbounded.storage.config.StartupCfg
-	24, // 1: unbounded.storage.config.Config.frontends:type_name -> unbounded.storage.config.FrontendSpec
-	19, // 2: unbounded.storage.config.Config.backends:type_name -> unbounded.storage.config.BackendSpec
-	15, // 3: unbounded.storage.config.Config.caches:type_name -> unbounded.storage.config.CacheSpec
-	10, // 4: unbounded.storage.config.Config.neighborhoods:type_name -> unbounded.storage.config.NeighborhoodSpec
-	16, // 5: unbounded.storage.config.Config.disks:type_name -> unbounded.storage.config.DiskSpec
-	3,  // 6: unbounded.storage.config.StartupCfg.memory:type_name -> unbounded.storage.config.MemoryCfg
-	4,  // 7: unbounded.storage.config.StartupCfg.fabric:type_name -> unbounded.storage.config.FabricCfg
-	9,  // 8: unbounded.storage.config.StartupCfg.topology:type_name -> unbounded.storage.config.TopologyCfg
-	2,  // 9: unbounded.storage.config.StartupCfg.metrics:type_name -> unbounded.storage.config.MetricsCfg
-	5,  // 10: unbounded.storage.config.FabricCfg.tcp:type_name -> unbounded.storage.config.TcpFabricBinds
-	6,  // 11: unbounded.storage.config.FabricCfg.rdma:type_name -> unbounded.storage.config.RdmaFabricBinds
-	7,  // 12: unbounded.storage.config.FabricCfg.auto_rdma:type_name -> unbounded.storage.config.AutoRdmaFabricBinds
-	8,  // 13: unbounded.storage.config.RdmaFabricBinds.binds:type_name -> unbounded.storage.config.RdmaFabricBind
-	11, // 14: unbounded.storage.config.NeighborhoodSpec.routing_plan:type_name -> unbounded.storage.config.RoutingPlan
-	12, // 15: unbounded.storage.config.NeighborhoodSpec.peers:type_name -> unbounded.storage.config.PeerSpec
-	13, // 16: unbounded.storage.config.PeerSpec.tcp:type_name -> unbounded.storage.config.TcpPeerConfig
-	14, // 17: unbounded.storage.config.PeerSpec.rdma:type_name -> unbounded.storage.config.RdmaPeerConfig
-	17, // 18: unbounded.storage.config.DiskSpec.block:type_name -> unbounded.storage.config.BlockDiskConfig
-	18, // 19: unbounded.storage.config.DiskSpec.file:type_name -> unbounded.storage.config.FileDiskConfig
-	20, // 20: unbounded.storage.config.BackendSpec.http:type_name -> unbounded.storage.config.HttpBackendConfig
-	21, // 21: unbounded.storage.config.BackendSpec.s3:type_name -> unbounded.storage.config.S3BackendConfig
-	22, // 22: unbounded.storage.config.BackendSpec.azure:type_name -> unbounded.storage.config.AzureBackendConfig
-	23, // 23: unbounded.storage.config.BackendSpec.fake:type_name -> unbounded.storage.config.FakeBackendConfig
-	25, // 24: unbounded.storage.config.FrontendSpec.http:type_name -> unbounded.storage.config.HttpFrontendConfig
-	26, // 25: unbounded.storage.config.FrontendSpec.s3:type_name -> unbounded.storage.config.S3FrontendConfig
-	27, // 26: unbounded.storage.config.FrontendSpec.loadgen:type_name -> unbounded.storage.config.LoadgenFrontendConfig
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	6,  // 0: unbounded.storage.config.Config.startup:type_name -> unbounded.storage.config.StartupCfg
+	23, // 1: unbounded.storage.config.Config.frontends:type_name -> unbounded.storage.config.FrontendSpec
+	18, // 2: unbounded.storage.config.Config.backends:type_name -> unbounded.storage.config.BackendSpec
+	5,  // 3: unbounded.storage.config.Config.caches:type_name -> unbounded.storage.config.CacheSpec
+	15, // 4: unbounded.storage.config.Config.disks:type_name -> unbounded.storage.config.DiskSpec
+	1,  // 5: unbounded.storage.config.Config.routing_plan:type_name -> unbounded.storage.config.RoutingPlan
+	2,  // 6: unbounded.storage.config.Config.peers:type_name -> unbounded.storage.config.PeerSpec
+	3,  // 7: unbounded.storage.config.PeerSpec.tcp:type_name -> unbounded.storage.config.TcpPeerConfig
+	4,  // 8: unbounded.storage.config.PeerSpec.rdma:type_name -> unbounded.storage.config.RdmaPeerConfig
+	8,  // 9: unbounded.storage.config.StartupCfg.memory:type_name -> unbounded.storage.config.MemoryCfg
+	9,  // 10: unbounded.storage.config.StartupCfg.fabric:type_name -> unbounded.storage.config.FabricCfg
+	14, // 11: unbounded.storage.config.StartupCfg.topology:type_name -> unbounded.storage.config.TopologyCfg
+	7,  // 12: unbounded.storage.config.StartupCfg.metrics:type_name -> unbounded.storage.config.MetricsCfg
+	10, // 13: unbounded.storage.config.FabricCfg.tcp:type_name -> unbounded.storage.config.TcpFabricBinds
+	11, // 14: unbounded.storage.config.FabricCfg.rdma:type_name -> unbounded.storage.config.RdmaFabricBinds
+	12, // 15: unbounded.storage.config.FabricCfg.auto_rdma:type_name -> unbounded.storage.config.AutoRdmaFabricBinds
+	13, // 16: unbounded.storage.config.RdmaFabricBinds.binds:type_name -> unbounded.storage.config.RdmaFabricBind
+	16, // 17: unbounded.storage.config.DiskSpec.block:type_name -> unbounded.storage.config.BlockDiskConfig
+	17, // 18: unbounded.storage.config.DiskSpec.file:type_name -> unbounded.storage.config.FileDiskConfig
+	19, // 19: unbounded.storage.config.BackendSpec.http:type_name -> unbounded.storage.config.HttpBackendConfig
+	20, // 20: unbounded.storage.config.BackendSpec.s3:type_name -> unbounded.storage.config.S3BackendConfig
+	21, // 21: unbounded.storage.config.BackendSpec.azure:type_name -> unbounded.storage.config.AzureBackendConfig
+	22, // 22: unbounded.storage.config.BackendSpec.fake:type_name -> unbounded.storage.config.FakeBackendConfig
+	24, // 23: unbounded.storage.config.FrontendSpec.http:type_name -> unbounded.storage.config.HttpFrontendConfig
+	25, // 24: unbounded.storage.config.FrontendSpec.s3:type_name -> unbounded.storage.config.S3FrontendConfig
+	26, // 25: unbounded.storage.config.FrontendSpec.loadgen:type_name -> unbounded.storage.config.LoadgenFrontendConfig
+	26, // [26:26] is the sub-list for method output_type
+	26, // [26:26] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_config_proto_init() }
@@ -2314,50 +2374,50 @@ func file_config_proto_init() {
 	if File_config_proto != nil {
 		return
 	}
-	file_config_proto_msgTypes[3].OneofWrappers = []any{}
-	file_config_proto_msgTypes[4].OneofWrappers = []any{
+	file_config_proto_msgTypes[0].OneofWrappers = []any{}
+	file_config_proto_msgTypes[1].OneofWrappers = []any{}
+	file_config_proto_msgTypes[2].OneofWrappers = []any{
+		(*PeerSpec_Tcp)(nil),
+		(*PeerSpec_Rdma)(nil),
+	}
+	file_config_proto_msgTypes[8].OneofWrappers = []any{}
+	file_config_proto_msgTypes[9].OneofWrappers = []any{
 		(*FabricCfg_Tcp)(nil),
 		(*FabricCfg_Rdma)(nil),
 		(*FabricCfg_AutoRdma)(nil),
 	}
-	file_config_proto_msgTypes[7].OneofWrappers = []any{}
-	file_config_proto_msgTypes[9].OneofWrappers = []any{}
-	file_config_proto_msgTypes[10].OneofWrappers = []any{}
-	file_config_proto_msgTypes[11].OneofWrappers = []any{}
-	file_config_proto_msgTypes[12].OneofWrappers = []any{
-		(*PeerSpec_Tcp)(nil),
-		(*PeerSpec_Rdma)(nil),
-	}
-	file_config_proto_msgTypes[16].OneofWrappers = []any{
+	file_config_proto_msgTypes[12].OneofWrappers = []any{}
+	file_config_proto_msgTypes[14].OneofWrappers = []any{}
+	file_config_proto_msgTypes[15].OneofWrappers = []any{
 		(*DiskSpec_Block)(nil),
 		(*DiskSpec_File)(nil),
 	}
+	file_config_proto_msgTypes[16].OneofWrappers = []any{}
 	file_config_proto_msgTypes[17].OneofWrappers = []any{}
-	file_config_proto_msgTypes[18].OneofWrappers = []any{}
-	file_config_proto_msgTypes[19].OneofWrappers = []any{
+	file_config_proto_msgTypes[18].OneofWrappers = []any{
 		(*BackendSpec_Http)(nil),
 		(*BackendSpec_S3)(nil),
 		(*BackendSpec_Azure)(nil),
 		(*BackendSpec_Fake)(nil),
 	}
+	file_config_proto_msgTypes[19].OneofWrappers = []any{}
 	file_config_proto_msgTypes[20].OneofWrappers = []any{}
 	file_config_proto_msgTypes[21].OneofWrappers = []any{}
 	file_config_proto_msgTypes[22].OneofWrappers = []any{}
-	file_config_proto_msgTypes[23].OneofWrappers = []any{}
-	file_config_proto_msgTypes[24].OneofWrappers = []any{
+	file_config_proto_msgTypes[23].OneofWrappers = []any{
 		(*FrontendSpec_Http)(nil),
 		(*FrontendSpec_S3)(nil),
 		(*FrontendSpec_Loadgen)(nil),
 	}
-	file_config_proto_msgTypes[25].OneofWrappers = []any{}
-	file_config_proto_msgTypes[27].OneofWrappers = []any{}
+	file_config_proto_msgTypes[24].OneofWrappers = []any{}
+	file_config_proto_msgTypes[26].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_config_proto_rawDesc), len(file_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/unbounded-storage/config.proto
+++ b/api/unbounded-storage/config.proto
@@ -8,6 +8,9 @@ package unbounded.storage.config;
 option go_package = "github.com/Azure/unbounded/api/unbounded-storage;storageconfig";
 
 message Config {
+  reserved 6, 10;
+  reserved "neighborhoods", "local_tags";
+
   // Operator-assigned opaque version tracked so operators can confirm which config has been applied. 0 means unversioned.
   uint64 version = 1;
 
@@ -17,8 +20,75 @@ message Config {
   repeated FrontendSpec frontends = 3;
   repeated BackendSpec backends = 4;
   repeated CacheSpec caches = 5;
-  repeated NeighborhoodSpec neighborhoods = 6;
   repeated DiskSpec disks = 7;
+
+  // Number of deterministic finger-table entries to derive per peer. Defaults to 100 when unset.
+  optional uint32 fingers_per_node = 8;
+
+  // Name of this process in the `peers` roster. Required when peers or a
+  // routing plan are configured. The internal ring and fabric ids are derived
+  // from this peer name and are startup-fixed.
+  string self = 9;
+
+  // Precomputed routing table for this process. When set, `peers` can be
+  // sparse, containing only this process's routing neighbors.
+  optional RoutingPlan routing_plan = 11;
+
+  // Process-wide peer definitions for the globally shared transport mesh.
+  repeated PeerSpec peers = 12;
+}
+
+// A precomputed routing table for a single node, produced by a
+// global-view planner. All names reference `PeerSpec.name` values in the
+// `peers` list (each must be present so a fabric connection exists). Ring
+// positions are derived from names, and tags do not affect runtime routing, so
+// only names are carried here.
+message RoutingPlan {
+  // Peer names selected for this routing plan.
+  repeated string fingers = 1;
+
+  // Peer name of the nearest-forward neighbor on the ring.
+  optional string successor = 2;
+
+  // Peer name of the nearest-backward neighbor on the ring.
+  optional string predecessor = 3;
+}
+
+message PeerSpec {
+  // Stable peer name. The process-wide fabric peer id, ring position, and route
+  // references are derived from this name.
+  string name = 1;
+
+  // Peer tags used by placement-aware planning.
+  repeated string tags = 2;
+
+  oneof config {
+    TcpPeerConfig tcp = 3;
+    RdmaPeerConfig rdma = 4;
+  }
+}
+
+message TcpPeerConfig {
+  // TCP socket address used as this peer's fabric wire address.
+  string addr = 1;
+}
+
+message RdmaPeerConfig {
+  // Default RDMA fabric address. Provider-native addresses are encoded as
+  // "hex:<fi_getname-bytes>"; RDMA-CM socket addresses are accepted when the
+  // provider reports them. Kept for single-endpoint peers and older writers.
+  string addr = 1;
+
+  // Ordered RDMA fabric addresses for peers that expose multiple fabric units,
+  // such as one endpoint per HCA. The daemon dials the address whose index
+  // matches the local fabric unit index, falling back to addr when absent.
+  repeated string addrs = 2;
+}
+
+message CacheSpec {
+  string name = 1;
+  // Backend source used for miss fills. Cache name is the only logical keyspace prefix.
+  string source = 2;
 }
 
 message StartupCfg {
@@ -110,76 +180,6 @@ message TopologyCfg {
   optional uint64 nic_workers = 7;
 }
 
-message NeighborhoodSpec {
-  string name = 1;
-  string source = 2;
-
-  // Number of deterministic finger-table entries to derive per node. Defaults to 100 when unset.
-  optional uint32 fingers_per_node = 3;
-
-  // Local node id on the P2P ring and process-wide fabric peer id; required when
-  // peers are configured, shared by every neighborhood when set, and must not
-  // match any peer id.
-  optional uint64 local_node_id = 4;
-
-  // Local tags used by placement-aware planning.
-  repeated string local_tags = 5;
-
-  // Precomputed routing table that replaces automatic finger-table derivation when set.
-  // When set, `peers` can be "sparse"; containing only this process's neighbors.
-  optional RoutingPlan routing_plan = 6;
-
-  // Peer definitions available to this neighborhood. Peer ids are process-wide
-  // fabric peer ids; repeating an id across neighborhoods requires the same
-  // peer data.
-  repeated PeerSpec peers = 7;
-}
-
-// A precomputed routing table for a single node, produced by a
-// global-view planner. All ids reference `PeerSpec.id` values in the
-// `peers` list (each must be present so a fabric connection exists).
-// Ring positions are derived from ids, and tags do not affect runtime
-// routing, so only ids are carried here.
-message RoutingPlan {
-  // Peer ids selected for this routing plan.
-  repeated uint64 fingers = 1;
-
-  // Peer id of the nearest-forward neighbor on the ring.
-  optional uint64 successor = 2;
-
-  // Peer id of the nearest-backward neighbor on the ring.
-  optional uint64 predecessor = 3;
-}
-
-message PeerSpec {
-  // Process-wide fabric peer id, also used for this neighborhood's ring
-  // position and route references.
-  uint64 id = 1;
-
-  // Peer tags used by placement-aware planning.
-  repeated string tags = 2;
-
-  oneof config {
-    TcpPeerConfig tcp = 3;
-    RdmaPeerConfig rdma = 4;
-  }
-}
-
-message TcpPeerConfig {
-  // TCP socket address used as this peer's fabric wire address.
-  string addr = 1;
-}
-
-message RdmaPeerConfig {
-  // Provider-native RDMA fabric address encoded as "hex:<fi_getname-bytes>".
-  string addr = 1;
-}
-
-message CacheSpec {
-  string name = 1;
-  string source = 2;
-}
-
 message DiskSpec {
   // Optional io_uring queue depth override for this disk.
   optional uint32 queue_depth = 1;
@@ -189,6 +189,26 @@ message DiskSpec {
 
   // Skips the recovery scan when no metadata page is valid; intended only for fresh or benchmark disks.
   bool skip_recovery_scan = 3;
+
+  // Destructively resets the cache index on open, ignoring any existing on-disk metadata.
+  // Intended only for benchmark cache devices that are safe to reformat between runs.
+  bool force_format = 6;
+
+  // Admit every write into the cache index instead of requiring the default
+  // second touch. Intended for benchmark warmups that must prefill NVMe devices
+  // with a cold synthetic keyspace.
+  bool bypass_admission = 7;
+
+  // Serve reads from the committed in-memory index mirror instead of reading
+  // the terminal btree leaf from disk. Intended only for benchmark devices
+  // where recovery/corruption validation has been deliberately traded for
+  // measuring the data-page path.
+  bool bypass_index_read = 8;
+
+  // Skip data checksum validation on reads. Intended only for benchmark
+  // devices where cache contents were just populated by the same daemon and
+  // the target is measuring the NVMe data path rather than CPU checksum cost.
+  bool bypass_checksum = 9;
 
   oneof config {
     BlockDiskConfig block = 4;
@@ -285,7 +305,7 @@ message FakeBackendConfig {
   // Must be a power of two.
   optional uint64 stripe_size_bytes = 1;
 
-  // Size of each synthetic zero-filled object in bytes. Defaults to 1 MiB when unset.
+  // Size of each deterministic synthetic object in bytes. Defaults to 1 MiB when unset.
   optional uint64 object_size_bytes = 2;
 }
 
@@ -317,15 +337,42 @@ message LoadgenFrontendConfig {
   // Synthetic read workers per serving shard. Defaults to 1 when unset.
   optional uint32 workers = 1;
 
-  // Deterministic object stream seed. Defaults to the loadgen frontend seed when unset.
+  // Deterministic synthetic keyspace and request stream seed.
   optional uint64 seed = 2;
 
-  // Number of distinct synthetic object ids to cycle over. Defaults to 1,000,000 when unset.
-  optional uint64 object_count = 3;
+  // Number of distinct synthetic object ids to sample. Defaults to 1,000,000 when unset.
+  optional uint64 keyspace_objects = 3;
 
-  // Bytes to read from the start of each object. When unset, reads the full resolved object length.
+  // Bytes to read from the start of each object. When unset or zero, reads the full resolved object length.
   optional uint64 read_bytes = 4;
 
-  // Verify every returned body byte is zero. Intended for fake backends.
+  // Verify returned metadata and body bytes against the deterministic synthetic dataset.
   bool verify = 5;
+
+  // Optional expected synthetic object size. When set with verify=true, rejects mismatched metadata.
+  optional uint64 object_size_bytes = 6;
+
+  // Zipf exponent for synthetic object rank sampling. Defaults to 1.1 when unset.
+  optional double zipf_exponent = 7;
+
+  // When true, workers keep sampling until the first requested stripe routes to
+  // a peer instead of local ownership. This is intended for fabric saturation
+  // benchmarks; the request still uses the normal cache/p2p/storage/origin path.
+  bool remote_only = 8;
+
+  // When true, loadgen stamps requests so peer handlers synthesize zero-filled
+  // response pages directly from their RPC scratch buffers. This bypasses disk
+  // and origin work while keeping normal peer routing, fabric RPC framing, and
+  // RDMA writes in the benchmark path.
+  bool fabric_only = 9;
+
+  // When true, workers keep sampling until the first requested stripe is owned
+  // by the local node. This is intended for benchmark warmup phases that prefill
+  // each node's own NVMe-backed cache before a remote-only measurement phase.
+  bool local_only = 10;
+
+  // When true, the initiating bufferpool skips local disk lookup and writeback.
+  // Peer handlers still use their local NVMe-backed cache, so this keeps the
+  // measured path focused on remote NVMe + RDMA instead of requester-side reuse.
+  bool skip_local_disk = 11;
 }

--- a/api/unbounded-storage/config.proto
+++ b/api/unbounded-storage/config.proto
@@ -8,9 +8,6 @@ package unbounded.storage.config;
 option go_package = "github.com/Azure/unbounded/api/unbounded-storage;storageconfig";
 
 message Config {
-  reserved 6, 10;
-  reserved "neighborhoods", "local_tags";
-
   // Operator-assigned opaque version tracked so operators can confirm which config has been applied. 0 means unversioned.
   uint64 version = 1;
 
@@ -20,22 +17,22 @@ message Config {
   repeated FrontendSpec frontends = 3;
   repeated BackendSpec backends = 4;
   repeated CacheSpec caches = 5;
-  repeated DiskSpec disks = 7;
+  repeated DiskSpec disks = 6;
 
   // Number of deterministic finger-table entries to derive per peer. Defaults to 100 when unset.
-  optional uint32 fingers_per_node = 8;
+  optional uint32 fingers_per_node = 7;
 
   // Name of this process in the `peers` roster. Required when peers or a
   // routing plan are configured. The internal ring and fabric ids are derived
   // from this peer name and are startup-fixed.
-  string self = 9;
+  string self = 8;
 
   // Precomputed routing table for this process. When set, `peers` can be
   // sparse, containing only this process's routing neighbors.
-  optional RoutingPlan routing_plan = 11;
+  optional RoutingPlan routing_plan = 9;
 
   // Process-wide peer definitions for the globally shared transport mesh.
-  repeated PeerSpec peers = 12;
+  repeated PeerSpec peers = 10;
 }
 
 // A precomputed routing table for a single node, produced by a
@@ -76,7 +73,7 @@ message TcpPeerConfig {
 message RdmaPeerConfig {
   // Default RDMA fabric address. Provider-native addresses are encoded as
   // "hex:<fi_getname-bytes>"; RDMA-CM socket addresses are accepted when the
-  // provider reports them. Kept for single-endpoint peers and older writers.
+  // provider reports them.
   string addr = 1;
 
   // Ordered RDMA fabric addresses for peers that expose multiple fabric units,
@@ -192,27 +189,27 @@ message DiskSpec {
 
   // Destructively resets the cache index on open, ignoring any existing on-disk metadata.
   // Intended only for benchmark cache devices that are safe to reformat between runs.
-  bool force_format = 6;
+  bool force_format = 4;
 
   // Admit every write into the cache index instead of requiring the default
   // second touch. Intended for benchmark warmups that must prefill NVMe devices
   // with a cold synthetic keyspace.
-  bool bypass_admission = 7;
+  bool bypass_admission = 5;
 
   // Serve reads from the committed in-memory index mirror instead of reading
   // the terminal btree leaf from disk. Intended only for benchmark devices
   // where recovery/corruption validation has been deliberately traded for
   // measuring the data-page path.
-  bool bypass_index_read = 8;
+  bool bypass_index_read = 6;
 
   // Skip data checksum validation on reads. Intended only for benchmark
   // devices where cache contents were just populated by the same daemon and
   // the target is measuring the NVMe data path rather than CPU checksum cost.
-  bool bypass_checksum = 9;
+  bool bypass_checksum = 7;
 
   oneof config {
-    BlockDiskConfig block = 4;
-    FileDiskConfig file = 5;
+    BlockDiskConfig block = 8;
+    FileDiskConfig file = 9;
   }
 }
 

--- a/cmd/unbounded-storage/ARCHITECTURE.md
+++ b/cmd/unbounded-storage/ARCHITECTURE.md
@@ -562,9 +562,10 @@ reloadable sections are
 reconciled in place on the live shard layer **without a restart**: the
 peer/disk/routing surfaces and each shard's backend and frontend
 registries are all updated without tearing the shard layer down. Backing
-memory, the topology plan, and the fabric max in-flight knob are fixed at
-startup (sourced from the config `[startup]` section, see the CLI
-section), not reloadable config fields.
+memory, the topology plan, the fabric max in-flight knob, and the local
+`self` peer identity are fixed at startup (mostly sourced from the
+config `[startup]` section, see the CLI section), not reloadable config
+fields.
 
 Sections (all optional, each falling back to defaults):
 
@@ -572,17 +573,15 @@ Sections (all optional, each falling back to defaults):
 - `[[backends]]` - `name` and one `config` table: `http`, `s3`, or `azure`
   with a required `url`, or `fake` for synthetic objects. Backend stripe size
   must be a power of two.
-- `[[neighborhoods]]` - `name`, `source` (a backend component name),
-  `local_node_id`, `local_tags`, `fingers_per_node` (100), and an optional
-  `[neighborhoods.routing_plan]` (`fingers`, `successor`, `predecessor`). When
+- `self`, `fingers_per_node` (100), optional `[routing_plan]` (`fingers`,
+  `successor`, `predecessor`), and `[[peers]]` define the process-wide
+  transport mesh. `self` selects the local peer by name; internal fabric peer
+  id and ring position are derived from that name and are startup-fixed. When
   `routing_plan` is present the node skips the global finger-table build and
-  uses exactly the listed neighbor ids (each must be a
-  `[[neighborhoods.peers]]` id, none may be `local_node_id`). This is "disjoint
-  discovery": a node is told only its direct routing neighbors rather than the
-  full cluster, yet routes identically to the global build (see
-  `designs/storage-disjoint-routing-parity.md`). If multiple neighborhoods set
-  `local_node_id`, they must set the same value because the fabric connection
-  layer has one process-wide self peer id.
+  uses exactly the listed neighbor names (each must be a `[[peers]]` name, none
+  may equal `self`). This is "disjoint discovery": a node is told only its
+  direct routing neighbors rather than the full cluster, yet routes identically
+  to the global build (see `designs/storage-disjoint-routing-parity.md`).
 - `[startup]` - startup-fixed knobs, read once at process start and
   excluded from the live-reload diff: `[startup.memory]`
   (`no_hugepages`, `memory_total_bytes`), `[startup.fabric]` (`binds`,
@@ -593,20 +592,24 @@ Sections (all optional, each falling back to defaults):
   `startup_to_core_plan_config` inverts the negative plan fields so the
   historical defaults hold. See the CLI section for the per-field
   defaults.
-- `[[neighborhoods.peers]]` - `id` (process-wide fabric peer id, also used as
-  the node's ring position within this neighborhood), `tags` for
-  placement-aware routing, and one transport table (`tcp` with a `SocketAddr`,
-  or `rdma` with a provider-native address encoded as
-  `hex:<fi_getname-bytes>`). The same peer id may appear in multiple
-  neighborhoods only with identical peer data.
-- `[[caches]]` - `name` and `source` (a backend or neighborhood component name).
+- `[[peers]]` - `name` (stable peer identity used to derive the internal fabric
+  peer id and ring position), `tags` for placement-aware routing, and one
+  transport table (`tcp` with a `SocketAddr`, or `rdma` with a provider-native
+  address encoded as `hex:<fi_getname-bytes>`). The roster includes the local
+  peer named by `self`; fabric reconciliation excludes that local entry from
+  outbound dials.
+- `[[caches]]` - `name` and `source` (a backend component name used for miss
+  fills). The cache name is the only logical keyspace prefix: cached stripe
+  keys are derived from cache id, logical object id, and stripe index, not from
+  backend or frontend ids. Changing a cache's backend does not invalidate its
+  existing keys.
 - `[[disks]]` - the shared local disk set available to every cache. Each disk has one
   `config` table (`block` with `path` and optional `numa`, or `file` with
   `path` and required `size`), `queue_depth` (optional), `page_size_bytes`, and
   `skip_recovery_scan` (fields that disk reconcile treats as drift, see 7.10).
   Disk paths must be unique across the shared set.
-- `[[frontends]]` - `name`, `source` (a backend, cache, or neighborhood
-  component name), and one `config` table (`http`, `s3`, or `loadgen`).
+- `[[frontends]]` - `name`, `source` (a backend or cache component name), and
+  one `config` table (`http`, `s3`, or `loadgen`).
 
 The watcher (`notify`-based) emits `ConfigUpdate`s; main's
 `wait_for_shutdown_with_updates` reconciles peers (remove + add on address/numa

--- a/cmd/unbounded-storage/README.md
+++ b/cmd/unbounded-storage/README.md
@@ -82,15 +82,20 @@ reloadable cluster state and the startup-fixed knobs (the fabric
 endpoint and threads, the fabric in-flight cap, memory sizing, CPU
 topology). The latter live in the `[startup]` section; they are read
 once at process start and cannot change without a restart, so they are
-deliberately excluded from the live-reload diff. The daemon tracks two
-config versions independently: the applied config version (advances as
-reloadable state is applied) and the startup config version (pinned to
-the config realized at process start). A later config that only changes
-a `[startup]` field bumps the applied version but leaves the startup
-version behind until the daemon restarts.
+deliberately excluded from the live-reload diff. The top-level `self`
+peer name is also startup-fixed because the process-wide fabric and ring
+identities are derived from it. The daemon tracks two config versions
+independently: the applied config version (advances as reloadable state
+is applied) and the startup config version (pinned to the config realized
+at process start). A later config that only changes a startup-fixed field
+bumps the applied version but leaves the startup version behind until the
+daemon restarts.
 
 ```toml
 # unbounded-storage.toml
+
+self = "node-a"                 # startup-fixed local peer name.
+fingers_per_node = 100           # routing finger-table fanout per node.
 
 [[backends]]
 name = "origin"
@@ -99,40 +104,39 @@ name = "origin"
 url = "origin.example.com:80"    # host:port resolved for origin fetches.
 stripe_size_bytes = 4194304      # optional; must be a power of two.
 
-[[neighborhoods]]
-name = "p2p"
-source = "origin"               # backend component name.
-local_node_id = 1                # u64; daemon/fabric id, shared across neighborhoods.
-local_tags = ["region-a", "rack-1"]
-fingers_per_node = 100           # routing finger-table fanout per node.
-
 # Optional. Disjoint discovery: configure this node with ONLY its direct
 # routing neighbors instead of the full cluster. When present, the global
-# finger-table build is bypassed and these ids are used verbatim. Every id
-# must reference a [[neighborhoods.peers]] entry below and must not be
-# local_node_id. The
+# finger-table build is bypassed and these peer names are used verbatim. Every
+# name must reference a [[peers]] entry below and must not equal self. The
 # resulting routes are identical to the global build fed the same neighbors,
-# so a controller with global view can plan these per node (see
+# so a controller with global view can plan these per process (see
 # designs/storage-disjoint-routing-parity.md).
-# [neighborhoods.routing_plan]
-# fingers     = [2, 5, 9, 17]    # ids of this node's finger neighbors.
-# successor   = 2                # id of the nearest forward neighbor on the ring.
-# predecessor = 64               # id of the nearest backward neighbor on the ring.
+# [routing_plan]
+# fingers     = ["node-b", "node-c"]
+# successor   = "node-b"        # nearest forward neighbor on the ring.
+# predecessor = "node-z"        # nearest backward neighbor on the ring.
 
-[[neighborhoods.peers]]          # repeat per remote peer; ids are fabric ids.
-id        = 2                    # u64, process-wide peer id and ring position.
+[[peers]]                        # include self plus remote peers.
+name      = "node-a"             # ring/fabric ids are derived from this name.
+tags      = ["region-a", "rack-1"]
+
+[peers.config.tcp]
+addr      = "10.0.0.10:9000"     # advertised local fabric address.
+
+[[peers]]
+name      = "node-b"
 tags      = ["region-a", "rack-2"]
 
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr      = "10.0.0.1:9000"      # parsed as SocketAddr.
 
 # Or, for RDMA peers:
-# [neighborhoods.peers.config.rdma]
+# [peers.config.rdma]
 # addr     = "hex:deadbeef"      # provider-native libfabric address bytes.
 
 [[caches]]
 name = "cache"
-source = "p2p"                  # backend or neighborhood component name.
+source = "origin"               # backend used for miss fills.
 
 [[disks]]                        # repeat per local device; paths must be unique.
 queue_depth = 32                 # optional u32; per-disk io_uring depth.
@@ -149,7 +153,7 @@ numa        = 0                  # optional u16; biases the open onto a CPU on t
 
 [[frontends]]
 name = "http"
-source = "cache"                # backend, cache, or neighborhood component name.
+source = "cache"                # backend or cache component name.
 
 [frontends.config.http]
 addr = "0.0.0.0:9000"

--- a/cmd/unbounded-storage/build.rs
+++ b/cmd/unbounded-storage/build.rs
@@ -102,7 +102,6 @@ fn generate_config_schema() {
         "BlockDiskConfig",
         "FileDiskConfig",
         "CacheSpec",
-        "NeighborhoodSpec",
         "BackendSpec",
         "HttpBackendConfig",
         "S3BackendConfig",
@@ -125,6 +124,7 @@ fn generate_config_schema() {
         prost.type_attribute(msg, "#[derive(::serde::Deserialize)]");
         prost.type_attribute(msg, "#[serde(default, deny_unknown_fields)]");
     }
+    prost.field_attribute("Config.self", "#[serde(rename = \"self\")]");
 
     for oneof in [
         "PeerSpec.config",

--- a/cmd/unbounded-storage/src/backend/fake.rs
+++ b/cmd/unbounded-storage/src/backend/fake.rs
@@ -2,31 +2,31 @@
 // Licensed under the MIT License.
 
 //! Synthetic origin backend for benchmarking. [`FakeBackend`] serves
-//! zero-filled objects of a single fixed size without any network I/O,
-//! so the cache and frontend read path can be load-tested in production
-//! without standing up a real origin.
+//! deterministic loadgen objects of a single fixed size without any
+//! network I/O, so the cache and frontend read path can be load-tested
+//! in production without standing up a real origin.
 //!
 //! It mirrors [`HttpBackend`](super::http::HttpBackend)'s
 //! `Backend`/`PageStream` shape but collapses the whole fetch to a
 //! synchronous page fill: there is no ring, no socket, and no future to
-//! drive. A data request zero-fills the destination pages directly; a
-//! metadata request writes the object's [`ObjectMetadata`] (carrying the
-//! fixed `object_size`) so the frontend learns the object's length and
-//! clamps served reads to it. Because the fill is synchronous and
-//! borrows nothing, the produced [`FakeFetchStream`] is fully owned and
-//! the backend can be served from behind an `Arc`/`ArcSwap` just like
-//! the real origin backends.
+//! drive. A data request fills destination pages from the shared
+//! deterministic synthetic object contract; a metadata request writes
+//! the object's [`ObjectMetadata`] (carrying the fixed `object_size`) so
+//! the frontend learns the object's length and clamps served reads to it.
+//! Because the fill is synchronous, the produced [`FakeFetchStream`]
+//! only needs to borrow the destination-page slice long enough to yield
+//! those copied page refs back to the pool.
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::bufferpool::{BulkRef, Error, PageRef, PageStream};
-use crate::storage::{ObjectMetadata, StripeReq};
+use crate::storage::{ObjectMetadata, StripeReq, fill_synthetic_pages, parse_synthetic_object_id};
 
 use super::Backend;
 use super::http::copy_body_into_pages;
 
-/// Origin backend that synthesizes zero-filled objects of a fixed size.
+/// Origin backend that synthesizes deterministic objects of a fixed size.
 ///
 /// Shard-pinned for the same reason as
 /// [`HttpBackend`](super::http::HttpBackend): the raw `backing_base`
@@ -35,7 +35,8 @@ use super::http::copy_body_into_pages;
 /// cross-thread concern is the backing pointer.
 pub struct FakeBackend {
     backend_id: String,
-    object_size: u64,
+    stripe_size: u64,
+    metadata_body: Box<[u8]>,
     page_size: usize,
     backing_base: *mut u8,
 }
@@ -52,13 +53,20 @@ unsafe impl Sync for FakeBackend {}
 impl FakeBackend {
     pub fn new(
         backend_id: String,
+        stripe_size: u64,
         object_size: u64,
         page_size: usize,
         backing_base: *mut u8,
     ) -> Self {
+        let metadata_body = ObjectMetadata::new(object_size)
+            .encode()
+            .expect("fake backend metadata encoding should not fail")
+            .into_boxed_slice();
+
         Self {
             backend_id,
-            object_size,
+            stripe_size,
+            metadata_body,
             page_size,
             backing_base,
         }
@@ -70,56 +78,69 @@ impl FakeBackend {
         &self.backend_id
     }
 
-    /// Owned-stream variant of [`Backend::bulk_get`].
-    ///
     /// Fills the destination pages synchronously, then returns a stream
-    /// that yields each filled [`PageRef`] in order. The returned stream
-    /// borrows nothing from `self`, so it is `'static` (see the module
-    /// docs and [`super::registry::BackendRegistry`]).
-    pub fn fetch_stream(
+    /// that yields each filled [`PageRef`] in order.
+    pub fn fetch_stream<'a>(
         &self,
         req: &StripeReq,
-        _src: BulkRef,
-        dsts: &[PageRef],
-    ) -> FakeFetchStream {
-        let Some(origin) = req.origin() else {
-            return FakeFetchStream::immediate_error("fake backend: request missing origin");
-        };
-
-        let dsts_owned = dsts.to_vec();
-        // A metadata entry reports the object's length; a data request is
-        // a byte range whose synthetic content is all zeros. Both reduce
-        // to a page fill via `copy_body_into_pages` (an empty body
-        // zero-fills every destination byte).
-        let fill = if origin.is_metadata_entry() {
-            self.fill_metadata(&dsts_owned)
-        } else {
-            copy_body_into_pages(&[], &dsts_owned, self.backing_base, self.page_size)
-        };
-
-        match fill {
-            Ok(()) => FakeFetchStream::ready(dsts_owned),
+        src: BulkRef,
+        dsts: &'a [PageRef],
+    ) -> FakeFetchStream<'a> {
+        match self.fill(req, src, dsts) {
+            Ok(()) => FakeFetchStream::ready(dsts),
             Err(e) => FakeFetchStream::immediate_err(e),
+        }
+    }
+
+    pub(super) fn fill(
+        &self,
+        req: &StripeReq,
+        src: BulkRef,
+        dsts: &[PageRef],
+    ) -> Result<(), Error> {
+        let Some(origin) = req.origin() else {
+            return Err(Error::from("fake backend: request missing origin"));
+        };
+        let Some(object) = parse_synthetic_object_id(&origin.origin_object_id) else {
+            return Err(Error::from("fake backend: invalid synthetic object id"));
+        };
+
+        if origin.is_metadata_entry() {
+            self.fill_metadata(dsts)
+        } else {
+            let Some(start_offset) = origin
+                .stripe_idx
+                .checked_mul(self.stripe_size)
+                .and_then(|base| base.checked_add(src.offset))
+            else {
+                return Err(Error::from("fake backend: synthetic offset overflow"));
+            };
+            fill_synthetic_pages(
+                object,
+                start_offset,
+                dsts,
+                self.backing_base,
+                self.page_size,
+            )
         }
     }
 
     /// Encode the object's [`ObjectMetadata`] and write it into the
     /// metadata entry's destination page(s).
     fn fill_metadata(&self, dsts: &[PageRef]) -> Result<(), Error> {
-        let body = ObjectMetadata::new(self.object_size).encode()?;
         let capacity: usize = dsts.iter().map(|p| p.len as usize).sum();
-        if body.len() > capacity {
+        if self.metadata_body.len() > capacity {
             return Err(Error::from(
                 "fake backend: metadata entry destination too small",
             ));
         }
-        copy_body_into_pages(&body, dsts, self.backing_base, self.page_size)
+        copy_body_into_pages(&self.metadata_body, dsts, self.backing_base, self.page_size)
     }
 }
 
 impl Backend for FakeBackend {
     type Req = StripeReq;
-    type Stream<'a> = FakeFetchStream;
+    type Stream<'a> = FakeFetchStream<'a>;
 
     fn bulk_get<'a>(
         &'a self,
@@ -135,10 +156,9 @@ impl Backend for FakeBackend {
 /// filled by the time it is constructed, so it simply yields each
 /// destination [`PageRef`] in order followed by `None`. On a fill error
 /// it yields that error once then `None`.
-pub struct FakeFetchStream {
+pub struct FakeFetchStream<'a> {
+    delivered: &'a [PageRef],
     state: FillState,
-    /// The destination pages to yield, in order.
-    delivered: Vec<PageRef>,
     next: usize,
 }
 
@@ -151,33 +171,25 @@ enum FillState {
     Done,
 }
 
-impl FakeFetchStream {
-    fn ready(delivered: Vec<PageRef>) -> Self {
+impl<'a> FakeFetchStream<'a> {
+    fn ready(delivered: &'a [PageRef]) -> Self {
         Self {
-            state: FillState::Delivering,
             delivered,
-            next: 0,
-        }
-    }
-
-    fn immediate_error(msg: &'static str) -> Self {
-        Self {
-            state: FillState::Failed(Some(Error::from(msg))),
-            delivered: Vec::new(),
+            state: FillState::Delivering,
             next: 0,
         }
     }
 
     fn immediate_err(err: Error) -> Self {
         Self {
+            delivered: &[],
             state: FillState::Failed(Some(err)),
-            delivered: Vec::new(),
             next: 0,
         }
     }
 }
 
-impl PageStream for FakeFetchStream {
+impl PageStream for FakeFetchStream<'_> {
     fn poll_next(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
@@ -230,8 +242,7 @@ mod tests {
 
     /// A backing buffer of `pages` contiguous pages plus the `PageRef`s
     /// that address them. The buffer is pre-filled with `0xAA` so a test
-    /// can prove the backend actually wrote zeros (rather than the page
-    /// having been zero to begin with).
+    /// can prove the backend actually wrote synthetic content.
     fn backing(pages: usize) -> (Vec<u8>, Vec<PageRef>) {
         let buf = vec![0xAAu8; pages * PAGE_SIZE];
         let dsts = (0..pages)
@@ -242,6 +253,16 @@ mod tests {
             })
             .collect();
         (buf, dsts)
+    }
+
+    fn fake_backend<'a>(buf: &'a mut [u8], object_size: u64) -> FakeBackend {
+        FakeBackend::new(
+            "fake".into(),
+            PAGE_SIZE as u64,
+            object_size,
+            PAGE_SIZE,
+            buf.as_mut_ptr(),
+        )
     }
 
     /// Drive a stream to completion, returning the yielded pages.
@@ -260,11 +281,13 @@ mod tests {
     }
 
     #[test]
-    fn data_request_zero_fills_every_page() {
+    fn data_request_fills_deterministic_bytes() {
         let (mut buf, dsts) = backing(2);
-        let backend = FakeBackend::new("fake".into(), 8192, PAGE_SIZE, buf.as_mut_ptr());
+        let backend = fake_backend(&mut buf, 8192);
 
-        let origin = OriginRef::new("fake", "obj", 0);
+        let object_id = crate::storage::synthetic_object_id(7, 11);
+        let object = crate::storage::parse_synthetic_object_id(&object_id).unwrap();
+        let origin = OriginRef::new("fake", object_id, 0);
         let req = StripeReq::new(origin.stripe_key()).with_origin(origin);
         let src = BulkRef {
             stripe: origin_key(),
@@ -274,19 +297,33 @@ mod tests {
 
         let pages = drain(backend.fetch_stream(&req, src, &dsts)).expect("fill");
         assert_eq!(pages.len(), 2, "every destination page must be yielded");
-        assert!(
-            buf.iter().all(|&b| b == 0),
-            "data pages must be fully zero-filled",
-        );
+        assert!(crate::storage::synthetic_matches_bytes(object, 0, &buf));
+    }
+
+    #[test]
+    fn invalid_synthetic_object_id_errors() {
+        let (mut buf, dsts) = backing(1);
+        let backend = fake_backend(&mut buf, 4096);
+
+        let origin = OriginRef::new("fake", "obj", 0);
+        let req = StripeReq::new(origin.stripe_key()).with_origin(origin);
+        let src = BulkRef {
+            stripe: origin_key(),
+            offset: 0,
+            len: PAGE_SIZE as u32,
+        };
+
+        drain(backend.fetch_stream(&req, src, &dsts))
+            .expect_err("invalid synthetic object id must error");
     }
 
     #[test]
     fn metadata_request_reports_configured_object_size() {
         let object_size = 7 * 1024 * 1024;
         let (mut buf, dsts) = backing(1);
-        let backend = FakeBackend::new("fake".into(), object_size, PAGE_SIZE, buf.as_mut_ptr());
+        let backend = fake_backend(&mut buf, object_size);
 
-        let origin = OriginRef::metadata_entry("fake", "obj");
+        let origin = OriginRef::metadata_entry("fake", crate::storage::synthetic_object_id(7, 11));
         let req = StripeReq::new(origin.stripe_key()).with_origin(origin);
         let src = BulkRef {
             stripe: origin_key(),
@@ -303,7 +340,13 @@ mod tests {
 
     #[test]
     fn missing_origin_yields_one_error_then_ends() {
-        let backend = FakeBackend::new("fake".into(), 4096, PAGE_SIZE, ptr::null_mut());
+        let backend = FakeBackend::new(
+            "fake".into(),
+            PAGE_SIZE as u64,
+            4096,
+            PAGE_SIZE,
+            ptr::null_mut(),
+        );
         let req = StripeReq::new(origin_key());
         let dsts: Vec<PageRef> = Vec::new();
         let src = BulkRef {
@@ -318,6 +361,6 @@ mod tests {
     }
 
     fn origin_key() -> StripeKey {
-        OriginRef::new("fake", "obj", 0).stripe_key()
+        OriginRef::new("fake", crate::storage::synthetic_object_id(7, 11), 0).stripe_key()
     }
 }

--- a/cmd/unbounded-storage/src/backend/origin.rs
+++ b/cmd/unbounded-storage/src/backend/origin.rs
@@ -5,16 +5,15 @@
 //!
 //! The node configures exactly one origin tier per `backend_id`, but
 //! that tier may be a plaintext HTTP origin ([`HttpBackend`]), an
-//! S3-compatible origin ([`S3Backend`]), or an Azure Blob origin
-//! ([`AzureBackend`]). Rather than box the backend
-//! behind `dyn Backend` (which the [`Backend`] trait's generic
-//! associated `Stream<'a>` type forbids without erasing the stream),
-//! [`OriginBackend`] is a static enum the embedder selects at
-//! construction time. Its [`Backend::Stream`] is [`OriginStream`], an
-//! enum that wraps whichever concrete stream the chosen backend
-//! produces and delegates [`PageStream::poll_next`] to it.
+//! S3-compatible origin ([`S3Backend`]), an Azure Blob origin
+//! ([`AzureBackend`]), or a synthetic [`FakeBackend`] for benchmarking.
+//! Rather than box the backend behind `dyn Backend` (which the
+//! [`Backend`] trait's generic associated `Stream<'a>` type forbids
+//! without erasing the stream), [`OriginBackend`] is a static enum the
+//! embedder selects at construction time.
 
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crate::bufferpool::{BulkRef, Error, PageRef, PageStream};
@@ -24,9 +23,7 @@ use super::{AzureBackend, Backend, FakeBackend, HttpBackend, S3Backend};
 
 /// One configured origin tier: a plaintext HTTP origin, an
 /// S3-compatible origin, an Azure Blob origin, or a synthetic
-/// [`FakeBackend`] for benchmarking. Implements [`Backend`] by
-/// delegating to the inner backend and wrapping its stream in
-/// [`OriginStream`].
+/// [`FakeBackend`] for benchmarking.
 pub enum OriginBackend {
     Http(HttpBackend),
     S3(S3Backend),
@@ -35,30 +32,41 @@ pub enum OriginBackend {
 }
 
 impl OriginBackend {
-    /// Owned-stream variant of [`Backend::bulk_get`]. Delegates to the
-    /// inner backend's `fetch_stream`, which borrows nothing from the
-    /// backend, so the returned [`OriginStream`] is `'static`. This is
-    /// what lets a [`super::registry::BackendRegistry`] serve a fetch
-    /// from a backend it holds behind an `Arc`/`ArcSwap` without the
-    /// temporary `Arc` guard having to outlive the stream.
-    pub fn fetch_stream(
-        &self,
+    /// Owned-stream variant used by [`super::registry::BackendRegistry`].
+    /// The registry gives the stream an `Arc` guard so a backend can be
+    /// borrowed safely without forcing every concrete backend to copy its
+    /// destination-page slice.
+    pub fn fetch_stream<'a>(
+        backend: Arc<Self>,
         req: &StripeReq,
         src: BulkRef,
-        dsts: &[PageRef],
-    ) -> OriginStream<'static> {
-        match self {
+        dsts: &'a [PageRef],
+    ) -> OriginStream<'a> {
+        match backend.as_ref() {
             OriginBackend::Http(b) => OriginStream::Http(b.fetch_stream(req, src, dsts)),
             OriginBackend::S3(b) => OriginStream::S3(b.fetch_stream(req, src, dsts)),
             OriginBackend::Azure(b) => OriginStream::Azure(b.fetch_stream(req, src, dsts)),
-            OriginBackend::Fake(b) => OriginStream::Fake(b.fetch_stream(req, src, dsts)),
+            OriginBackend::Fake(b) => match b.fill(req, src, dsts) {
+                Ok(()) => OriginStream::Fake {
+                    backend,
+                    delivered: dsts,
+                    state: FakeOwnedState::Delivering,
+                    next: 0,
+                },
+                Err(e) => OriginStream::Fake {
+                    backend,
+                    delivered: &[],
+                    state: FakeOwnedState::Failed(Some(e)),
+                    next: 0,
+                },
+            },
         }
     }
 }
 
 impl Backend for OriginBackend {
     type Req = StripeReq;
-    type Stream<'a> = OriginStream<'a>;
+    type Stream<'a> = OriginBorrowedStream<'a>;
 
     fn bulk_get<'a>(
         &'a self,
@@ -66,28 +74,32 @@ impl Backend for OriginBackend {
         src: BulkRef,
         dsts: &'a [PageRef],
     ) -> Self::Stream<'a> {
-        // NB: this cannot delegate to the inherent `fetch_stream`, which
-        // returns `OriginStream<'static>`: `OriginStream<'a>` projects
-        // each inner backend's associated `Stream<'a>` and so is
-        // invariant in `'a`, which blocks the `'static -> 'a` coercion.
-        // The inner `bulk_get`s build the correctly-lifetimed stream.
         match self {
-            OriginBackend::Http(b) => OriginStream::Http(b.bulk_get(req, src, dsts)),
-            OriginBackend::S3(b) => OriginStream::S3(b.bulk_get(req, src, dsts)),
-            OriginBackend::Azure(b) => OriginStream::Azure(b.bulk_get(req, src, dsts)),
-            OriginBackend::Fake(b) => OriginStream::Fake(b.bulk_get(req, src, dsts)),
+            OriginBackend::Http(b) => OriginBorrowedStream::Http(b.bulk_get(req, src, dsts)),
+            OriginBackend::S3(b) => OriginBorrowedStream::S3(b.bulk_get(req, src, dsts)),
+            OriginBackend::Azure(b) => OriginBorrowedStream::Azure(b.bulk_get(req, src, dsts)),
+            OriginBackend::Fake(b) => OriginBorrowedStream::Fake(b.bulk_get(req, src, dsts)),
         }
     }
 }
 
-/// Stream produced by [`OriginBackend::bulk_get`]: whichever concrete
-/// page stream the selected inner backend yields. [`PageStream`] is
-/// delegated to the active variant.
+/// Stream produced by [`OriginBackend::fetch_stream`] for registry use.
 pub enum OriginStream<'a> {
-    Http(<HttpBackend as Backend>::Stream<'a>),
-    S3(<S3Backend as Backend>::Stream<'a>),
-    Azure(<AzureBackend as Backend>::Stream<'a>),
-    Fake(<FakeBackend as Backend>::Stream<'a>),
+    Http(<HttpBackend as Backend>::Stream<'static>),
+    S3(<S3Backend as Backend>::Stream<'static>),
+    Azure(<AzureBackend as Backend>::Stream<'static>),
+    Fake {
+        backend: Arc<OriginBackend>,
+        delivered: &'a [PageRef],
+        state: FakeOwnedState,
+        next: usize,
+    },
+}
+
+enum FakeOwnedState {
+    Delivering,
+    Failed(Option<Error>),
+    Done,
 }
 
 impl PageStream for OriginStream<'_> {
@@ -95,14 +107,60 @@ impl PageStream for OriginStream<'_> {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<PageRef, Error>>> {
-        // Both inner streams are `Unpin` (their only pinned state is a
-        // `Pin<Box<dyn Future>>`, which is itself `Unpin`), so the enum
-        // is `Unpin` and the inner streams can be re-pinned in place.
         match self.get_mut() {
             OriginStream::Http(s) => Pin::new(s).poll_next(cx),
             OriginStream::S3(s) => Pin::new(s).poll_next(cx),
             OriginStream::Azure(s) => Pin::new(s).poll_next(cx),
-            OriginStream::Fake(s) => Pin::new(s).poll_next(cx),
+            OriginStream::Fake {
+                backend,
+                delivered,
+                state,
+                next,
+            } => {
+                let _keepalive = backend;
+                loop {
+                    match state {
+                        FakeOwnedState::Delivering => {
+                            if *next >= delivered.len() {
+                                *state = FakeOwnedState::Done;
+                                return Poll::Ready(None);
+                            }
+
+                            let page = delivered[*next];
+                            *next += 1;
+                            return Poll::Ready(Some(Ok(page)));
+                        }
+                        FakeOwnedState::Failed(slot) => {
+                            let e = slot.take();
+                            *state = FakeOwnedState::Done;
+                            return Poll::Ready(e.map(Err));
+                        }
+                        FakeOwnedState::Done => return Poll::Ready(None),
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Stream produced by direct [`OriginBackend::bulk_get`] calls.
+pub enum OriginBorrowedStream<'a> {
+    Http(<HttpBackend as Backend>::Stream<'a>),
+    S3(<S3Backend as Backend>::Stream<'a>),
+    Azure(<AzureBackend as Backend>::Stream<'a>),
+    Fake(<FakeBackend as Backend>::Stream<'a>),
+}
+
+impl PageStream for OriginBorrowedStream<'_> {
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<PageRef, Error>>> {
+        match self.get_mut() {
+            OriginBorrowedStream::Http(s) => Pin::new(s).poll_next(cx),
+            OriginBorrowedStream::S3(s) => Pin::new(s).poll_next(cx),
+            OriginBorrowedStream::Azure(s) => Pin::new(s).poll_next(cx),
+            OriginBorrowedStream::Fake(s) => Pin::new(s).poll_next(cx),
         }
     }
 }

--- a/cmd/unbounded-storage/src/backend/registry.rs
+++ b/cmd/unbounded-storage/src/backend/registry.rs
@@ -184,6 +184,7 @@ impl BuildCtx {
             }
             Some(backend_spec::Config::Fake(cfg)) => Ok(OriginBackend::Fake(FakeBackend::new(
                 spec.name.clone(),
+                cfg.stripe_size_bytes.expect("stripe_size_bytes defaulted"),
                 cfg.object_size_bytes.expect("object_size_bytes defaulted"),
                 self.page_size,
                 self.backing_base,
@@ -232,7 +233,7 @@ fn build_origin_endpoint(
 
 impl Backend for BackendRegistry {
     type Req = StripeReq;
-    type Stream<'a> = RegistryFetchStream;
+    type Stream<'a> = RegistryFetchStream<'a>;
 
     fn bulk_get<'a>(
         &'a self,
@@ -246,10 +247,12 @@ impl Backend for BackendRegistry {
         };
         let map = self.backends.load();
         match map.get(backend_id) {
-            // `fetch_stream` returns a fully owned `'static` stream that
-            // borrows nothing from the backend, so the `Arc` guard can
-            // be dropped the moment the call returns.
-            Some(backend) => RegistryFetchStream::Origin(backend.fetch_stream(req, src, dsts)),
+            Some(backend) => RegistryFetchStream::Origin(OriginBackend::fetch_stream(
+                Arc::clone(backend),
+                req,
+                src,
+                dsts,
+            )),
             None => RegistryFetchStream::unknown(backend_id),
         }
     }
@@ -289,12 +292,12 @@ impl BackendReconcileTarget for BackendRegistry {
 /// guarantees every frontend's backend exists), but a request can race
 /// a `remove`, so it is surfaced as a transport error rather than a
 /// panic.
-pub enum RegistryFetchStream {
-    Origin(OriginStream<'static>),
+pub enum RegistryFetchStream<'a> {
+    Origin(OriginStream<'a>),
     Unknown(Option<Error>),
 }
 
-impl RegistryFetchStream {
+impl RegistryFetchStream<'_> {
     fn unknown(backend_id: &str) -> Self {
         let msg = format!("unknown backend id: {backend_id:?}");
         let err = Error::transport(io::Error::new(io::ErrorKind::NotFound, msg));
@@ -302,7 +305,7 @@ impl RegistryFetchStream {
     }
 }
 
-impl PageStream for RegistryFetchStream {
+impl PageStream for RegistryFetchStream<'_> {
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/cmd/unbounded-storage/src/bufferpool/pool.rs
+++ b/cmd/unbounded-storage/src/bufferpool/pool.rs
@@ -815,7 +815,7 @@ where
                     // A bypass request bridges straight to the origin:
                     // skip the local-disk lookup so the miss path always
                     // drives the transport (which forces the origin too).
-                    let hit = if req.as_ref().bypass() {
+                    let hit = if req.as_ref().bypass() || req.as_ref().skip_local_disk() {
                         false
                     } else {
                         inner
@@ -878,7 +878,7 @@ where
                 // across the tee via `tee_pending` plus the
                 // leader's `ConsumerHold`.
                 // A bypass request never admits to the disk cache.
-                let need_tee = !hit && !req.as_ref().bypass();
+                let need_tee = !hit && !req.as_ref().bypass() && !req.as_ref().skip_local_disk();
                 if need_tee {
                     slot.tee_pending.set(true);
                 }

--- a/cmd/unbounded-storage/src/bufferpool/traits.rs
+++ b/cmd/unbounded-storage/src/bufferpool/traits.rs
@@ -26,16 +26,26 @@ pub trait Req {
         false
     }
 
+    /// Benchmark-only local-disk bypass. Unlike [`Req::bypass`], this
+    /// leaves peer routing enabled but skips the initiator's local disk
+    /// lookup/writeback. Peer handlers still consult their own local
+    /// store, so remote NVMe reads remain in the path.
+    fn skip_local_disk(&self) -> bool {
+        false
+    }
+
     /// Stable cache namespace selected by the frontend binding. `None` means
-    /// this request has no local cache tier.
+    /// this request has no local cache tier or mesh route.
     fn cache_id(&self) -> Option<&String> {
         None
     }
 
-    /// Stable P2P neighborhood selected by the frontend binding. `None` means
-    /// origin routing after a local miss.
-    fn neighborhood_id(&self) -> Option<&String> {
-        None
+    /// Benchmark-only fast response mode. Normal requests use the
+    /// production store/backend path; request types that return true let
+    /// peer handlers synthesize response pages while still using the
+    /// real fabric RPC/RMA path.
+    fn fabric_only(&self) -> bool {
+        false
     }
 }
 

--- a/cmd/unbounded-storage/src/config/apply.rs
+++ b/cmd/unbounded-storage/src/config/apply.rs
@@ -5,13 +5,17 @@
 //! types. Kept separate so the schema crate never has to depend on the
 //! daemon's runtime types and vice versa.
 
-use crate::fabric::{ConnectionSpec, FabricAddress, PeerId};
+use std::net::SocketAddr;
 
-use super::schema::{PeerSpec, peer_spec};
+use crate::fabric::{ConnectionSpec, FabricAddress, PeerId};
+use crate::p2p::node_id_from_name;
+
+use super::schema::{peer_spec, PeerSpec};
 
 pub fn peer_spec_to_connection(p: &PeerSpec) -> ConnectionSpec {
+    let node_id = node_id_from_name(&p.name);
     ConnectionSpec {
-        peer: PeerId(p.id),
+        peer: PeerId(node_id.0),
         address: peer_address(p),
         hca_numa: None,
         tags: p.tags.clone(),
@@ -21,8 +25,16 @@ pub fn peer_spec_to_connection(p: &PeerSpec) -> ConnectionSpec {
 fn peer_address(p: &PeerSpec) -> FabricAddress {
     match p.config.as_ref() {
         Some(peer_spec::Config::Tcp(cfg)) => FabricAddress::socket(cfg.addr.clone()),
-        Some(peer_spec::Config::Rdma(cfg)) => FabricAddress::native(cfg.addr.clone()),
+        Some(peer_spec::Config::Rdma(cfg)) => rdma_address(&cfg.addr),
         None => FabricAddress::native(""),
+    }
+}
+
+fn rdma_address(addr: &str) -> FabricAddress {
+    if addr.parse::<SocketAddr>().is_ok() {
+        FabricAddress::socket(addr.to_string())
+    } else {
+        FabricAddress::native(addr.to_string())
     }
 }
 
@@ -35,14 +47,14 @@ mod tests {
     #[test]
     fn tcp_peer_spec_maps_directly() {
         let p = PeerSpec {
-            id: 42,
+            name: "node-a".to_string(),
             tags: vec!["us-west".to_string(), "rack7".to_string()],
             config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
                 addr: "10.0.0.1:9000".into(),
             })),
         };
         let c = peer_spec_to_connection(&p);
-        assert_eq!(c.peer, PeerId(42));
+        assert_eq!(c.peer, PeerId(node_id_from_name("node-a").0));
         assert_eq!(c.address, FabricAddress::socket("10.0.0.1:9000"));
         assert_eq!(c.hca_numa, None);
         assert_eq!(c.tags, p.tags);
@@ -51,15 +63,33 @@ mod tests {
     #[test]
     fn rdma_peer_spec_maps_directly() {
         let p = PeerSpec {
-            id: 42,
+            name: "node-a".to_string(),
             tags: vec!["us-west".to_string(), "rack7".to_string()],
             config: Some(peer_spec::Config::Rdma(RdmaPeerConfig {
                 addr: "hex:01020304".into(),
+                addrs: Vec::new(),
             })),
         };
         let c = peer_spec_to_connection(&p);
-        assert_eq!(c.peer, PeerId(42));
+        assert_eq!(c.peer, PeerId(node_id_from_name("node-a").0));
         assert_eq!(c.address, FabricAddress::native("hex:01020304"));
+        assert_eq!(c.hca_numa, None);
+        assert_eq!(c.tags, p.tags);
+    }
+
+    #[test]
+    fn rdma_socket_peer_spec_maps_to_socket_address() {
+        let p = PeerSpec {
+            name: "node-a".to_string(),
+            tags: vec!["us-west".to_string(), "rack7".to_string()],
+            config: Some(peer_spec::Config::Rdma(RdmaPeerConfig {
+                addr: "10.0.0.1:9000".into(),
+                addrs: Vec::new(),
+            })),
+        };
+        let c = peer_spec_to_connection(&p);
+        assert_eq!(c.peer, PeerId(node_id_from_name("node-a").0));
+        assert_eq!(c.address, FabricAddress::socket("10.0.0.1:9000"));
         assert_eq!(c.hca_numa, None);
         assert_eq!(c.tags, p.tags);
     }

--- a/cmd/unbounded-storage/src/config/control.rs
+++ b/cmd/unbounded-storage/src/config/control.rs
@@ -561,6 +561,7 @@ mod tests {
         let mut c = Config::default();
         c.apply_defaults();
         c.version = version;
+        c.self_ = "node-a".to_string();
         c.backends.push(crate::config::BackendSpec {
             name: "b".to_string(),
             config: Some(crate::config::backend_spec::Config::Fake(
@@ -570,21 +571,13 @@ mod tests {
                 },
             )),
         });
-        c.neighborhoods.push(crate::config::NeighborhoodSpec {
-            name: "n".to_string(),
-            source: "b".to_string(),
-            fingers_per_node: Some(100),
-            local_node_id: Some(0),
-            local_tags: Vec::new(),
-            routing_plan: None,
-            peers: vec![tcp_peer(1, "127.0.0.1:9999")],
-        });
+        c.peers.push(tcp_peer("node-a", "127.0.0.1:9999"));
         c
     }
 
-    fn tcp_peer(id: u64, addr: &str) -> crate::config::PeerSpec {
+    fn tcp_peer(name: &str, addr: &str) -> crate::config::PeerSpec {
         crate::config::PeerSpec {
-            id,
+            name: name.to_string(),
             tags: Vec::new(),
             config: Some(crate::config::peer_spec::Config::Tcp(
                 crate::config::TcpPeerConfig {
@@ -628,9 +621,7 @@ mod tests {
         let mut ctrl = ConfigController::new(RecordingTarget::default(), base.clone());
 
         let mut next = config_with_peer(2);
-        next.neighborhoods[0]
-            .peers
-            .push(tcp_peer(2, "127.0.0.1:9998"));
+        next.peers.push(tcp_peer("node-b", "127.0.0.1:9998"));
 
         let out = ctrl.apply(Arc::new(next)).unwrap();
         assert_eq!(out.tier, ApplyTier::InPlace);
@@ -683,18 +674,13 @@ mod tests {
         let mut ctrl = ConfigController::new(target, base.clone());
 
         let mut next = config_with_peer(5);
-        next.neighborhoods[0]
-            .peers
-            .push(tcp_peer(2, "127.0.0.1:9998"));
+        next.peers.push(tcp_peer("node-b", "127.0.0.1:9998"));
         let next = Arc::new(next);
 
         assert!(ctrl.apply(next.clone()).is_err());
         // Current must still be the original so a retry re-derives the
         // same diff.
-        assert_eq!(
-            ctrl.current().neighborhoods[0].peers.len(),
-            base.neighborhoods[0].peers.len()
-        );
+        assert_eq!(ctrl.current().peers.len(), base.peers.len());
         // A failed apply records the version as known (we loaded it) but
         // must NOT advance the applied version: the process did not
         // converge on the submitted config.
@@ -720,9 +706,7 @@ mod tests {
         );
 
         let mut next = config_with_peer(11);
-        next.neighborhoods[0]
-            .peers
-            .push(tcp_peer(2, "127.0.0.1:9998"));
+        next.peers.push(tcp_peer("node-b", "127.0.0.1:9998"));
         ctrl.apply(Arc::new(next)).unwrap();
 
         assert_eq!(versions.known(), 11);
@@ -749,9 +733,7 @@ mod tests {
 
         // A failed apply advances known but neither applied nor startup.
         let mut failing = config_with_peer(7);
-        failing.neighborhoods[0]
-            .peers
-            .push(tcp_peer(2, "127.0.0.1:9998"));
+        failing.peers.push(tcp_peer("node-b", "127.0.0.1:9998"));
         assert!(ctrl.apply(Arc::new(failing)).is_err());
         assert_eq!(ctrl.config_versions().known(), 7);
         assert_eq!(ctrl.config_versions().applied(), 1);
@@ -761,9 +743,7 @@ mod tests {
         // still leaves startup pinned to the config realized at start.
         ctrl.target_mut().fail_in_place = false;
         let mut next = config_with_peer(8);
-        next.neighborhoods[0]
-            .peers
-            .push(tcp_peer(3, "127.0.0.1:9997"));
+        next.peers.push(tcp_peer("node-c", "127.0.0.1:9997"));
         ctrl.apply(Arc::new(next)).unwrap();
         assert_eq!(ctrl.config_versions().applied(), 8);
         assert_eq!(ctrl.config_versions().startup(), 1);

--- a/cmd/unbounded-storage/src/config/diff.rs
+++ b/cmd/unbounded-storage/src/config/diff.rs
@@ -10,10 +10,15 @@
 //! [`ConfigApplyTarget`](crate::config::ConfigApplyTarget) can skip
 //! untouched work:
 //!
-//! * **`[[neighborhoods]]`.** Rebuilds the projected routing surface,
-//!   republishes it to every shard, and reconciles fabric connections.
-//! * **`[[caches]]`.** Cache bindings participate in route selection, so cache
-//!   changes reload the projected routing surface and reconcile disks.
+//! * **process identity (`self`).** Startup-fixed because it determines the
+//!   process-wide fabric peer id. A change requires a restart.
+//! * **process routing (`fingers_per_node`, `routing_plan`).** Rebuilds the
+//!   projected routing surface and republishes it to every shard.
+//! * **`[[peers]]`.** Reconciles fabric connections and rebuilds the projected
+//!   routing surface. The peer named by `self` is used as the local topology
+//!   entry and is not dialed.
+//! * **`[[caches]]`.** Cache names are route ids, so cache changes reload the
+//!   projected routing surface and reconcile disks.
 //! * **`[[disks]]`.** Reconciled in place against the disk registry.
 //! * **`[[backends]]` / `[[frontends]]`.** Broadcast to every shard,
 //!   which reconciles its own origin-backend and frontend registries on
@@ -43,13 +48,17 @@ use crate::config::schema::Config;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ConfigDiff {
     /// `[[caches]]` changed. Reconciled in place against the disk registry;
-    /// may also alter which neighborhood a cache routes through.
+    /// may also alter which cache route ids exist.
     pub caches_changed: bool,
     /// `[[disks]]` changed. Reconciled in place against the disk registry.
     pub disks_changed: bool,
-    /// `[[neighborhoods]]` changed. Reconciles fabric connections and
-    /// rebuilds the routing surface.
-    pub neighborhoods_changed: bool,
+    /// `self` changed. This controls the fabric identity and requires restart.
+    pub identity_changed: bool,
+    /// Process-wide routing knobs changed. Rebuilds the routing surface.
+    pub routing_changed: bool,
+    /// `[[peers]]` changed. Reconciles fabric connections and rebuilds the
+    /// routing surface.
+    pub peers_changed: bool,
     /// `[[backends]]` changed. Broadcast to every shard, which rebuilds
     /// its origin-backend registry in place (no shard restart).
     pub backends_changed: bool,
@@ -68,7 +77,10 @@ impl ConfigDiff {
         Self {
             caches_changed: old.caches != new.caches,
             disks_changed: old.disks != new.disks,
-            neighborhoods_changed: old.neighborhoods != new.neighborhoods,
+            identity_changed: old.self_ != new.self_,
+            routing_changed: old.fingers_per_node != new.fingers_per_node
+                || old.routing_plan != new.routing_plan,
+            peers_changed: old.peers != new.peers,
             backends_changed: old.backends != new.backends,
             frontends_changed: old.frontends != new.frontends,
         }
@@ -79,19 +91,30 @@ impl ConfigDiff {
     pub fn any(&self) -> bool {
         self.caches_changed
             || self.disks_changed
-            || self.neighborhoods_changed
+            || self.identity_changed
+            || self.routing_changed
+            || self.peers_changed
             || self.backends_changed
             || self.frontends_changed
     }
 
     /// Whether the routing surface must be rebuilt and republished.
-    /// Neighborhood changes alter the projected route table directly.
+    /// Mesh and peer changes alter the projected route table directly.
     /// Cache diffs are intentionally conservative: disk-only changes do not
-    /// affect routes, but cache source changes can move request traffic
-    /// between neighborhoods and peers, so the whole cache section reloads the
-    /// projected routing surface for now.
+    /// affect routes, but cache names are route ids, so the whole cache
+    /// section reloads the projected routing surface for now.
     pub fn requires_routing_reload(&self) -> bool {
-        self.neighborhoods_changed || self.caches_changed
+        self.routing_changed || self.peers_changed || self.caches_changed
+    }
+
+    /// Whether the process must restart before the new config can be applied.
+    pub fn requires_restart(&self) -> bool {
+        self.identity_changed
+    }
+
+    /// Whether fabric peer connections must be reconciled.
+    pub fn requires_peer_reconcile(&self) -> bool {
+        self.peers_changed
     }
 }
 
@@ -100,7 +123,7 @@ mod tests {
     use super::*;
     use crate::config::schema::{
         BackendSpec, BlockDiskConfig, CacheSpec, DiskSpec, FrontendSpec, HttpBackendConfig,
-        HttpFrontendConfig, NeighborhoodSpec, PeerSpec, TcpPeerConfig, backend_spec, disk_spec,
+        HttpFrontendConfig, PeerSpec, RoutingPlan, TcpPeerConfig, backend_spec, disk_spec,
         frontend_spec, peer_spec,
     };
 
@@ -120,45 +143,48 @@ mod tests {
     }
 
     #[test]
-    fn neighborhood_peer_change_is_routing_reload() {
+    fn peer_change_is_routing_reload_and_peer_reconcile() {
         let a = base();
         let mut b = base();
-        b.neighborhoods.push(NeighborhoodSpec {
-            name: "n".to_string(),
-            source: "b".to_string(),
-            fingers_per_node: Some(100),
-            local_node_id: Some(1),
-            local_tags: vec![],
-            routing_plan: None,
-            peers: vec![PeerSpec {
-                id: 2,
-                tags: vec![],
-                config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
-                    addr: "127.0.0.1:9000".to_string(),
-                })),
-            }],
+        b.peers.push(PeerSpec {
+            name: "node-a".to_string(),
+            tags: vec![],
+            config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
+                addr: "127.0.0.1:9000".to_string(),
+            })),
         });
         let d = ConfigDiff::between(&a, &b);
-        assert!(d.neighborhoods_changed);
+        assert!(d.peers_changed);
         assert!(d.requires_routing_reload());
+        assert!(d.requires_peer_reconcile());
     }
 
     #[test]
-    fn neighborhood_only_change_is_routing_reload() {
+    fn routing_only_change_is_routing_reload() {
         let a = base();
         let mut b = base();
-        b.neighborhoods.push(NeighborhoodSpec {
-            name: "n".to_string(),
-            source: "b".to_string(),
-            fingers_per_node: Some(64),
-            local_node_id: None,
-            local_tags: vec![],
-            routing_plan: None,
-            peers: vec![],
+        b.fingers_per_node = Some(64);
+        b.routing_plan = Some(RoutingPlan {
+            fingers: vec!["node-b".to_string()],
+            successor: Some("node-b".to_string()),
+            predecessor: None,
         });
         let d = ConfigDiff::between(&a, &b);
-        assert!(d.neighborhoods_changed);
+        assert!(d.routing_changed);
         assert!(d.requires_routing_reload());
+        assert!(!d.requires_peer_reconcile());
+    }
+
+    #[test]
+    fn self_change_requires_restart_not_routing_reload() {
+        let a = base();
+        let mut b = base();
+        b.self_ = "node-a".to_string();
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.identity_changed);
+        assert!(d.any());
+        assert!(d.requires_restart());
+        assert!(!d.requires_routing_reload());
     }
 
     #[test]
@@ -173,6 +199,7 @@ mod tests {
         assert!(d.caches_changed);
         assert!(d.any());
         assert!(d.requires_routing_reload());
+        assert!(!d.requires_peer_reconcile());
     }
 
     #[test]
@@ -183,6 +210,10 @@ mod tests {
             queue_depth: None,
             page_size_bytes: None,
             skip_recovery_scan: false,
+            force_format: false,
+            bypass_admission: false,
+            bypass_index_read: false,
+            bypass_checksum: false,
             config: Some(disk_spec::Config::Block(BlockDiskConfig {
                 numa: None,
                 path: "/dev/nvme0n1".to_string(),

--- a/cmd/unbounded-storage/src/config/graph.rs
+++ b/cmd/unbounded-storage/src/config/graph.rs
@@ -7,51 +7,46 @@ use std::collections::{HashMap, HashSet};
 
 use super::schema::{Config, DiskSpec, PeerSpec, RoutingPlan};
 use crate::fabric::PeerId;
-use crate::p2p::NodeId;
+use crate::p2p::{node_id_from_name, NodeId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedFrontendBinding {
     pub frontend_id: String,
     pub backend_id: String,
     pub cache_id: Option<String>,
-    pub neighborhood_id: Option<String>,
     pub bypass_cache: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct RuntimeP2p {
+pub struct RuntimeMesh {
     pub fingers_per_node: u32,
-    pub local_node_id: Option<u64>,
-    pub local_tags: Vec<String>,
+    pub self_name: Option<String>,
+    pub self_node_id: NodeId,
+    pub self_peer_id: PeerId,
+    pub self_tags: Vec<String>,
     pub routing_plan: Option<RoutingPlan>,
+    pub peers: Vec<RuntimePeer>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeCache {
     pub id: String,
+    pub backend_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimePeer {
-    pub neighborhood_id: String,
+    pub name: String,
     pub node_id: NodeId,
     pub fabric_peer_id: PeerId,
     pub spec: PeerSpec,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct RuntimeNeighborhood {
-    pub id: String,
-    pub backend_id: String,
-    pub p2p: RuntimeP2p,
-    pub peers: Vec<RuntimePeer>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeGraph {
     pub disks: Vec<DiskSpec>,
     pub caches: HashMap<String, RuntimeCache>,
-    pub neighborhoods: HashMap<String, RuntimeNeighborhood>,
+    pub mesh: RuntimeMesh,
     pub frontends: HashMap<String, ResolvedFrontendBinding>,
 }
 
@@ -64,10 +59,6 @@ pub fn validate_binding_graph(config: &Config) -> Result<(), String> {
         insert_id(&mut ids, "cache", &c.name)?;
         require_source("cache", &c.name, &c.source)?;
     }
-    for n in &config.neighborhoods {
-        insert_id(&mut ids, "neighborhood", &n.name)?;
-        require_source("neighborhood", &n.name, &n.source)?;
-    }
     for f in &config.frontends {
         insert_id(&mut ids, "frontend", &f.name)?;
         require_source("frontend", &f.name, &f.source)?;
@@ -75,35 +66,20 @@ pub fn validate_binding_graph(config: &Config) -> Result<(), String> {
 
     let backends = by_id(&config.backends, |b| b.name.as_str());
     let caches = by_id(&config.caches, |c| c.name.as_str());
-    let neighborhoods = by_id(&config.neighborhoods, |n| n.name.as_str());
 
     for c in &config.caches {
-        if !neighborhoods.contains_key(c.source.as_str())
-            && !backends.contains_key(c.source.as_str())
-        {
+        if !backends.contains_key(c.source.as_str()) {
             return Err(format!(
-                "cache {:?} source {:?}, which is not a backend or neighborhood",
+                "cache {:?} source {:?}, which is not a backend",
                 c.name, c.source
             ));
         }
     }
-    for n in &config.neighborhoods {
-        if !backends.contains_key(n.source.as_str()) {
-            return Err(format!(
-                "neighborhood {:?} source {:?}, which is not a backend",
-                n.name, n.source
-            ));
-        }
-        validate_peer_ids(n)?;
-    }
-    validate_fabric_peer_ids(config)?;
+    validate_peer_names(config)?;
     for f in &config.frontends {
-        if !backends.contains_key(f.source.as_str())
-            && !caches.contains_key(f.source.as_str())
-            && !neighborhoods.contains_key(f.source.as_str())
-        {
+        if !backends.contains_key(f.source.as_str()) && !caches.contains_key(f.source.as_str()) {
             return Err(format!(
-                "frontend {:?} source {:?}, which is not a backend, cache, or neighborhood",
+                "frontend {:?} source {:?}, which is not a backend or cache",
                 f.name, f.source
             ));
         }
@@ -112,67 +88,34 @@ pub fn validate_binding_graph(config: &Config) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_peer_ids(neighborhood: &super::schema::NeighborhoodSpec) -> Result<(), String> {
-    let mut seen = HashSet::new();
+fn validate_peer_names(config: &Config) -> Result<(), String> {
+    let mut names = HashSet::new();
+    let mut derived_ids = HashMap::new();
+    let mut self_seen = config.self_.is_empty();
 
-    for peer in &neighborhood.peers {
-        if !seen.insert(peer.id) {
+    for peer in &config.peers {
+        if peer.name.is_empty() {
+            return Err("peer name must not be empty".to_string());
+        }
+        if !names.insert(peer.name.as_str()) {
+            return Err(format!("peer {:?} is duplicated", peer.name));
+        }
+        if peer.name == config.self_ {
+            self_seen = true;
+        }
+        let node_id = node_id_from_name(&peer.name);
+        if let Some(prev) = derived_ids.insert(node_id, peer.name.as_str()) {
             return Err(format!(
-                "neighborhood {:?} peer {} is duplicated",
-                neighborhood.name, peer.id,
+                "peer names {prev:?} and {:?} derive the same node id {}",
+                peer.name, node_id.0
             ));
         }
     }
-
-    Ok(())
-}
-
-fn validate_fabric_peer_ids(config: &Config) -> Result<(), String> {
-    let mut local_ids = Vec::new();
-    for neighborhood in &config.neighborhoods {
-        if let Some(local_node_id) = neighborhood.local_node_id {
-            local_ids.push((neighborhood.name.as_str(), local_node_id));
-        }
-    }
-    local_ids.sort_by_key(|(name, _)| *name);
-
-    let process_local_id = match local_ids.first().map(|(_, id)| *id) {
-        Some(id) => {
-            if local_ids.iter().any(|(_, other)| *other != id) {
-                let configured = local_ids
-                    .iter()
-                    .map(|(neighborhood_id, node_id)| format!("{neighborhood_id}:{node_id}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                return Err(format!(
-                    "neighborhoods declare different local_node_id values, but the storage fabric uses one process-wide peer id ({configured})"
-                ));
-            }
-            Some(id)
-        }
-        None => None,
-    };
-
-    let mut peers_by_id: HashMap<u64, (&str, &PeerSpec)> = HashMap::new();
-    for neighborhood in &config.neighborhoods {
-        for peer in &neighborhood.peers {
-            if Some(peer.id) == process_local_id {
-                return Err(format!(
-                    "neighborhood {:?} peer {} collides with process local_node_id {}",
-                    neighborhood.name, peer.id, peer.id
-                ));
-            }
-            if let Some((first_neighborhood, first_peer)) = peers_by_id.get(&peer.id) {
-                if *first_peer != peer {
-                    return Err(format!(
-                        "peer id {} is declared with different peer data in neighborhoods {:?} and {:?}",
-                        peer.id, first_neighborhood, neighborhood.name
-                    ));
-                }
-            } else {
-                peers_by_id.insert(peer.id, (neighborhood.name.as_str(), peer));
-            }
-        }
+    if !self_seen {
+        return Err(format!(
+            "self peer {:?} is not present in peers",
+            config.self_
+        ));
     }
 
     Ok(())
@@ -183,7 +126,6 @@ pub fn runtime_projection(config: &Config) -> Result<RuntimeGraph, String> {
 
     let backends = by_id(&config.backends, |b| b.name.as_str());
     let caches = by_id(&config.caches, |c| c.name.as_str());
-    let neighborhoods = by_id(&config.neighborhoods, |n| n.name.as_str());
 
     let mut bindings = HashMap::new();
 
@@ -193,34 +135,17 @@ pub fn runtime_projection(config: &Config) -> Result<RuntimeGraph, String> {
                 frontend_id: frontend.name.clone(),
                 backend_id: frontend.source.clone(),
                 cache_id: None,
-                neighborhood_id: None,
                 bypass_cache: true,
             }
         } else if let Some(cache) = caches.get(frontend.source.as_str()) {
-            let (backend_id, neighborhood_id) =
-                if let Some(neighborhood) = neighborhoods.get(cache.source.as_str()) {
-                    (neighborhood.source.clone(), Some(neighborhood.name.clone()))
-                } else {
-                    (cache.source.clone(), None)
-                };
             ResolvedFrontendBinding {
                 frontend_id: frontend.name.clone(),
-                backend_id,
+                backend_id: cache.source.clone(),
                 cache_id: Some(cache.name.clone()),
-                neighborhood_id,
                 bypass_cache: false,
             }
         } else {
-            let neighborhood = neighborhoods
-                .get(frontend.source.as_str())
-                .expect("binding graph validation checked frontend target");
-            ResolvedFrontendBinding {
-                frontend_id: frontend.name.clone(),
-                backend_id: neighborhood.source.clone(),
-                cache_id: None,
-                neighborhood_id: Some(neighborhood.name.clone()),
-                bypass_cache: false,
-            }
+            unreachable!("binding graph validation checked frontend target")
         };
         bindings.insert(frontend.name.clone(), binding);
     }
@@ -233,46 +158,50 @@ pub fn runtime_projection(config: &Config) -> Result<RuntimeGraph, String> {
                 cache.name.clone(),
                 RuntimeCache {
                     id: cache.name.clone(),
+                    backend_id: cache.source.clone(),
                 },
             )
         })
         .collect();
 
-    let neighborhoods = config
-        .neighborhoods
+    let self_peer = config
+        .peers
         .iter()
-        .map(|neighborhood| {
-            let peers = neighborhood
-                .peers
-                .iter()
-                .map(|peer| RuntimePeer {
-                    neighborhood_id: neighborhood.name.clone(),
-                    node_id: NodeId(peer.id),
-                    fabric_peer_id: PeerId(peer.id),
-                    spec: peer.clone(),
-                })
-                .collect();
-            (
-                neighborhood.name.clone(),
-                RuntimeNeighborhood {
-                    id: neighborhood.name.clone(),
-                    backend_id: neighborhood.source.clone(),
-                    p2p: RuntimeP2p {
-                        fingers_per_node: neighborhood.fingers_per_node.unwrap_or(100).max(1),
-                        local_node_id: neighborhood.local_node_id,
-                        local_tags: neighborhood.local_tags.clone(),
-                        routing_plan: neighborhood.routing_plan.clone(),
-                    },
-                    peers,
-                },
-            )
+        .find(|peer| !config.self_.is_empty() && peer.name == config.self_);
+    let self_node_id = self_peer
+        .map(|peer| node_id_from_name(&peer.name))
+        .unwrap_or(NodeId(0));
+    let self_peer_id = PeerId(self_node_id.0);
+    let self_tags = self_peer.map(|peer| peer.tags.clone()).unwrap_or_default();
+    let self_name = (!config.self_.is_empty()).then(|| config.self_.clone());
+
+    let peers = config
+        .peers
+        .iter()
+        .filter(|peer| Some(peer.name.as_str()) != self_name.as_deref())
+        .map(|peer| {
+            let node_id = node_id_from_name(&peer.name);
+            RuntimePeer {
+                name: peer.name.clone(),
+                node_id,
+                fabric_peer_id: PeerId(node_id.0),
+                spec: peer.clone(),
+            }
         })
         .collect();
 
     Ok(RuntimeGraph {
         disks: config.disks.clone(),
         caches,
-        neighborhoods,
+        mesh: RuntimeMesh {
+            fingers_per_node: config.fingers_per_node.unwrap_or(100).max(1),
+            self_name,
+            self_node_id,
+            self_peer_id,
+            self_tags,
+            routing_plan: config.routing_plan.clone(),
+            peers,
+        },
         frontends: bindings,
     })
 }
@@ -282,11 +211,7 @@ pub fn runtime_disks(graph: &RuntimeGraph) -> Vec<DiskSpec> {
 }
 
 pub fn runtime_peers(graph: &RuntimeGraph) -> Vec<RuntimePeer> {
-    let mut peers = Vec::new();
-    for neighborhood in graph.neighborhoods.values() {
-        peers.extend(neighborhood.peers.clone());
-    }
-    peers
+    graph.mesh.peers.clone()
 }
 
 pub fn frontend_backend_map(
@@ -324,9 +249,8 @@ fn by_id<'a, T>(items: &'a [T], id: impl Fn(&'a T) -> &'a str) -> HashMap<&'a st
 #[cfg(test)]
 mod tests {
     use super::super::schema::{
-        BackendSpec, CacheSpec, FrontendSpec, HttpBackendConfig, HttpFrontendConfig,
-        NeighborhoodSpec, PeerSpec, RdmaPeerConfig, TcpPeerConfig, backend_spec, frontend_spec,
-        peer_spec,
+        backend_spec, frontend_spec, peer_spec, BackendSpec, CacheSpec, FrontendSpec,
+        HttpBackendConfig, HttpFrontendConfig, PeerSpec, RdmaPeerConfig, TcpPeerConfig,
     };
     use super::*;
 
@@ -350,18 +274,6 @@ mod tests {
         }
     }
 
-    fn neighborhood(id: &str, source: &str) -> NeighborhoodSpec {
-        NeighborhoodSpec {
-            name: id.to_string(),
-            source: source.to_string(),
-            fingers_per_node: Some(100),
-            local_node_id: Some(1),
-            local_tags: Vec::new(),
-            routing_plan: None,
-            peers: Vec::new(),
-        }
-    }
-
     fn frontend(id: &str, source: &str) -> FrontendSpec {
         FrontendSpec {
             name: id.to_string(),
@@ -373,9 +285,9 @@ mod tests {
         }
     }
 
-    fn tcp_peer(id: u64, addr: &str) -> PeerSpec {
+    fn tcp_peer(name: &str, addr: &str) -> PeerSpec {
         PeerSpec {
-            id,
+            name: name.to_string(),
             tags: Vec::new(),
             config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
                 addr: addr.to_string(),
@@ -383,12 +295,13 @@ mod tests {
         }
     }
 
-    fn rdma_peer(id: u64, addr: &str) -> PeerSpec {
+    fn rdma_peer(name: &str, addr: &str) -> PeerSpec {
         PeerSpec {
-            id,
+            name: name.to_string(),
             tags: Vec::new(),
             config: Some(peer_spec::Config::Rdma(RdmaPeerConfig {
                 addr: addr.to_string(),
+                addrs: Vec::new(),
             })),
         }
     }
@@ -398,159 +311,74 @@ mod tests {
         let mut cfg = Config::default();
         cfg.backends.push(backend("b"));
         cfg.caches.push(cache("c-backend", "b"));
-        cfg.neighborhoods.push(neighborhood("n", "b"));
-        cfg.caches.push(cache("c-neighborhood", "n"));
         cfg.frontends.push(frontend("direct", "b"));
         cfg.frontends.push(frontend("cache", "c-backend"));
-        cfg.frontends.push(frontend("neighborhood", "n"));
-        cfg.frontends.push(frontend("full", "c-neighborhood"));
 
         let graph = runtime_projection(&cfg).unwrap();
 
-        assert_binding(&graph, "direct", "b", None, None, true);
-        assert_binding(&graph, "cache", "b", Some("c-backend"), None, false);
-        assert_binding(&graph, "neighborhood", "b", None, Some("n"), false);
-        assert_binding(
-            &graph,
-            "full",
-            "b",
-            Some("c-neighborhood"),
-            Some("n"),
-            false,
-        );
-        assert_eq!(graph.caches.len(), 2);
-        assert_eq!(graph.neighborhoods.len(), 1);
+        assert_binding(&graph, "direct", "b", None, true);
+        assert_binding(&graph, "cache", "b", Some("c-backend"), false);
+        assert_eq!(graph.caches.len(), 1);
     }
 
     #[test]
-    fn runtime_projection_accepts_unique_rdma_peer_ids() {
+    fn runtime_projection_accepts_unique_rdma_peer_names() {
         let mut cfg = Config::default();
         cfg.backends.push(backend("b"));
-        let mut n = neighborhood("n", "b");
-        n.peers.push(rdma_peer(7, "hex:00"));
-        n.peers.push(rdma_peer(8, "hex:01"));
-        cfg.neighborhoods.push(n);
+        cfg.self_ = "node-a".to_string();
+        cfg.peers.push(rdma_peer("node-a", "hex:00"));
+        cfg.peers.push(rdma_peer("node-b", "hex:01"));
 
         let graph = runtime_projection(&cfg).unwrap();
-        let peers = &graph.neighborhoods["n"].peers;
+        let peers = &graph.mesh.peers;
 
-        assert_eq!(peers.len(), 2);
-        assert_eq!(peers[0].node_id, NodeId(7));
-        assert_eq!(peers[1].node_id, NodeId(8));
-        assert_eq!(peers[0].fabric_peer_id, PeerId(7));
-        assert_eq!(peers[1].fabric_peer_id, PeerId(8));
-    }
-
-    #[test]
-    fn runtime_projection_accepts_reused_peer_id_with_same_endpoint() {
-        let mut cfg = Config::default();
-        cfg.backends.push(backend("b"));
-        let mut a = neighborhood("n-a", "b");
-        a.peers.push(tcp_peer(7, "127.0.0.1:7"));
-        let mut b = neighborhood("n-b", "b");
-        b.peers.push(tcp_peer(7, "127.0.0.1:7"));
-        cfg.neighborhoods.push(a);
-        cfg.neighborhoods.push(b);
-
-        let graph = runtime_projection(&cfg).unwrap();
-
+        assert_eq!(graph.mesh.self_name.as_deref(), Some("node-a"));
+        assert_eq!(graph.mesh.self_node_id, node_id_from_name("node-a"));
         assert_eq!(
-            graph.neighborhoods["n-a"].peers[0].fabric_peer_id,
-            PeerId(7)
+            graph.mesh.self_peer_id,
+            PeerId(node_id_from_name("node-a").0)
         );
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].name, "node-b");
+        assert_eq!(peers[0].node_id, node_id_from_name("node-b"));
         assert_eq!(
-            graph.neighborhoods["n-b"].peers[0].fabric_peer_id,
-            PeerId(7)
+            peers[0].fabric_peer_id,
+            PeerId(node_id_from_name("node-b").0)
         );
     }
 
     #[test]
-    fn runtime_projection_rejects_reused_peer_id_with_different_peer_data() {
+    fn runtime_projection_rejects_missing_self_peer() {
         let mut cfg = Config::default();
         cfg.backends.push(backend("b"));
-        let mut a = neighborhood("n-a", "b");
-        a.peers.push(tcp_peer(7, "127.0.0.1:7"));
-        let mut b = neighborhood("n-b", "b");
-        b.peers.push(tcp_peer(7, "127.0.0.1:8"));
-        cfg.neighborhoods.push(a);
-        cfg.neighborhoods.push(b);
+        cfg.self_ = "node-a".to_string();
+        cfg.peers.push(tcp_peer("node-b", "127.0.0.1:7"));
 
         let err = runtime_projection(&cfg).unwrap_err();
 
-        assert!(err.contains("different peer data"), "{err}");
+        assert!(err.contains("self peer"), "{err}");
     }
 
     #[test]
-    fn runtime_projection_accepts_same_local_node_id_across_neighborhoods() {
+    fn runtime_projection_rejects_duplicate_peer_names() {
         let mut cfg = Config::default();
         cfg.backends.push(backend("b"));
-        let mut a = neighborhood("n-a", "b");
-        a.local_node_id = Some(7);
-        let mut b = neighborhood("n-b", "b");
-        b.local_node_id = Some(7);
-        cfg.neighborhoods.push(a);
-        cfg.neighborhoods.push(b);
-
-        runtime_projection(&cfg).unwrap();
-    }
-
-    #[test]
-    fn runtime_projection_rejects_different_local_node_ids() {
-        let mut cfg = Config::default();
-        cfg.backends.push(backend("b"));
-        let mut a = neighborhood("n-a", "b");
-        a.local_node_id = Some(7);
-        let mut b = neighborhood("n-b", "b");
-        b.local_node_id = Some(8);
-        cfg.neighborhoods.push(a);
-        cfg.neighborhoods.push(b);
+        cfg.peers.push(tcp_peer("node-a", "127.0.0.1:1"));
+        cfg.peers.push(tcp_peer("node-a", "127.0.0.1:2"));
 
         let err = runtime_projection(&cfg).unwrap_err();
-
-        assert!(err.contains("different local_node_id values"), "{err}");
+        assert!(err.contains("peer \"node-a\" is duplicated"), "{err}");
     }
 
     #[test]
-    fn runtime_projection_rejects_peer_colliding_with_process_local_node_id() {
+    fn runtime_projection_rejects_duplicate_rdma_peer_names() {
         let mut cfg = Config::default();
         cfg.backends.push(backend("b"));
-        let mut a = neighborhood("n-a", "b");
-        a.local_node_id = Some(7);
-        let mut b = neighborhood("n-b", "b");
-        b.local_node_id = Some(7);
-        b.peers.push(tcp_peer(7, "127.0.0.1:7"));
-        cfg.neighborhoods.push(a);
-        cfg.neighborhoods.push(b);
+        cfg.peers.push(rdma_peer("node-a", "hex:00"));
+        cfg.peers.push(rdma_peer("node-a", "hex:01"));
 
         let err = runtime_projection(&cfg).unwrap_err();
-
-        assert!(err.contains("collides with process local_node_id"), "{err}");
-    }
-
-    #[test]
-    fn runtime_projection_rejects_duplicate_peer_ids() {
-        let mut cfg = Config::default();
-        cfg.backends.push(backend("b"));
-        let mut n = neighborhood("n", "b");
-        n.peers.push(tcp_peer(7, "127.0.0.1:1"));
-        n.peers.push(tcp_peer(7, "127.0.0.1:2"));
-        cfg.neighborhoods.push(n);
-
-        let err = runtime_projection(&cfg).unwrap_err();
-        assert!(err.contains("peer 7 is duplicated"), "{err}");
-    }
-
-    #[test]
-    fn runtime_projection_rejects_duplicate_rdma_peer_ids() {
-        let mut cfg = Config::default();
-        cfg.backends.push(backend("b"));
-        let mut n = neighborhood("n", "b");
-        n.peers.push(rdma_peer(7, "hex:00"));
-        n.peers.push(rdma_peer(7, "hex:01"));
-        cfg.neighborhoods.push(n);
-
-        let err = runtime_projection(&cfg).unwrap_err();
-        assert!(err.contains("peer 7 is duplicated"), "{err}");
+        assert!(err.contains("peer \"node-a\" is duplicated"), "{err}");
     }
 
     fn assert_binding(
@@ -558,13 +386,11 @@ mod tests {
         frontend_id: &str,
         backend_id: &str,
         cache_id: Option<&str>,
-        neighborhood_id: Option<&str>,
         bypass_cache: bool,
     ) {
         let binding = graph.frontends.get(frontend_id).unwrap();
         assert_eq!(binding.backend_id, backend_id);
         assert_eq!(binding.cache_id.as_deref(), cache_id);
-        assert_eq!(binding.neighborhood_id.as_deref(), neighborhood_id);
         assert_eq!(binding.bypass_cache, bypass_cache);
     }
 }

--- a/cmd/unbounded-storage/src/config/load.rs
+++ b/cmd/unbounded-storage/src/config/load.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 use prost::Message;
 
 use super::graph::runtime_projection;
-use super::schema::{Config, backend_spec, disk_spec, frontend_spec, peer_spec};
+use super::schema::{backend_spec, disk_spec, frontend_spec, peer_spec, Config};
 
 #[derive(Debug)]
 pub enum ConfigError {
@@ -42,33 +42,33 @@ pub enum ConfigError {
         page_size: u64,
     },
     InvalidTcpAddr {
-        peer_id: u64,
+        peer_name: String,
         addr: String,
     },
     InvalidNativePeerAddr {
-        peer_id: u64,
+        peer_name: String,
         addr: String,
     },
     EmptyDiskPath,
-    MissingLocalNodeId,
-    LocalNodeIdCollidesWithPeer(u64),
+    MissingSelfPeer,
+    SelfPeerNotFound(String),
+    EmptyPeerName,
+    DuplicatePeerName(String),
     RoutingPlanUnknownPeer {
-        id: u64,
+        name: String,
         role: &'static str,
     },
     RoutingPlanSelfReference {
-        id: u64,
+        name: String,
         role: &'static str,
     },
-    RoutingPlanDuplicateFinger(u64),
+    RoutingPlanDuplicateFinger(String),
     DuplicateBackendName(String),
     DuplicateFrontendName(String),
     DuplicateCacheName(String),
-    DuplicateNeighborhoodName(String),
     EmptyBackendName,
     EmptyFrontendName,
     EmptyCacheName,
-    EmptyNeighborhoodName,
     MissingBackendConfig(String),
     MissingFrontendConfig(String),
     EmptyBackendUrl(String),
@@ -93,7 +93,7 @@ pub enum ConfigError {
         addr: String,
     },
     ZeroFrontendMaxRequestsPerConnection(String),
-    MissingPeerConfig(u64),
+    MissingPeerConfig(String),
     MissingDiskConfig,
     InvalidMetricsAddr {
         addr: String,
@@ -124,38 +124,37 @@ impl fmt::Display for ConfigError {
                 f,
                 "disk {path}: file size {size} must be a positive multiple of the page size {page_size}"
             ),
-            ConfigError::InvalidTcpAddr { peer_id, addr } => {
-                write!(f, "peer {peer_id}: invalid tcp socket address {addr:?}")
+            ConfigError::InvalidTcpAddr { peer_name, addr } => {
+                write!(f, "peer {peer_name:?}: invalid tcp socket address {addr:?}")
             }
-            ConfigError::InvalidNativePeerAddr { peer_id, addr } => {
-                write!(f, "peer {peer_id}: invalid native fabric address {addr:?}")
+            ConfigError::InvalidNativePeerAddr { peer_name, addr } => {
+                write!(f, "peer {peer_name:?}: invalid rdma fabric address {addr:?}")
             }
             ConfigError::EmptyDiskPath => write!(f, "disk path must not be empty"),
-            ConfigError::MissingLocalNodeId => write!(
+            ConfigError::MissingSelfPeer => write!(
                 f,
-                "neighborhood local_node_id must be set when peers are configured: a multi-node \
-                 deployment requires a stable local node id to avoid silent NodeId(0) collisions"
+                "self must be set when peers or routing_plan are configured: a multi-node \
+                 deployment requires a stable local peer name"
             ),
-            ConfigError::LocalNodeIdCollidesWithPeer(id) => write!(
+            ConfigError::SelfPeerNotFound(name) => write!(
                 f,
-                "neighborhood local_node_id {id} collides with a peer id: the local node and a peer \
-                 cannot share a node id, or the p2p finger table will silently drop that peer"
+                "self peer {name:?} is not present in peers: the local process must be listed \
+                 in the peer roster"
             ),
-            ConfigError::RoutingPlanUnknownPeer { id, role } => write!(
+            ConfigError::EmptyPeerName => write!(f, "peer name must not be empty"),
+            ConfigError::DuplicatePeerName(name) => write!(f, "duplicate peer name: {name:?}"),
+            ConfigError::RoutingPlanUnknownPeer { name, role } => write!(
                 f,
-                "neighborhood routing_plan {role} {id} does not reference any peer id: every \
+                "routing_plan {role} {name:?} does not reference any peer name: every \
                  routing-plan neighbor must have a matching peer so a fabric connection exists"
             ),
-            ConfigError::RoutingPlanSelfReference { id, role } => write!(
+            ConfigError::RoutingPlanSelfReference { name, role } => write!(
                 f,
-                "neighborhood routing_plan {role} {id} equals local_node_id: a node cannot list \
+                "routing_plan {role} {name:?} equals self: a node cannot list \
                  itself as a routing neighbor"
             ),
-            ConfigError::RoutingPlanDuplicateFinger(id) => {
-                write!(
-                    f,
-                    "neighborhood routing_plan.fingers contains duplicate id {id}"
-                )
+            ConfigError::RoutingPlanDuplicateFinger(name) => {
+                write!(f, "routing_plan.fingers contains duplicate peer {name:?}")
             }
             ConfigError::DuplicateBackendName(name) => {
                 write!(f, "duplicate backend name: {name:?}")
@@ -164,13 +163,9 @@ impl fmt::Display for ConfigError {
                 write!(f, "duplicate frontend name: {name:?}")
             }
             ConfigError::DuplicateCacheName(name) => write!(f, "duplicate cache name: {name:?}"),
-            ConfigError::DuplicateNeighborhoodName(name) => {
-                write!(f, "duplicate neighborhood name: {name:?}")
-            }
             ConfigError::EmptyBackendName => write!(f, "backend name must not be empty"),
             ConfigError::EmptyFrontendName => write!(f, "frontend name must not be empty"),
             ConfigError::EmptyCacheName => write!(f, "cache name must not be empty"),
-            ConfigError::EmptyNeighborhoodName => write!(f, "neighborhood name must not be empty"),
             ConfigError::MissingBackendConfig(id) => {
                 write!(f, "backend {id:?}: config must set one backend type")
             }
@@ -226,8 +221,8 @@ impl fmt::Display for ConfigError {
                 f,
                 "frontend {frontend_name:?}: max_requests_per_connection must be greater than zero"
             ),
-            ConfigError::MissingPeerConfig(peer_id) => {
-                write!(f, "peer {peer_id}: config must set one peer transport")
+            ConfigError::MissingPeerConfig(peer_name) => {
+                write!(f, "peer {peer_name:?}: config must set one peer transport")
             }
             ConfigError::MissingDiskConfig => write!(f, "disk config must set one disk type"),
             ConfigError::InvalidMetricsAddr { addr } => {
@@ -358,18 +353,7 @@ fn validate(cfg: &Config) -> Result<(), ConfigError> {
         }
     }
 
-    let mut seen_neighborhoods: HashSet<&str> = HashSet::new();
-    for neighborhood in &cfg.neighborhoods {
-        if neighborhood.name.is_empty() {
-            return Err(ConfigError::EmptyNeighborhoodName);
-        }
-        if !seen_neighborhoods.insert(neighborhood.name.as_str()) {
-            return Err(ConfigError::DuplicateNeighborhoodName(
-                neighborhood.name.clone(),
-            ));
-        }
-        validate_neighborhood(neighborhood)?;
-    }
+    validate_mesh(cfg)?;
 
     let mut seen_frontends: HashSet<&str> = HashSet::new();
     let mut seen_addrs: HashSet<&str> = HashSet::new();
@@ -460,59 +444,84 @@ fn validate_frontend_addr<'a>(
     Ok(())
 }
 
-fn validate_neighborhood(
-    neighborhood: &super::schema::NeighborhoodSpec,
-) -> Result<(), ConfigError> {
-    if !neighborhood.peers.is_empty() && neighborhood.local_node_id.is_none() {
-        return Err(ConfigError::MissingLocalNodeId);
+fn validate_mesh(cfg: &Config) -> Result<(), ConfigError> {
+    if (!cfg.peers.is_empty() || cfg.routing_plan.is_some()) && cfg.self_.is_empty() {
+        return Err(ConfigError::MissingSelfPeer);
     }
 
-    let mut peer_ids: HashSet<u64> = HashSet::new();
-    for p in &neighborhood.peers {
-        peer_ids.insert(p.id);
-        if neighborhood.local_node_id == Some(p.id) {
-            return Err(ConfigError::LocalNodeIdCollidesWithPeer(p.id));
+    let mut peer_names: HashSet<&str> = HashSet::new();
+    let mut self_seen = cfg.self_.is_empty();
+    for p in &cfg.peers {
+        if p.name.is_empty() {
+            return Err(ConfigError::EmptyPeerName);
+        }
+        if !peer_names.insert(p.name.as_str()) {
+            return Err(ConfigError::DuplicatePeerName(p.name.clone()));
+        }
+        if p.name == cfg.self_ {
+            self_seen = true;
         }
         match p.config.as_ref() {
             Some(peer_spec::Config::Tcp(cfg)) => {
                 if cfg.addr.parse::<SocketAddr>().is_err() {
                     return Err(ConfigError::InvalidTcpAddr {
-                        peer_id: p.id,
+                        peer_name: p.name.clone(),
                         addr: cfg.addr.clone(),
                     });
                 }
             }
             Some(peer_spec::Config::Rdma(cfg)) => {
-                if !is_valid_native_address(&cfg.addr) {
+                if !is_valid_rdma_peer_address(&cfg.addr) {
                     return Err(ConfigError::InvalidNativePeerAddr {
-                        peer_id: p.id,
+                        peer_name: p.name.clone(),
                         addr: cfg.addr.clone(),
                     });
                 }
+                for addr in &cfg.addrs {
+                    if !is_valid_rdma_peer_address(addr) {
+                        return Err(ConfigError::InvalidNativePeerAddr {
+                            peer_name: p.name.clone(),
+                            addr: addr.clone(),
+                        });
+                    }
+                }
             }
-            None => return Err(ConfigError::MissingPeerConfig(p.id)),
+            None => return Err(ConfigError::MissingPeerConfig(p.name.clone())),
         }
     }
+    if !self_seen {
+        return Err(ConfigError::SelfPeerNotFound(cfg.self_.clone()));
+    }
 
-    if let Some(plan) = &neighborhood.routing_plan {
-        let mut seen_fingers: HashSet<u64> = HashSet::new();
-        for &id in &plan.fingers {
-            if !seen_fingers.insert(id) {
-                return Err(ConfigError::RoutingPlanDuplicateFinger(id));
+    if let Some(plan) = &cfg.routing_plan {
+        let mut seen_fingers: HashSet<&str> = HashSet::new();
+        for name in &plan.fingers {
+            if !seen_fingers.insert(name.as_str()) {
+                return Err(ConfigError::RoutingPlanDuplicateFinger(name.clone()));
             }
         }
-        for (id, role) in plan
+        for (name, role) in plan
             .fingers
             .iter()
-            .map(|id| (*id, "finger"))
-            .chain(plan.successor.map(|id| (id, "successor")))
-            .chain(plan.predecessor.map(|id| (id, "predecessor")))
+            .map(|name| (name.as_str(), "finger"))
+            .chain(plan.successor.as_deref().map(|name| (name, "successor")))
+            .chain(
+                plan.predecessor
+                    .as_deref()
+                    .map(|name| (name, "predecessor")),
+            )
         {
-            if neighborhood.local_node_id == Some(id) {
-                return Err(ConfigError::RoutingPlanSelfReference { id, role });
+            if name == cfg.self_ {
+                return Err(ConfigError::RoutingPlanSelfReference {
+                    name: name.to_string(),
+                    role,
+                });
             }
-            if !peer_ids.contains(&id) {
-                return Err(ConfigError::RoutingPlanUnknownPeer { id, role });
+            if !peer_names.contains(name) {
+                return Err(ConfigError::RoutingPlanUnknownPeer {
+                    name: name.to_string(),
+                    role,
+                });
             }
         }
     }
@@ -575,6 +584,10 @@ fn is_valid_native_address(addr: &str) -> bool {
     is_valid_even_hex(hex)
 }
 
+fn is_valid_rdma_peer_address(addr: &str) -> bool {
+    is_valid_native_address(addr) || addr.parse::<SocketAddr>().is_ok()
+}
+
 fn is_valid_even_hex(s: &str) -> bool {
     !s.is_empty() && s.len() % 2 == 0 && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
@@ -615,17 +628,20 @@ name = "b"
 "#
     }
 
-    fn neighborhood_toml() -> &'static str {
+    fn mesh_toml() -> &'static str {
         r#"
+self = "node-a"
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 99
+[[peers]]
+name = "node-a"
+
+[peers.config.tcp]
+addr = "10.0.0.99:9000"
 "#
     }
 
@@ -646,38 +662,35 @@ source = "b"
     fn loads_minimal_config() {
         let f = write_cfg("");
         let cfg = load(f.path()).unwrap();
-        assert!(cfg.neighborhoods.is_empty());
+        assert!(cfg.peers.is_empty());
         assert!(cfg.caches.is_empty());
     }
 
     #[test]
     fn loads_full_happy_path() {
         let s = r#"
+self = "node-a"
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 99
+[[peers]]
+name = "node-a"
 
-[[neighborhoods.peers]]
-id = 1
-
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.1:9000"
 
-[[neighborhoods.peers]]
-id = 2
+[[peers]]
+name = "node-b"
 
-[neighborhoods.peers.config.rdma]
+[peers.config.rdma]
 addr = "hex:deadbeef"
 
 [[caches]]
 name = "c"
-source = "n"
+source = "b"
 
 [[disks]]
 [disks.config.block]
@@ -697,44 +710,39 @@ addr = "0.0.0.0:9000"
 "#;
         let f = write_cfg(s);
         let cfg = load(f.path()).unwrap();
-        assert_eq!(cfg.neighborhoods[0].peers.len(), 2);
+        assert_eq!(cfg.peers.len(), 2);
         assert_eq!(cfg.disks.len(), 2);
-        assert_eq!(cfg.neighborhoods[0].local_node_id, Some(99));
+        assert_eq!(cfg.self_, "node-a");
         let projection = runtime_projection(&cfg).unwrap();
         assert!(!projection.frontends["f"].bypass_cache);
         assert_eq!(projection.frontends["f"].backend_id, "b");
     }
 
     #[test]
-    fn rejects_duplicate_peer_ids() {
+    fn rejects_duplicate_peer_names() {
         let s = r#"
+self = "node-a"
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 99
+[[peers]]
+name = "node-a"
 
-[[neighborhoods.peers]]
-id = 1
-
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.1:9000"
 
-[[neighborhoods.peers]]
-id = 1
+[[peers]]
+name = "node-a"
 
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.2:9000"
 "#;
         let f = write_cfg(s);
         match load(f.path()) {
-            Err(ConfigError::InvalidBindingGraph(err)) => {
-                assert!(err.contains("peer 1 is duplicated"), "{err}");
-            }
+            Err(ConfigError::DuplicatePeerName(name)) if name == "node-a" => {}
             other => panic!("expected duplicate peer error, got {other:?}"),
         }
     }
@@ -764,17 +772,17 @@ path = "/dev/nvme0n1"
     fn rejects_invalid_tcp_addr() {
         let s = format!(
             r#"{}
-[[neighborhoods.peers]]
-id = 7
+[[peers]]
+name = "node-b"
 
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "not-an-addr"
 "#,
-            neighborhood_toml()
+            mesh_toml()
         );
         let f = write_cfg(&s);
         match load(f.path()) {
-            Err(ConfigError::InvalidTcpAddr { peer_id: 7, .. }) => {}
+            Err(ConfigError::InvalidTcpAddr { peer_name, .. }) if peer_name == "node-b" => {}
             other => panic!("expected InvalidTcpAddr, got {other:?}"),
         }
     }
@@ -783,18 +791,18 @@ addr = "not-an-addr"
     fn rejects_hostname_for_tcp() {
         let s = format!(
             r#"{}
-[[neighborhoods.peers]]
-id = 8
+[[peers]]
+name = "node-b"
 
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "example.com:9000"
 "#,
-            neighborhood_toml()
+            mesh_toml()
         );
         let f = write_cfg(&s);
         assert!(matches!(
             load(f.path()),
-            Err(ConfigError::InvalidTcpAddr { peer_id: 8, .. })
+            Err(ConfigError::InvalidTcpAddr { peer_name, .. }) if peer_name == "node-b"
         ));
     }
 
@@ -802,44 +810,131 @@ addr = "example.com:9000"
     fn accepts_native_peer_addr() {
         let s = format!(
             r#"{}
-[[neighborhoods.peers]]
-id = 9
+[[peers]]
+name = "node-rdma"
 
-[neighborhoods.peers.config.rdma]
+[peers.config.rdma]
 addr = "hex:01020304"
 "#,
-            neighborhood_toml()
+            mesh_toml()
         );
         let f = write_cfg(&s);
         let cfg = load(f.path()).expect("load should succeed");
-        match cfg.neighborhoods[0].peers[0].config.as_ref().unwrap() {
+        let peer = cfg
+            .peers
+            .iter()
+            .find(|peer| peer.name == "node-rdma")
+            .unwrap();
+        match peer.config.as_ref().unwrap() {
             peer_spec::Config::Rdma(cfg) => assert_eq!(cfg.addr, "hex:01020304"),
             other => panic!("expected rdma config, got {other:?}"),
         }
     }
 
     #[test]
+    fn accepts_rdma_socket_peer_addr() {
+        let s = format!(
+            r#"{}
+[[peers]]
+name = "node-rdma"
+
+[peers.config.rdma]
+addr = "10.0.0.2:5000"
+"#,
+            mesh_toml()
+        );
+        let f = write_cfg(&s);
+        let cfg = load(f.path()).expect("load should succeed");
+        let peer = cfg
+            .peers
+            .iter()
+            .find(|peer| peer.name == "node-rdma")
+            .unwrap();
+        match peer.config.as_ref().unwrap() {
+            peer_spec::Config::Rdma(cfg) => assert_eq!(cfg.addr, "10.0.0.2:5000"),
+            other => panic!("expected rdma config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accepts_rdma_peer_addr_list() {
+        let s = format!(
+            r#"{}
+[[peers]]
+name = "node-rdma"
+
+[peers.config.rdma]
+addr = "hex:01020304"
+addrs = ["hex:01020304", "10.0.0.2:5000"]
+"#,
+            mesh_toml()
+        );
+        let f = write_cfg(&s);
+        let cfg = load(f.path()).expect("load should succeed");
+        let peer = cfg
+            .peers
+            .iter()
+            .find(|peer| peer.name == "node-rdma")
+            .unwrap();
+        match peer.config.as_ref().unwrap() {
+            peer_spec::Config::Rdma(cfg) => {
+                assert_eq!(cfg.addr, "hex:01020304");
+                assert_eq!(cfg.addrs, ["hex:01020304", "10.0.0.2:5000"]);
+            }
+            other => panic!("expected rdma config, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn rejects_invalid_native_peer_addr() {
-        for bad in ["gid:bad", "hex:", "hex:abc", "hex:deadbeefg0"] {
+        for bad in [
+            "gid:bad",
+            "hex:",
+            "hex:abc",
+            "hex:deadbeefg0",
+            "example.com:9000",
+        ] {
             let s = format!(
                 r#"{}
-[[neighborhoods.peers]]
-id = 9
+[[peers]]
+name = "node-rdma"
 
-[neighborhoods.peers.config.rdma]
+[peers.config.rdma]
 addr = "{bad}"
 "#,
-                neighborhood_toml()
+                mesh_toml()
             );
             let f = write_cfg(&s);
             assert!(
                 matches!(
                     load(f.path()),
-                    Err(ConfigError::InvalidNativePeerAddr { peer_id: 9, .. })
+                    Err(ConfigError::InvalidNativePeerAddr { peer_name, .. }) if peer_name == "node-rdma"
                 ),
                 "expected InvalidNativePeerAddr for {bad:?}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_invalid_rdma_peer_addr_list_entry() {
+        let s = format!(
+            r#"{}
+[[peers]]
+name = "node-rdma"
+
+[peers.config.rdma]
+addr = "hex:01020304"
+addrs = ["hex:01020304", "example.com:5000"]
+"#,
+            mesh_toml()
+        );
+        let f = write_cfg(&s);
+
+        assert!(matches!(
+            load(f.path()),
+            Err(ConfigError::InvalidNativePeerAddr { peer_name, addr })
+                if peer_name == "node-rdma" && addr == "example.com:5000"
+        ));
     }
 
     #[test]
@@ -958,78 +1053,68 @@ path = "/dev/nvme0n1"
     }
 
     #[test]
-    fn rejects_peers_without_local_node_id() {
+    fn rejects_peers_without_self() {
         let s = r#"
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
+[[peers]]
+name = "node-a"
 
-[[neighborhoods.peers]]
-id = 1
-
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.1:9000"
 "#;
         let f = write_cfg(s);
         match load(f.path()) {
-            Err(ConfigError::MissingLocalNodeId) => {}
-            other => panic!("expected MissingLocalNodeId, got {other:?}"),
+            Err(ConfigError::MissingSelfPeer) => {}
+            other => panic!("expected MissingSelfPeer, got {other:?}"),
         }
     }
 
     #[test]
-    fn accepts_peers_with_local_node_id() {
+    fn accepts_peers_with_self() {
         let s = r#"
+self = "node-a"
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 7
+[[peers]]
+name = "node-a"
 
-[[neighborhoods.peers]]
-id = 1
-
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.1:9000"
 "#;
         let f = write_cfg(s);
         let cfg = load(f.path()).expect("load should succeed");
-        assert_eq!(cfg.neighborhoods[0].local_node_id, Some(7));
-        assert_eq!(cfg.neighborhoods[0].peers.len(), 1);
+        assert_eq!(cfg.self_, "node-a");
+        assert_eq!(cfg.peers.len(), 1);
     }
 
     #[test]
-    fn rejects_local_node_id_colliding_with_peer() {
+    fn rejects_self_not_in_peer_roster() {
         let s = r#"
+self = "node-a"
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 1
+[[peers]]
+name = "node-b"
 
-[[neighborhoods.peers]]
-id = 1
-
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.1:9000"
 "#;
         let f = write_cfg(s);
         match load(f.path()) {
-            Err(ConfigError::LocalNodeIdCollidesWithPeer(1)) => {}
-            other => panic!("expected LocalNodeIdCollidesWithPeer(1), got {other:?}"),
+            Err(ConfigError::SelfPeerNotFound(name)) if name == "node-a" => {}
+            other => panic!("expected SelfPeerNotFound(node-a), got {other:?}"),
         }
     }
 
@@ -1467,8 +1552,6 @@ url = "https://acct.blob.core.windows.net:443"
         // A typo in a key now fails loudly at parse time instead of being
         // silently dropped (deny_unknown_fields on the TOML path).
         let s = r#"
-[[neighborhoods]]
-name = "n"
 fingers_per_nod = 128
 "#;
         let f = write_cfg(s);
@@ -1478,22 +1561,19 @@ fingers_per_nod = 128
     #[test]
     fn rejects_missing_peer_config() {
         let s = r#"
+self = "node-a"
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 99
-
-[[neighborhoods.peers]]
-id = 1
+[[peers]]
+name = "node-a"
 "#;
         let f = write_cfg(s);
         match load(f.path()) {
-            Err(ConfigError::MissingPeerConfig(1)) => {}
+            Err(ConfigError::MissingPeerConfig(name)) if name == "node-a" => {}
             other => panic!("expected MissingPeerConfig, got {other:?}"),
         }
     }
@@ -1518,25 +1598,22 @@ id = 1
         // A `.binpb` file is decoded from the protobuf wire format that
         // the TOML loader's `Config` round-trips to.
         let toml = r#"
+self = "node-a"
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 99
+[[peers]]
+name = "node-a"
 
-[[neighborhoods.peers]]
-id = 1
-
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.1:9000"
 
 [[caches]]
 name = "c"
-source = "n"
+source = "b"
 
 [[disks]]
 [disks.config.block]
@@ -1552,10 +1629,10 @@ addr = "0.0.0.0:9000"
         let cfg: Config = toml::from_str(toml).unwrap();
         let f = write_binpb(&encode_config(&cfg));
         let loaded = load(f.path()).unwrap();
-        assert_eq!(loaded.neighborhoods[0].peers.len(), 1);
-        assert_eq!(loaded.neighborhoods[0].peers[0].id, 1);
+        assert_eq!(loaded.peers.len(), 1);
+        assert_eq!(loaded.peers[0].name, "node-a");
         assert_eq!(loaded.disks.len(), 1);
-        assert_eq!(loaded.neighborhoods[0].local_node_id, Some(99));
+        assert_eq!(loaded.self_, "node-a");
     }
 
     #[test]
@@ -1563,7 +1640,7 @@ addr = "0.0.0.0:9000"
         // The binpb path shares the TOML path's defaulting finalization.
         let f = write_binpb(&encode_config(&Config::default()));
         let loaded = load(f.path()).unwrap();
-        assert!(loaded.neighborhoods.is_empty());
+        assert!(loaded.peers.is_empty());
         assert_eq!(
             loaded.startup().fabric().default_listen_addr(),
             Some("0.0.0.0:0")
@@ -1576,35 +1653,30 @@ addr = "0.0.0.0:9000"
         // endpoints are rejected even when they arrive over the protobuf wire
         // path.
         let toml = r#"
+self = "node-a"
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
 
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 99
+[[peers]]
+name = "node-a"
 
-[[neighborhoods.peers]]
-id = 1
-
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.1:9000"
 
-[[neighborhoods.peers]]
-id = 2
+[[peers]]
+name = "node-b"
 
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "10.0.0.2:9000"
 "#;
         let mut cfg: Config = toml::from_str(toml).unwrap();
-        cfg.neighborhoods[0].peers[1].id = 1;
+        cfg.peers[1].name = "node-a".to_string();
         let f = write_binpb(&encode_config(&cfg));
         match load(f.path()) {
-            Err(ConfigError::InvalidBindingGraph(err)) => {
-                assert!(err.contains("peer 1 is duplicated"), "{err}");
-            }
+            Err(ConfigError::DuplicatePeerName(name)) if name == "node-a" => {}
             other => panic!("expected duplicate peer error, got {other:?}"),
         }
     }

--- a/cmd/unbounded-storage/src/config/mod.rs
+++ b/cmd/unbounded-storage/src/config/mod.rs
@@ -20,9 +20,8 @@ pub use control::{
 };
 pub use diff::ConfigDiff;
 pub use graph::{
-    ResolvedFrontendBinding, RuntimeCache, RuntimeGraph, RuntimeNeighborhood, RuntimeP2p,
-    RuntimePeer, frontend_backend_map, runtime_disks, runtime_peers, runtime_projection,
-    validate_binding_graph,
+    ResolvedFrontendBinding, RuntimeCache, RuntimeGraph, RuntimeMesh, RuntimePeer,
+    frontend_backend_map, runtime_disks, runtime_peers, runtime_projection, validate_binding_graph,
 };
 pub use load::ConfigError;
 pub use reconcile::{
@@ -33,8 +32,8 @@ pub use reconcile::{
 pub use schema::{
     AutoRdmaFabricBinds, AzureBackendConfig, BackendSpec, BlockDiskConfig, CacheSpec, Config,
     DiskSpec, FabricCfg, FakeBackendConfig, FileDiskConfig, FrontendSpec, HttpBackendConfig,
-    HttpFrontendConfig, LoadgenFrontendConfig, MemoryCfg, NeighborhoodSpec, PeerSpec,
-    RdmaPeerConfig, RoutingPlan, S3BackendConfig, S3FrontendConfig, StartupCfg, TcpFabricBinds,
-    TcpPeerConfig, TopologyCfg, backend_spec, disk_spec, fabric_cfg, frontend_spec, peer_spec,
+    HttpFrontendConfig, LoadgenFrontendConfig, MemoryCfg, PeerSpec, RdmaPeerConfig, RoutingPlan,
+    S3BackendConfig, S3FrontendConfig, StartupCfg, TcpFabricBinds, TcpPeerConfig, TopologyCfg,
+    backend_spec, disk_spec, fabric_cfg, frontend_spec, peer_spec,
 };
 pub use watch::{ConfigUpdate, ConfigWatcher, WatchError};

--- a/cmd/unbounded-storage/src/config/reconcile.rs
+++ b/cmd/unbounded-storage/src/config/reconcile.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use crate::fabric::PeerId;
 use crate::fabric::{ConnectionSpec, Fabric, FabricError};
-
 use super::apply::peer_spec_to_connection;
 use super::schema::{BackendSpec, FrontendSpec, PeerSpec};
 
@@ -43,7 +42,7 @@ impl PeerReconcileTarget for Arc<Fabric> {
 #[derive(Debug, Default)]
 pub struct ApplyReport {
     pub applied: usize,
-    pub failures: Vec<(u64, String)>,
+    pub failures: Vec<(PeerId, String)>,
 }
 
 /// Outcome of one [`reconcile_peers`] pass. `applied` is the map the
@@ -62,9 +61,10 @@ pub struct ReconcileReport {
 pub fn apply_peers_startup(target: &dyn PeerReconcileTarget, peers: &[PeerSpec]) -> ApplyReport {
     let mut report = ApplyReport::default();
     for p in peers {
-        match target.add(peer_spec_to_connection(p)) {
+        let spec = peer_spec_to_connection(p);
+        match target.add(spec.clone()) {
             Ok(()) => report.applied += 1,
-            Err(e) => report.failures.push((p.id, e.to_string())),
+            Err(e) => report.failures.push((spec.peer, e.to_string())),
         }
     }
     report
@@ -624,12 +624,35 @@ mod tests {
         HttpBackendConfig, HttpFrontendConfig, TcpPeerConfig, backend_spec, frontend_spec,
         peer_spec,
     };
+    use crate::p2p::node_id_from_name;
     use std::cell::RefCell;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum Op {
         Add(u64),
         Remove(u64),
+    }
+
+    fn peer_id(id: u64) -> u64 {
+        node_id_from_name(&format!("node-{id}")).0
+    }
+
+    fn peer_key(id: u64) -> PeerId {
+        PeerId(peer_id(id))
+    }
+
+    fn add(id: u64) -> Op {
+        Op::Add(peer_id(id))
+    }
+
+    fn added(ids: &[u64]) -> Vec<Op> {
+        let mut ids: Vec<u64> = ids.iter().map(|id| peer_id(*id)).collect();
+        ids.sort_unstable();
+        ids.into_iter().map(Op::Add).collect()
+    }
+
+    fn remove(id: u64) -> Op {
+        Op::Remove(peer_id(id))
     }
 
     struct MockTarget {
@@ -643,19 +666,19 @@ mod tests {
         fn new(initial: &[u64]) -> Self {
             Self {
                 ops: RefCell::new(Vec::new()),
-                present: RefCell::new(initial.iter().map(|i| PeerId(*i)).collect()),
+                present: RefCell::new(initial.iter().map(|i| peer_key(*i)).collect()),
                 fail_add_on: None,
                 fail_remove_on: None,
             }
         }
 
         fn with_add_failure(mut self, id: u64) -> Self {
-            self.fail_add_on = Some(id);
+            self.fail_add_on = Some(peer_id(id));
             self
         }
 
         fn with_remove_failure(mut self, id: u64) -> Self {
-            self.fail_remove_on = Some(id);
+            self.fail_remove_on = Some(peer_id(id));
             self
         }
     }
@@ -686,7 +709,7 @@ mod tests {
 
     fn peer(id: u64) -> PeerSpec {
         PeerSpec {
-            id,
+            name: format!("node-{id}"),
             tags: Vec::new(),
             config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
                 addr: format!("10.0.0.{id}:9000"),
@@ -696,7 +719,7 @@ mod tests {
 
     fn peer_addr(id: u64, addr: &str) -> PeerSpec {
         PeerSpec {
-            id,
+            name: format!("node-{id}"),
             tags: Vec::new(),
             config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
                 addr: addr.to_string(),
@@ -706,7 +729,7 @@ mod tests {
 
     fn peer_tags(id: u64, tags: &[&str]) -> PeerSpec {
         PeerSpec {
-            id,
+            name: format!("node-{id}"),
             tags: tags.iter().map(|s| s.to_string()).collect(),
             config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
                 addr: format!("10.0.0.{id}:9000"),
@@ -721,7 +744,7 @@ mod tests {
         let r = apply_peers_startup(&t, &peers);
         assert_eq!(r.applied, 3);
         assert!(r.failures.is_empty());
-        assert_eq!(*t.ops.borrow(), vec![Op::Add(1), Op::Add(2), Op::Add(3)]);
+        assert_eq!(*t.ops.borrow(), vec![add(1), add(2), add(3)]);
     }
 
     #[test]
@@ -731,8 +754,8 @@ mod tests {
         let r = apply_peers_startup(&t, &peers);
         assert_eq!(r.applied, 2);
         assert_eq!(r.failures.len(), 1);
-        assert_eq!(r.failures[0].0, 2);
-        assert_eq!(*t.ops.borrow(), vec![Op::Add(1), Op::Add(2), Op::Add(3)]);
+        assert_eq!(r.failures[0].0, peer_key(2));
+        assert_eq!(*t.ops.borrow(), vec![add(1), add(2), add(3)]);
     }
 
     #[test]
@@ -754,7 +777,7 @@ mod tests {
         assert_eq!(r.updated, 0);
         assert!(r.failures.is_empty());
         assert_eq!(r.applied.len(), 3);
-        assert_eq!(*t.ops.borrow(), vec![Op::Add(1), Op::Add(2), Op::Add(3)]);
+        assert_eq!(*t.ops.borrow(), added(&[1, 2, 3]));
     }
 
     #[test]
@@ -766,15 +789,15 @@ mod tests {
         assert_eq!(r.removed, 1);
         assert_eq!(r.updated, 0);
         assert!(r.failures.is_empty());
-        assert_eq!(*t.ops.borrow(), vec![Op::Remove(1), Op::Add(4)]);
+        assert_eq!(*t.ops.borrow(), vec![remove(1), add(4)]);
     }
 
     #[test]
     fn reconcile_steady_state_is_noop() {
         let t = MockTarget::new(&[1, 2]);
         let mut prev = HashMap::new();
-        prev.insert(PeerId(1), peer_spec_to_connection(&peer(1)));
-        prev.insert(PeerId(2), peer_spec_to_connection(&peer(2)));
+        prev.insert(peer_key(1), peer_spec_to_connection(&peer(1)));
+        prev.insert(peer_key(2), peer_spec_to_connection(&peer(2)));
         let peers = vec![peer(1), peer(2)];
         let r = reconcile_peers(&t, &peers, Some(&prev));
         assert_eq!(r.added, 0);
@@ -789,16 +812,16 @@ mod tests {
     fn reconcile_detects_address_drift_as_update() {
         let t = MockTarget::new(&[1]);
         let mut prev = HashMap::new();
-        prev.insert(PeerId(1), peer_spec_to_connection(&peer_addr(1, "a:1")));
+        prev.insert(peer_key(1), peer_spec_to_connection(&peer_addr(1, "a:1")));
         let peers = vec![peer_addr(1, "b:2")];
         let r = reconcile_peers(&t, &peers, Some(&prev));
         assert_eq!(r.added, 0);
         assert_eq!(r.removed, 0);
         assert_eq!(r.updated, 1);
         assert!(r.failures.is_empty());
-        assert_eq!(*t.ops.borrow(), vec![Op::Remove(1), Op::Add(1)]);
+        assert_eq!(*t.ops.borrow(), vec![remove(1), add(1)]);
         assert_eq!(
-            r.applied[&PeerId(1)].address,
+            r.applied[&peer_key(1)].address,
             crate::fabric::FabricAddress::socket("b:2")
         );
     }
@@ -811,7 +834,7 @@ mod tests {
         let t = MockTarget::new(&[1]);
         let mut prev = HashMap::new();
         prev.insert(
-            PeerId(1),
+            peer_key(1),
             peer_spec_to_connection(&peer_tags(1, &["us-west"])),
         );
         let peers = vec![peer_tags(1, &["us-east", "rack9"])];
@@ -821,18 +844,18 @@ mod tests {
         assert_eq!(r.updated, 1);
         assert!(r.failures.is_empty());
         // The connection was churned via remove-then-add.
-        assert_eq!(*t.ops.borrow(), vec![Op::Remove(1), Op::Add(1)]);
+        assert_eq!(*t.ops.borrow(), vec![remove(1), add(1)]);
         // Applied state carries the freshest desired tags.
         assert_eq!(
-            r.applied[&PeerId(1)].tags,
+            r.applied[&peer_key(1)].tags,
             vec!["us-east".to_string(), "rack9".to_string()]
         );
         // Address/HCA are unchanged.
         assert_eq!(
-            r.applied[&PeerId(1)].address,
+            r.applied[&peer_key(1)].address,
             crate::fabric::FabricAddress::socket("10.0.0.1:9000")
         );
-        assert_eq!(r.applied[&PeerId(1)].hca_numa, None);
+        assert_eq!(r.applied[&peer_key(1)].hca_numa, None);
     }
 
     #[test]
@@ -842,11 +865,11 @@ mod tests {
         let r = reconcile_peers(&t, &peers, None);
         assert_eq!(r.added, 2);
         assert_eq!(r.failures.len(), 1);
-        assert_eq!(r.failures[0].0, PeerId(2));
+        assert_eq!(r.failures[0].0, peer_key(2));
         assert!(r.failures[0].1.starts_with("add: "));
-        assert!(r.applied.contains_key(&PeerId(1)));
-        assert!(!r.applied.contains_key(&PeerId(2)));
-        assert!(r.applied.contains_key(&PeerId(3)));
+        assert!(r.applied.contains_key(&peer_key(1)));
+        assert!(!r.applied.contains_key(&peer_key(2)));
+        assert!(r.applied.contains_key(&peer_key(3)));
     }
 
     #[test]
@@ -856,20 +879,20 @@ mod tests {
         // next pass re-detects the drift.
         let t = MockTarget::new(&[1]).with_remove_failure(1);
         let mut prev = HashMap::new();
-        prev.insert(PeerId(1), peer_spec_to_connection(&peer_addr(1, "a:1")));
+        prev.insert(peer_key(1), peer_spec_to_connection(&peer_addr(1, "a:1")));
         let peers = vec![peer_addr(1, "b:2")];
         let r = reconcile_peers(&t, &peers, Some(&prev));
         assert_eq!(r.updated, 0);
         assert_eq!(r.added, 0);
         assert_eq!(r.removed, 0);
         assert_eq!(r.failures.len(), 1);
-        assert_eq!(r.failures[0].0, PeerId(1));
+        assert_eq!(r.failures[0].0, peer_key(1));
         assert!(r.failures[0].1.starts_with("update-remove:"));
         assert_eq!(
-            r.applied[&PeerId(1)].address,
+            r.applied[&peer_key(1)].address,
             crate::fabric::FabricAddress::socket("a:1")
         );
-        assert_eq!(*t.ops.borrow(), vec![Op::Remove(1)]);
+        assert_eq!(*t.ops.borrow(), vec![remove(1)]);
 
         // Second pass: with the recovered remove, drift detection
         // must fire again using the carried-forward old spec.
@@ -879,10 +902,10 @@ mod tests {
         assert_eq!(r2.updated, 1);
         assert!(r2.failures.is_empty());
         assert_eq!(
-            r2.applied[&PeerId(1)].address,
+            r2.applied[&peer_key(1)].address,
             crate::fabric::FabricAddress::socket("b:2")
         );
-        assert_eq!(*t2.ops.borrow(), vec![Op::Remove(1), Op::Add(1)]);
+        assert_eq!(*t2.ops.borrow(), vec![remove(1), add(1)]);
     }
 
     #[test]
@@ -892,16 +915,16 @@ mod tests {
         // be carried forward; the id simply drops out of `applied`.
         let t = MockTarget::new(&[1]).with_add_failure(1);
         let mut prev = HashMap::new();
-        prev.insert(PeerId(1), peer_spec_to_connection(&peer_addr(1, "a:1")));
+        prev.insert(peer_key(1), peer_spec_to_connection(&peer_addr(1, "a:1")));
         let peers = vec![peer_addr(1, "b:2")];
         let r = reconcile_peers(&t, &peers, Some(&prev));
         assert_eq!(r.updated, 0);
         assert_eq!(r.added, 0);
         assert_eq!(r.failures.len(), 1);
-        assert_eq!(r.failures[0].0, PeerId(1));
+        assert_eq!(r.failures[0].0, peer_key(1));
         assert!(r.failures[0].1.starts_with("update-add:"));
-        assert!(!r.applied.contains_key(&PeerId(1)));
-        assert_eq!(*t.ops.borrow(), vec![Op::Remove(1), Op::Add(1)]);
+        assert!(!r.applied.contains_key(&peer_key(1)));
+        assert_eq!(*t.ops.borrow(), vec![remove(1), add(1)]);
 
         // Second pass: the id is in `desired` but not in
         // `target.list()` (fabric is empty post-remove), so the
@@ -913,10 +936,10 @@ mod tests {
         assert_eq!(r2.updated, 0);
         assert!(r2.failures.is_empty());
         assert_eq!(
-            r2.applied[&PeerId(1)].address,
+            r2.applied[&peer_key(1)].address,
             crate::fabric::FabricAddress::socket("b:2")
         );
-        assert_eq!(*t2.ops.borrow(), vec![Op::Add(1)]);
+        assert_eq!(*t2.ops.borrow(), vec![add(1)]);
     }
 
     #[test]
@@ -928,20 +951,20 @@ mod tests {
         // `desired_map`, driving the same remove path).
         let t = MockTarget::new(&[1]).with_remove_failure(1);
         let mut prev = HashMap::new();
-        prev.insert(PeerId(1), peer_spec_to_connection(&peer_addr(1, "a:1")));
+        prev.insert(peer_key(1), peer_spec_to_connection(&peer_addr(1, "a:1")));
         let peers: Vec<PeerSpec> = vec![];
         let r = reconcile_peers(&t, &peers, Some(&prev));
         assert_eq!(r.removed, 0);
         assert_eq!(r.added, 0);
         assert_eq!(r.updated, 0);
         assert_eq!(r.failures.len(), 1);
-        assert_eq!(r.failures[0].0, PeerId(1));
+        assert_eq!(r.failures[0].0, peer_key(1));
         assert!(r.failures[0].1.starts_with("remove:"));
         assert_eq!(
-            r.applied[&PeerId(1)].address,
+            r.applied[&peer_key(1)].address,
             crate::fabric::FabricAddress::socket("a:1")
         );
-        assert_eq!(*t.ops.borrow(), vec![Op::Remove(1)]);
+        assert_eq!(*t.ops.borrow(), vec![remove(1)]);
     }
 
     // ---- backend / frontend reconcile ----

--- a/cmd/unbounded-storage/src/config/schema.rs
+++ b/cmd/unbounded-storage/src/config/schema.rs
@@ -32,9 +32,7 @@ impl Config {
     /// explicit zero, is left untouched. Run once after load (or after
     /// decoding a protobuf message) before the config is consumed.
     pub fn apply_defaults(&mut self) {
-        for n in &mut self.neighborhoods {
-            n.fingers_per_node.get_or_insert(100);
-        }
+        self.fingers_per_node.get_or_insert(100);
 
         for backend in &mut self.backends {
             backend.apply_defaults();
@@ -307,10 +305,11 @@ mod tests {
         let mut c: Config = toml::from_str("").unwrap();
         c.apply_defaults();
         assert_eq!(c.version, 0);
-        assert!(c.neighborhoods.is_empty());
+        assert!(c.peers.is_empty());
         assert!(c.caches.is_empty());
         assert!(c.backends.is_empty());
         assert!(c.frontends.is_empty());
+        assert_eq!(c.fingers_per_node, Some(100));
     }
 
     #[test]
@@ -404,6 +403,10 @@ path = "/dev/nvme0n1"
         c.apply_defaults();
         assert_eq!(c.disks[0].page_size_bytes, None);
         assert!(!c.disks[0].skip_recovery_scan);
+        assert!(!c.disks[0].force_format);
+        assert!(!c.disks[0].bypass_admission);
+        assert!(!c.disks[0].bypass_index_read);
+        assert!(!c.disks[0].bypass_checksum);
     }
 
     #[test]
@@ -412,6 +415,10 @@ path = "/dev/nvme0n1"
 [[disks]]
 page_size_bytes = 4096
 skip_recovery_scan = true
+force_format = true
+bypass_admission = true
+bypass_index_read = true
+bypass_checksum = true
 
 [disks.config.block]
 path = "/dev/nvme0n1"
@@ -420,84 +427,71 @@ path = "/dev/nvme0n1"
         c.apply_defaults();
         assert_eq!(c.disks[0].page_size_bytes, Some(4096));
         assert!(c.disks[0].skip_recovery_scan);
+        assert!(c.disks[0].force_format);
+        assert!(c.disks[0].bypass_admission);
+        assert!(c.disks[0].bypass_index_read);
+        assert!(c.disks[0].bypass_checksum);
     }
 
     #[test]
-    fn neighborhood_round_trips() {
+    fn mesh_round_trips() {
         let s = r#"
-[[neighborhoods]]
-name = "n"
-source = "b"
 fingers_per_node = 128
-local_node_id = 42
-local_tags = ["us-west", "az1", "row3", "rack7"]
+self = "node-a"
 "#;
         let mut c: Config = toml::from_str(s).unwrap();
         c.apply_defaults();
-        assert_eq!(c.neighborhoods[0].fingers_per_node, Some(128));
-        assert_eq!(c.neighborhoods[0].local_node_id, Some(42));
+        assert_eq!(c.fingers_per_node, Some(128));
+        assert_eq!(c.self_, "node-a");
+    }
+
+    #[test]
+    fn routing_plan_round_trips() {
+        let s = r#"
+self = "node-a"
+
+[routing_plan]
+fingers = ["node-b", "node-c", "node-d", "node-e"]
+successor = "node-b"
+predecessor = "node-z"
+"#;
+        let mut c: Config = toml::from_str(s).unwrap();
+        c.apply_defaults();
+        let plan = c.routing_plan.as_ref().expect("routing_plan set");
         assert_eq!(
-            c.neighborhoods[0].local_tags,
+            plan.fingers,
             vec![
-                "us-west".to_string(),
-                "az1".to_string(),
-                "row3".to_string(),
-                "rack7".to_string(),
+                "node-b".to_string(),
+                "node-c".to_string(),
+                "node-d".to_string(),
+                "node-e".to_string(),
             ]
         );
+        assert_eq!(plan.successor.as_deref(), Some("node-b"));
+        assert_eq!(plan.predecessor.as_deref(), Some("node-z"));
     }
 
     #[test]
-    fn neighborhood_routing_plan_round_trips() {
-        let s = r#"
-[[neighborhoods]]
-name = "n"
-source = "b"
-local_node_id = 1
-
-[neighborhoods.routing_plan]
-fingers = [2, 5, 9, 17]
-successor = 2
-predecessor = 64
-"#;
-        let mut c: Config = toml::from_str(s).unwrap();
+    fn routing_plan_absent_by_default() {
+        let mut c: Config = toml::from_str("self = \"node-a\"\n").unwrap();
         c.apply_defaults();
-        let plan = c.neighborhoods[0]
-            .routing_plan
-            .as_ref()
-            .expect("routing_plan set");
-        assert_eq!(plan.fingers, vec![2, 5, 9, 17]);
-        assert_eq!(plan.successor, Some(2));
-        assert_eq!(plan.predecessor, Some(64));
-    }
-
-    #[test]
-    fn neighborhood_routing_plan_absent_by_default() {
-        let mut c: Config =
-            toml::from_str("[[neighborhoods]]\nname = \"n\"\nsource = \"b\"\nlocal_node_id = 1\n")
-                .unwrap();
-        c.apply_defaults();
-        assert!(c.neighborhoods[0].routing_plan.is_none());
+        assert!(c.routing_plan.is_none());
     }
 
     #[test]
     fn peer_tags_round_trip() {
         let s = r#"
-[[neighborhoods]]
-name = "n"
-source = "b"
-
-[[neighborhoods.peers]]
-id = 1
+[[peers]]
+name = "node-a"
 tags = ["us-west", "az1", "row3", "rack7"]
 
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "127.0.0.1:9000"
 "#;
         let mut c: Config = toml::from_str(s).unwrap();
         c.apply_defaults();
         assert_eq!(
-            c.neighborhoods[0].peers[0].tags,
+            c.peers[0].tags,
             vec![
                 "us-west".to_string(),
                 "az1".to_string(),
@@ -555,7 +549,7 @@ max_requests_per_connection = 256
         let s = r#"
 [[caches]]
 name = "cache"
-source = "n"
+source = "backend"
 
 [[frontends]]
 name = "cached-http"
@@ -654,8 +648,10 @@ source = "cache"
 [frontends.config.loadgen]
 workers = 8
 seed = 1234
-object_count = 4096
+keyspace_objects = 4096
+object_size_bytes = 1048576
 read_bytes = 131072
+zipf_exponent = 1.2
 verify = true
 "#;
         let mut c: Config = toml::from_str(s).unwrap();
@@ -672,8 +668,10 @@ verify = true
         };
         assert_eq!(loadgen.workers, Some(8));
         assert_eq!(loadgen.seed, Some(1234));
-        assert_eq!(loadgen.object_count, Some(4096));
+        assert_eq!(loadgen.keyspace_objects, Some(4096));
+        assert_eq!(loadgen.object_size_bytes, Some(1024 * 1024));
         assert_eq!(loadgen.read_bytes, Some(128 * 1024));
+        assert_eq!(loadgen.zipf_exponent, Some(1.2));
         assert!(loadgen.verify);
     }
 

--- a/cmd/unbounded-storage/src/config/watch.rs
+++ b/cmd/unbounded-storage/src/config/watch.rs
@@ -226,41 +226,32 @@ mod tests {
     use tempfile::TempDir;
 
     const VALID_A: &str = r#"
+fingers_per_node = 1234
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
-
-[[neighborhoods]]
-name = "n"
-source = "b"
-fingers_per_node = 1234
 "#;
 
     const VALID_B: &str = r#"
+fingers_per_node = 5678
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
-
-[[neighborhoods]]
-name = "n"
-source = "b"
-fingers_per_node = 5678
 "#;
 
     fn valid_config_with_fingers(fingers_per_node: u32) -> String {
         format!(
             r#"
+fingers_per_node = {fingers_per_node}
+
 [[backends]]
 name = "b"
 
 [backends.config.fake]
-
-[[neighborhoods]]
-name = "n"
-source = "b"
-fingers_per_node = {fingers_per_node}
 "#,
         )
     }
@@ -383,7 +374,7 @@ fingers_per_node = {fingers_per_node}
         write(&path, VALID_B);
         let update = recv_within(&rx, Duration::from_secs(3))
             .expect("a valid modification must yield a ConfigUpdate");
-        assert_eq!(update.config.neighborhoods[0].fingers_per_node, Some(5678));
+        assert_eq!(update.config.fingers_per_node, Some(5678));
         assert!(update.generation >= 1, "generation must advance");
 
         // (2a) An unrelated sibling write is filtered out.
@@ -399,7 +390,7 @@ fingers_per_node = {fingers_per_node}
         write(&path, VALID_A);
         let update = recv_within(&rx, Duration::from_secs(3))
             .expect("a config change after a sibling write must still emit");
-        assert_eq!(update.config.neighborhoods[0].fingers_per_node, Some(1234));
+        assert_eq!(update.config.fingers_per_node, Some(1234));
     }
 
     fn event_for(paths: &[&Path]) -> notify::Event {

--- a/cmd/unbounded-storage/src/fabric/fabric.rs
+++ b/cmd/unbounded-storage/src/fabric/fabric.rs
@@ -16,6 +16,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
+use std::net::SocketAddr;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -25,9 +26,9 @@ use super::backing::LocalMrCtx;
 use super::cm;
 use super::completion::CompletionRegistry;
 use super::config::{FabricConfig, Provider};
-use super::connection::{ConnectionTable, Dialer, install_connection};
+use super::connection::{install_connection, ConnectionTable, Dialer};
 use super::dispatch::InboundDispatch;
-use super::error::{FabricError, Result, check};
+use super::error::{check, FabricError, Result};
 use super::ffi;
 use super::progress::ProgressGroup;
 use super::sendpool::SendPool;
@@ -179,6 +180,14 @@ impl Fabric {
                         if rc != 0 {
                             return Err(FabricError::Pkg("ub_fi_hints_set_src_addr", rc));
                         }
+                        (None, None)
+                    } else if matches!(cfg.provider, Provider::Verbs)
+                        && is_unspecified_ephemeral_socket(addr)
+                    {
+                        // Auto-RDMA on InfiniBand HCAs has no netdev-backed
+                        // IP address to bind. Passing NULL node/service lets
+                        // verbs pick a native AF_IB source address, which is
+                        // what peers can dial through RDMA-CM.
                         (None, None)
                     } else {
                         let (host, port) = addr.rsplit_once(':').ok_or(FabricError::BadConfig(
@@ -655,6 +664,11 @@ impl FabricInner {
     }
 }
 
+fn is_unspecified_ephemeral_socket(addr: &str) -> bool {
+    addr.parse::<SocketAddr>()
+        .is_ok_and(|addr| addr.ip().is_unspecified() && addr.port() == 0)
+}
+
 impl Drop for FabricInner {
     fn drop(&mut self) {
         // Stop accepting first so no new connection/CQ appears mid-teardown.
@@ -793,6 +807,15 @@ mod tests {
     #[test]
     fn thread_safe_value_is_fi_thread_safe() {
         assert_eq!(unsafe { ffi::ub_fi_thread_safe_value() }, 1);
+    }
+
+    #[test]
+    fn unspecified_ephemeral_socket_detects_auto_rdma_bind() {
+        assert!(is_unspecified_ephemeral_socket("0.0.0.0:0"));
+        assert!(is_unspecified_ephemeral_socket("[::]:0"));
+        assert!(!is_unspecified_ephemeral_socket("0.0.0.0:1"));
+        assert!(!is_unspecified_ephemeral_socket("127.0.0.1:0"));
+        assert!(!is_unspecified_ephemeral_socket("hex:001122"));
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/fabric/tests.rs
+++ b/cmd/unbounded-storage/src/fabric/tests.rs
@@ -978,24 +978,31 @@ use std::collections::HashMap;
 
 use crate::backend::{Backend, NullBackend};
 use crate::p2p::{
-    FingerTable, FingerTableConfig, NodeId, PeerEntry, RecursiveHandler, RingId, TopologyTags,
+    FingerTable, FingerTableConfig, NodeId, PeerEntry, RecursiveHandler, RingId, RouteTableHandle,
+    RoutingSnapshot, TopologyTags,
 };
 
 /// Ring position the relay (B) forwards for and the owner (C) serves.
 /// Chosen to sit in the open arc `(B.ring, C.ring)` so B's finger
 /// lookup forwards to C and C owns it.
 const CHAIN_TARGET_RING: u64 = 150;
+const CHAIN_CACHE_ID: &str = "cache";
 
 /// Request whose stripe key's leading 8 bytes encode a ring id, so
 /// `stripe_to_ring(req.key())` is controllable from the test.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct RingReq {
     key_bytes: [u8; 32],
+    cache_id: Option<String>,
 }
 
 impl Req for RingReq {
     fn key(&self) -> StripeKey {
         StripeKey(self.key_bytes)
+    }
+
+    fn cache_id(&self) -> Option<&String> {
+        self.cache_id.as_ref()
     }
 }
 
@@ -1099,18 +1106,27 @@ where
     B: Backend<Req = RingReq> + 'static,
 {
     let handler = Arc::new(
-        RecursiveHandler::new(
+        RecursiveHandler::with_routes(
             store,
             scratch,
             RECURSIVE_SCRATCH_PAGES as u32,
-            fingers,
-            node_to_peer,
+            RouteTableHandle::new(
+                [(
+                    CHAIN_CACHE_ID.to_string(),
+                    RoutingSnapshot {
+                        fingers,
+                        node_to_peer,
+                    },
+                )]
+                .into_iter()
+                .collect(),
+            ),
             fabric.clone(),
             scratch_mr,
             page_size,
             backend,
         )
-        .expect("RecursiveHandler::new failed after provider availability gate"),
+        .expect("RecursiveHandler::with_routes failed after provider availability gate"),
     );
     Fabric::start_rpc_server::<RingReq, _>(fabric, handler, Some(scratch_mr), page_size)
         .expect("start_rpc_server failed after provider availability gate")
@@ -1292,7 +1308,10 @@ fn run_chain_request(
     timeout: Duration,
 ) -> Vec<Result<PageRef, PoolError>> {
     let key = key_for_ring(CHAIN_TARGET_RING);
-    let req = RingReq { key_bytes: key.0 };
+    let req = RingReq {
+        key_bytes: key.0,
+        cache_id: Some(CHAIN_CACHE_ID.to_string()),
+    };
     let dsts = vec![PageRef {
         page_idx: 0,
         offset: 0,

--- a/cmd/unbounded-storage/src/fabric_group.rs
+++ b/cmd/unbounded-storage/src/fabric_group.rs
@@ -18,17 +18,18 @@
 //! the (hardware-only) verbs path uses.
 
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use unbounded_storage::backend::{BackendRegistry, FixedRegion, OriginRing};
 use unbounded_storage::bufferpool::BlockStore;
 use unbounded_storage::config::{self, BackendSpec, RuntimePeer};
 use unbounded_storage::fabric::{self, ConnectionSpec, Fabric, PeerId, Provider, RpcServerHandle};
-use unbounded_storage::memory::{BackingKind, BackingRequest, HUGEPAGE_2MB, allocate};
+use unbounded_storage::memory::{allocate, BackingKind, BackingRequest, HUGEPAGE_2MB};
 use unbounded_storage::p2p::{RecursiveHandler, RouteTableHandle, RouteTableSnapshot};
 use unbounded_storage::runtime::{Threading, WorkerIdx};
-use unbounded_storage::storage::StripeReq;
 use unbounded_storage::storage::disks::{CacheDirectorySet, ChainLocalStore};
+use unbounded_storage::storage::StripeReq;
 use unbounded_storage::topology::{NicWorkerGroup, ServingShard};
 
 use crate::FabricStartup;
@@ -66,13 +67,24 @@ pub struct FabricPlan {
     pub shard_to_unit: Vec<usize>,
 }
 
+/// Fabric address published by a live unit after libfabric bind/listen
+/// completed. These are the addresses peers must dial; configured bind
+/// strings are not sufficient for verbs because libfabric owns the native
+/// address encoding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FabricUnitAddress {
+    pub device_name: String,
+    pub rdma: bool,
+    pub addr: String,
+}
+
 /// Decide how serving shards map onto fabric endpoints. This function is
 /// THE tcp/verbs seam (see the module docs).
 ///
 /// `shard_devices` is all-`None` (tcp fallback) or all-`Some` (verbs),
 /// per `assign_shard_devices`:
 /// - tcp: a single `lo` endpoint shared by every serving shard, pinned to
-///   worker 0. Peers reach a node through one static neighborhood peer addr,
+///   worker 0. Peers reach a node through one static process peer addr,
 ///   so a node must expose exactly one inbound
 ///   fabric endpoint on that fixed port; binding one endpoint per shard
 ///   would make every shard past the first collide on the port
@@ -228,6 +240,9 @@ struct FabricUnit<S = RpcServerHandle, Rg = BackendRegistry, Rt = RouteTableHand
     handler_registry: Rg,
     routes: Rt,
     fabric: F,
+    device_name: String,
+    rdma: bool,
+    self_addr: String,
     hca_numa: Option<u16>,
     applied_peers: HashMap<PeerId, ConnectionSpec>,
     last_backends: HashMap<String, BackendSpec>,
@@ -304,6 +319,18 @@ impl FabricGroup {
         self.units[unit].fabric.clone()
     }
 
+    /// Live local addresses for every fabric unit in deterministic unit order.
+    pub fn unit_addresses(&self) -> Vec<FabricUnitAddress> {
+        self.units
+            .iter()
+            .map(|unit| FabricUnitAddress {
+                device_name: unit.device_name.clone(),
+                rdma: unit.rdma,
+                addr: unit.self_addr.clone(),
+            })
+            .collect()
+    }
+
     /// Reload every endpoint's RPC-handler routing from a new snapshot.
     /// Driven in lockstep with the per-shard transport reload so the
     /// classify and forward paths move together.
@@ -317,8 +344,8 @@ impl FabricGroup {
     /// Connections live at the fabric/address-vector level, so this runs
     /// once per endpoint rather than once per shard.
     pub fn reconcile_peers(&mut self, peers: &[RuntimePeer]) {
-        for unit in &mut self.units {
-            let desired = runtime_peer_connections(peers);
+        for (unit_idx, unit) in self.units.iter_mut().enumerate() {
+            let desired = runtime_peer_connections_for_unit(peers, unit_idx);
             let report = config::reconcile::reconcile_connections(
                 &unit.fabric,
                 &desired,
@@ -476,7 +503,7 @@ fn build_unit(
 
     fabric.check_shared_domain_capacity(spec.expected_mr);
 
-    let desired_peers = runtime_peer_connections(peers);
+    let desired_peers = runtime_peer_connections_for_unit(peers, spec.unit_idx);
     let applied_peers =
         config::reconcile::reconcile_connections(&fabric, &desired_peers, None).applied;
     // Seed the desired-peer set so the background reconnect thread can
@@ -492,6 +519,9 @@ fn build_unit(
         handler_registry,
         routes,
         fabric,
+        device_name: spec.device_name.clone(),
+        rdma: spec.provider == Provider::Verbs,
+        self_addr,
         hca_numa: spec.numa,
         applied_peers,
         last_backends,
@@ -499,26 +529,44 @@ fn build_unit(
 }
 
 fn runtime_peer_connections(peers: &[RuntimePeer]) -> Vec<ConnectionSpec> {
+    runtime_peer_connections_for_unit(peers, 0)
+}
+
+fn runtime_peer_connections_for_unit(
+    peers: &[RuntimePeer],
+    unit_idx: usize,
+) -> Vec<ConnectionSpec> {
     peers
         .iter()
         .map(|peer| ConnectionSpec {
             peer: peer.fabric_peer_id,
-            address: runtime_peer_address(&peer.spec),
+            address: runtime_peer_address_for_unit(&peer.spec, unit_idx),
             hca_numa: None,
             tags: peer.spec.tags.clone(),
         })
         .collect()
 }
 
-fn runtime_peer_address(peer: &config::PeerSpec) -> fabric::FabricAddress {
+fn runtime_peer_address_for_unit(
+    peer: &config::PeerSpec,
+    unit_idx: usize,
+) -> fabric::FabricAddress {
     match peer.config.as_ref() {
         Some(config::peer_spec::Config::Tcp(cfg)) => {
             fabric::FabricAddress::socket(cfg.addr.clone())
         }
         Some(config::peer_spec::Config::Rdma(cfg)) => {
-            fabric::FabricAddress::native(cfg.addr.clone())
+            rdma_fabric_address(cfg.addrs.get(unit_idx).unwrap_or(&cfg.addr))
         }
         None => fabric::FabricAddress::native(""),
+    }
+}
+
+fn rdma_fabric_address(addr: &str) -> fabric::FabricAddress {
+    if addr.parse::<SocketAddr>().is_ok() {
+        fabric::FabricAddress::socket(addr.to_string())
+    } else {
+        fabric::FabricAddress::native(addr.to_string())
     }
 }
 
@@ -529,8 +577,8 @@ mod tests {
 
     use super::*;
 
-    use unbounded_storage::config::{PeerSpec, RdmaPeerConfig, peer_spec};
-    use unbounded_storage::p2p::NodeId;
+    use unbounded_storage::config::{peer_spec, PeerSpec, RdmaPeerConfig};
+    use unbounded_storage::p2p::node_id_from_name;
 
     fn shard(cpu: u32, numa: Option<u16>) -> ServingShard {
         ServingShard { cpu, numa }
@@ -550,15 +598,36 @@ mod tests {
     }
 
     fn runtime_peer(id: u64, addr: &str) -> RuntimePeer {
+        let name = format!("node-{id}");
+        let node_id = node_id_from_name(&name);
         RuntimePeer {
-            neighborhood_id: "n".to_string(),
-            node_id: NodeId(id),
-            fabric_peer_id: PeerId(id),
+            name: name.clone(),
+            node_id,
+            fabric_peer_id: PeerId(node_id.0),
             spec: PeerSpec {
-                id,
+                name,
                 tags: Vec::new(),
                 config: Some(peer_spec::Config::Rdma(RdmaPeerConfig {
                     addr: addr.to_string(),
+                    addrs: Vec::new(),
+                })),
+            },
+        }
+    }
+
+    fn runtime_peer_with_addrs(id: u64, addr: &str, addrs: Vec<&str>) -> RuntimePeer {
+        let name = format!("node-{id}");
+        let node_id = node_id_from_name(&name);
+        RuntimePeer {
+            name: name.clone(),
+            node_id,
+            fabric_peer_id: PeerId(node_id.0),
+            spec: PeerSpec {
+                name,
+                tags: Vec::new(),
+                config: Some(peer_spec::Config::Rdma(RdmaPeerConfig {
+                    addr: addr.to_string(),
+                    addrs: addrs.into_iter().map(str::to_string).collect(),
                 })),
             },
         }
@@ -671,6 +740,40 @@ mod tests {
         assert_eq!(connections[1].hca_numa, None);
     }
 
+    #[test]
+    fn rdma_socket_peer_connections_use_socket_addresses() {
+        let peers = [runtime_peer(1, "10.0.0.1:9000")];
+
+        let connections = runtime_peer_connections(&peers);
+
+        assert_eq!(connections.len(), 1);
+        assert_eq!(
+            connections[0].address,
+            fabric::FabricAddress::socket("10.0.0.1:9000")
+        );
+        assert_eq!(connections[0].hca_numa, None);
+    }
+
+    #[test]
+    fn rdma_peer_connections_select_unit_index_address() {
+        let peers = [runtime_peer_with_addrs(
+            1,
+            "hex:fallback",
+            vec!["hex:unit0", "hex:unit1"],
+        )];
+
+        let unit0 = runtime_peer_connections_for_unit(&peers, 0);
+        let unit1 = runtime_peer_connections_for_unit(&peers, 1);
+        let unit2 = runtime_peer_connections_for_unit(&peers, 2);
+
+        assert_eq!(unit0[0].address, fabric::FabricAddress::native("hex:unit0"));
+        assert_eq!(unit1[0].address, fabric::FabricAddress::native("hex:unit1"));
+        assert_eq!(
+            unit2[0].address,
+            fabric::FabricAddress::native("hex:fallback")
+        );
+    }
+
     /// Drop-logging stand-in for a `FabricUnit` resource: records its
     /// label when dropped so a test can observe field teardown order.
     struct DropToken {
@@ -711,6 +814,9 @@ mod tests {
             handler_registry: DropToken::new("handler_registry", &log),
             routes: DropToken::new("routes", &log),
             fabric: DropToken::new("fabric", &log),
+            device_name: "mlx5_0".to_string(),
+            rdma: true,
+            self_addr: "hex:01".to_string(),
             hca_numa: None,
             applied_peers: HashMap::new(),
             last_backends: HashMap::new(),

--- a/cmd/unbounded-storage/src/frontend/http_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/http_serve.rs
@@ -147,7 +147,6 @@ pub struct HttpDriver<P: BufferPool<Req = StripeReq> + 'static> {
     frontend_id: Rc<str>,
     backend_id: String,
     cache_id: Option<String>,
-    neighborhood_id: Option<String>,
     stripe_size: u64,
     page_size: usize,
     fanout: Rc<FanoutTable>,
@@ -173,7 +172,6 @@ impl<P: BufferPool<Req = StripeReq> + 'static> HttpDriver<P> {
         frontend_id: Rc<str>,
         backend_id: String,
         cache_id: Option<String>,
-        neighborhood_id: Option<String>,
         stripe_size: u64,
         page_size: usize,
         fanout: Rc<FanoutTable>,
@@ -188,7 +186,6 @@ impl<P: BufferPool<Req = StripeReq> + 'static> HttpDriver<P> {
             frontend_id,
             backend_id,
             cache_id,
-            neighborhood_id,
             stripe_size,
             page_size,
             fanout,
@@ -244,7 +241,6 @@ impl<P: BufferPool<Req = StripeReq> + 'static> HttpDriver<P> {
                             Rc::clone(&self.frontend_id),
                             self.backend_id.clone(),
                             self.cache_id.clone(),
-                            self.neighborhood_id.clone(),
                             self.stripe_size,
                             self.page_size,
                             Rc::clone(&self.fanout),
@@ -304,7 +300,6 @@ async fn serve_connection<P: BufferPool<Req = StripeReq>>(
     frontend_id: Rc<str>,
     backend_id: String,
     cache_id: Option<String>,
-    neighborhood_id: Option<String>,
     stripe_size: u64,
     page_size: usize,
     fanout: Rc<FanoutTable>,
@@ -326,7 +321,6 @@ async fn serve_connection<P: BufferPool<Req = StripeReq>>(
             conn_fd,
             &backend_id,
             cache_id.as_deref(),
-            neighborhood_id.as_deref(),
             stripe_size,
             page_size,
             &fanout,
@@ -376,7 +370,6 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
     conn_fd: RawFd,
     backend_id: &str,
     cache_id: Option<&str>,
-    neighborhood_id: Option<&str>,
     stripe_size: u64,
     page_size: usize,
     fanout: &Rc<FanoutTable>,
@@ -461,17 +454,7 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
     // metadata entry through the pool. The HTTP backend fills it from
     // an origin HEAD on a miss; local-disk and peer hits skip the
     // origin entirely.
-    let len = match read_object_length(
-        pool,
-        backend_id,
-        cache_id,
-        neighborhood_id,
-        &path,
-        page_size,
-        bypass,
-    )
-    .await
-    {
+    let len = match read_object_length(pool, backend_id, cache_id, &path, page_size, bypass).await {
         LenResult::Len(len) => len,
         LenResult::NotFound => {
             let _ = send_all(handle, conn_fd, status_line_response(404, keep_alive)).await;
@@ -540,7 +523,6 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
         conn_fd,
         backend_id,
         cache_id,
-        neighborhood_id,
         &path,
         page_size,
         resolved,
@@ -585,7 +567,6 @@ enum Ticket {
 fn stripe_request(
     backend_id: &str,
     cache_id: Option<&str>,
-    neighborhood_id: Option<&str>,
     path: &str,
     slice: StripeSlice,
     bypass: bool,
@@ -595,13 +576,12 @@ fn stripe_request(
         origin_object_id: path.to_string(),
         stripe_idx: slice.stripe_idx,
     };
-    let key = origin_ref.stripe_key();
+    let key = cache_id
+        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+        .unwrap_or_else(|| origin_ref.stripe_key());
     let req = StripeReq::new(key)
         .with_origin(origin_ref)
-        .with_chain(
-            cache_id.map(ToOwned::to_owned),
-            neighborhood_id.map(ToOwned::to_owned),
-        )
+        .with_cache_id(cache_id.map(ToOwned::to_owned))
         .with_bypass(bypass);
     (key, req)
 }
@@ -663,12 +643,11 @@ async fn dispatch_ticket(
     fanout: &Rc<FanoutTable>,
     backend_id: &str,
     cache_id: Option<&str>,
-    neighborhood_id: Option<&str>,
     path: &str,
     slice: StripeSlice,
     bypass: bool,
 ) -> Ticket {
-    let (key, req) = stripe_request(backend_id, cache_id, neighborhood_id, path, slice, bypass);
+    let (key, req) = stripe_request(backend_id, cache_id, path, slice, bypass);
     match fanout.owner_of_cache(&key, cache_id, slice.intra_offset) {
         Owner::Local => Ticket::Local { slice },
         Owner::Peer(peer) => {
@@ -712,7 +691,6 @@ async fn stream_body<P: BufferPool<Req = StripeReq>>(
     conn_fd: RawFd,
     backend_id: &str,
     cache_id: Option<&str>,
-    neighborhood_id: Option<&str>,
     path: &str,
     page_size: usize,
     resolved: ResolvedRange,
@@ -728,8 +706,7 @@ async fn stream_body<P: BufferPool<Req = StripeReq>>(
         let plans: Vec<StripePlan<StripeReq>> = slices
             .into_iter()
             .map(|slice| {
-                let (_key, req) =
-                    stripe_request(backend_id, cache_id, neighborhood_id, path, slice, bypass);
+                let (_key, req) = stripe_request(backend_id, cache_id, path, slice, bypass);
                 StripePlan {
                     req,
                     intra_offset: slice.intra_offset,
@@ -753,23 +730,13 @@ async fn stream_body<P: BufferPool<Req = StripeReq>>(
     let mut window: VecDeque<Ticket> = VecDeque::new();
     while next < slices.len() && window.len() < WINDOW {
         window.push_back(
-            dispatch_ticket(
-                fanout,
-                backend_id,
-                cache_id,
-                neighborhood_id,
-                path,
-                slices[next],
-                bypass,
-            )
-            .await,
+            dispatch_ticket(fanout, backend_id, cache_id, path, slices[next], bypass).await,
         );
         next += 1;
     }
 
     let local_plan = |slice: StripeSlice| {
-        let (_key, req) =
-            stripe_request(backend_id, cache_id, neighborhood_id, path, slice, bypass);
+        let (_key, req) = stripe_request(backend_id, cache_id, path, slice, bypass);
         StripePlan {
             req,
             intra_offset: slice.intra_offset,
@@ -820,16 +787,9 @@ async fn stream_body<P: BufferPool<Req = StripeReq>>(
                     // its pins, so retries eventually succeed.
                     Err(crate::bufferpool::Error::Busy) => {
                         yield_now().await;
-                        let retry = dispatch_ticket(
-                            fanout,
-                            backend_id,
-                            cache_id,
-                            neighborhood_id,
-                            path,
-                            slice,
-                            bypass,
-                        )
-                        .await;
+                        let retry =
+                            dispatch_ticket(fanout, backend_id, cache_id, path, slice, bypass)
+                                .await;
                         window.push_front(retry);
                         continue;
                     }
@@ -864,16 +824,7 @@ async fn stream_body<P: BufferPool<Req = StripeReq>>(
 
         while next < slices.len() && window.len() < WINDOW {
             window.push_back(
-                dispatch_ticket(
-                    fanout,
-                    backend_id,
-                    cache_id,
-                    neighborhood_id,
-                    path,
-                    slices[next],
-                    bypass,
-                )
-                .await,
+                dispatch_ticket(fanout, backend_id, cache_id, path, slices[next], bypass).await,
             );
             next += 1;
         }
@@ -890,18 +841,17 @@ async fn read_object_length<P: BufferPool<Req = StripeReq>>(
     pool: &Rc<P>,
     backend_id: &str,
     cache_id: Option<&str>,
-    neighborhood_id: Option<&str>,
     path: &str,
     page_size: usize,
     bypass: bool,
 ) -> LenResult {
     let origin_ref = OriginRef::metadata_entry(backend_id, path);
-    let req = StripeReq::new(origin_ref.stripe_key())
+    let key = cache_id
+        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+        .unwrap_or_else(|| origin_ref.stripe_key());
+    let req = StripeReq::new(key)
         .with_origin(origin_ref)
-        .with_chain(
-            cache_id.map(ToOwned::to_owned),
-            neighborhood_id.map(ToOwned::to_owned),
-        )
+        .with_cache_id(cache_id.map(ToOwned::to_owned))
         .with_bypass(bypass);
     let mut rs: ReadStream = match pool.read(&req, 0, page_size as u64).await {
         Ok(rs) => rs,
@@ -1287,22 +1237,15 @@ mod tests {
             intra_len: 4,
         };
         // Non-bypass requests carry the cache path (bypass == false).
-        let (_k, normal) = stripe_request(
-            "primary",
-            Some("cache-a"),
-            Some("site-a"),
-            "/o",
-            slice,
-            false,
-        );
+        let (_k, normal) = stripe_request("primary", Some("cache-a"), "/o", slice, false);
         assert!(!normal.bypass());
         assert_eq!(normal.cache_id(), Some("cache-a"));
-        assert_eq!(normal.neighborhood_id(), Some("site-a"));
         // Bridge-mode frontends stamp bypass == true onto every request.
-        let (k, bridged) = stripe_request("primary", None, None, "/o", slice, true);
+        let (k, bridged) = stripe_request("primary", None, "/o", slice, true);
         assert!(bridged.bypass());
-        // The flag does not perturb the routing key or origin mapping.
-        assert_eq!(normal.key(), k);
+        // Cache id is the only logical key prefix, so cached and uncached
+        // requests for the same origin intentionally use different keys.
+        assert_ne!(normal.key(), k);
         assert_eq!(bridged.origin(), normal.origin());
     }
 
@@ -1314,9 +1257,10 @@ mod tests {
         let origin_ref = OriginRef::metadata_entry("primary", "/o");
         assert!(origin_ref.is_metadata_entry());
 
-        let req = StripeReq::new(origin_ref.stripe_key()).with_origin(origin_ref);
+        let req =
+            StripeReq::new(origin_ref.stripe_key_for_cache("cache-a")).with_origin(origin_ref);
         assert!(req.origin().unwrap().is_metadata_entry());
-        assert_eq!(req.key(), stripe_key("primary", "/o", METADATA_STRIPE_IDX));
+        assert_eq!(req.key(), stripe_key("cache-a", "/o", METADATA_STRIPE_IDX));
         assert_eq!(METADATA_STRIPE_IDX, u64::MAX);
     }
 
@@ -1379,7 +1323,7 @@ mod tests {
         });
 
         let result = block_on(read_object_length(
-            &pool, "primary", None, None, "/missing", 4096, false,
+            &pool, "primary", None, "/missing", 4096, false,
         ));
 
         assert_eq!(result, LenResult::NotFound);
@@ -1392,7 +1336,7 @@ mod tests {
         });
 
         let result = block_on(read_object_length(
-            &pool, "primary", None, None, "/broken", 4096, false,
+            &pool, "primary", None, "/broken", 4096, false,
         ));
 
         assert_eq!(result, LenResult::Other);
@@ -1424,7 +1368,6 @@ mod tests {
             listen_fd,
             Rc::from("primary"),
             "primary".to_string(),
-            None,
             None,
             4 * 1024 * 1024,
             2 * 1024 * 1024,

--- a/cmd/unbounded-storage/src/frontend/loadgen_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/loadgen_serve.rs
@@ -9,23 +9,32 @@
 //! as a client-facing GET. Prometheus service metrics are the benchmark
 //! result surface.
 
+use std::cell::Cell;
 use std::future::Future;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::task::{Context, Waker};
+use std::task::{Context, Poll, Waker};
 use std::time::Instant;
 
-use crate::bufferpool::{BufferPool, ReadStream, StripePlan};
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use crate::bufferpool::{BufferPool, ReadStream, Req, StripePlan};
 use crate::config::{FrontendSpec, frontend_spec};
 use crate::frontend::FrontendError;
-use crate::frontend::range::{ResolvedRange, stripe_set};
+use crate::frontend::range::ResolvedRange;
 use crate::metrics;
-use crate::runtime::noop_waker;
-use crate::storage::{ObjectMetadata, OriginRef, StripeReq};
+use crate::p2p::{RouteTableHandle, stripe_to_ring};
+use crate::storage::{
+    ObjectMetadata, OriginRef, StripeReq, SyntheticObjectId, object_hash, splitmix64,
+    synthetic_matches_bytes, synthetic_object_id,
+};
 
 const DEFAULT_WORKERS: u32 = 1;
 const DEFAULT_SEED: u64 = 0xBE_DE_CA_FE;
-const DEFAULT_OBJECT_COUNT: u64 = 1_000_000;
+const DEFAULT_KEYSPACE_OBJECTS: u64 = 1_000_000;
+const DEFAULT_ZIPF_EXPONENT: f64 = 1.1;
 
 /// Synthetic frontend factory. Built once per [`FrontendSpec`]; holds
 /// only immutable load-shaping configuration.
@@ -33,9 +42,15 @@ pub struct LoadgenFrontend {
     id: String,
     workers: u32,
     seed: u64,
-    object_count: u64,
+    keyspace_objects: u64,
+    expected_object_size_bytes: Option<u64>,
     read_bytes: u64,
+    zipf_exponent: f64,
     verify: bool,
+    remote_only: bool,
+    fabric_only: bool,
+    local_only: bool,
+    skip_local_disk: bool,
 }
 
 impl LoadgenFrontend {
@@ -48,13 +63,26 @@ impl LoadgenFrontend {
                 ));
             }
         };
+        let zipf_exponent = loadgen.zipf_exponent.unwrap_or(DEFAULT_ZIPF_EXPONENT);
+        if !zipf_exponent.is_finite() || zipf_exponent <= 0.0 {
+            return Err(FrontendError::BadConfig(
+                "loadgen zipf_exponent must be positive",
+            ));
+        }
+
         Ok(Self {
             id: spec.name.clone(),
             workers: loadgen.workers.unwrap_or(DEFAULT_WORKERS),
             seed: loadgen.seed.unwrap_or(DEFAULT_SEED),
-            object_count: loadgen.object_count.unwrap_or(DEFAULT_OBJECT_COUNT),
+            keyspace_objects: loadgen.keyspace_objects.unwrap_or(DEFAULT_KEYSPACE_OBJECTS),
+            expected_object_size_bytes: loadgen.object_size_bytes,
             read_bytes: loadgen.read_bytes.unwrap_or(0),
+            zipf_exponent,
             verify: loadgen.verify,
+            remote_only: loadgen.remote_only,
+            fabric_only: loadgen.fabric_only,
+            local_only: loadgen.local_only,
+            skip_local_disk: loadgen.skip_local_disk,
         })
     }
 
@@ -66,9 +94,8 @@ impl LoadgenFrontend {
 /// Per-shard synthetic read driver, generic over the concrete pool type.
 pub struct LoadgenDriver<P: BufferPool<Req = StripeReq> + 'static> {
     workers: Vec<LoadgenWorker>,
-    cfg: Rc<LoadgenRun>,
-    pool: Rc<P>,
     waker: Waker,
+    _marker: PhantomData<fn() -> P>,
 }
 
 impl<P: BufferPool<Req = StripeReq> + 'static> LoadgenDriver<P> {
@@ -78,59 +105,62 @@ impl<P: BufferPool<Req = StripeReq> + 'static> LoadgenDriver<P> {
         pool: Rc<P>,
         backend_id: String,
         cache_id: Option<String>,
-        neighborhood_id: Option<String>,
         stripe_size: u64,
         page_size: usize,
+        routes: RouteTableHandle,
         bypass: bool,
         shard_idx: u16,
+        waker: Waker,
     ) -> Self {
         let worker_count = frontend.workers as usize;
         let cfg = Rc::new(LoadgenRun {
             frontend_id: frontend.id,
             backend_id,
             cache_id,
-            neighborhood_id,
             stripe_size,
             page_size,
             bypass,
             shard_idx,
             seed: frontend.seed,
-            object_count: frontend.object_count,
+            expected_object_size_bytes: frontend.expected_object_size_bytes,
             read_bytes: frontend.read_bytes,
+            sampler: ZipfSampler::new(frontend.keyspace_objects, frontend.zipf_exponent),
             verify: frontend.verify,
+            routes,
+            remote_only: frontend.remote_only,
+            fabric_only: frontend.fabric_only,
+            local_only: frontend.local_only,
+            skip_local_disk: frontend.skip_local_disk,
         });
         let workers = (0..worker_count)
-            .map(|worker_idx| LoadgenWorker {
-                worker_idx,
-                seq: 0,
-                fut: loadgen_op(Rc::clone(&pool), Rc::clone(&cfg), worker_idx, 0),
+            .map(|worker_idx| {
+                let rng = worker_rng(cfg.seed, cfg.shard_idx, worker_idx);
+                let completed = Rc::new(Cell::new(false));
+                LoadgenWorker {
+                    completed: Rc::clone(&completed),
+                    fut: loadgen_worker_loop(Rc::clone(&pool), Rc::clone(&cfg), rng, completed),
+                }
             })
             .collect();
         Self {
             workers,
-            cfg,
-            pool,
-            waker: noop_waker(),
+            waker,
+            _marker: PhantomData,
         }
     }
 
-    /// Poll every synthetic worker once. A completed operation is
-    /// immediately replaced with that worker's next operation, so load
-    /// runs until the frontend is removed or the shard shuts down.
+    /// Poll every synthetic worker once. Each worker owns a long-lived
+    /// loop future, so load runs until the frontend is removed or the
+    /// shard shuts down.
     pub fn progress(&mut self) -> bool {
         let mut busy = false;
         let waker = self.waker.clone();
         let mut cx = Context::from_waker(&waker);
         for worker in &mut self.workers {
-            if worker.fut.as_mut().poll(&mut cx).is_ready() {
+            worker.completed.set(false);
+            let _ = worker.fut.as_mut().poll(&mut cx);
+            if worker.completed.replace(false) {
                 busy = true;
-                worker.seq = worker.seq.wrapping_add(1);
-                worker.fut = loadgen_op(
-                    Rc::clone(&self.pool),
-                    Rc::clone(&self.cfg),
-                    worker.worker_idx,
-                    worker.seq,
-                );
             }
         }
         busy
@@ -138,64 +168,144 @@ impl<P: BufferPool<Req = StripeReq> + 'static> LoadgenDriver<P> {
 }
 
 struct LoadgenWorker {
-    worker_idx: usize,
-    seq: u64,
+    completed: Rc<Cell<bool>>,
     fut: Pin<Box<dyn Future<Output = ()>>>,
 }
+
+type WorkerRng = ChaCha8Rng;
 
 struct LoadgenRun {
     frontend_id: String,
     backend_id: String,
     cache_id: Option<String>,
-    neighborhood_id: Option<String>,
     stripe_size: u64,
     page_size: usize,
     bypass: bool,
     shard_idx: u16,
     seed: u64,
-    object_count: u64,
+    expected_object_size_bytes: Option<u64>,
     read_bytes: u64,
+    sampler: ZipfSampler,
     verify: bool,
+    routes: RouteTableHandle,
+    remote_only: bool,
+    fabric_only: bool,
+    local_only: bool,
+    skip_local_disk: bool,
 }
 
-fn loadgen_op<P: BufferPool<Req = StripeReq> + 'static>(
+fn loadgen_worker_loop<P: BufferPool<Req = StripeReq> + 'static>(
     pool: Rc<P>,
     cfg: Rc<LoadgenRun>,
-    worker_idx: usize,
-    seq: u64,
+    mut rng: WorkerRng,
+    completed: Rc<Cell<bool>>,
 ) -> Pin<Box<dyn Future<Output = ()>>> {
     Box::pin(async move {
-        let start = Instant::now();
-        let result = read_generated_object(&pool, &cfg, worker_idx, seq).await;
-        let (status, bytes) = match result {
-            Ok(bytes) => (200, bytes),
-            Err(()) => (500, 0),
-        };
-        metrics::frontend_request(
-            &cfg.frontend_id,
-            "GET",
-            status,
-            bytes,
-            start.elapsed().as_secs_f64(),
-        );
+        loop {
+            let object = sample_object(&cfg, &mut rng);
+            let start = Instant::now();
+            let result = read_generated_object(&pool, &cfg, object).await;
+            let (status, bytes) = match result {
+                Ok(bytes) => (200, bytes),
+                Err(()) => (500, 0),
+            };
+            metrics::frontend_request(
+                &cfg.frontend_id,
+                "GET",
+                status,
+                bytes,
+                start.elapsed().as_secs_f64(),
+            );
+            completed.set(true);
+            YieldOnce::new().await;
+        }
     })
+}
+
+fn sample_object(cfg: &LoadgenRun, rng: &mut WorkerRng) -> SyntheticObjectId {
+    const MAX_REMOTE_SAMPLE_ATTEMPTS: usize = 1024;
+
+    let mut fallback = None;
+    for _ in 0..MAX_REMOTE_SAMPLE_ATTEMPTS {
+        let object = cfg.sampler.sample(cfg.seed, rng);
+        if fallback.is_none() {
+            fallback = Some(object);
+        }
+        if sample_object_matches_route_mode(cfg, object) {
+            return object;
+        }
+    }
+
+    fallback.expect("sampler loop always records first sample")
+}
+
+fn sample_object_matches_route_mode(cfg: &LoadgenRun, object: SyntheticObjectId) -> bool {
+    let remote = first_stripe_routes_remote(cfg, object);
+    match (cfg.remote_only, cfg.local_only) {
+        (true, true) => false,
+        (true, false) => remote,
+        (false, true) => !remote,
+        (false, false) => true,
+    }
+}
+
+fn first_stripe_routes_remote(cfg: &LoadgenRun, object: SyntheticObjectId) -> bool {
+    if cfg.bypass || cfg.cache_id.is_none() {
+        return false;
+    }
+
+    let object_id = synthetic_object_id(object.seed, object.ordinal);
+    let req = request_from_origin(OriginRef::new(&cfg.backend_id, &object_id, 0), cfg);
+    let Some(route) = cfg.routes.route_for_req(&req) else {
+        return false;
+    };
+
+    route.fingers.next_hop(stripe_to_ring(req.key())).is_some()
+}
+
+struct YieldOnce {
+    yielded: bool,
+}
+
+impl YieldOnce {
+    fn new() -> Self {
+        Self { yielded: false }
+    }
+}
+
+impl Future for YieldOnce {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.yielded {
+            Poll::Ready(())
+        } else {
+            self.yielded = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
 }
 
 async fn read_generated_object<P: BufferPool<Req = StripeReq>>(
     pool: &Rc<P>,
     cfg: &LoadgenRun,
-    worker_idx: usize,
-    seq: u64,
+    object: SyntheticObjectId,
 ) -> Result<u64, ()> {
-    let object_id = object_id(
-        &cfg.frontend_id,
-        cfg.shard_idx,
-        worker_idx,
-        cfg.seed,
-        cfg.object_count,
-        seq,
-    );
-    let object_len = read_object_length(pool, cfg, &object_id).await?;
+    let object_id = synthetic_object_id(object.seed, object.ordinal);
+    let object_len = if cfg.verify || cfg.expected_object_size_bytes.is_none() {
+        let actual = read_object_length(pool, cfg, &object_id).await?;
+        if cfg
+            .expected_object_size_bytes
+            .is_some_and(|expected| actual != expected)
+        {
+            return Err(());
+        }
+        actual
+    } else {
+        cfg.expected_object_size_bytes
+            .expect("object_size_bytes presence checked")
+    };
     let read_len = if cfg.read_bytes == 0 {
         object_len
     } else {
@@ -205,7 +315,7 @@ async fn read_generated_object<P: BufferPool<Req = StripeReq>>(
         start: 0,
         end: read_len,
     };
-    read_body(pool, cfg, &object_id, range).await
+    read_body(pool, cfg, object, &object_id, range).await
 }
 
 async fn read_object_length<P: BufferPool<Req = StripeReq>>(
@@ -227,57 +337,179 @@ async fn read_object_length<P: BufferPool<Req = StripeReq>>(
 async fn read_body<P: BufferPool<Req = StripeReq>>(
     pool: &Rc<P>,
     cfg: &LoadgenRun,
+    object: SyntheticObjectId,
     object_id: &str,
     range: ResolvedRange,
 ) -> Result<u64, ()> {
-    let plans: Vec<StripePlan<StripeReq>> = stripe_set(range, cfg.stripe_size)
-        .into_iter()
-        .map(|slice| {
-            let origin_ref = OriginRef::new(&cfg.backend_id, object_id, slice.stripe_idx);
-            StripePlan {
-                req: request_from_origin(origin_ref, cfg),
-                intra_offset: slice.intra_offset,
-                intra_len: slice.intra_len,
-            }
-        })
-        .collect();
+    let plans = stripe_plans(range, cfg, object_id);
     let mut bytes = 0u64;
+    let mut checked_offset = range.start;
     let mut rs = pool.read_pipelined(plans, usize::MAX).map_err(|_| ())?;
     while let Some(page) = rs.next_page().await {
         let page = page.map_err(|_| ())?;
-        if cfg.verify && page.as_slice().iter().any(|b| *b != 0) {
+        if cfg.verify && !synthetic_matches_bytes(object, checked_offset, page.as_slice()) {
             return Err(());
         }
+        checked_offset = checked_offset.wrapping_add(page.len() as u64);
         bytes += page.len() as u64;
         drop(page);
     }
     Ok(bytes)
 }
 
-fn request_from_origin(origin_ref: OriginRef, cfg: &LoadgenRun) -> StripeReq {
-    StripeReq::new(origin_ref.stripe_key())
-        .with_origin(origin_ref)
-        .with_chain(cfg.cache_id.clone(), cfg.neighborhood_id.clone())
-        .with_bypass(cfg.bypass)
+fn stripe_plans(
+    range: ResolvedRange,
+    cfg: &LoadgenRun,
+    object_id: &str,
+) -> Vec<StripePlan<StripeReq>> {
+    if cfg.stripe_size == 0 || range.is_empty() {
+        return Vec::new();
+    }
+
+    let first = range.start / cfg.stripe_size;
+    let last = (range.end - 1) / cfg.stripe_size;
+    let mut plans = Vec::with_capacity((last - first + 1) as usize);
+    for stripe_idx in first..=last {
+        let stripe_start = stripe_idx * cfg.stripe_size;
+        let start = range.start.max(stripe_start);
+        let end = range.end.min(stripe_start + cfg.stripe_size);
+        let origin_ref = OriginRef::new(&cfg.backend_id, object_id, stripe_idx);
+        plans.push(StripePlan {
+            req: request_from_origin(origin_ref, cfg),
+            intra_offset: start - stripe_start,
+            intra_len: end - start,
+        });
+    }
+    plans
 }
 
-fn object_id(
-    frontend_id: &str,
-    shard_idx: u16,
-    worker_idx: usize,
-    seed: u64,
-    object_count: u64,
-    seq: u64,
-) -> String {
-    let ordinal = seed.wrapping_add(seq) % object_count.max(1);
-    format!("/__loadgen/{frontend_id}/{shard_idx}/{worker_idx}/{ordinal}")
+fn request_from_origin(origin_ref: OriginRef, cfg: &LoadgenRun) -> StripeReq {
+    let key = cfg
+        .cache_id
+        .as_deref()
+        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+        .unwrap_or_else(|| origin_ref.stripe_key());
+    StripeReq::new(key)
+        .with_origin(origin_ref)
+        .with_cache_id(cfg.cache_id.clone())
+        .with_bypass(cfg.bypass)
+        .with_fabric_only(cfg.fabric_only)
+        .with_skip_local_disk(cfg.skip_local_disk)
+}
+
+#[derive(Clone, Copy)]
+struct ZipfSampler {
+    keyspace_objects: u64,
+    exponent: f64,
+    t: f64,
+    q: f64,
+}
+
+impl ZipfSampler {
+    fn new(keyspace_objects: u64, exponent: f64) -> Self {
+        let keyspace_objects = keyspace_objects.max(1);
+        let n = keyspace_objects as f64;
+        let (t, q) = if exponent == 1.0 {
+            (1.0 + n.ln(), 0.0)
+        } else {
+            let one_minus_s = 1.0 - exponent;
+            (
+                (n.powf(one_minus_s) - exponent) / one_minus_s,
+                1.0 / one_minus_s,
+            )
+        };
+
+        Self {
+            keyspace_objects,
+            exponent,
+            t,
+            q,
+        }
+    }
+
+    fn sample(&self, seed: u64, rng: &mut WorkerRng) -> SyntheticObjectId {
+        let rank = self.sample_rank(rng);
+        let ordinal = rank - 1;
+        SyntheticObjectId {
+            seed,
+            ordinal,
+            hash: object_hash(seed, ordinal),
+        }
+    }
+
+    fn sample_rank(&self, rng: &mut WorkerRng) -> u64 {
+        if self.keyspace_objects == 1 {
+            return 1;
+        }
+
+        loop {
+            let inv = self.inverse_cdf(unit_f64(rng));
+            let rank = (inv + 1.0).floor();
+            let mut accept = rank.powf(-self.exponent);
+            if rank > 1.0 {
+                accept *= inv.powf(self.exponent);
+            }
+
+            if unit_f64(rng) < accept {
+                return (rank as u64).clamp(1, self.keyspace_objects);
+            }
+        }
+    }
+
+    fn inverse_cdf(&self, p: f64) -> f64 {
+        let scaled = p * self.t;
+        if scaled <= 1.0 {
+            scaled
+        } else if self.exponent == 1.0 {
+            (scaled - 1.0).exp()
+        } else {
+            (scaled.mul_add(1.0 - self.exponent, self.exponent)).powf(self.q)
+        }
+    }
+}
+
+fn worker_rng(seed: u64, shard_idx: u16, worker_idx: usize) -> WorkerRng {
+    let mixed = splitmix64(seed ^ ((shard_idx as u64) << 48) ^ worker_idx as u64);
+    WorkerRng::seed_from_u64(mixed)
+}
+
+fn unit_f64(rng: &mut WorkerRng) -> f64 {
+    const SCALE: f64 = 1.0 / ((1u64 << 53) as f64);
+    ((rng.next_u64() >> 11) as f64) * SCALE
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bufferpool::Req;
+    use std::pin::Pin;
+    use std::task::{RawWaker, RawWakerVTable, Waker};
+
+    use crate::bufferpool::{PageRef, Req};
     use crate::config::{HttpFrontendConfig, LoadgenFrontendConfig};
+    use crate::p2p::{FingerTable, FingerTableConfig, NodeId, PeerEntry, RingId, TopologyTags};
+
+    fn noop_waker() -> Waker {
+        fn no_op(_: *const ()) {}
+        fn clone(_: *const ()) -> RawWaker {
+            RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, no_op, no_op, no_op);
+        // SAFETY: the vtable's fns are all no-ops over a null data pointer.
+        unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+    }
+
+    fn block_on<F: Future>(fut: F) -> F::Output {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = Box::pin(fut);
+        loop {
+            match Future::poll(Pin::as_mut(&mut fut), &mut cx) {
+                Poll::Ready(v) => return v,
+                Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
 
     fn loadgen_spec() -> FrontendSpec {
         FrontendSpec {
@@ -294,15 +526,117 @@ mod tests {
             frontend_id: "lg".to_string(),
             backend_id: "fake".to_string(),
             cache_id: Some("cache".to_string()),
-            neighborhood_id: Some("n".to_string()),
             stripe_size: 4096,
             page_size: 4096,
             bypass: false,
             shard_idx: 2,
             seed: 7,
-            object_count: 5,
+            expected_object_size_bytes: None,
             read_bytes: 0,
+            sampler: ZipfSampler::new(5, DEFAULT_ZIPF_EXPONENT),
             verify: false,
+            routes: RouteTableHandle::empty(),
+            remote_only: false,
+            fabric_only: false,
+            local_only: false,
+            skip_local_disk: false,
+        }
+    }
+
+    fn route_handle(local_ring: u64, peer_ring: u64) -> RouteTableHandle {
+        let local = PeerEntry {
+            node: NodeId(1),
+            ring: RingId(local_ring),
+            tags: TopologyTags(Vec::new()),
+        };
+        let peer = PeerEntry {
+            node: NodeId(2),
+            ring: RingId(peer_ring),
+            tags: TopologyTags(Vec::new()),
+        };
+        let fingers = std::sync::Arc::new(FingerTable::build(
+            local,
+            &[peer],
+            FingerTableConfig { k: 4 },
+        ));
+        let node_to_peer = std::sync::Arc::new(std::collections::HashMap::from([(
+            NodeId(2),
+            crate::fabric::PeerId(2),
+        )]));
+        let mut routes = std::collections::HashMap::new();
+        routes.insert(
+            "cache".to_string(),
+            crate::p2p::RoutingSnapshot {
+                fingers,
+                node_to_peer,
+            },
+        );
+
+        RouteTableHandle::new(routes)
+    }
+
+    fn find_object_with_remote_route(cfg: &LoadgenRun, want_remote: bool) -> SyntheticObjectId {
+        for ordinal in 0..100_000 {
+            let object = SyntheticObjectId {
+                seed: cfg.seed,
+                ordinal,
+                hash: object_hash(cfg.seed, ordinal),
+            };
+            if first_stripe_routes_remote(cfg, object) == want_remote {
+                return object;
+            }
+        }
+
+        panic!("could not find object with desired route");
+    }
+
+    struct MetadataProbePool {
+        metadata_reads: Cell<u32>,
+    }
+
+    impl MetadataProbePool {
+        fn new() -> Self {
+            Self {
+                metadata_reads: Cell::new(0),
+            }
+        }
+    }
+
+    impl BufferPool for MetadataProbePool {
+        type Req = StripeReq;
+
+        async fn read<'p>(
+            &'p self,
+            _req: &'p Self::Req,
+            _offset: u64,
+            _len: u64,
+        ) -> Result<ReadStream<'p>, crate::bufferpool::Error> {
+            self.metadata_reads.set(self.metadata_reads.get() + 1);
+            Err(crate::bufferpool::Error::from("metadata probe"))
+        }
+
+        fn read_windowed<'p>(
+            &'p self,
+            _req: &'p Self::Req,
+            _offset: u64,
+            _len: u64,
+            _window: usize,
+        ) -> Result<crate::bufferpool::WindowedRead<'p>, crate::bufferpool::Error> {
+            unimplemented!()
+        }
+
+        fn read_pipelined<'p>(
+            &'p self,
+            stripes: Vec<StripePlan<Self::Req>>,
+            _window: usize,
+        ) -> Result<crate::bufferpool::PipelinedRead<'p>, crate::bufferpool::Error> {
+            assert!(
+                stripes.is_empty(),
+                "zero-length object should not read data"
+            );
+            Err(crate::bufferpool::Error::from(
+                "end test after metadata skip",
+            ))
         }
     }
 
@@ -312,9 +646,15 @@ mod tests {
         assert_eq!(frontend.id(), "lg");
         assert_eq!(frontend.workers, DEFAULT_WORKERS);
         assert_eq!(frontend.seed, DEFAULT_SEED);
-        assert_eq!(frontend.object_count, DEFAULT_OBJECT_COUNT);
+        assert_eq!(frontend.keyspace_objects, DEFAULT_KEYSPACE_OBJECTS);
+        assert_eq!(frontend.expected_object_size_bytes, None);
         assert_eq!(frontend.read_bytes, 0);
+        assert_eq!(frontend.zipf_exponent, DEFAULT_ZIPF_EXPONENT);
         assert!(!frontend.verify);
+        assert!(!frontend.remote_only);
+        assert!(!frontend.fabric_only);
+        assert!(!frontend.local_only);
+        assert!(!frontend.skip_local_disk);
     }
 
     #[test]
@@ -323,36 +663,233 @@ mod tests {
         spec.config = Some(frontend_spec::Config::Loadgen(LoadgenFrontendConfig {
             workers: Some(0),
             seed: Some(0),
-            object_count: Some(0),
+            keyspace_objects: Some(0),
+            object_size_bytes: Some(0),
             read_bytes: Some(0),
+            zipf_exponent: Some(1.0),
             verify: false,
+            remote_only: false,
+            fabric_only: false,
+            local_only: false,
+            skip_local_disk: false,
         }));
         let frontend = LoadgenFrontend::from_spec(&spec).unwrap();
         assert_eq!(frontend.workers, 0);
         assert_eq!(frontend.seed, 0);
-        assert_eq!(frontend.object_count, 0);
+        assert_eq!(frontend.keyspace_objects, 0);
+        assert_eq!(frontend.expected_object_size_bytes, Some(0));
         assert_eq!(frontend.read_bytes, 0);
     }
 
     #[test]
-    fn object_ids_are_deterministic_and_bounded() {
-        assert_eq!(object_id("lg", 2, 3, 7, 5, 0), "/__loadgen/lg/2/3/2");
-        assert_eq!(object_id("lg", 2, 3, 7, 5, 1), "/__loadgen/lg/2/3/3");
-        assert_eq!(object_id("lg", 2, 3, 7, 0, 1), "/__loadgen/lg/2/3/0");
+    fn remote_only_flag_loads_from_spec() {
+        let mut spec = loadgen_spec();
+        spec.config = Some(frontend_spec::Config::Loadgen(LoadgenFrontendConfig {
+            remote_only: true,
+            ..LoadgenFrontendConfig::default()
+        }));
+
+        let frontend = LoadgenFrontend::from_spec(&spec).unwrap();
+        assert!(frontend.remote_only);
+    }
+
+    #[test]
+    fn fabric_only_flag_loads_from_spec() {
+        let mut spec = loadgen_spec();
+        spec.config = Some(frontend_spec::Config::Loadgen(LoadgenFrontendConfig {
+            fabric_only: true,
+            ..LoadgenFrontendConfig::default()
+        }));
+
+        let frontend = LoadgenFrontend::from_spec(&spec).unwrap();
+        assert!(frontend.fabric_only);
+    }
+
+    #[test]
+    fn local_only_flag_loads_from_spec() {
+        let mut spec = loadgen_spec();
+        spec.config = Some(frontend_spec::Config::Loadgen(LoadgenFrontendConfig {
+            local_only: true,
+            ..LoadgenFrontendConfig::default()
+        }));
+
+        let frontend = LoadgenFrontend::from_spec(&spec).unwrap();
+        assert!(frontend.local_only);
+    }
+
+    #[test]
+    fn skip_local_disk_flag_loads_from_spec() {
+        let mut spec = loadgen_spec();
+        spec.config = Some(frontend_spec::Config::Loadgen(LoadgenFrontendConfig {
+            skip_local_disk: true,
+            ..LoadgenFrontendConfig::default()
+        }));
+
+        let frontend = LoadgenFrontend::from_spec(&spec).unwrap();
+        assert!(frontend.skip_local_disk);
+    }
+
+    #[test]
+    fn invalid_zipf_exponent_is_rejected() {
+        let mut spec = loadgen_spec();
+        spec.config = Some(frontend_spec::Config::Loadgen(LoadgenFrontendConfig {
+            zipf_exponent: Some(0.0),
+            ..LoadgenFrontendConfig::default()
+        }));
+
+        assert!(matches!(
+            LoadgenFrontend::from_spec(&spec),
+            Err(FrontendError::BadConfig(_))
+        ));
+    }
+
+    #[test]
+    fn zipf_sampler_is_deterministic_and_bounded() {
+        let sampler = ZipfSampler::new(5, DEFAULT_ZIPF_EXPONENT);
+        let mut first = worker_rng(7, 2, 3);
+        let mut second = worker_rng(7, 2, 3);
+
+        for _ in 0..100 {
+            let a = sampler.sample(7, &mut first);
+            let b = sampler.sample(7, &mut second);
+            assert_eq!(a, b);
+            assert_eq!(a.seed, 7);
+            assert!(a.ordinal < 5);
+        }
+    }
+
+    #[test]
+    fn zipf_sampler_can_reach_tail_rank() {
+        let sampler = ZipfSampler::new(10, 1.0);
+        let mut rng = worker_rng(7, 2, 3);
+        let mut saw_tail = false;
+        for _ in 0..100_000 {
+            saw_tail |= sampler.sample_rank(&mut rng) == 10;
+        }
+
+        assert!(
+            saw_tail,
+            "finite Zipf sampler should be able to sample rank n"
+        );
+    }
+
+    #[test]
+    fn zipf_sampler_rank_counts_decrease_with_rank() {
+        let sampler = ZipfSampler::new(5, DEFAULT_ZIPF_EXPONENT);
+        let mut rng = worker_rng(7, 2, 3);
+        let mut counts = [0usize; 5];
+        for _ in 0..100_000 {
+            counts[(sampler.sample_rank(&mut rng) - 1) as usize] += 1;
+        }
+
+        for pair in counts.windows(2) {
+            assert!(
+                pair[0] > pair[1],
+                "rank counts were not descending: {counts:?}"
+            );
+        }
     }
 
     #[test]
     fn request_carries_origin_chain_and_bypass() {
         let mut cfg = run_cfg();
         cfg.bypass = true;
+        cfg.fabric_only = true;
+        cfg.skip_local_disk = true;
         let origin = OriginRef::new("fake", "obj", 3);
-        let key = origin.stripe_key();
+        let key = origin.stripe_key_for_cache("cache");
         let req = request_from_origin(origin, &cfg);
         assert_eq!(req.key(), key);
         assert_eq!(req.origin().unwrap().backend_id, "fake");
         assert_eq!(req.cache_id(), Some("cache"));
-        assert_eq!(req.neighborhood_id(), Some("n"));
         assert!(crate::bufferpool::Req::bypass(&req));
+        assert!(req.fabric_only());
+        assert!(req.skip_local_disk());
+    }
+
+    #[test]
+    fn route_mode_predicate_selects_local_or_remote() {
+        let mut cfg = run_cfg();
+        cfg.routes = route_handle(100, u64::MAX / 2);
+
+        let remote = find_object_with_remote_route(&cfg, true);
+        let local = find_object_with_remote_route(&cfg, false);
+
+        cfg.remote_only = true;
+        assert!(sample_object_matches_route_mode(&cfg, remote));
+        assert!(!sample_object_matches_route_mode(&cfg, local));
+
+        cfg.remote_only = false;
+        cfg.local_only = true;
+        assert!(!sample_object_matches_route_mode(&cfg, remote));
+        assert!(sample_object_matches_route_mode(&cfg, local));
+
+        cfg.remote_only = true;
+        assert!(!sample_object_matches_route_mode(&cfg, remote));
+        assert!(!sample_object_matches_route_mode(&cfg, local));
+    }
+
+    #[test]
+    fn remote_route_predicate_uses_route_table() {
+        let mut cfg = run_cfg();
+        cfg.routes = route_handle(100, u64::MAX / 2);
+
+        let remote = find_object_with_remote_route(&cfg, true);
+        let local = find_object_with_remote_route(&cfg, false);
+
+        assert!(first_stripe_routes_remote(&cfg, remote));
+        assert!(!first_stripe_routes_remote(&cfg, local));
+    }
+
+    #[test]
+    fn remote_route_predicate_is_false_for_bypass_or_missing_cache() {
+        let mut cfg = run_cfg();
+        cfg.routes = route_handle(100, u64::MAX / 2);
+        let remote = find_object_with_remote_route(&cfg, true);
+
+        cfg.bypass = true;
+        assert!(!first_stripe_routes_remote(&cfg, remote));
+
+        cfg.bypass = false;
+        cfg.cache_id = None;
+        assert!(!first_stripe_routes_remote(&cfg, remote));
+    }
+
+    #[test]
+    fn configured_object_size_skips_metadata_read() {
+        let mut cfg = run_cfg();
+        cfg.expected_object_size_bytes = Some(0);
+        let pool = Rc::new(MetadataProbePool::new());
+        let object = SyntheticObjectId {
+            seed: cfg.seed,
+            ordinal: 0,
+            hash: object_hash(cfg.seed, 0),
+        };
+
+        assert_eq!(
+            block_on(read_generated_object(&pool, &cfg, object)),
+            Err(())
+        );
+        assert_eq!(pool.metadata_reads.get(), 0);
+    }
+
+    #[test]
+    fn configured_object_size_with_verify_reads_metadata() {
+        let mut cfg = run_cfg();
+        cfg.expected_object_size_bytes = Some(0);
+        cfg.verify = true;
+        let pool = Rc::new(MetadataProbePool::new());
+        let object = SyntheticObjectId {
+            seed: cfg.seed,
+            ordinal: 0,
+            hash: object_hash(cfg.seed, 0),
+        };
+
+        assert_eq!(
+            block_on(read_generated_object(&pool, &cfg, object)),
+            Err(())
+        );
+        assert_eq!(pool.metadata_reads.get(), 1);
     }
 
     #[test]
@@ -367,6 +904,9 @@ mod tests {
 
     #[test]
     fn full_object_helper_is_available_for_zero_length() {
-        assert!(stripe_set(crate::frontend::range::full_object(0), 4096).is_empty());
+        assert!(
+            crate::frontend::range::stripe_set(crate::frontend::range::full_object(0), 4096)
+                .is_empty()
+        );
     }
 }

--- a/cmd/unbounded-storage/src/frontend/s3_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/s3_serve.rs
@@ -129,7 +129,6 @@ pub struct S3Driver<P: BufferPool<Req = StripeReq> + 'static> {
     frontend_id: Rc<str>,
     backend_id: String,
     cache_id: Option<String>,
-    neighborhood_id: Option<String>,
     stripe_size: u64,
     page_size: usize,
     bypass: bool,
@@ -151,7 +150,6 @@ impl<P: BufferPool<Req = StripeReq> + 'static> S3Driver<P> {
         frontend_id: Rc<str>,
         backend_id: String,
         cache_id: Option<String>,
-        neighborhood_id: Option<String>,
         stripe_size: u64,
         page_size: usize,
         bypass: bool,
@@ -164,7 +162,6 @@ impl<P: BufferPool<Req = StripeReq> + 'static> S3Driver<P> {
             frontend_id,
             backend_id,
             cache_id,
-            neighborhood_id,
             stripe_size,
             page_size,
             bypass,
@@ -210,7 +207,6 @@ impl<P: BufferPool<Req = StripeReq> + 'static> S3Driver<P> {
                             Rc::clone(&self.frontend_id),
                             self.backend_id.clone(),
                             self.cache_id.clone(),
-                            self.neighborhood_id.clone(),
                             self.stripe_size,
                             self.page_size,
                             self.bypass,
@@ -269,7 +265,6 @@ async fn serve_connection_s3<P: BufferPool<Req = StripeReq>>(
     frontend_id: Rc<str>,
     backend_id: String,
     cache_id: Option<String>,
-    neighborhood_id: Option<String>,
     stripe_size: u64,
     page_size: usize,
     bypass: bool,
@@ -285,7 +280,6 @@ async fn serve_connection_s3<P: BufferPool<Req = StripeReq>>(
         conn_fd,
         &backend_id,
         cache_id.as_deref(),
-        neighborhood_id.as_deref(),
         stripe_size,
         page_size,
         bypass,
@@ -310,7 +304,6 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
     conn_fd: RawFd,
     backend_id: &str,
     cache_id: Option<&str>,
-    neighborhood_id: Option<&str>,
     stripe_size: u64,
     page_size: usize,
     bypass: bool,
@@ -402,39 +395,30 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
     // (404 NoSuchKey) from any other failure (500 InternalError). Unlike
     // the plain HTTP frontend, a length-read failure is never a silently
     // dropped connection.
-    let len = match read_object_length_s3(
-        pool,
-        backend_id,
-        cache_id,
-        neighborhood_id,
-        &path,
-        page_size,
-        bypass,
-    )
-    .await
-    {
-        LenResult::Len(l) => l,
-        LenResult::NotFound => {
-            let bytes = error_bytes(S3ErrorCode::NoSuchKey, &path, &request_id, is_head, None);
-            let _ = send_all(handle, conn_fd, bytes).await;
-            log.field("status", 404);
-            outcome.status = 404;
-            return Ok(());
-        }
-        LenResult::Other => {
-            let bytes = error_bytes(
-                S3ErrorCode::InternalError,
-                &path,
-                &request_id,
-                is_head,
-                None,
-            );
-            let _ = send_all(handle, conn_fd, bytes).await;
-            log.field("status", 500);
-            outcome.status = 500;
-            return Ok(());
-        }
-    };
+    let len =
+        match read_object_length_s3(pool, backend_id, cache_id, &path, page_size, bypass).await {
+            LenResult::Len(l) => l,
+            LenResult::NotFound => {
+                let bytes = error_bytes(S3ErrorCode::NoSuchKey, &path, &request_id, is_head, None);
+                let _ = send_all(handle, conn_fd, bytes).await;
+                log.field("status", 404);
+                outcome.status = 404;
+                return Ok(());
+            }
+            LenResult::Other => {
+                let bytes = error_bytes(
+                    S3ErrorCode::InternalError,
+                    &path,
+                    &request_id,
+                    is_head,
+                    None,
+                );
+                let _ = send_all(handle, conn_fd, bytes).await;
+                log.field("status", 500);
+                outcome.status = 500;
+                return Ok(());
+            }
+        };
 
     // 6. Resolve the requested range against the length.
     let resolved = match range {
@@ -519,13 +503,13 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
                 origin_object_id: path.clone(),
                 stripe_idx: slice.stripe_idx,
             };
+            let key = cache_id
+                .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+                .unwrap_or_else(|| origin_ref.stripe_key());
             StripePlan {
-                req: StripeReq::new(origin_ref.stripe_key())
+                req: StripeReq::new(key)
                     .with_origin(origin_ref)
-                    .with_chain(
-                        cache_id.map(ToOwned::to_owned),
-                        neighborhood_id.map(ToOwned::to_owned),
-                    )
+                    .with_cache_id(cache_id.map(ToOwned::to_owned))
                     .with_bypass(bypass),
                 intra_offset: slice.intra_offset,
                 intra_len: slice.intra_len,
@@ -591,18 +575,17 @@ async fn read_object_length_s3<P: BufferPool<Req = StripeReq>>(
     pool: &Rc<P>,
     backend_id: &str,
     cache_id: Option<&str>,
-    neighborhood_id: Option<&str>,
     path: &str,
     page_size: usize,
     bypass: bool,
 ) -> LenResult {
     let origin_ref = OriginRef::metadata_entry(backend_id, path);
-    let req = StripeReq::new(origin_ref.stripe_key())
+    let key = cache_id
+        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+        .unwrap_or_else(|| origin_ref.stripe_key());
+    let req = StripeReq::new(key)
         .with_origin(origin_ref)
-        .with_chain(
-            cache_id.map(ToOwned::to_owned),
-            neighborhood_id.map(ToOwned::to_owned),
-        )
+        .with_cache_id(cache_id.map(ToOwned::to_owned))
         .with_bypass(bypass);
     let mut rs = match pool.read(&req, 0, page_size as u64).await {
         Ok(rs) => rs,
@@ -895,7 +878,6 @@ mod tests {
             listen_fd,
             Rc::from("primary"),
             "primary".to_string(),
-            None,
             None,
             4 * 1024 * 1024,
             2 * 1024 * 1024,

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::task::Waker;
 use std::thread;
 use std::time::Duration;
 
@@ -42,6 +43,7 @@ use unbounded_storage::memory::{BackingKind, BackingRequest, allocate};
 use unbounded_storage::metrics;
 
 mod fabric_group;
+mod rdma_inventory;
 mod shard_layer;
 
 const DEFAULT_CONFIG_PATH: &str = "/etc/unbounded-storage/config.toml";
@@ -418,6 +420,11 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    let rdma_inventory = metrics::RdmaInventoryStatus::new();
+    rdma_inventory.set_json(rdma_inventory::to_json(
+        &host,
+        &layer.fabric_unit_addresses(),
+    ));
 
     // Reconcile the startup disk set now that the shards are up, then
     // publish the channel set so shards can reach their disks.
@@ -448,7 +455,12 @@ fn main() -> ExitCode {
     let metrics_exporter = if metrics_bind.is_empty() {
         None
     } else {
-        match metrics::spawn(&metrics_bind, controller.config_versions(), &SHUTDOWN) {
+        match metrics::spawn(
+            &metrics_bind,
+            controller.config_versions(),
+            rdma_inventory,
+            &SHUTDOWN,
+        ) {
             Ok(handle) => {
                 eprintln!("metrics: exporter listening on {metrics_bind}");
                 Some(handle)
@@ -858,9 +870,11 @@ fn run_shard(
         handle: NetHandle::new(socket.clone()),
         fanout: fanout.clone(),
         geometry: geometry.clone(),
+        routes: routes.clone(),
         bindings: Rc::new(RefCell::new((*frontend_bindings).clone())),
         page_size,
         worker_idx: widx.0,
+        waker: shard_loop.waker(),
     };
     let frontend_registry = match FrontendRegistry::new(&frontend_specs, frontend_ctx) {
         Ok(r) => r,
@@ -1077,67 +1091,73 @@ fn panic_payload_str(payload: &(dyn std::any::Any + Send)) -> &str {
 
 fn build_routes(config: &Config) -> RouteTableSnapshot {
     let projection = config::runtime_projection(config).expect("loaded config projects to runtime");
-    let routes = projection
-        .neighborhoods
+    if projection.caches.is_empty() {
+        return RouteTableSnapshot {
+            routes: HashMap::new(),
+        };
+    }
+
+    let mesh = &projection.mesh;
+    let local = PeerEntry {
+        node: mesh.self_node_id,
+        ring: node_to_ring(mesh.self_node_id),
+        tags: TopologyTags(mesh.self_tags.clone()),
+    };
+    let node_to_peer: HashMap<NodeId, unbounded_storage::fabric::PeerId> = mesh
+        .peers
         .iter()
-        .map(|(id, neighborhood)| {
-            let local_id = neighborhood.p2p.local_node_id.unwrap_or(0);
-            let local = PeerEntry {
-                node: NodeId(local_id),
-                ring: node_to_ring(NodeId(local_id)),
-                tags: TopologyTags(neighborhood.p2p.local_tags.clone()),
-            };
-            let node_to_peer: HashMap<NodeId, unbounded_storage::fabric::PeerId> = neighborhood
-                .peers
-                .iter()
-                .map(|peer| (peer.node_id, peer.fabric_peer_id))
-                .collect();
-            let fingers = if let Some(plan) = &neighborhood.p2p.routing_plan {
-                let tags_of = |node: NodeId| -> TopologyTags {
-                    neighborhood
-                        .peers
-                        .iter()
-                        .find(|peer| peer.node_id == node)
-                        .map(|peer| TopologyTags(peer.spec.tags.clone()))
-                        .unwrap_or_default()
-                };
-                let entry_of = |raw: u64| {
-                    let node = NodeId(raw);
-                    PeerEntry {
-                        node,
-                        ring: node_to_ring(node),
-                        tags: tags_of(node),
-                    }
-                };
-                Arc::new(FingerTable::from_explicit(
-                    local,
-                    plan.fingers.iter().map(|id| entry_of(*id)).collect(),
-                    plan.successor.map(entry_of),
-                    plan.predecessor.map(entry_of),
-                ))
-            } else {
-                let peers: Vec<PeerEntry> = neighborhood
-                    .peers
-                    .iter()
-                    .map(|peer| PeerEntry {
-                        node: peer.node_id,
-                        ring: node_to_ring(peer.node_id),
-                        tags: TopologyTags(peer.spec.tags.clone()),
-                    })
-                    .collect();
-                Arc::new(FingerTable::build(
-                    local,
-                    &peers,
-                    FingerTableConfig {
-                        k: neighborhood.p2p.fingers_per_node.max(1),
-                    },
-                ))
-            };
+        .map(|peer| (peer.node_id, peer.fabric_peer_id))
+        .collect();
+    let node_to_peer = Arc::new(node_to_peer);
+    let fingers = if let Some(plan) = &mesh.routing_plan {
+        let peer_by_name: HashMap<&str, &config::RuntimePeer> = mesh
+            .peers
+            .iter()
+            .map(|peer| (peer.name.as_str(), peer))
+            .collect();
+        let entry_of = |name: &str| {
+            let peer = peer_by_name
+                .get(name)
+                .expect("validated routing_plan names reference peers");
+            PeerEntry {
+                node: peer.node_id,
+                ring: node_to_ring(peer.node_id),
+                tags: TopologyTags(peer.spec.tags.clone()),
+            }
+        };
+        Arc::new(FingerTable::from_explicit(
+            local,
+            plan.fingers.iter().map(|name| entry_of(name)).collect(),
+            plan.successor.as_deref().map(entry_of),
+            plan.predecessor.as_deref().map(entry_of),
+        ))
+    } else {
+        let peers: Vec<PeerEntry> = mesh
+            .peers
+            .iter()
+            .map(|peer| PeerEntry {
+                node: peer.node_id,
+                ring: node_to_ring(peer.node_id),
+                tags: TopologyTags(peer.spec.tags.clone()),
+            })
+            .collect();
+        Arc::new(FingerTable::build(
+            local,
+            &peers,
+            FingerTableConfig {
+                k: mesh.fingers_per_node.max(1),
+            },
+        ))
+    };
+    let routes = projection
+        .caches
+        .keys()
+        .map(|id| {
             (
                 id.clone(),
                 RoutingSnapshot {
-                    fingers,
-                    node_to_peer: Arc::new(node_to_peer),
+                    fingers: fingers.clone(),
+                    node_to_peer: node_to_peer.clone(),
                 },
             )
         })
@@ -1245,9 +1265,13 @@ struct FrontendBuildCtx {
     /// stripe change sees the new geometry. A frontend's stripe size is
     /// that of the backend it serves.
     geometry: Rc<RefCell<HashMap<String, u64>>>,
+    /// Per-cache peer routing table. Loadgen can optionally use it for
+    /// remote-only key selection while issuing normal cache reads.
+    routes: RouteTableHandle,
     bindings: Rc<RefCell<HashMap<String, ResolvedFrontendBinding>>>,
     page_size: usize,
     worker_idx: u16,
+    waker: Waker,
 }
 
 /// Resolve the stripe size a frontend should serve from the shard's
@@ -1319,7 +1343,6 @@ impl FrontendBuildCtx {
                     Rc::from(spec.name.as_str()),
                     binding.backend_id.clone(),
                     binding.cache_id.clone(),
-                    binding.neighborhood_id.clone(),
                     stripe_size,
                     self.page_size,
                     self.fanout.clone(),
@@ -1340,7 +1363,6 @@ impl FrontendBuildCtx {
                     Rc::from(spec.name.as_str()),
                     binding.backend_id.clone(),
                     binding.cache_id.clone(),
-                    binding.neighborhood_id.clone(),
                     stripe_size,
                     self.page_size,
                     binding.bypass_cache,
@@ -1354,11 +1376,12 @@ impl FrontendBuildCtx {
                     self.pool.clone(),
                     binding.backend_id.clone(),
                     binding.cache_id.clone(),
-                    binding.neighborhood_id.clone(),
                     stripe_size,
                     self.page_size,
+                    self.routes.clone(),
                     binding.bypass_cache,
                     self.worker_idx,
+                    self.waker.clone(),
                 )))
             }
             None => Err(format!("frontend {} missing config", spec.name)),
@@ -1538,7 +1561,7 @@ impl Drop for PhaseBGuard {
 /// Parsed command-line options for one run of the daemon.
 ///
 /// The daemon takes all of its configuration - both the dynamically
-/// reloadable cluster state (neighborhoods, caches, backends, frontends)
+/// reloadable cluster state (mesh, caches, backends, frontends)
 /// and the startup-fixed knobs (`[startup]`: memory sizing, fabric
 /// endpoint/thread pools, CPU-topology selection) - from the config
 /// file. The only command-line option is the path to that file, since
@@ -1974,7 +1997,6 @@ mod tests {
             frontend_id: frontend_id.to_string(),
             backend_id: backend_id.to_string(),
             cache_id: None,
-            neighborhood_id: None,
             bypass_cache: true,
         }
     }

--- a/cmd/unbounded-storage/src/metrics/exporter.rs
+++ b/cmd/unbounded-storage/src/metrics/exporter.rs
@@ -24,6 +24,7 @@
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -58,6 +59,28 @@ impl std::fmt::Display for ExporterError {
 
 impl std::error::Error for ExporterError {}
 
+#[derive(Clone, Default)]
+pub struct RdmaInventoryStatus {
+    json: Arc<RwLock<Option<Vec<u8>>>>,
+}
+
+impl RdmaInventoryStatus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_json(&self, json: Vec<u8>) {
+        *self.json.write().expect("rdma inventory lock poisoned") = Some(json);
+    }
+
+    fn body(&self) -> Option<Vec<u8>> {
+        self.json
+            .read()
+            .expect("rdma inventory lock poisoned")
+            .clone()
+    }
+}
+
 /// Start the metrics exporter on `bind`, scraping the global registry
 /// and reporting `versions`. Returns a join handle for the listener
 /// thread; the thread exits once `shutdown` is set and the next accept
@@ -65,6 +88,7 @@ impl std::error::Error for ExporterError {}
 pub fn spawn(
     bind: &str,
     versions: ConfigVersionStatus,
+    rdma_inventory: RdmaInventoryStatus,
     shutdown: &'static AtomicBool,
 ) -> Result<JoinHandle<()>, ExporterError> {
     let addr: SocketAddr = bind
@@ -79,17 +103,22 @@ pub fn spawn(
 
     let handle = std::thread::Builder::new()
         .name("metrics-exporter".to_string())
-        .spawn(move || run(listener, versions, shutdown))
+        .spawn(move || run(listener, versions, rdma_inventory, shutdown))
         .map_err(ExporterError::Bind)?;
     Ok(handle)
 }
 
-fn run(listener: TcpListener, versions: ConfigVersionStatus, shutdown: &'static AtomicBool) {
+fn run(
+    listener: TcpListener,
+    versions: ConfigVersionStatus,
+    rdma_inventory: RdmaInventoryStatus,
+    shutdown: &'static AtomicBool,
+) {
     for stream in accept_loop(&listener, shutdown) {
         if let Ok(stream) = stream {
             // One scrape at a time is plenty; handle inline so a slow
             // client cannot spawn unbounded threads.
-            handle_conn(stream, &versions);
+            handle_conn(stream, &versions, &rdma_inventory);
         }
     }
 }
@@ -117,7 +146,11 @@ fn accept_loop<'a>(
     })
 }
 
-fn handle_conn(mut stream: TcpStream, versions: &ConfigVersionStatus) {
+fn handle_conn(
+    mut stream: TcpStream,
+    versions: &ConfigVersionStatus,
+    rdma_inventory: &RdmaInventoryStatus,
+) {
     let _ = stream.set_read_timeout(Some(IO_TIMEOUT));
     let _ = stream.set_write_timeout(Some(IO_TIMEOUT));
     stream.set_nonblocking(false).ok();
@@ -147,6 +180,19 @@ fn handle_conn(mut stream: TcpStream, versions: &ConfigVersionStatus) {
             let body = super::render(versions);
             let _ = write_response(&mut stream, 200, super::TEXT_CONTENT_TYPE, &body);
         }
+        "/inventory/rdma" => match rdma_inventory.body() {
+            Some(body) => {
+                let _ = write_response(&mut stream, 200, "application/json", &body);
+            }
+            None => {
+                let _ = write_response(
+                    &mut stream,
+                    503,
+                    "text/plain; charset=utf-8",
+                    b"rdma inventory not ready\n",
+                );
+            }
+        },
         "/" | "/health" | "/healthz" => {
             let _ = write_response(&mut stream, 200, "text/plain; charset=utf-8", b"ok\n");
         }
@@ -195,6 +241,7 @@ fn reason(status: u16) -> &'static str {
         200 => "OK",
         404 => "Not Found",
         405 => "Method Not Allowed",
+        503 => "Service Unavailable",
         _ => "OK",
     }
 }
@@ -245,7 +292,10 @@ mod tests {
         listener.set_nonblocking(true).unwrap();
         let shutdown: &'static AtomicBool = Box::leak(Box::new(AtomicBool::new(false)));
         let versions = ConfigVersionStatus::new(9);
-        let t = std::thread::spawn(move || run(listener, versions, shutdown));
+        let inventory = RdmaInventoryStatus::new();
+        inventory.set_json(br#"{"schemaVersion":1,"hcas":[]}"#.to_vec());
+        let inventory_for_thread = inventory.clone();
+        let t = std::thread::spawn(move || run(listener, versions, inventory_for_thread, shutdown));
 
         let (head, body) = get(addr, "/metrics");
         assert!(head.contains("200 OK"), "head: {head}");
@@ -255,11 +305,36 @@ mod tests {
         let (head, _) = get(addr, "/health");
         assert!(head.contains("200 OK"));
 
+        let (head, body) = get(addr, "/inventory/rdma");
+        assert!(head.contains("200 OK"));
+        assert!(head.contains("application/json"));
+        assert_eq!(body, br#"{"schemaVersion":1,"hcas":[]}"#);
+
         let (head, _) = get(addr, "/nope");
         assert!(head.contains("404 Not Found"));
 
         shutdown.store(true, Ordering::Relaxed);
         // Nudge the accept loop so it observes shutdown without waiting.
+        let _ = TcpStream::connect(addr);
+        t.join().unwrap();
+    }
+
+    #[test]
+    fn rdma_inventory_reports_not_ready_until_set() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let shutdown: &'static AtomicBool = Box::leak(Box::new(AtomicBool::new(false)));
+        let versions = ConfigVersionStatus::new(9);
+        let t = std::thread::spawn(move || {
+            run(listener, versions, RdmaInventoryStatus::new(), shutdown)
+        });
+
+        let (head, body) = get(addr, "/inventory/rdma");
+        assert!(head.contains("503 Service Unavailable"), "head: {head}");
+        assert_eq!(body, b"rdma inventory not ready\n");
+
+        shutdown.store(true, Ordering::Relaxed);
         let _ = TcpStream::connect(addr);
         t.join().unwrap();
     }

--- a/cmd/unbounded-storage/src/metrics/mod.rs
+++ b/cmd/unbounded-storage/src/metrics/mod.rs
@@ -37,7 +37,7 @@ use prometheus::{
 
 use crate::config::ConfigVersionStatus;
 
-pub use exporter::{ExporterError, spawn};
+pub use exporter::{ExporterError, RdmaInventoryStatus, spawn};
 
 /// Content type for the Prometheus text exposition format (v0.0.4),
 /// sent in the `/metrics` response.

--- a/cmd/unbounded-storage/src/p2p/handler.rs
+++ b/cmd/unbounded-storage/src/p2p/handler.rs
@@ -366,6 +366,15 @@ where
     /// because RPC worker threads are separate from shard threads.
     fn serve(&mut self) -> Result<PageRef, RecursiveHandlerError> {
         let page_size = self.scratch.page_size();
+        if self.req.fabric_only() {
+            crate::metrics::p2p_request(crate::metrics::Disposition::Local);
+
+            let (idx, page) = serve_synthetic_page(&self.scratch, self.src, page_size)?;
+            self.page_idx = Some(idx);
+
+            return Ok(page);
+        }
+
         let target = stripe_to_ring(self.key);
         let route = self
             .fingers
@@ -443,6 +452,29 @@ fn scratch_page(idx: u32, page_size: usize) -> PageRef {
         offset: 0,
         len: page_size as u32,
     }
+}
+
+/// Synthetic fabric benchmark path: reserve one zeroed scratch page and
+/// return it as if it were a resolved stripe. The RPC layer still sends
+/// the response by RDMA-writing this page to the requester.
+fn serve_synthetic_page(
+    scratch: &ScratchBacking,
+    src: BulkRef,
+    page_size: usize,
+) -> Result<(u32, PageRef), RecursiveHandlerError> {
+    let idx = scratch
+        .take_zeroed()
+        .ok_or(RecursiveHandlerError::NoScratchPage)?;
+    let len = (src.len as usize).min(page_size) as u32;
+
+    Ok((
+        idx,
+        PageRef {
+            page_idx: idx,
+            offset: 0,
+            len,
+        },
+    ))
 }
 
 /// Owner path: read the page from the local store, falling back to the
@@ -804,6 +836,22 @@ mod tests {
             Err(RecursiveHandlerError::BlockStore(_)) => {}
             other => panic!("expected BlockStore error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn fabric_only_request_yields_zeroed_scratch_without_store_or_backend() {
+        let (backing, base) = scratch_backing();
+        let key = key_for_ring(11);
+        let scratch = ScratchBacking::new(backing, SCRATCH_PAGES as u32);
+
+        let (_idx, page) = match serve_synthetic_page(&scratch, src_for(key), PAGE) {
+            Ok(page) => page,
+            Err(e) => panic!("fabric-only request failed: {e}"),
+        };
+
+        assert_eq!(page.page_idx, 0);
+        assert_eq!(page.len, PAGE as u32);
+        assert!(page_all(base, page.page_idx).iter().all(|&b| b == 0));
     }
 
     // --- scratch recycling (cross-request leak guard) ---

--- a/cmd/unbounded-storage/src/p2p/mod.rs
+++ b/cmd/unbounded-storage/src/p2p/mod.rs
@@ -24,7 +24,7 @@ mod tests;
 pub use finger_router::{ChainFingerRouter, FingerRouter};
 pub use fingers::{FingerTable, FingerTableConfig};
 pub use handler::{RecursiveHandler, RecursiveHandlerError, RecursiveHandlerStream};
-pub use ring::{node_to_ring, splitmix64, stripe_to_ring};
+pub use ring::{node_id_from_name, node_to_ring, splitmix64, stripe_to_ring};
 pub use routing_handle::{RouteTableHandle, RouteTableSnapshot, RoutingHandle, RoutingSnapshot};
 pub use transport::{RoutedStream, RoutedTransport};
 pub use types::{NodeId, P2pReq, PeerEntry, RingId, TopologyTags};

--- a/cmd/unbounded-storage/src/p2p/ring.rs
+++ b/cmd/unbounded-storage/src/p2p/ring.rs
@@ -42,6 +42,14 @@ pub fn node_to_ring(node: NodeId) -> RingId {
     RingId(splitmix64(node.0))
 }
 
+/// Derive a stable internal node id from an operator-facing peer name.
+pub fn node_id_from_name(name: &str) -> NodeId {
+    let digest = blake3::hash(name.as_bytes());
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&digest.as_bytes()[..8]);
+    NodeId(u64::from_le_bytes(buf))
+}
+
 /// Forward distance on the ring from `from` to `to`. Returns 0 only
 /// when `from == to`; wraps modulo `2^64` otherwise.
 pub fn ring_distance(from: RingId, to: RingId) -> u64 {
@@ -125,6 +133,14 @@ mod tests {
         let b = node_to_ring(NodeId(1));
         assert_ne!(a, b);
         assert_eq!(a, node_to_ring(NodeId(0)));
+    }
+
+    #[test]
+    fn node_id_from_name_is_stable_and_distinguishes_names() {
+        let a = node_id_from_name("node-a");
+        let b = node_id_from_name("node-b");
+        assert_eq!(a, node_id_from_name("node-a"));
+        assert_ne!(a, b);
     }
 
     fn tags(parts: &[&str]) -> TopologyTags {

--- a/cmd/unbounded-storage/src/p2p/routing_handle.rs
+++ b/cmd/unbounded-storage/src/p2p/routing_handle.rs
@@ -5,7 +5,7 @@
 //! consumers.
 //!
 //! The finger table and the `node -> peer` map are derived together
-//! from the active neighborhood projected by the config graph. Three independent
+//! from the active cache keyspace projected by the config graph. Three independent
 //! consumers read them on the hot path:
 //!
 //! * [`crate::p2p::FingerRouter`] (the first-hop lookup wrapped by
@@ -116,18 +116,15 @@ impl RouteTableHandle {
         self.0.load_full()
     }
 
-    pub fn route(&self, neighborhood_id: &str) -> Option<RoutingSnapshot> {
-        self.snapshot().routes.get(neighborhood_id).cloned()
+    pub fn route(&self, route_id: &str) -> Option<RoutingSnapshot> {
+        self.snapshot().routes.get(route_id).cloned()
     }
 
     pub fn route_for_req<R: crate::bufferpool::Req + ?Sized>(
         &self,
         req: &R,
     ) -> Option<RoutingSnapshot> {
-        let route_id = req
-            .neighborhood_id()
-            .map_or(Self::LEGACY_ROUTE_ID, String::as_str);
-        self.route(route_id)
+        self.route(req.cache_id()?.as_str())
     }
 }
 

--- a/cmd/unbounded-storage/src/rdma_inventory.rs
+++ b/cmd/unbounded-storage/src/rdma_inventory.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::BTreeMap;
+
+use unbounded_storage::topology::Host;
+
+use crate::fabric_group::FabricUnitAddress;
+
+pub fn to_json(host: &Host, unit_addresses: &[FabricUnitAddress]) -> Vec<u8> {
+    let mut addrs_by_hca: BTreeMap<&str, Vec<String>> = BTreeMap::new();
+
+    for unit in unit_addresses.iter().filter(|unit| unit.rdma) {
+        addrs_by_hca
+            .entry(unit.device_name.as_str())
+            .or_default()
+            .push(unit.addr.clone());
+    }
+
+    for addrs in addrs_by_hca.values_mut() {
+        addrs.sort();
+    }
+
+    let mut out = String::from("{\"schemaVersion\":1,\"hcas\":[");
+    for (idx, hca) in host.hcas.iter().enumerate() {
+        if idx != 0 {
+            out.push(',');
+        }
+
+        out.push_str("{\"name\":");
+        push_json_string(&mut out, &hca.dev_name);
+        if let Some(pci_bdf) = &hca.pci_bdf {
+            out.push_str(",\"pciBdf\":");
+            push_json_string(&mut out, pci_bdf);
+        }
+        if let Some(pcie_root) = &hca.pcie_root {
+            out.push_str(",\"pcieRoot\":");
+            push_json_string(&mut out, pcie_root);
+        }
+        if let Some(numa) = hca.numa {
+            out.push_str(",\"numa\":");
+            out.push_str(&numa.to_string());
+        }
+        out.push_str(",\"portsActive\":");
+        out.push_str(if hca.ports_active { "true" } else { "false" });
+        out.push_str(",\"addrs\":[");
+        if let Some(addrs) = addrs_by_hca.get(hca.dev_name.as_str()) {
+            for (addr_idx, addr) in addrs.iter().enumerate() {
+                if addr_idx != 0 {
+                    out.push(',');
+                }
+                push_json_string(&mut out, addr);
+            }
+        }
+        out.push_str("]}");
+    }
+    out.push_str("]}");
+
+    out.into_bytes()
+}
+
+fn push_json_string(out: &mut String, value: &str) {
+    out.push('"');
+    for c in value.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c <= '\u{1f}' => {
+                out.push_str("\\u");
+                out.push_str(&format!("{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use unbounded_storage::topology::Hca;
+
+    #[test]
+    fn inventory_json_is_single_line_and_includes_all_hcas() {
+        let host = Host {
+            hcas: vec![
+                Hca {
+                    dev_name: "mlx5_0".to_string(),
+                    pci_bdf: Some("0000:af:00.0".to_string()),
+                    pcie_root: Some("0000:ae:00.0".to_string()),
+                    numa: Some(0),
+                    ports_active: true,
+                },
+                Hca {
+                    dev_name: "mlx5_1".to_string(),
+                    pci_bdf: None,
+                    pcie_root: None,
+                    numa: None,
+                    ports_active: false,
+                },
+            ],
+            ..Host::default()
+        };
+        let units = vec![
+            FabricUnitAddress {
+                device_name: "mlx5_0".to_string(),
+                rdma: true,
+                addr: "hex:02".to_string(),
+            },
+            FabricUnitAddress {
+                device_name: "lo".to_string(),
+                rdma: false,
+                addr: "127.0.0.1:9000".to_string(),
+            },
+            FabricUnitAddress {
+                device_name: "mlx5_0".to_string(),
+                rdma: true,
+                addr: "hex:01".to_string(),
+            },
+        ];
+
+        let json = String::from_utf8(to_json(&host, &units)).unwrap();
+
+        assert!(!json.contains('\n'));
+        assert_eq!(
+            json,
+            concat!(
+                "{\"schemaVersion\":1,\"hcas\":[",
+                "{\"name\":\"mlx5_0\",\"pciBdf\":\"0000:af:00.0\",",
+                "\"pcieRoot\":\"0000:ae:00.0\",\"numa\":0,",
+                "\"portsActive\":true,\"addrs\":[\"hex:01\",\"hex:02\"]},",
+                "{\"name\":\"mlx5_1\",\"portsActive\":false,\"addrs\":[]}]}",
+            )
+        );
+    }
+
+    #[test]
+    fn inventory_json_escapes_strings() {
+        let host = Host {
+            hcas: vec![Hca {
+                dev_name: "mlx5_\"0".to_string(),
+                pci_bdf: Some("0000\\af".to_string()),
+                pcie_root: None,
+                numa: None,
+                ports_active: true,
+            }],
+            ..Host::default()
+        };
+
+        let json = String::from_utf8(to_json(&host, &[])).unwrap();
+
+        assert_eq!(
+            json,
+            "{\"schemaVersion\":1,\"hcas\":[{\"name\":\"mlx5_\\\"0\",\"pciBdf\":\"0000\\\\af\",\"portsActive\":true,\"addrs\":[]}]}",
+        );
+    }
+}

--- a/cmd/unbounded-storage/src/shard_layer.rs
+++ b/cmd/unbounded-storage/src/shard_layer.rs
@@ -34,14 +34,14 @@ use unbounded_storage::config::{
     self, ApplyError, Config, ConfigApplyTarget, ConfigDiff, ShardControlGroup,
 };
 use unbounded_storage::fabric::PeerId;
-use unbounded_storage::p2p::RouteTableHandle;
+use unbounded_storage::p2p::{NodeId, RouteTableHandle};
 use unbounded_storage::runtime::{JoinHandle, Threading, WorkerIdx};
 use unbounded_storage::storage::StripeReq;
 use unbounded_storage::storage::disks::{CacheDirectorySet, DiskRegistrySet, UringDiskTarget};
 use unbounded_storage::topology::ServingShard;
 
 use crate::StartupSettings;
-use crate::fabric_group::{FabricGroup, FabricPlan};
+use crate::fabric_group::{FabricGroup, FabricPlan, FabricUnitAddress};
 
 /// Inputs that are constant across the life of the process and used to
 /// spawn the shard layer. Cloned cheaply into every shard thread.
@@ -94,6 +94,12 @@ pub struct ShardLayer {
     /// strictly after all joins, so no ring ever references unmapped
     /// memory.
     _backing_keepalives: Vec<Arc<dyn Send + Sync>>,
+}
+
+impl ShardLayer {
+    pub fn fabric_unit_addresses(&self) -> Vec<FabricUnitAddress> {
+        self.fabric_group.unit_addresses()
+    }
 }
 
 /// Bring up a shard layer from `config` on the runtime in `deps`,
@@ -341,30 +347,7 @@ pub fn spawn_shard_layer(
 }
 
 fn local_self_peer(projection: &config::RuntimeGraph) -> Result<PeerId, String> {
-    let mut local_ids: Vec<(&str, u64)> = projection
-        .neighborhoods
-        .values()
-        .filter_map(|n| n.p2p.local_node_id.map(|id| (n.id.as_str(), id)))
-        .collect();
-    local_ids.sort_by_key(|(neighborhood_id, _)| *neighborhood_id);
-
-    if let Some((_, self_peer)) = local_ids.first()
-        && local_ids.iter().any(|(_, node_id)| node_id != self_peer)
-    {
-        let configured = local_ids
-            .iter()
-            .map(|(neighborhood_id, node_id)| format!("{neighborhood_id}:{node_id}"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        return Err(format!(
-            "neighborhoods declare different local_node_id values, but the storage fabric uses one process-wide peer id ({configured})"
-        ));
-    }
-
-    Ok(local_ids
-        .first()
-        .map(|(_, node_id)| PeerId(*node_id))
-        .unwrap_or(PeerId(0)))
+    Ok(projection.mesh.self_peer_id)
 }
 
 /// Retire a shard layer: signal its shards to exit, then join every
@@ -444,6 +427,12 @@ impl ProcessApplyTarget {
 
 impl ConfigApplyTarget for ProcessApplyTarget {
     fn apply_in_place(&mut self, new: &Arc<Config>, diff: &ConfigDiff) -> Result<(), ApplyError> {
+        if diff.requires_restart() {
+            return Err(ApplyError::Target(
+                "self peer identity changed; restart required".to_string(),
+            ));
+        }
+
         let projection = config::runtime_projection(new)
             .map_err(|e| ApplyError::Target(format!("config projection failed: {e}")))?;
 
@@ -472,6 +461,8 @@ impl ConfigApplyTarget for ProcessApplyTarget {
             // backend/frontend-only change leaves them untouched.
             if diff.requires_routing_reload() {
                 layer.fabric_group.reload_routes(&routes);
+            }
+            if diff.requires_peer_reconcile() {
                 let runtime_peers = config::runtime_peers(&projection);
                 layer.fabric_group.reconcile_peers(&runtime_peers);
             }
@@ -505,64 +496,27 @@ mod tests {
 
     use super::*;
 
-    fn graph_with_local_ids(ids: &[(&str, Option<u64>)]) -> config::RuntimeGraph {
-        let neighborhoods = ids
-            .iter()
-            .map(|(id, local_node_id)| {
-                (
-                    (*id).to_string(),
-                    config::RuntimeNeighborhood {
-                        id: (*id).to_string(),
-                        backend_id: "backend".to_string(),
-                        p2p: config::RuntimeP2p {
-                            fingers_per_node: 100,
-                            local_node_id: *local_node_id,
-                            local_tags: Vec::new(),
-                            routing_plan: None,
-                        },
-                        peers: Vec::new(),
-                    },
-                )
-            })
-            .collect();
-
+    fn graph_with_self_peer(self_peer_id: PeerId) -> config::RuntimeGraph {
         config::RuntimeGraph {
             disks: Vec::new(),
             caches: HashMap::new(),
-            neighborhoods,
+            mesh: config::RuntimeMesh {
+                fingers_per_node: 100,
+                self_name: None,
+                self_node_id: NodeId(self_peer_id.0),
+                self_peer_id,
+                self_tags: Vec::new(),
+                routing_plan: None,
+                peers: Vec::new(),
+            },
             frontends: HashMap::new(),
         }
     }
 
     #[test]
-    fn local_self_peer_is_zero_without_local_node_id() {
-        let graph = graph_with_local_ids(&[("n-a", None), ("n-b", None)]);
-
-        assert_eq!(local_self_peer(&graph).unwrap(), PeerId(0));
-    }
-
-    #[test]
-    fn local_self_peer_uses_raw_node_id() {
-        let graph = graph_with_local_ids(&[("n-a", None), ("n-b", Some(7))]);
+    fn local_self_peer_uses_projection_identity() {
+        let graph = graph_with_self_peer(PeerId(7));
 
         assert_eq!(local_self_peer(&graph).unwrap(), PeerId(7));
-    }
-
-    #[test]
-    fn local_self_peer_accepts_repeated_local_node_id() {
-        let graph = graph_with_local_ids(&[("n-b", Some(7)), ("n-a", Some(7))]);
-
-        assert_eq!(local_self_peer(&graph).unwrap(), PeerId(7));
-    }
-
-    #[test]
-    fn local_self_peer_rejects_different_local_node_ids() {
-        let graph = graph_with_local_ids(&[("n-b", Some(2)), ("n-a", Some(1))]);
-
-        let err = local_self_peer(&graph).unwrap_err();
-
-        assert!(err.contains("different local_node_id values"), "{err}");
-        assert!(err.contains("n-a:1"), "{err}");
-        assert!(err.contains("n-b:2"), "{err}");
     }
 }

--- a/cmd/unbounded-storage/src/storage/btree/mod.rs
+++ b/cmd/unbounded-storage/src/storage/btree/mod.rs
@@ -215,10 +215,23 @@ impl<B: BlockDevice> BTreeIndex<B> {
         scratch: Rc<ScratchPool>,
         btree_page_bytes: usize,
         skip_recovery_scan_if_no_meta: bool,
+        force_format: bool,
     ) -> Result<Self, Error> {
         // Reserve the meta slots regardless of disk state.
         let _ = allocator.mark_in_use(page::META_SLOT_A);
         let _ = allocator.mark_in_use(page::META_SLOT_B);
+
+        if force_format {
+            return Self::bootstrap_from_entries(
+                device,
+                allocator,
+                scratch,
+                btree_page_bytes,
+                1,
+                BTreeMap::new(),
+            )
+            .await;
+        }
 
         let loaded = meta::load_meta(&*device, &scratch).await?;
         if let Some(state) = loaded {
@@ -431,6 +444,13 @@ impl<B: BlockDevice> BTreeIndex<B> {
             key,
         )
         .await
+    }
+
+    /// Benchmark-only lookup path backed by the committed in-memory
+    /// mirror. This skips the terminal leaf read, so it must not be used
+    /// for production recovery/corruption semantics.
+    pub fn lookup_committed_mirror(&self, key: &PageKey) -> Option<LeafEntry> {
+        self.mutator.borrow().entries.get(key).copied()
     }
 
     /// Apply a batch of mutations atomically. Must be called by

--- a/cmd/unbounded-storage/src/storage/btree/tests.rs
+++ b/cmd/unbounded-storage/src/storage/btree/tests.rs
@@ -64,7 +64,15 @@ fn open_btree(
     alloc: Arc<Allocator>,
 ) -> impl Future<Output = Result<BTreeIndex<MockDevice>, crate::storage::types::Error>> {
     let scratch = ScratchPool::new(&*dev, 4096, 8).expect("scratch pool");
-    BTreeIndex::open(dev, alloc, scratch, 4096, false)
+    BTreeIndex::open(dev, alloc, scratch, 4096, false, false)
+}
+
+fn open_btree_force_format(
+    dev: Arc<MockDevice>,
+    alloc: Arc<Allocator>,
+) -> impl Future<Output = Result<BTreeIndex<MockDevice>, crate::storage::types::Error>> {
+    let scratch = ScratchPool::new(&*dev, 4096, 8).expect("scratch pool");
+    BTreeIndex::open(dev, alloc, scratch, 4096, false, true)
 }
 
 #[test]
@@ -161,6 +169,64 @@ fn restart_from_meta_restores_entries() {
             "key {i} survived restart",
         );
     }
+}
+
+#[test]
+fn force_format_ignores_existing_meta() {
+    let (dev, alloc) = fresh(128);
+    {
+        let idx = block_on(open_btree(dev.clone(), alloc)).unwrap();
+        block_on(idx.apply_batch(vec![Mutation::Insert {
+            key: key(1),
+            value: entry(11),
+        }]))
+        .unwrap();
+    }
+
+    let alloc2 = Arc::new(Allocator::new(128));
+    let idx2 = block_on(open_btree_force_format(dev, alloc2)).unwrap();
+
+    assert!(block_on(idx2.lookup(&key(1))).unwrap().is_none());
+    assert_eq!(idx2.live_entries(), 0);
+    assert_eq!(idx2.current_txn(), 1);
+}
+
+#[test]
+fn lookup_uses_committed_mirror_without_leaf_io() {
+    let (dev, alloc) = fresh(128);
+    let idx = block_on(open_btree(dev.clone(), alloc)).unwrap();
+    block_on(idx.apply_batch(vec![Mutation::Insert {
+        key: key(1),
+        value: entry(11),
+    }]))
+    .unwrap();
+    let reads_after_commit = dev.reads();
+
+    assert_eq!(idx.lookup_committed_mirror(&key(1)), Some(entry(11)));
+    assert_eq!(
+        dev.reads(),
+        reads_after_commit,
+        "lookup should use the in-memory committed mirror"
+    );
+}
+
+#[test]
+fn skip_recovery_scan_does_not_ignore_existing_meta() {
+    let (dev, alloc) = fresh(128);
+    {
+        let idx = block_on(open_btree(dev.clone(), alloc)).unwrap();
+        block_on(idx.apply_batch(vec![Mutation::Insert {
+            key: key(1),
+            value: entry(11),
+        }]))
+        .unwrap();
+    }
+
+    let alloc2 = Arc::new(Allocator::new(128));
+    let scratch = ScratchPool::new(&*dev, 4096, 8).expect("scratch pool");
+    let idx2 = block_on(BTreeIndex::open(dev, alloc2, scratch, 4096, true, false)).unwrap();
+
+    assert_eq!(block_on(idx2.lookup(&key(1))).unwrap(), Some(entry(11)));
 }
 
 #[test]
@@ -838,7 +904,7 @@ fn open_gate_pool(
     pool_pages: usize,
 ) -> impl Future<Output = Result<BTreeIndex<GateDevice>, crate::storage::types::Error>> {
     let scratch = ScratchPool::new(&*dev, 4096, pool_pages).expect("scratch pool");
-    BTreeIndex::open(dev, alloc, scratch, 4096, false)
+    BTreeIndex::open(dev, alloc, scratch, 4096, false, false)
 }
 
 fn gate_dev(capacity_pages: u64) -> (Arc<GateDevice>, Arc<Allocator>) {

--- a/cmd/unbounded-storage/src/storage/disks/mod.rs
+++ b/cmd/unbounded-storage/src/storage/disks/mod.rs
@@ -150,7 +150,8 @@ impl<T: DiskTarget> DiskRegistry<T> {
     /// Paths present in `desired` but not currently open are opened.
     /// Paths whose [`DiskSpec`] drifted in any field that affects how
     /// the disk is opened (config / queue_depth / page_size_bytes /
-    /// skip_recovery_scan) are treated as a remove followed by an add.
+    /// skip_recovery_scan / force_format / bypass_admission /
+    /// bypass_index_read / bypass_checksum) are treated as a remove followed by an add.
     /// Partial failures during opens are reported but do not abort the
     /// reconcile.
     pub fn reconcile(&mut self, desired: &[DiskSpec]) -> DiskReport {
@@ -426,6 +427,10 @@ fn specs_drifted(prev: Option<&DiskSpec>, next: &DiskSpec) -> bool {
                 || p.queue_depth != next.queue_depth
                 || p.page_size_bytes != next.page_size_bytes
                 || p.skip_recovery_scan != next.skip_recovery_scan
+                || p.force_format != next.force_format
+                || p.bypass_admission != next.bypass_admission
+                || p.bypass_index_read != next.bypass_index_read
+                || p.bypass_checksum != next.bypass_checksum
         }
     }
 }
@@ -513,6 +518,10 @@ mod tests {
             queue_depth: qd,
             page_size_bytes: None,
             skip_recovery_scan: false,
+            force_format: false,
+            bypass_admission: false,
+            bypass_index_read: false,
+            bypass_checksum: false,
             config: Some(disk_spec::Config::Block(BlockDiskConfig {
                 numa: None,
                 path: path.to_string(),
@@ -856,6 +865,10 @@ mod tests {
             queue_depth: None,
             page_size_bytes: None,
             skip_recovery_scan: false,
+            force_format: false,
+            bypass_admission: false,
+            bypass_index_read: false,
+            bypass_checksum: false,
             config: Some(disk_spec::Config::File(FileDiskConfig {
                 size: Some(size),
                 path: "/a".to_string(),
@@ -883,6 +896,58 @@ mod tests {
         assert_eq!(report.added, 1);
         assert_eq!(report.removed, 1);
         assert!(reg.applied[&PathBuf::from("/a")].skip_recovery_scan);
+    }
+
+    #[test]
+    fn force_format_drift_triggers_remove_add() {
+        let (target, _state) = MockDiskTarget::new();
+        let mut reg = DiskRegistry::new(target, vec![]);
+        reg.reconcile(&[spec("/a", None)]);
+        let mut next = spec("/a", None);
+        next.force_format = true;
+        let report = reg.reconcile(&[next]);
+        assert_eq!(report.added, 1);
+        assert_eq!(report.removed, 1);
+        assert!(reg.applied[&PathBuf::from("/a")].force_format);
+    }
+
+    #[test]
+    fn bypass_admission_drift_triggers_remove_add() {
+        let (target, _state) = MockDiskTarget::new();
+        let mut reg = DiskRegistry::new(target, vec![]);
+        reg.reconcile(&[spec("/a", None)]);
+        let mut next = spec("/a", None);
+        next.bypass_admission = true;
+        let report = reg.reconcile(&[next]);
+        assert_eq!(report.added, 1);
+        assert_eq!(report.removed, 1);
+        assert!(reg.applied[&PathBuf::from("/a")].bypass_admission);
+    }
+
+    #[test]
+    fn bypass_index_read_drift_triggers_remove_add() {
+        let (target, _state) = MockDiskTarget::new();
+        let mut reg = DiskRegistry::new(target, vec![]);
+        reg.reconcile(&[spec("/a", None)]);
+        let mut next = spec("/a", None);
+        next.bypass_index_read = true;
+        let report = reg.reconcile(&[next]);
+        assert_eq!(report.added, 1);
+        assert_eq!(report.removed, 1);
+        assert!(reg.applied[&PathBuf::from("/a")].bypass_index_read);
+    }
+
+    #[test]
+    fn bypass_checksum_drift_triggers_remove_add() {
+        let (target, _state) = MockDiskTarget::new();
+        let mut reg = DiskRegistry::new(target, vec![]);
+        reg.reconcile(&[spec("/a", None)]);
+        let mut next = spec("/a", None);
+        next.bypass_checksum = true;
+        let report = reg.reconcile(&[next]);
+        assert_eq!(report.added, 1);
+        assert_eq!(report.removed, 1);
+        assert!(reg.applied[&PathBuf::from("/a")].bypass_checksum);
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/storage/disks/uring.rs
+++ b/cmd/unbounded-storage/src/storage/disks/uring.rs
@@ -392,7 +392,15 @@ fn run_core_loop<B, R>(
         if mutator_done && close_signaled && !service.has_inflight() && ring.in_flight() == 0 {
             break;
         }
-        idle();
+        // Keep the steady-state storage core hot while page I/O is
+        // outstanding. During teardown, still yield through the idle hook so
+        // late arrivals and ring-drain progress can be observed instead of
+        // spinning forever with a nonzero test/fake in-flight count.
+        let steady_state_busy =
+            !close_signaled && (service.has_inflight() || ring.in_flight() != 0);
+        if !steady_state_busy {
+            idle();
+        }
     }
 }
 
@@ -403,9 +411,9 @@ fn disk_open_mode(spec: &DiskSpec) -> DiskOpenMode {
     }
 
     if spec.is_file() {
-        ring_cfg.iopoll = false;
-        ring_cfg.single_issuer = false;
-        ring_cfg.defer_taskrun = false;
+        disable_polled_ring(&mut ring_cfg);
+    } else if let Some(path) = spec.path() {
+        disable_iopoll_if_unsupported(&mut ring_cfg, Path::new(path), Path::new("/sys/block"));
     }
 
     DiskOpenMode {
@@ -414,16 +422,43 @@ fn disk_open_mode(spec: &DiskSpec) -> DiskOpenMode {
     }
 }
 
+fn disable_iopoll_if_unsupported(ring_cfg: &mut StorageRingConfig, path: &Path, sys_block: &Path) {
+    if matches!(block_queue_iopoll(path, sys_block), Some(false)) {
+        disable_polled_ring(ring_cfg);
+    }
+}
+
+fn block_queue_iopoll(path: &Path, sys_block: &Path) -> Option<bool> {
+    let name = path.file_name()?.to_str()?;
+    let value = std::fs::read_to_string(sys_block.join(name).join("queue/io_poll")).ok()?;
+
+    match value.trim() {
+        "0" => Some(false),
+        "1" => Some(true),
+        _ => None,
+    }
+}
+
+fn disable_polled_ring(ring_cfg: &mut StorageRingConfig) {
+    ring_cfg.iopoll = false;
+    ring_cfg.single_issuer = false;
+    ring_cfg.defer_taskrun = false;
+}
+
 /// Build an [`EngineConfig`] from a [`DiskSpec`]. Production defaults
 /// come from [`EngineConfig::default`]; the spec only overrides what
-/// the operator chose to expose: `page_size_bytes` and
-/// `skip_recovery_scan`.
+/// the operator chose to expose: `page_size_bytes`, recovery-scan
+/// behavior, and benchmark-only cache reset/admission controls.
 fn engine_config_from(spec: &DiskSpec) -> EngineConfig {
     let mut cfg = EngineConfig::default();
     if let Some(p) = spec.page_size_bytes {
         cfg.page_size_bytes = p as usize;
     }
     cfg.skip_recovery_scan_if_no_meta = spec.skip_recovery_scan;
+    cfg.force_format = spec.force_format;
+    cfg.bypass_admission = spec.bypass_admission;
+    cfg.bypass_index_read = spec.bypass_index_read;
+    cfg.bypass_checksum = spec.bypass_checksum;
     cfg.disk_id = spec
         .path()
         .expect("disk path is validated at config load")
@@ -447,6 +482,7 @@ mod tests {
     use crate::bufferpool::{Error as BpError, StripeKey};
     use crate::storage::blockdev::{MockDevice, MockDeviceConfig};
     use std::cell::{Cell, RefCell};
+    use std::fs;
 
     /// Spin a future to completion on the same noop-waker pattern the
     /// storage core uses. Bounded so a stuck future fails loudly.
@@ -692,6 +728,10 @@ mod tests {
             queue_depth: Some(32),
             page_size_bytes: None,
             skip_recovery_scan: false,
+            force_format: false,
+            bypass_admission: false,
+            bypass_index_read: false,
+            bypass_checksum: false,
             config: Some(crate::config::schema::disk_spec::Config::File(
                 crate::config::schema::FileDiskConfig {
                     path: "/tmp/unbounded-storage-test-disk".to_string(),
@@ -715,10 +755,14 @@ mod tests {
             queue_depth: Some(64),
             page_size_bytes: None,
             skip_recovery_scan: false,
+            force_format: false,
+            bypass_admission: false,
+            bypass_index_read: false,
+            bypass_checksum: false,
             config: Some(crate::config::schema::disk_spec::Config::Block(
                 crate::config::schema::BlockDiskConfig {
                     numa: None,
-                    path: "/dev/nvme0n1".to_string(),
+                    path: "/dev/unbounded-test-block".to_string(),
                 },
             )),
         };
@@ -730,6 +774,62 @@ mod tests {
         assert!(mode.ring_cfg.single_issuer);
         assert!(mode.ring_cfg.defer_taskrun);
         assert_eq!(mode.ring_cfg.queue_depth, 64);
+    }
+
+    #[test]
+    fn block_iopoll_probe_reads_sysfs_queue_flag() {
+        let dir = tempfile::tempdir().expect("create temp sysfs");
+        let queue = dir.path().join("nvme0n1/queue");
+        fs::create_dir_all(&queue).expect("create queue dir");
+
+        fs::write(queue.join("io_poll"), "0\n").expect("write io_poll");
+        assert_eq!(
+            block_queue_iopoll(Path::new("/dev/nvme0n1"), dir.path()),
+            Some(false)
+        );
+
+        fs::write(queue.join("io_poll"), "1\n").expect("write io_poll");
+        assert_eq!(
+            block_queue_iopoll(Path::new("/dev/nvme0n1"), dir.path()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn block_iopoll_probe_is_unknown_when_sysfs_missing() {
+        let dir = tempfile::tempdir().expect("create temp sysfs");
+
+        assert_eq!(
+            block_queue_iopoll(Path::new("/dev/nvme0n1"), dir.path()),
+            None
+        );
+    }
+
+    #[test]
+    fn block_disks_disable_iopoll_when_queue_does_not_support_it() {
+        let dir = tempfile::tempdir().expect("create temp sysfs");
+        let queue = dir.path().join("nvme0n1/queue");
+        fs::create_dir_all(&queue).expect("create queue dir");
+        fs::write(queue.join("io_poll"), "0\n").expect("write io_poll");
+
+        let mut ring_cfg = StorageRingConfig::default();
+        disable_iopoll_if_unsupported(&mut ring_cfg, Path::new("/dev/nvme0n1"), dir.path());
+
+        assert!(!ring_cfg.iopoll);
+        assert!(!ring_cfg.single_issuer);
+        assert!(!ring_cfg.defer_taskrun);
+    }
+
+    #[test]
+    fn block_disks_keep_iopoll_when_queue_support_is_unknown() {
+        let dir = tempfile::tempdir().expect("create temp sysfs");
+
+        let mut ring_cfg = StorageRingConfig::default();
+        disable_iopoll_if_unsupported(&mut ring_cfg, Path::new("/dev/nvme0n1"), dir.path());
+
+        assert!(ring_cfg.iopoll);
+        assert!(ring_cfg.single_issuer);
+        assert!(ring_cfg.defer_taskrun);
     }
 
     /// Regression for BUG 2: a `ring.progress()` error in STEADY STATE

--- a/cmd/unbounded-storage/src/storage/engine.rs
+++ b/cmd/unbounded-storage/src/storage/engine.rs
@@ -96,6 +96,14 @@ pub struct EngineConfig {
     /// and always proceeds. Intended for benchmarking/tooling;
     /// production should leave this false.
     pub bypass_admission: bool,
+    /// When true, reads use the committed in-memory index mirror instead
+    /// of reading the terminal btree leaf from disk. This is benchmark
+    /// only: production reads must hit the on-disk leaf so corruption and
+    /// snapshot semantics are preserved.
+    pub bypass_index_read: bool,
+    /// When true, reads skip data checksum validation. This is benchmark
+    /// only: production reads must verify cached bytes before returning a hit.
+    pub bypass_checksum: bool,
     /// When true, [`BTreeIndex::open`] skips the LBA-order leaf
     /// scan on disks that have no valid meta page. Intended for
     /// benchmarking and bring-up against freshly wiped devices
@@ -103,6 +111,11 @@ pub struct EngineConfig {
     /// per terabyte. Production should leave this false so partial
     /// recovery still runs when the meta slots are corrupted.
     pub skip_recovery_scan_if_no_meta: bool,
+    /// When true, ignore any existing on-disk btree metadata and
+    /// bootstrap an empty cache index. This is destructive: old cache
+    /// entries become unreachable and may be overwritten. Intended for
+    /// benchmark devices that are explicitly reset between runs.
+    pub force_format: bool,
     /// Stable identifier for this disk, used as the `disk` label on
     /// the engine's Prometheus metrics. Empty when unset (e.g. in
     /// tests and benchmarks); production wiring sets it from the
@@ -125,7 +138,10 @@ impl Default for EngineConfig {
             restart_scan_queue_depth: 256,
             btree_scratch_pages: 64,
             bypass_admission: false,
+            bypass_index_read: false,
+            bypass_checksum: false,
             skip_recovery_scan_if_no_meta: false,
+            force_format: false,
             disk_id: String::new(),
         }
     }
@@ -266,6 +282,7 @@ impl<B: BlockDevice> StorageEngine<B> {
                 scratch.clone(),
                 cfg.btree_page_bytes,
                 cfg.skip_recovery_scan_if_no_meta,
+                cfg.force_format,
             )
             .await?,
         );
@@ -565,9 +582,9 @@ impl<B: BlockDevice> StorageEngine<B> {
     ) -> Result<bool, bufferpool::Error> {
         let pk = Self::page_key(&key, stripe_off, self.cfg.page_size_bytes);
 
-        let entry = match self.btree.lookup(&pk).await {
-            Ok(Some(e)) => e,
-            Ok(None) | Err(_) => {
+        let entry = match self.lookup_entry(&pk).await {
+            Some(e) => e,
+            None => {
                 self.metric(|m| m.misses += 1);
                 crate::metrics::storage_lookup(crate::metrics::Lookup::Miss);
                 return Ok(false);
@@ -605,8 +622,9 @@ impl<B: BlockDevice> StorageEngine<B> {
             crate::metrics::Outcome::Ok,
         );
 
-        let cs = Xxh3Checksum::checksum_of(dst_buf);
-        if cs.0 != entry.data_checksum.0 {
+        if !self.cfg.bypass_checksum
+            && Xxh3Checksum::checksum_of(dst_buf).0 != entry.data_checksum.0
+        {
             self.metric(|m| {
                 m.misses += 1;
                 m.checksum_misses += 1;
@@ -620,6 +638,17 @@ impl<B: BlockDevice> StorageEngine<B> {
         self.metric(|m| m.hits += 1);
         crate::metrics::storage_lookup(crate::metrics::Lookup::Hit);
         Ok(true)
+    }
+
+    async fn lookup_entry(&self, pk: &PageKey) -> Option<LeafEntry> {
+        if self.cfg.bypass_index_read {
+            return self.btree.lookup_committed_mirror(pk);
+        }
+
+        match self.btree.lookup(pk).await {
+            Ok(Some(e)) => Some(e),
+            Ok(None) | Err(_) => None,
+        }
     }
 
     /// Write the contents of `src` to `(key, stripe_off)`. The

--- a/cmd/unbounded-storage/src/storage/mod.rs
+++ b/cmd/unbounded-storage/src/storage/mod.rs
@@ -30,6 +30,7 @@ mod origin;
 mod page_channel;
 mod refcount;
 mod singleflight;
+mod synthetic;
 mod traits;
 
 pub use admission::{AdmissionFilter, AdmitDecision, StripeAdmission};
@@ -38,5 +39,10 @@ pub use local::{LocalStorage, ShardLocalStore, disk_for};
 pub use metadata::ObjectMetadata;
 pub use origin::{METADATA_STRIPE_IDX, OriginRef, StripeReq, stripe_key};
 pub use page_channel::{PageChannel, PageChannelReceiver, PageCommand, PageService, ReplySlot};
+pub use synthetic::{
+    SyntheticObjectId, byte_at, fill_pages as fill_synthetic_pages,
+    matches_bytes as synthetic_matches_bytes, object_hash, object_id as synthetic_object_id,
+    parse_object_id as parse_synthetic_object_id, splitmix64,
+};
 pub use traits::PageChecksum;
 pub use types::{Checksum, DiskId, Error, Lba, PageKey};

--- a/cmd/unbounded-storage/src/storage/origin.rs
+++ b/cmd/unbounded-storage/src/storage/origin.rs
@@ -3,13 +3,14 @@
 
 //! Stripe-to-origin mapping.
 //!
-//! The P2P cache is content-addressed: a stripe is identified solely
-//! by its 32-byte [`StripeKey`](crate::bufferpool::StripeKey). That is
-//! sufficient for peer routing and dedup, but it carries no
-//! information about *where the bytes came from*. When a read misses
-//! all the way through to the origin tier, the backend needs to map a
-//! [`StripeKey`] back to a concrete origin object and byte range so it
-//! can issue (for example) an S3 `GET` with the right `Range` header.
+//! The P2P cache is keyspace-addressed: a cached stripe is identified
+//! by its cache id, logical object id, and stripe index. That key is
+//! sufficient for peer routing and dedup inside one cache, but it
+//! carries no information about *where the bytes came from*. When a
+//! read misses all the way through to the origin tier, the backend
+//! needs to map a [`StripeKey`] back to a concrete origin object and
+//! byte range so it can issue (for example) an S3 `GET` with the right
+//! `Range` header.
 //!
 //! Rather than maintain a reverse sidecar from key back to origin, the
 //! origin coordinates ride on the request itself ([`OriginRef`] on
@@ -21,10 +22,10 @@
 //!
 //! - [`OriginRef`] names the origin object a stripe belongs to and the
 //!   stripe index within that object.
-//! - [`OriginRef::stripe_key`] derives the content-addressed
-//!   [`StripeKey`] from an [`OriginRef`] deterministically, so the
-//!   frontend (which knows the origin) and any peer (which only knows
-//!   the key) agree on routing without coordination.
+//! - [`OriginRef::stripe_key_for_cache`] derives the cached
+//!   [`StripeKey`] from a cache id and an [`OriginRef`] deterministically,
+//!   so the frontend (which knows the origin) and any peer (which only
+//!   knows the key) agree on routing without coordination.
 
 use serde::{Deserialize, Serialize};
 
@@ -91,18 +92,28 @@ impl OriginRef {
         }
     }
 
-    /// Derive the canonical content-addressed [`StripeKey`] for this
-    /// origin stripe.
+    /// Derive the uncached origin [`StripeKey`] for this origin stripe.
+    ///
+    /// Cached requests must use [`Self::stripe_key_for_cache`] so the
+    /// cache id is the only logical keyspace prefix. This method exists
+    /// for direct-backend and bypass requests that never populate a
+    /// cache.
+    pub fn stripe_key(&self) -> StripeKey {
+        origin_stripe_key(&self.backend_id, &self.origin_object_id, self.stripe_idx)
+    }
+
+    /// Derive the canonical cached [`StripeKey`] for this origin stripe
+    /// within `cache_id`.
     ///
     /// The key is `blake3(...)` over the following exact byte layout,
     /// fed to a single streaming hasher in this order. Each
     /// variable-length string field is length-prefixed with its byte
-    /// length as a little-endian `u64`, so distinct `(backend_id,
+    /// length as a little-endian `u64`, so distinct `(cache_id,
     /// origin_object_id)` splits can never alias:
     ///
-    /// 1. `backend_id.len()` as 8 little-endian bytes
+    /// 1. `cache_id.len()` as 8 little-endian bytes
     ///    (`u64::to_le_bytes`).
-    /// 2. `backend_id` as raw UTF-8 bytes.
+    /// 2. `cache_id` as raw UTF-8 bytes.
     /// 3. `origin_object_id.len()` as 8 little-endian bytes.
     /// 4. `origin_object_id` as raw UTF-8 bytes.
     /// 5. `stripe_idx` as 8 little-endian bytes (`u64::to_le_bytes`).
@@ -113,11 +124,11 @@ impl OriginRef {
     /// The length prefix on each variable-length field makes the
     /// encoding unambiguous: `("ab", "c")` and `("a", "bc")` frame to
     /// different byte streams and therefore different keys, so the
-    /// split between `backend_id` and `origin_object_id` need not be
+    /// split between `cache_id` and `origin_object_id` need not be
     /// pinned out-of-band for correctness. The 8-byte little-endian
     /// `stripe_idx` suffix is fixed width.
-    pub fn stripe_key(&self) -> StripeKey {
-        stripe_key(&self.backend_id, &self.origin_object_id, self.stripe_idx)
+    pub fn stripe_key_for_cache(&self, cache_id: &str) -> StripeKey {
+        stripe_key(cache_id, &self.origin_object_id, self.stripe_idx)
     }
 
     /// Whether this reference names an object's metadata entry rather
@@ -146,7 +157,6 @@ pub struct StripeReq {
     key: StripeKey,
     origin: Option<OriginRef>,
     cache_id: Option<String>,
-    neighborhood_id: Option<String>,
     /// Local-only bridge flag. Never serialized: a bypass request is
     /// served straight from the origin on this node and never crosses
     /// the fabric, so a request decoded from a peer is by definition
@@ -154,6 +164,19 @@ pub struct StripeReq {
     /// and defaults the field to `false` on decode.
     #[serde(skip)]
     bypass: bool,
+    /// Benchmark-only flag carried over the fabric. Peer handlers use it
+    /// to synthesize response pages from their RPC scratch buffers so a
+    /// loadgen run can measure fabric RPC/RMA capacity without disk or
+    /// origin work in the server path.
+    fabric_only: bool,
+    /// Local-only benchmark flag. Never serialized: the initiating
+    /// bufferpool skips its own disk lookup/writeback when this is set,
+    /// but peer handlers still use their local NVMe-backed cache after
+    /// decoding the request from the fabric. This keeps measurements
+    /// focused on remote NVMe + RDMA without short-circuiting on the
+    /// requester's disk.
+    #[serde(skip)]
+    skip_local_disk: bool,
 }
 
 impl StripeReq {
@@ -164,8 +187,9 @@ impl StripeReq {
             key,
             origin: None,
             cache_id: None,
-            neighborhood_id: None,
             bypass: false,
+            fabric_only: false,
+            skip_local_disk: false,
         }
     }
 
@@ -184,26 +208,23 @@ impl StripeReq {
         self
     }
 
-    /// Attach the p2p neighborhood this request should route through.
-    /// `None` means the request resolves directly against its origin
-    /// backend after any local cache miss.
-    pub fn with_neighborhood_id(mut self, neighborhood_id: Option<String>) -> Self {
-        self.neighborhood_id = neighborhood_id;
-        self
-    }
-
-    /// Attach both runtime chain selectors in one step.
-    pub fn with_chain(mut self, cache_id: Option<String>, neighborhood_id: Option<String>) -> Self {
-        self.cache_id = cache_id;
-        self.neighborhood_id = neighborhood_id;
-        self
-    }
-
     /// Mark the request to bypass the p2p cache layer (disk cache,
     /// peer routing, and cross-shard fanout), bridging straight to the
     /// origin backend. See [`Req::bypass`].
     pub fn with_bypass(mut self, bypass: bool) -> Self {
         self.bypass = bypass;
+        self
+    }
+
+    /// Mark the request as a synthetic fabric benchmark request.
+    pub fn with_fabric_only(mut self, fabric_only: bool) -> Self {
+        self.fabric_only = fabric_only;
+        self
+    }
+
+    /// Mark the request to skip the initiator's local disk cache.
+    pub fn with_skip_local_disk(mut self, skip_local_disk: bool) -> Self {
+        self.skip_local_disk = skip_local_disk;
         self
     }
 
@@ -217,8 +238,12 @@ impl StripeReq {
         self.cache_id.as_deref()
     }
 
-    pub fn neighborhood_id(&self) -> Option<&str> {
-        self.neighborhood_id.as_deref()
+    pub fn fabric_only(&self) -> bool {
+        self.fabric_only
+    }
+
+    pub fn skip_local_disk(&self) -> bool {
+        self.skip_local_disk
     }
 }
 
@@ -235,15 +260,29 @@ impl Req for StripeReq {
         self.cache_id.as_ref()
     }
 
-    fn neighborhood_id(&self) -> Option<&String> {
-        self.neighborhood_id.as_ref()
+    fn fabric_only(&self) -> bool {
+        self.fabric_only
+    }
+
+    fn skip_local_disk(&self) -> bool {
+        self.skip_local_disk
     }
 }
 
-/// Free-function form of [`OriginRef::stripe_key`], for callers that
+/// Free-function form of [`OriginRef::stripe_key_for_cache`], for callers that
 /// have the parts in hand without an `OriginRef` value. See
-/// [`OriginRef::stripe_key`] for the exact byte layout.
-pub fn stripe_key(backend_id: &str, origin_object_id: &str, stripe_idx: u64) -> StripeKey {
+/// [`OriginRef::stripe_key_for_cache`] for the exact byte layout.
+pub fn stripe_key(cache_id: &str, origin_object_id: &str, stripe_idx: u64) -> StripeKey {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&(cache_id.len() as u64).to_le_bytes());
+    hasher.update(cache_id.as_bytes());
+    hasher.update(&(origin_object_id.len() as u64).to_le_bytes());
+    hasher.update(origin_object_id.as_bytes());
+    hasher.update(&stripe_idx.to_le_bytes());
+    StripeKey(*hasher.finalize().as_bytes())
+}
+
+fn origin_stripe_key(backend_id: &str, origin_object_id: &str, stripe_idx: u64) -> StripeKey {
     let mut hasher = blake3::Hasher::new();
     hasher.update(&(backend_id.len() as u64).to_le_bytes());
     hasher.update(backend_id.as_bytes());
@@ -260,52 +299,56 @@ mod tests {
     #[test]
     fn stripe_key_is_deterministic() {
         let a = OriginRef::new("primary-s3", "models/llama.bin", 12);
-        let b = OriginRef::new("primary-s3", "models/llama.bin", 12);
-        assert_eq!(a.stripe_key(), b.stripe_key());
+        let b = OriginRef::new("secondary-s3", "models/llama.bin", 12);
+        assert_eq!(
+            a.stripe_key_for_cache("cache-a"),
+            b.stripe_key_for_cache("cache-a")
+        );
         // Free function agrees with the method.
         assert_eq!(
-            a.stripe_key(),
-            stripe_key("primary-s3", "models/llama.bin", 12)
+            a.stripe_key_for_cache("cache-a"),
+            stripe_key("cache-a", "models/llama.bin", 12)
         );
     }
 
     #[test]
     fn stripe_key_differs_on_any_field() {
         let base = OriginRef::new("primary-s3", "models/llama.bin", 12);
-        let diff_backend = OriginRef::new("secondary-s3", "models/llama.bin", 12);
+        let diff_cache = OriginRef::new("secondary-s3", "models/llama.bin", 12);
         let diff_object = OriginRef::new("primary-s3", "models/other.bin", 12);
         let diff_idx = OriginRef::new("primary-s3", "models/llama.bin", 13);
 
-        let k = base.stripe_key();
-        assert_ne!(k, diff_backend.stripe_key());
-        assert_ne!(k, diff_object.stripe_key());
-        assert_ne!(k, diff_idx.stripe_key());
+        let k = base.stripe_key_for_cache("cache-a");
+        assert_eq!(k, diff_cache.stripe_key_for_cache("cache-a"));
+        assert_ne!(k, base.stripe_key_for_cache("cache-b"));
+        assert_ne!(k, diff_object.stripe_key_for_cache("cache-a"));
+        assert_ne!(k, diff_idx.stripe_key_for_cache("cache-a"));
     }
 
     #[test]
     fn stripe_key_matches_documented_byte_layout() {
         // Reconstruct the digest by hand from the documented layout:
-        // backend_len_le || backend_id bytes || object_len_le ||
+        // cache_len_le || cache_id bytes || object_len_le ||
         // origin_object_id bytes || idx_le.
-        let backend = "b";
+        let cache = "c";
         let object = "obj";
         let idx: u64 = 0x0102_0304_0506_0708;
 
         let mut expected_input = Vec::new();
-        expected_input.extend_from_slice(&(backend.len() as u64).to_le_bytes());
-        expected_input.extend_from_slice(backend.as_bytes());
+        expected_input.extend_from_slice(&(cache.len() as u64).to_le_bytes());
+        expected_input.extend_from_slice(cache.as_bytes());
         expected_input.extend_from_slice(&(object.len() as u64).to_le_bytes());
         expected_input.extend_from_slice(object.as_bytes());
         expected_input.extend_from_slice(&idx.to_le_bytes());
         let expected = StripeKey(*blake3::hash(&expected_input).as_bytes());
 
-        assert_eq!(stripe_key(backend, object, idx), expected);
+        assert_eq!(stripe_key(cache, object, idx), expected);
     }
 
     #[test]
     fn stripe_key_field_lengths_prevent_collision() {
         // The length prefix on each variable-length field must make
-        // distinct (backend_id, origin_object_id) splits unambiguous:
+        // distinct (cache_id, origin_object_id) splits unambiguous:
         // without it, "ab"+"c" and "a"+"bc" hash the same bytes.
         assert_ne!(stripe_key("ab", "c", 0), stripe_key("a", "bc", 0));
 
@@ -433,6 +476,28 @@ mod tests {
     }
 
     #[test]
+    fn stripe_req_fabric_only_round_trips_through_bincode() {
+        let origin = OriginRef::new("primary-s3", "models/llama.bin", 7);
+        let req = StripeReq::new(origin.stripe_key())
+            .with_origin(origin.clone())
+            .with_fabric_only(true);
+
+        let bytes = bincode::serialize(&req).unwrap();
+        let back: StripeReq = bincode::deserialize(&bytes).unwrap();
+
+        assert!(back.fabric_only());
+        assert_eq!(back.origin(), Some(&origin));
+    }
+
+    #[test]
+    fn stripe_req_fabric_only_defaults_false() {
+        let k = OriginRef::new("primary-s3", "models/llama.bin", 12).stripe_key();
+
+        assert!(!StripeReq::new(k).fabric_only());
+        assert!(!StripeReq::new(k).skip_local_disk());
+    }
+
+    #[test]
     fn stripe_req_bypass_is_not_serialized() {
         // `bypass` is `#[serde(skip)]`: it never crosses the fabric, so
         // a request decoded from the wire is always non-bypass even if
@@ -447,11 +512,24 @@ mod tests {
     }
 
     #[test]
-    fn stripe_req_chain_context_round_trips_through_bincode() {
+    fn stripe_req_skip_local_disk_is_not_serialized() {
+        // `skip_local_disk` is local to the requester: peer handlers must
+        // still read from their own NVMe cache after decoding the request.
+        let origin = OriginRef::new("primary-s3", "models/llama.bin", 7);
+        let req = StripeReq::new(origin.stripe_key())
+            .with_origin(origin)
+            .with_skip_local_disk(true);
+        let bytes = bincode::serialize(&req).unwrap();
+        let back: StripeReq = bincode::deserialize(&bytes).unwrap();
+        assert!(!back.skip_local_disk());
+    }
+
+    #[test]
+    fn stripe_req_cache_context_round_trips_through_bincode() {
         let origin = OriginRef::new("primary-s3", "models/llama.bin", 7);
         let req = StripeReq::new(origin.stripe_key())
             .with_origin(origin.clone())
-            .with_chain(Some("cache-a".to_string()), Some("site-a".to_string()))
+            .with_cache_id(Some("cache-a".to_string()))
             .with_bypass(true);
 
         let bytes = bincode::serialize(&req).unwrap();
@@ -459,7 +537,6 @@ mod tests {
 
         assert_eq!(back.origin(), Some(&origin));
         assert_eq!(back.cache_id(), Some("cache-a"));
-        assert_eq!(back.neighborhood_id(), Some("site-a"));
         assert!(!back.bypass());
     }
 

--- a/cmd/unbounded-storage/src/storage/synthetic.rs
+++ b/cmd/unbounded-storage/src/storage/synthetic.rs
@@ -1,0 +1,330 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Deterministic synthetic object model used by load generation.
+
+use crate::bufferpool::{Error, PageRef};
+
+const OBJECT_PREFIX: &str = "/__unbounded/loadgen/v1/";
+const SYNTHETIC_BLOCK_WORDS: usize = 512;
+const SYNTHETIC_BLOCK_BYTES: usize = SYNTHETIC_BLOCK_WORDS * 8;
+const INTRA_WORD_MUL_A: u64 = 0xD6E8_FEB8_6659_FD93;
+const INTRA_WORD_MUL_B: u64 = 0xA076_1D64_78BD_642F;
+const BLOCK_SALT_MUL: u64 = 0xE703_7ED1_A0B4_28DB;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SyntheticObjectId {
+    pub seed: u64,
+    pub ordinal: u64,
+    pub hash: u64,
+}
+
+pub fn object_id(seed: u64, ordinal: u64) -> String {
+    format!(
+        "{OBJECT_PREFIX}{seed:016x}/{ordinal:016x}-{:016x}",
+        object_hash(seed, ordinal),
+    )
+}
+
+pub fn parse_object_id(raw: &str) -> Option<SyntheticObjectId> {
+    let rest = raw.strip_prefix(OBJECT_PREFIX)?;
+    let (seed_hex, object_hex) = rest.split_once('/')?;
+    let (ordinal_hex, hash_hex) = object_hex.split_once('-')?;
+    if seed_hex.len() != 16 || ordinal_hex.len() != 16 || hash_hex.len() != 16 {
+        return None;
+    }
+
+    let seed = u64::from_str_radix(seed_hex, 16).ok()?;
+    let ordinal = u64::from_str_radix(ordinal_hex, 16).ok()?;
+    let hash = u64::from_str_radix(hash_hex, 16).ok()?;
+    if hash != object_hash(seed, ordinal) {
+        return None;
+    }
+
+    Some(SyntheticObjectId {
+        seed,
+        ordinal,
+        hash,
+    })
+}
+
+pub fn object_hash(seed: u64, ordinal: u64) -> u64 {
+    splitmix64(seed ^ ordinal)
+}
+
+pub fn byte_at(seed: u64, ordinal: u64, offset: u64) -> u8 {
+    word_bytes(seed, ordinal, offset / 8)[(offset % 8) as usize]
+}
+
+pub fn fill_pages(
+    object: SyntheticObjectId,
+    start_offset: u64,
+    dsts: &[PageRef],
+    backing_base: *mut u8,
+    page_size: usize,
+) -> Result<(), Error> {
+    let mut object_offset = start_offset;
+    for page in dsts {
+        let page_offset = page_byte_offset(page, page_size)?;
+        for_pattern_ranges(
+            object.seed,
+            object.ordinal,
+            object_offset,
+            page.len as usize,
+            |chunk, pattern| {
+                // SAFETY: `page_offset + chunk.dst_offset` starts inside the registered backing owned by the shard.
+                let dst = unsafe { backing_base.add(page_offset + chunk.dst_offset) };
+                // SAFETY: `dst` points to `chunk.len` writable bytes and the source is an in-bounds subslice of `pattern`.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        pattern.as_ptr().add(chunk.pattern_offset),
+                        dst,
+                        chunk.len,
+                    );
+                }
+                true
+            },
+        );
+        object_offset = object_offset.wrapping_add(page.len as u64);
+    }
+    Ok(())
+}
+
+pub fn matches_bytes(object: SyntheticObjectId, start_offset: u64, body: &[u8]) -> bool {
+    for_pattern_ranges(
+        object.seed,
+        object.ordinal,
+        start_offset,
+        body.len(),
+        |chunk, pattern| {
+            body[chunk.dst_offset..chunk.dst_offset + chunk.len]
+                == pattern[chunk.pattern_offset..chunk.pattern_offset + chunk.len]
+        },
+    )
+}
+
+pub fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^ (x >> 31)
+}
+
+fn page_byte_offset(page: &PageRef, page_size: usize) -> Result<usize, Error> {
+    (page.page_idx as usize)
+        .checked_mul(page_size)
+        .and_then(|base| base.checked_add(page.offset as usize))
+        .ok_or_else(|| Error::from("synthetic object: page byte offset overflow"))
+}
+
+fn word_bytes(seed: u64, ordinal: u64, word_idx: u64) -> [u8; 8] {
+    let object_salt = synthetic_object_salt(seed, ordinal);
+    let block_idx = word_idx / SYNTHETIC_BLOCK_WORDS as u64;
+    let intra_word = word_idx % SYNTHETIC_BLOCK_WORDS as u64;
+    let block_salt = synthetic_block_salt(object_salt, block_idx);
+    synthetic_word(object_salt, block_salt, intra_word).to_le_bytes()
+}
+
+fn synthetic_object_salt(seed: u64, ordinal: u64) -> u64 {
+    splitmix64(seed ^ ordinal.rotate_left(17))
+}
+
+fn synthetic_block_salt(object_salt: u64, block_idx: u64) -> u64 {
+    splitmix64(object_salt ^ block_idx.wrapping_mul(BLOCK_SALT_MUL))
+}
+
+fn synthetic_word(object_salt: u64, block_salt: u64, intra_word: u64) -> u64 {
+    let intra = intra_word
+        .wrapping_mul(INTRA_WORD_MUL_A)
+        .rotate_left(((intra_word as u32) & 31) + 1)
+        ^ intra_word.wrapping_mul(INTRA_WORD_MUL_B).rotate_right(17);
+    intra ^ object_salt ^ block_salt.rotate_left(((intra_word as u32).wrapping_mul(13)) & 63)
+}
+
+fn object_pattern(object_salt: u64, block_idx: u64) -> [u8; SYNTHETIC_BLOCK_BYTES] {
+    let block_salt = synthetic_block_salt(object_salt, block_idx);
+    let mut pattern = [0u8; SYNTHETIC_BLOCK_BYTES];
+    for (word_idx, dst) in pattern.chunks_exact_mut(8).enumerate() {
+        dst.copy_from_slice(
+            &synthetic_word(object_salt, block_salt, word_idx as u64).to_le_bytes(),
+        );
+    }
+    pattern
+}
+
+fn for_pattern_ranges<F>(seed: u64, ordinal: u64, start_offset: u64, len: usize, mut f: F) -> bool
+where
+    F: FnMut(PatternRange, &[u8; SYNTHETIC_BLOCK_BYTES]) -> bool,
+{
+    let object_salt = synthetic_object_salt(seed, ordinal);
+    let mut next_object_offset = start_offset;
+    let mut next_dst_offset = 0usize;
+    let mut remaining = len;
+    let mut block_idx_seen = None;
+    let mut pattern = [0u8; SYNTHETIC_BLOCK_BYTES];
+
+    while remaining > 0 {
+        let block_idx = next_object_offset / SYNTHETIC_BLOCK_BYTES as u64;
+        if block_idx_seen != Some(block_idx) {
+            pattern = object_pattern(object_salt, block_idx);
+            block_idx_seen = Some(block_idx);
+        }
+
+        let pattern_offset = (next_object_offset % SYNTHETIC_BLOCK_BYTES as u64) as usize;
+        let len = remaining.min(SYNTHETIC_BLOCK_BYTES - pattern_offset);
+        let chunk = PatternRange {
+            pattern_offset,
+            dst_offset: next_dst_offset,
+            len,
+        };
+
+        if !f(chunk, &pattern) {
+            return false;
+        }
+
+        next_object_offset = next_object_offset.wrapping_add(len as u64);
+        next_dst_offset += len;
+        remaining -= len;
+    }
+
+    true
+}
+
+struct PatternRange {
+    pattern_offset: usize,
+    dst_offset: usize,
+    len: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PAGE_SIZE: usize = 16;
+
+    #[test]
+    fn object_id_round_trips_and_validates_hash() {
+        let id = object_id(0x1234, 0x5678);
+        assert_eq!(
+            id,
+            "/__unbounded/loadgen/v1/0000000000001234/0000000000005678-6a631dbadf9c8837"
+        );
+
+        let parsed = parse_object_id(&id).expect("parse object id");
+        assert_eq!(parsed.seed, 0x1234);
+        assert_eq!(parsed.ordinal, 0x5678);
+        assert_eq!(parsed.hash, object_hash(0x1234, 0x5678));
+
+        assert!(
+            parse_object_id(
+                "/__unbounded/loadgen/v1/0000000000001234/0000000000005678-0000000000000000"
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn content_is_stable_by_absolute_offset() {
+        let object = parse_object_id(&object_id(7, 11)).unwrap();
+        let mut backing = vec![0u8; PAGE_SIZE * 2];
+        let dsts = vec![
+            PageRef {
+                page_idx: 0,
+                offset: 3,
+                len: 5,
+            },
+            PageRef {
+                page_idx: 1,
+                offset: 2,
+                len: 4,
+            },
+        ];
+
+        fill_pages(object, 9, &dsts, backing.as_mut_ptr(), PAGE_SIZE).unwrap();
+
+        assert!(matches_bytes(object, 9, &backing[3..8]));
+        assert!(matches_bytes(
+            object,
+            14,
+            &backing[PAGE_SIZE + 2..PAGE_SIZE + 6]
+        ));
+    }
+
+    #[test]
+    fn fill_matches_byte_contract_across_word_boundaries() {
+        let object = parse_object_id(&object_id(13, 17)).unwrap();
+        let mut backing = vec![0u8; PAGE_SIZE * 3];
+        let dsts = vec![PageRef {
+            page_idx: 1,
+            offset: 1,
+            len: 19,
+        }];
+
+        fill_pages(object, 5, &dsts, backing.as_mut_ptr(), PAGE_SIZE).unwrap();
+
+        let filled = &backing[PAGE_SIZE + 1..PAGE_SIZE + 20];
+        let expected: Vec<u8> = (0..19)
+            .map(|idx| byte_at(object.seed, object.ordinal, 5 + idx))
+            .collect();
+        assert_eq!(filled, expected.as_slice());
+        assert!(matches_bytes(object, 5, filled));
+    }
+
+    #[test]
+    fn content_differs_by_absolute_synthetic_block() {
+        let object = parse_object_id(&object_id(19, 23)).unwrap();
+        let mut backing = vec![0u8; SYNTHETIC_BLOCK_BYTES + 32];
+        let dsts = vec![PageRef {
+            page_idx: 0,
+            offset: 0,
+            len: backing.len() as u32,
+        }];
+
+        fill_pages(object, 0, &dsts, backing.as_mut_ptr(), backing.len()).unwrap();
+
+        assert_ne!(backing[0..32], backing[SYNTHETIC_BLOCK_BYTES..][..32]);
+        assert!(matches_bytes(
+            object,
+            SYNTHETIC_BLOCK_BYTES as u64 - 8,
+            &backing[SYNTHETIC_BLOCK_BYTES - 8..SYNTHETIC_BLOCK_BYTES + 24]
+        ));
+    }
+
+    #[test]
+    fn matches_bytes_rejects_block_shift() {
+        let object = parse_object_id(&object_id(21, 25)).unwrap();
+        let body: Vec<u8> = (0..64)
+            .map(|idx| {
+                byte_at(
+                    object.seed,
+                    object.ordinal,
+                    SYNTHETIC_BLOCK_BYTES as u64 + idx,
+                )
+            })
+            .collect();
+
+        assert!(matches_bytes(object, SYNTHETIC_BLOCK_BYTES as u64, &body));
+        assert!(!matches_bytes(object, 0, &body));
+    }
+
+    #[test]
+    fn matches_bytes_rejects_corruption() {
+        let object = parse_object_id(&object_id(23, 29)).unwrap();
+        let mut body: Vec<u8> = (0..24)
+            .map(|idx| byte_at(object.seed, object.ordinal, 3 + idx))
+            .collect();
+
+        assert!(matches_bytes(object, 3, &body));
+
+        body[9] ^= 0xff;
+        assert!(!matches_bytes(object, 3, &body));
+    }
+
+    #[test]
+    fn chunked_matching_wraps_object_offset() {
+        let object = parse_object_id(&object_id(31, 37)).unwrap();
+        let body = [byte_at(object.seed, object.ordinal, u64::MAX)];
+
+        assert!(matches_bytes(object, u64::MAX, &body));
+    }
+}

--- a/cmd/unbounded-storage/tests/lifecycle/workload.rs
+++ b/cmd/unbounded-storage/tests/lifecycle/workload.rs
@@ -17,9 +17,9 @@ use proptest::prelude::*;
 use unbounded_storage::bufferpool::{Error, StripeKey};
 use unbounded_storage::config::{
     ApplyError, BackendSpec, CacheSpec, Config, ConfigApplyTarget, ConfigController, ConfigDiff,
-    DiskSpec, FileDiskConfig, FrontendSpec, HttpBackendConfig, HttpFrontendConfig,
-    NeighborhoodSpec, PeerSpec, TcpPeerConfig, backend_spec, disk_spec, frontend_spec, peer_spec,
-    runtime_disks, runtime_projection,
+    DiskSpec, FileDiskConfig, FrontendSpec, HttpBackendConfig, HttpFrontendConfig, PeerSpec,
+    TcpPeerConfig, backend_spec, disk_spec, frontend_spec, peer_spec, runtime_disks,
+    runtime_projection,
 };
 use unbounded_storage::runtime::ShardLoop;
 use unbounded_storage::storage::blockdev::MockDeviceConfig;
@@ -855,18 +855,12 @@ fn config_for_generation(version: u64, disks: Vec<DiskSpec>) -> Config {
     cfg.apply_defaults();
     cfg.version = version;
     cfg.backends = backend_specs(0, 1);
-    cfg.neighborhoods = vec![NeighborhoodSpec {
-        name: "neighborhood-0".to_string(),
-        source: "backend-0".to_string(),
-        fingers_per_node: Some(100),
-        local_node_id: Some(1),
-        local_tags: Vec::new(),
-        routing_plan: None,
-        peers: Vec::new(),
-    }];
+    cfg.self_ = "node-self".to_string();
+    cfg.fingers_per_node = Some(100);
+    cfg.peers = vec![self_peer_spec()];
     cfg.caches = vec![CacheSpec {
         name: "cache-0".to_string(),
-        source: "neighborhood-0".to_string(),
+        source: "backend-0".to_string(),
     }];
     cfg.disks = disks;
     cfg.frontends = frontend_specs(0, 1);
@@ -877,12 +871,10 @@ fn mutate_config(cfg: &mut Config, apply: &ApplySpec, generation: usize) {
     match apply.kind {
         ApplyKind::Noop => {}
         ApplyKind::Peers { count } => {
-            let neighborhood = cfg
-                .neighborhoods
-                .first_mut()
-                .expect("lifecycle sim has a neighborhood");
-            neighborhood.fingers_per_node = Some(count.max(1) as u32);
-            neighborhood.peers = (0..count.max(1)).map(peer_spec_for).collect();
+            cfg.fingers_per_node = Some(count.max(1) as u32);
+            cfg.peers = std::iter::once(self_peer_spec())
+                .chain((0..count.max(1)).map(peer_spec_for))
+                .collect();
         }
         ApplyKind::Backends { count } => {
             cfg.backends = backend_specs(generation, count.max(1));
@@ -930,10 +922,20 @@ fn frontend_specs(generation: usize, count: u8) -> Vec<FrontendSpec> {
 
 fn peer_spec_for(idx: u8) -> PeerSpec {
     PeerSpec {
-        id: idx as u64 + 2,
+        name: format!("node-{idx}"),
         tags: vec![format!("rack-{}", idx % 2)],
         config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
             addr: format!("127.0.0.1:{}", 9000 + idx as u16),
+        })),
+    }
+}
+
+fn self_peer_spec() -> PeerSpec {
+    PeerSpec {
+        name: "node-self".to_string(),
+        tags: vec!["rack-self".to_string()],
+        config: Some(peer_spec::Config::Tcp(TcpPeerConfig {
+            addr: "127.0.0.1:8999".to_string(),
         })),
     }
 }
@@ -944,6 +946,10 @@ fn generation_disk_specs(generation: usize, count: usize) -> Vec<DiskSpec> {
             queue_depth: Some(32),
             page_size_bytes: Some(4096),
             skip_recovery_scan: true,
+            force_format: false,
+            bypass_admission: false,
+            bypass_index_read: false,
+            bypass_checksum: false,
             config: Some(disk_spec::Config::File(FileDiskConfig {
                 size: Some(64 * 1024 * 1024),
                 path: format!("/dst/generation-{generation}/disk-{idx}"),

--- a/cmd/unbounded-storage/tests/p2p/mocks.rs
+++ b/cmd/unbounded-storage/tests/p2p/mocks.rs
@@ -127,7 +127,7 @@ impl SimCluster {
     /// rebuilt via [`FingerTable::from_explicit`] from only the
     /// neighbors the global build would have selected (its distinct
     /// non-self fingers plus successor and predecessor). This mirrors
-    /// exactly what `build_routing` does when a `[p2p.routing_plan]`
+    /// exactly what the process route builder does when a `[routing_plan]`
     /// is supplied. A cluster built this way must route every target
     /// identically to one built with [`Self::new`]; the proptest
     /// `disjoint_routing_matches_global` pins that equivalence.

--- a/designs/storage-disjoint-routing-parity.md
+++ b/designs/storage-disjoint-routing-parity.md
@@ -8,7 +8,7 @@ sorted roster of cluster nodes (`FingerTable::build`), which requires
 each node to know every other node.
 
 "Disjoint discovery" lets a node be configured with **only its direct
-routing neighbors** via a `[p2p.routing_plan]` block instead of the full
+routing neighbors** via a top-level `[routing_plan]` block instead of the full
 roster. The node feeds those neighbors straight into
 `FingerTable::from_explicit` and skips the global build entirely.
 
@@ -38,7 +38,8 @@ re-implementation must match this same algorithm.
 For a target node `L` being planned, the planner needs the global roster:
 the set of all nodes, each with:
 
-- `id`: the `u64` node id (the `[[peers]].id` / `local_node_id`).
+- `name`: the stable peer name. `unbounded-storage` derives the internal
+  `u64` node id from this name.
 - `labels`: the ordered topology label vector (coarsest to finest, e.g.
   `[region, zone, row, rack]`). Empty if unset.
 
@@ -62,15 +63,16 @@ splitmix64(x):
 
 All arithmetic is unsigned 64-bit with wraparound.
 
-### Ring position of a node
+### Node id and ring position
 
 ```
-node_to_ring(id) = splitmix64(id)
+node_id_from_name(name) = first_u64_le(blake3(name))
+node_to_ring(node_id) = splitmix64(node_id)
 ```
 
-So every node's ring position is `splitmix64(node_id)`. (Stripe keys map
-to the ring via the leading 8 bytes little-endian of their SHA-256
-digest, but the planner does not need that for neighbor selection.)
+So every node's ring position is `splitmix64(node_id_from_name(name))`.
+Stripe keys map to the ring via the leading 8 bytes little-endian of their
+SHA-256 digest, but the planner does not need that for neighbor selection.
 
 ### Forward ring distance
 
@@ -119,9 +121,9 @@ rendezvous_hash(local_ring, candidate_ring, arc) =
 
 Compute `L`'s neighbors exactly as `FingerTable::build` does.
 
-Let `local_ring = node_to_ring(L.id)`, `k = max(fingers_per_node, 1)`,
-and `arc_span = floor((2^64 - 1) / k)` (integer division of `u64::MAX`
-by `k`).
+Let `local_id = node_id_from_name(L.name)`,
+`local_ring = node_to_ring(local_id)`, `k = max(fingers_per_node, 1)`, and
+`arc_span = floor((2^64 - 1) / k)` (integer division of `u64::MAX` by `k`).
 
 ### Arc index
 
@@ -139,10 +141,11 @@ arc_index(local_ring, cand_ring, arc_span, k):
 ### Fingers
 
 Initialize one slot per arc as empty. For every candidate node `c` where
-`c.id != L.id`:
+`c.name != L.name`:
 
-1. `a = arc_index(local_ring, node_to_ring(c.id), arc_span, k)`.
-2. If arc `a` is empty, place `c` there. Otherwise replace the incumbent
+1. `c_id = node_id_from_name(c.name)`.
+2. `a = arc_index(local_ring, node_to_ring(c_id), arc_span, k)`.
+3. If arc `a` is empty, place `c` there. Otherwise replace the incumbent
    `inc` with `c` iff `better(c, inc, a)` (below).
 
 ```
@@ -150,10 +153,10 @@ better(c, inc, arc):                   # is challenger c better than incumbent i
     ct = topology_distance(L.labels, c.labels)
     it = topology_distance(L.labels, inc.labels)
     if ct != it: return ct < it
-    cr = rendezvous_hash(local_ring, node_to_ring(c.id), arc)
-    ir = rendezvous_hash(local_ring, node_to_ring(inc.id), arc)
+    cr = rendezvous_hash(local_ring, node_to_ring(node_id_from_name(c.name)), arc)
+    ir = rendezvous_hash(local_ring, node_to_ring(node_id_from_name(inc.name)), arc)
     if cr != ir: return cr < ir
-    return node_to_ring(c.id) < node_to_ring(inc.id)   # raw u64 ring position
+    return node_to_ring(node_id_from_name(c.name)) < node_to_ring(node_id_from_name(inc.name))
 ```
 
 That is: prefer the topologically nearer candidate; break ties by lower
@@ -168,41 +171,42 @@ and the lookup path ignores them either way.)
 
 ### Successor and predecessor
 
-Over the same candidates (`c.id != L.id`):
+Over the same candidates (`c.name != L.name`):
 
 - `successor` = the candidate minimizing `ring_distance(local_ring,
-  node_to_ring(c.id))` among nonzero distances (the nearest node
+  node_to_ring(node_id_from_name(c.name)))` among nonzero distances (the nearest node
   *forward* on the ring).
 - `predecessor` = the candidate minimizing `ring_distance(node_to_ring(
-  c.id), local_ring)` among nonzero distances (the nearest node
-  *backward* on the ring).
+  node_id_from_name(c.name)), local_ring)` among nonzero distances (the
+  nearest node *backward* on the ring).
 
 Both are absent only for a single-node cluster. If two candidates tie on
-distance (only possible with colliding ring positions, which
-`splitmix64` makes vanishingly unlikely for distinct ids), the first
+distance (only possible with colliding ring positions, which the name hash and
+`splitmix64` make vanishingly unlikely for distinct names), the first
 encountered wins; planners should treat a tie as a misconfiguration.
 
 ## Output mapping
 
 The planner emits, for node `L`:
 
-- `[p2p.routing_plan].fingers` = the list of arc-winner node ids
+- `[routing_plan].fingers` = the list of arc-winner peer names
   (deduplicated, `L` excluded). Order does not matter.
-- `[p2p.routing_plan].successor` = the successor node id (omit for a
+- `[routing_plan].successor` = the successor peer name (omit for a
   single-node cluster).
-- `[p2p.routing_plan].predecessor` = the predecessor node id (omit for a
+- `[routing_plan].predecessor` = the predecessor peer name (omit for a
   single-node cluster).
 
-`L`'s `[[peers]]` list must contain exactly one entry per id referenced
-by the routing plan (fingers, successor, predecessor), carrying that
-peer's transport/address so `L` opens connections only to its routing
-neighbors. `unbounded-storage` validates this at config load:
+`L`'s `[[peers]]` list must contain one entry for `L` itself and exactly one
+entry per name referenced by the routing plan (fingers, successor,
+predecessor), carrying that peer's transport/address so `L` opens connections
+only to its routing neighbors. `unbounded-storage` validates this at config
+load:
 
-- every routing-plan id must be a known `[[peers]].id`
+- every routing-plan name must be a known `[[peers]].name`
   (`RoutingPlanUnknownPeer`),
-- no routing-plan id may equal `local_node_id`
+- no routing-plan name may equal `self`
   (`RoutingPlanSelfReference`),
-- finger ids must be unique (`RoutingPlanDuplicateFinger`).
+- finger names must be unique (`RoutingPlanDuplicateFinger`).
 
 Labels for finger peers are looked up from their `[[peers]]` entry (or
 empty if unset); labels do not affect runtime routing, only the

--- a/designs/storage-high-level.md
+++ b/designs/storage-high-level.md
@@ -63,7 +63,7 @@ the name to the same ID without fetching the full object.
   bounded subset of peers, not a full mesh, so NIC queue-pair (QP)
   usage stays well under hardware limits.
 - **Disjoint discovery.** A node can be configured with only its
-  direct routing neighbors (a `routing_plan`) instead of the full
+  direct routing neighbors (the top-level `routing_plan`) instead of the full
   cluster roster. Because the recursive routing math only ever
   consults a node's own fingers/successor/predecessor, a planner with
   global view can compute each node's neighbor set offline and the

--- a/hack/scripts/gen-storage-mesh-config.sh
+++ b/hack/scripts/gen-storage-mesh-config.sh
@@ -3,8 +3,8 @@
 # Licensed under the MIT License.
 
 # gen-storage-mesh-config.sh -- Generate a test unbounded-storage TOML config
-# for one node of the current Kubernetes cluster, wiring every other node in as
-# a TCP peer (a full peer mesh) using each node's InternalIP.
+# for one node of the current Kubernetes cluster, wiring every selected node in
+# as a named TCP peer using each node's InternalIP.
 #
 # Usage:
 #   hack/scripts/gen-storage-mesh-config.sh [options]
@@ -195,7 +195,7 @@ NODE_LINES=$(kubectl "${KUBECTL_CFG_ARGS[@]}" "${KUBECTL_CTX_ARGS[@]}" get nodes
 
 [[ -z "$NODE_LINES" ]] && die "no nodes found in the current cluster."
 
-# Parse into parallel arrays of names and IPs, assigning ids 1..N by sort order.
+# Parse into parallel arrays of names and IPs in sorted order.
 NAMES=()
 IPS=()
 while IFS=' ' read -r name ip; do
@@ -228,7 +228,6 @@ done
 
 LOCAL_NAME="${NAMES[$LOCAL_IDX]}"
 LOCAL_IP="${IPS[$LOCAL_IDX]}"
-LOCAL_ID=$((LOCAL_IDX + 1))
 
 # ── resolve the s3 origin endpoint ────────────────────────────────────────────
 
@@ -269,11 +268,14 @@ cat >&3 <<EOF
 #
 #   name:        $LOCAL_NAME
 #   internal ip: $LOCAL_IP
-#   node id:     $LOCAL_ID  (of $NODE_COUNT nodes; ids assigned by sorted name)
+#   peer roster: $NODE_COUNT node(s) selected by name
 #
-# Every other node in the cluster is wired into the p2p neighborhood below as a
-# TCP peer. Regenerate the peer config for a different node with --local-node
-# <name>.
+# Every selected node in the cluster is wired into the peer roster below. The
+# local process identity is selected by self; internal ring and fabric ids are
+# derived from peer names. Regenerate the peer config for a different node with
+# --local-node <name>.
+
+self = "$LOCAL_NAME"
 
 [[backends]]
 name = "origin"
@@ -281,24 +283,16 @@ name = "origin"
 [backends.config.s3]
 url = "$OPT_ORIGIN"
 stripe_size_bytes = $STRIPE_SIZE
-
-[[neighborhoods]]
-name = "p2p"
-source = "origin"
-local_node_id = $LOCAL_ID
 EOF
 
-# Peers: every node except the local one.
+# Peers: every selected node, including self. Fabric reconcile excludes self.
 for i in "${!NAMES[@]}"; do
-	[[ "$i" -eq "$LOCAL_IDX" ]] && continue
-	peer_id=$((i + 1))
 	cat >&3 <<EOF
 
-[[neighborhoods.peers]]
-# peer node: ${NAMES[$i]}
-id = $peer_id
+[[peers]]
+name = "${NAMES[$i]}"
 
-[neighborhoods.peers.config.tcp]
+[peers.config.tcp]
 addr = "${IPS[$i]}:$OPT_PORT"
 EOF
 done
@@ -307,7 +301,7 @@ cat >&3 <<EOF
 
 [[caches]]
 name = "cache"
-source = "p2p"
+source = "origin"
 
 [[disks]]
 page_size_bytes = 4096
@@ -326,8 +320,8 @@ addr = "0.0.0.0:$OPT_FRONTEND_PORT"
 
 [startup.fabric.binds.tcp]
 # Bind the node's own routable IP, not 0.0.0.0. This must be the exact
-# address peers use to reach this node (their [[neighborhoods.peers]] TCP addr
-# points here); the libfabric tcp provider uses it both to bind and as its
+# address peers use to reach this node (their [[peers]] TCP addr points here);
+# the libfabric tcp provider uses it both to bind and as its
 # connection-manager identity and does not come up on an INADDR_ANY bind.
 addr = "$LOCAL_IP:$OPT_PORT"
 

--- a/hack/smoke-storage.py
+++ b/hack/smoke-storage.py
@@ -30,6 +30,9 @@ frontend/backend implementations are covered against the real fabric:
             record payloads land zero-copy in the page cache; the origin's
             self-signed cert is pinned via the backend's `ca_cert_path`,
             exercising custom-CA verification end to end.
+  - `loadgen`: the in-process load generator frontend backed by the
+            synthetic fake backend, with results verified through the
+            daemon's Prometheus metrics endpoint.
 
 A single `unbounded-storage` process serves exactly one frontend (the
 first configured spec wins), so the two kinds cannot share a ring; each
@@ -668,8 +671,8 @@ def write_config(
     path: Path,
     *,
     kind: str,
-    local_id: int,
-    peer_id: int,
+    self_name: str,
+    peer_name: str,
     peer_addr: str,
     disk_path: Path,
     origin_addr: str,
@@ -700,6 +703,8 @@ def write_config(
         tls_lines += "insecure_skip_verify = true\n"
     path.write_text(
         f"""\
+self = "{self_name}"
+
 [[backends]]
 name = "origin"
 
@@ -708,20 +713,21 @@ url = "{origin_addr}"
 stripe_size_bytes = {STRIPE_SIZE}
 {tls_lines}
 
-[[neighborhoods]]
-name = "p2p"
-source = "origin"
-local_node_id = {local_id}
+[[peers]]
+name = "{self_name}"
 
-[[neighborhoods.peers]]
-id = {peer_id}
+[peers.config.tcp]
+addr = "{fabric_addr}"
 
-[neighborhoods.peers.config.tcp]
+[[peers]]
+name = "{peer_name}"
+
+[peers.config.tcp]
 addr = "{peer_addr}"
 
 [[caches]]
 name = "cache"
-source = "p2p"
+source = "origin"
 
 [[disks]]
 page_size_bytes = 4096
@@ -769,6 +775,82 @@ serving_cores = 2
     )
 
 
+def write_loadgen_config(
+    path: Path,
+    *,
+    local_id: int,
+    peer_id: int,
+    peer_addr: str,
+    disk_path: Path,
+    fabric_addr: str,
+    metrics_addr: str,
+) -> None:
+    self_name = f"node-{local_id}"
+    peer_name = f"node-{peer_id}"
+    path.write_text(
+        f"""\
+self = "{self_name}"
+
+[[backends]]
+name = "fake"
+
+[backends.config.fake]
+stripe_size_bytes = {STRIPE_SIZE}
+object_size_bytes = {STRIPE_SIZE}
+
+[[peers]]
+name = "{self_name}"
+
+[peers.config.tcp]
+addr = "{fabric_addr}"
+
+[[peers]]
+name = "{peer_name}"
+
+[peers.config.tcp]
+addr = "{peer_addr}"
+
+[[caches]]
+name = "cache"
+source = "fake"
+
+[[disks]]
+page_size_bytes = 4096
+skip_recovery_scan = true
+
+[disks.config.file]
+path = "{disk_path}"
+size = {DISK_SIZE}
+
+[[frontends]]
+name = "loadgen"
+source = "cache"
+
+[frontends.config.loadgen]
+workers = 1
+seed = 1234
+keyspace_objects = 16
+object_size_bytes = {STRIPE_SIZE}
+read_bytes = {STRIPE_SIZE // 16}
+zipf_exponent = 1.1
+verify = true
+
+[startup.memory]
+memory_total_bytes = {MEMORY_TOTAL_BYTES}
+
+[startup.fabric.binds.tcp]
+addr = "{fabric_addr}"
+
+[startup.metrics]
+addr = "{metrics_addr}"
+
+[startup.topology]
+disable_rdma = true
+serving_cores = 2
+"""
+    )
+
+
 # ============================================================================
 # READINESS & CLIENT
 # ============================================================================
@@ -810,13 +892,16 @@ def fetch(url: str, timeout: int = 30) -> tuple[int, bytes]:
     raise AssertionError("unreachable")
 
 
-def scrape_metric_sum(url: str, name: str, timeout: int = 30) -> float:
+def scrape_metric_sum(
+    url: str, name: str, timeout: int = 30, labels: dict[str, str] | None = None
+) -> float:
     """Scrape Prometheus text from *url* and sum all samples of *name*.
 
     Sums across every label-set series whose metric name matches *name*
     (ignoring comment/HELP/TYPE lines), so a counter split across labels
     like `frontend_requests_total{frontend="fe",method="GET",status="200"}`
-    is totaled. Dies if the endpoint never responds.
+    is totaled. When *labels* is set, only series carrying every requested
+    `key="value"` label are included. Dies if the endpoint never responds.
     """
     status, body = fetch(url, timeout)
     if status != 200:
@@ -829,13 +914,43 @@ def scrape_metric_sum(url: str, name: str, timeout: int = 30) -> float:
             continue
         # "<name>{labels} <value>" or "<name> <value>"
         head, _, value = line.rpartition(" ")
-        metric = head.split("{", 1)[0]
+        metric, label_text = metric_name_and_labels(head)
         if metric == name:
+            if labels is not None and not all(
+                f'{k}="{v}"' in label_text for k, v in labels.items()
+            ):
+                continue
             try:
                 total += float(value)
             except ValueError:
                 continue
     return total
+
+
+def metric_name_and_labels(head: str) -> tuple[str, str]:
+    metric, sep, rest = head.partition("{")
+    if not sep:
+        return metric, ""
+    return metric, rest.rsplit("}", 1)[0]
+
+
+def wait_metric_at_least(
+    url: str,
+    name: str,
+    threshold: float,
+    *,
+    labels: dict[str, str] | None = None,
+    timeout: int = 60,
+) -> float:
+    deadline = time.monotonic() + timeout
+    last = 0.0
+    while time.monotonic() < deadline:
+        last = scrape_metric_sum(url, name, timeout=5, labels=labels)
+        if last >= threshold:
+            return last
+        time.sleep(1)
+    die(f"metric {name} at {url} reached {last}, expected >= {threshold}")
+    raise AssertionError("unreachable")
 
 
 # ============================================================================
@@ -922,8 +1037,8 @@ def run_scenario(
     write_config(
         cfg1,
         kind=kind,
-        local_id=1,
-        peer_id=2,
+        self_name="node-a",
+        peer_name="node-b",
         peer_addr=f"127.0.0.1:{fab_b}",
         disk_path=TMPDIR / f"{name}-node1.disk",
         origin_addr=origin_addr,
@@ -936,8 +1051,8 @@ def run_scenario(
     write_config(
         cfg2,
         kind=kind,
-        local_id=2,
-        peer_id=1,
+        self_name="node-b",
+        peer_name="node-a",
         peer_addr=f"127.0.0.1:{fab_a}",
         disk_path=TMPDIR / f"{name}-node2.disk",
         origin_addr=origin_addr,
@@ -1013,6 +1128,95 @@ def run_scenario(
         terminate(nodes)
 
 
+def run_loadgen_scenario() -> None:
+    """Bring up a fake-backend/loadgen ring and assert it makes progress."""
+    log("")
+    log("=== Scenario: loadgen (loadgen frontend + fake backend) ===")
+
+    nodes: list[_Node] = []
+    fab_a, fab_b = free_port(), free_port()
+    met_a, met_b = free_port(), free_port()
+    log(f"Ports: fabric=({fab_a},{fab_b}) metrics=({met_a},{met_b})")
+
+    log("Writing loadgen node configs")
+    cfg1 = TMPDIR / "loadgen-node1.toml"
+    cfg2 = TMPDIR / "loadgen-node2.toml"
+    write_loadgen_config(
+        cfg1,
+        local_id=1,
+        peer_id=2,
+        peer_addr=f"127.0.0.1:{fab_b}",
+        disk_path=TMPDIR / "loadgen-node1.disk",
+        fabric_addr=f"127.0.0.1:{fab_a}",
+        metrics_addr=f"127.0.0.1:{met_a}",
+    )
+    write_loadgen_config(
+        cfg2,
+        local_id=2,
+        peer_id=1,
+        peer_addr=f"127.0.0.1:{fab_a}",
+        disk_path=TMPDIR / "loadgen-node2.disk",
+        fabric_addr=f"127.0.0.1:{fab_b}",
+        metrics_addr=f"127.0.0.1:{met_b}",
+    )
+
+    try:
+        log("Bringing up two loadgen storage nodes")
+        nodes.append(start_node("loadgen", 1, cfg1, TMPDIR / "loadgen-node1.log"))
+        nodes.append(start_node("loadgen", 2, cfg2, TMPDIR / "loadgen-node2.log"))
+
+        wait_port("127.0.0.1", met_a)
+        wait_port("127.0.0.1", met_b)
+        log("  Letting fabric peers establish...")
+        time.sleep(3)
+
+        request_metric = "unbounded_storage_frontend_requests_total"
+        bytes_metric = "unbounded_storage_frontend_response_bytes_total"
+        request_labels = {
+            "frontend": "loadgen",
+            "method": "GET",
+            "status": "200",
+        }
+        bytes_labels = {"frontend": "loadgen"}
+        for label, met_port in (("A", met_a), ("B", met_b)):
+            url = f"http://127.0.0.1:{met_port}/metrics"
+            log(f"Waiting for loadgen metrics from node {label} ({url})")
+            count = wait_metric_at_least(
+                url,
+                request_metric,
+                1,
+                labels=request_labels,
+            )
+            bytes_total = wait_metric_at_least(
+                url,
+                bytes_metric,
+                STRIPE_SIZE // 16,
+                labels=bytes_labels,
+            )
+            # Loadgen starts with the daemon, so peer-dial warmup can leave
+            # early status=500 samples in lifetime counters before the ring is
+            # ready. Successful verified reads and response bytes are the
+            # smoke-test signal here.
+            failures = scrape_metric_sum(
+                url,
+                request_metric,
+                labels={
+                    "frontend": "loadgen",
+                    "method": "GET",
+                    "status": "500",
+                },
+            )
+            log(
+                f"  node {label} reports loadgen requests={count} "
+                f"response_bytes={bytes_total} startup_failures={failures}"
+            )
+
+        log("  loadgen scenario PASSED")
+    finally:
+        log("  Tearing down loadgen ring")
+        terminate(nodes)
+
+
 # ============================================================================
 # MAIN
 # ============================================================================
@@ -1077,6 +1281,7 @@ def main() -> None:
         tls_origin,
         ca_cert_path=TLS_CERT,
     )
+    run_loadgen_scenario()
 
     log("")
     log("Smoke test PASSED")

--- a/internal/orca/inttest/storageprocess.go
+++ b/internal/orca/inttest/storageprocess.go
@@ -127,30 +127,33 @@ func freeLoopbackPort(t *testing.T) int {
 // backend/frontend/peer/disk implementations are selected by oneof
 // config table names. The startup-fixed knobs (heap backing, fabric
 // bind address, forcing the tcp provider) live in the `[startup.*]` sections.
-func writeStorageConfig(t *testing.T, path, fabricAddr string, localID, peerID int, peerAddr, diskPath, orcaEdge, frontendBind string) {
+func writeStorageConfig(t *testing.T, path, fabricAddr, selfName, peerName, peerAddr, diskPath, orcaEdge, frontendBind string) {
 	t.Helper()
 
-	cfg := fmt.Sprintf(`[[backends]]
+	cfg := fmt.Sprintf(`self = %q
+
+[[backends]]
 name = "origin"
 
 [backends.config.s3]
 url = "http://%s"
 stripe_size_bytes = %d
 
-[[neighborhoods]]
-name = "p2p"
-source = "origin"
-local_node_id = %d
+[[peers]]
+name = %q
 
-[[neighborhoods.peers]]
-id = %d
+[peers.config.tcp]
+addr = %q
 
-[neighborhoods.peers.config.tcp]
-addr = "%s"
+[[peers]]
+name = %q
+
+[peers.config.tcp]
+addr = %q
 
 [[caches]]
 name = "cache"
-source = "p2p"
+source = "origin"
 
 [[disks]]
 page_size_bytes = %d
@@ -176,9 +179,9 @@ addr = "%s"
 [startup.topology]
 disable_rdma = true
 serving_cores = 2
-`, orcaEdge, storageStripeSize,
-		localID,
-		peerID, peerAddr,
+`, selfName, orcaEdge, storageStripeSize,
+		selfName, fabricAddr,
+		peerName, peerAddr,
 		storagePageSize, diskPath, storageDiskSize,
 		frontendBind,
 		fabricAddr)
@@ -211,10 +214,10 @@ func startStorageRing(ctx context.Context, t *testing.T, orcaEdge string) *stora
 	cfg2 := filepath.Join(dir, "node2.toml")
 
 	writeStorageConfig(t, cfg1,
-		fmt.Sprintf("127.0.0.1:%d", fabA), 1, 2, fmt.Sprintf("127.0.0.1:%d", fabB),
+		fmt.Sprintf("127.0.0.1:%d", fabA), "node-a", "node-b", fmt.Sprintf("127.0.0.1:%d", fabB),
 		filepath.Join(dir, "node1.disk"), orcaEdge, fmt.Sprintf("127.0.0.1:%d", feA))
 	writeStorageConfig(t, cfg2,
-		fmt.Sprintf("127.0.0.1:%d", fabB), 2, 1, fmt.Sprintf("127.0.0.1:%d", fabA),
+		fmt.Sprintf("127.0.0.1:%d", fabB), "node-b", "node-a", fmt.Sprintf("127.0.0.1:%d", fabA),
 		filepath.Join(dir, "node2.disk"), orcaEdge, fmt.Sprintf("127.0.0.1:%d", feB))
 
 	spawnStorageNode(ctx, t, bin, cfg1, filepath.Join(dir, "node1.log"))

--- a/internal/storagesupervisor/disks.go
+++ b/internal/storagesupervisor/disks.go
@@ -23,6 +23,10 @@ const (
 	diskOptionQueueDepth       = "queue_depth"
 	diskOptionPageSizeBytes    = "page_size_bytes"
 	diskOptionSkipRecoveryScan = "skip_recovery_scan"
+	diskOptionForceFormat      = "force_format"
+	diskOptionBypassAdmission  = "bypass_admission"
+	diskOptionBypassIndexRead  = "bypass_index_read"
+	diskOptionBypassChecksum   = "bypass_checksum"
 	diskOptionNuma             = "numa"
 )
 
@@ -178,6 +182,62 @@ func applyDiskOption(disk *storageconfig.DiskSpec, raw string, seen map[string]s
 		}
 
 		disk.SkipRecoveryScan = v
+		seen[key] = struct{}{}
+	case diskOptionForceFormat:
+		if isDuplicateDiskOption(seen, path, key) {
+			return
+		}
+
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage disk bool option", "path", path, "key", key, "value", value)
+
+			return
+		}
+
+		disk.ForceFormat = v
+		seen[key] = struct{}{}
+	case diskOptionBypassAdmission:
+		if isDuplicateDiskOption(seen, path, key) {
+			return
+		}
+
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage disk bool option", "path", path, "key", key, "value", value)
+
+			return
+		}
+
+		disk.BypassAdmission = v
+		seen[key] = struct{}{}
+	case diskOptionBypassIndexRead:
+		if isDuplicateDiskOption(seen, path, key) {
+			return
+		}
+
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage disk bool option", "path", path, "key", key, "value", value)
+
+			return
+		}
+
+		disk.BypassIndexRead = v
+		seen[key] = struct{}{}
+	case diskOptionBypassChecksum:
+		if isDuplicateDiskOption(seen, path, key) {
+			return
+		}
+
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage disk bool option", "path", path, "key", key, "value", value)
+
+			return
+		}
+
+		disk.BypassChecksum = v
 		seen[key] = struct{}{}
 	case diskOptionNuma:
 		if isDuplicateDiskOption(seen, path, key) {

--- a/internal/storagesupervisor/peers.go
+++ b/internal/storagesupervisor/peers.go
@@ -230,6 +230,7 @@ func computeRing(nodes []*corev1.Node, selfName, ringLabel string, port int) rin
 		if n.Labels[ringLabel] != ringValue {
 			continue
 		}
+
 		if _, dup := seen[n.Name]; dup {
 			continue
 		}

--- a/internal/storagesupervisor/peers.go
+++ b/internal/storagesupervisor/peers.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"log/slog"
 	"net"
 	"sort"
@@ -40,14 +39,13 @@ type ringState struct {
 	// the renderer leaves the per-node sections untouched and passes the
 	// ConfigMap's fabric addr through verbatim.
 	active bool
-	// localNodeID is this node's stable id (hash of its node name), written to
-	// neighborhoods[].local_node_id.
-	localNodeID uint64
+	// selfName is this node's stable peer name, written to self.
+	selfName string
 	// selfListenAddr is this node's own routable fabric bind, "<internalIP>:
 	// <port>", overriding the ConfigMap's fabric addr so the tcp provider
 	// binds an address peers can actually dial.
 	selfListenAddr string
-	// peers is the other ring members as daemon PeerSpecs, sorted by id.
+	// peers is the ring roster as daemon PeerSpecs, including self, sorted by name.
 	peers []*storageconfig.PeerSpec
 }
 
@@ -188,10 +186,8 @@ func (w *peerWatcher) snapshot(port int, portOK bool) renderState {
 // informer plumbing so the membership logic is unit-testable.
 //
 // Membership is by equal label value: every node whose ring label matches this
-// node's becomes a peer, this node excluded. Ids are a stable hash of the node
-// name so a node keeps the same id across membership churn. A peer with no
-// usable InternalIP, or whose id collides with this node or an already-emitted
-// peer, is skipped and logged rather than corrupting the set.
+// node's becomes a named peer, including this node. A peer with no usable
+// InternalIP is skipped and logged rather than corrupting the set.
 func computeRing(nodes []*corev1.Node, selfName, ringLabel string, port int) ringState {
 	var self *corev1.Node
 
@@ -222,22 +218,19 @@ func computeRing(nodes []*corev1.Node, selfName, ringLabel string, port int) rin
 		return ringState{}
 	}
 
-	localID := nodeID(selfName)
-
 	ring := ringState{
 		active:         true,
-		localNodeID:    localID,
+		selfName:       selfName,
 		selfListenAddr: net.JoinHostPort(selfIP, strconv.Itoa(port)),
 	}
 
-	seen := map[uint64]string{localID: selfName}
+	seen := map[string]struct{}{}
 
 	for _, n := range nodes {
-		if n.Name == selfName {
+		if n.Labels[ringLabel] != ringValue {
 			continue
 		}
-
-		if n.Labels[ringLabel] != ringValue {
+		if _, dup := seen[n.Name]; dup {
 			continue
 		}
 
@@ -248,25 +241,17 @@ func computeRing(nodes []*corev1.Node, selfName, ringLabel string, port int) rin
 			continue
 		}
 
-		id := nodeID(n.Name)
-		if other, dup := seen[id]; dup {
-			slog.Warn("skipping storage ring peer: node id collision",
-				"peer", n.Name, "collides_with", other, "id", id)
-
-			continue
-		}
-
-		seen[id] = n.Name
+		seen[n.Name] = struct{}{}
 
 		ring.peers = append(ring.peers, &storageconfig.PeerSpec{
-			Id: id,
+			Name: n.Name,
 			Config: &storageconfig.PeerSpec_Tcp{
 				Tcp: &storageconfig.TcpPeerConfig{Addr: net.JoinHostPort(ip, strconv.Itoa(port))},
 			},
 		})
 	}
 
-	sort.Slice(ring.peers, func(i, j int) bool { return ring.peers[i].Id < ring.peers[j].Id })
+	sort.Slice(ring.peers, func(i, j int) bool { return ring.peers[i].Name < ring.peers[j].Name })
 
 	return ring
 }
@@ -290,24 +275,6 @@ func selfAnnotations(nodes []*corev1.Node, selfName string) map[string]string {
 	}
 
 	return nil
-}
-
-// nodeID derives a node's stable storage id from its name via 64-bit FNV-1a.
-// The id doubles as the daemon's NodeId and PeerId, so it must be stable
-// across membership changes (a hash of the immutable node name is) and
-// non-zero (zero is the daemon's "no local id / single peerless node"
-// sentinel), which the +1 guard ensures without weakening uniqueness in
-// practice.
-func nodeID(name string) uint64 {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(name)) //nolint:errcheck // hash.Write never errors.
-
-	id := h.Sum64()
-	if id == 0 {
-		id = 1
-	}
-
-	return id
 }
 
 // internalIP returns the node's first InternalIP address, or "" when none is

--- a/internal/storagesupervisor/peers_test.go
+++ b/internal/storagesupervisor/peers_test.go
@@ -42,15 +42,6 @@ func nodeWithAnnotations(name, ring, ip string, annotations map[string]string) *
 	return n
 }
 
-func TestNodeIDStableAndNonZero(t *testing.T) {
-	// Deterministic across calls and distinct for distinct names.
-	assert.Equal(t, nodeID("node-a"), nodeID("node-a"))
-	assert.NotEqual(t, nodeID("node-a"), nodeID("node-b"))
-	// Never zero (zero is the daemon's peerless sentinel).
-	assert.NotZero(t, nodeID(""))
-	assert.NotZero(t, nodeID("node-a"))
-}
-
 func TestParseFabricPort(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -89,23 +80,23 @@ func TestComputeRingMembership(t *testing.T) {
 	ring := computeRing(nodes, "self", testRingLabel, 9000)
 
 	require.True(t, ring.active)
-	assert.Equal(t, nodeID("self"), ring.localNodeID)
+	assert.Equal(t, "self", ring.selfName)
 	assert.Equal(t, "10.0.0.1:9000", ring.selfListenAddr)
 
-	require.Len(t, ring.peers, 2)
-	// Peers are sorted by id; verify both red peers are present with their
-	// hashed ids and InternalIP:port sockets, and self is excluded.
-	got := map[uint64]string{}
+	require.Len(t, ring.peers, 3)
+	// Peers are sorted by name; verify all red peers are present with their
+	// names and InternalIP:port sockets, including self.
+	got := map[string]string{}
 	for _, p := range ring.peers {
-		got[p.GetId()] = p.GetTcp().GetAddr()
+		got[p.GetName()] = p.GetTcp().GetAddr()
 	}
 
-	assert.Equal(t, "10.0.0.2:9000", got[nodeID("peer-a")])
-	assert.Equal(t, "10.0.0.3:9000", got[nodeID("peer-b")])
-	assert.NotContains(t, got, ring.localNodeID)
+	assert.Equal(t, "10.0.0.1:9000", got["self"])
+	assert.Equal(t, "10.0.0.2:9000", got["peer-a"])
+	assert.Equal(t, "10.0.0.3:9000", got["peer-b"])
 }
 
-func TestComputeRingPeersSortedByID(t *testing.T) {
+func TestComputeRingPeersSortedByName(t *testing.T) {
 	nodes := []*corev1.Node{
 		node("self", "red", "10.0.0.1"),
 		node("zeta", "red", "10.0.0.2"),
@@ -114,8 +105,10 @@ func TestComputeRingPeersSortedByID(t *testing.T) {
 
 	ring := computeRing(nodes, "self", testRingLabel, 9000)
 
-	require.Len(t, ring.peers, 2)
-	assert.Less(t, ring.peers[0].GetId(), ring.peers[1].GetId())
+	require.Len(t, ring.peers, 3)
+	assert.Equal(t, "alpha", ring.peers[0].GetName())
+	assert.Equal(t, "self", ring.peers[1].GetName())
+	assert.Equal(t, "zeta", ring.peers[2].GetName())
 }
 
 func TestComputeRingSelfNotLabelled(t *testing.T) {
@@ -160,20 +153,23 @@ func TestComputeRingSkipsPeerWithoutInternalIP(t *testing.T) {
 	ring := computeRing(nodes, "self", testRingLabel, 9000)
 
 	require.True(t, ring.active)
-	require.Len(t, ring.peers, 1)
-	assert.Equal(t, nodeID("peer-a"), ring.peers[0].GetId())
+	require.Len(t, ring.peers, 2)
+	assert.Equal(t, "peer-a", ring.peers[0].GetName())
+	assert.Equal(t, "self", ring.peers[1].GetName())
 }
 
 func TestComputeRingSingleMember(t *testing.T) {
 	// A lone ring member still activates so its fabric addr is made routable,
-	// with an empty peer set.
+	// with itself in the peer roster.
 	nodes := []*corev1.Node{node("self", "red", "10.0.0.1")}
 
 	ring := computeRing(nodes, "self", testRingLabel, 9000)
 
 	require.True(t, ring.active)
 	assert.Equal(t, "10.0.0.1:9000", ring.selfListenAddr)
-	assert.Empty(t, ring.peers)
+	require.Len(t, ring.peers, 1)
+	assert.Equal(t, "self", ring.peers[0].GetName())
+	assert.Equal(t, "10.0.0.1:9000", ring.peers[0].GetTcp().GetAddr())
 }
 
 func TestNewPeerWatcherDisabledWithoutNodeName(t *testing.T) {
@@ -231,9 +227,11 @@ func TestPeerWatcherSnapshotFromInformer(t *testing.T) {
 
 	require.True(t, ring.active)
 	assert.Equal(t, "10.0.0.1:9000", ring.selfListenAddr)
-	require.Len(t, ring.peers, 1)
-	assert.Equal(t, nodeID("peer-a"), ring.peers[0].GetId())
+	require.Len(t, ring.peers, 2)
+	assert.Equal(t, "peer-a", ring.peers[0].GetName())
 	assert.Equal(t, "10.0.0.2:9000", ring.peers[0].GetTcp().GetAddr())
+	assert.Equal(t, "self", ring.peers[1].GetName())
+	assert.Equal(t, "10.0.0.1:9000", ring.peers[1].GetTcp().GetAddr())
 }
 
 func TestPeerWatcherSnapshotIncludesSelfAnnotations(t *testing.T) {

--- a/internal/storagesupervisor/render.go
+++ b/internal/storagesupervisor/render.go
@@ -33,14 +33,13 @@ type renderState struct {
 // loudly rather than silently dropping a setting. Any field left unset keeps its
 // proto3 zero value, which the daemon promotes to the documented default.
 //
-// The per-node sections (neighborhood local_node_id and discovered peer sets)
-// come from state, computed from the Kubernetes node watch. When the ring is
-// active, this node's id is injected into every declared neighborhood,
-// discovered peers are merged with any neighborhood peers declared in the YAML
-// (discovered peers win on id collision), and startup.fabric.tcp.addr is
-// overridden with the node's own routable bind. The default disk pool is
-// populated from the self node's storage disk annotations, or from a default
-// file-backed disk when no valid annotation disks are present.
+// The per-node mesh fields (self and discovered peer set) come from state,
+// computed from the Kubernetes node watch. When the ring is active, this node's
+// peer name is injected and discovered peers are merged with any peers declared
+// in the YAML (discovered peers win on name collision). TCP rings also override
+// startup.fabric.tcp.addr with the node's own routable bind. The default disk
+// set is populated from the self node's storage disk annotations, or from a
+// default file-backed disk when no valid annotation disks are present.
 func RenderConfig(sourceDir string, state renderState) ([]byte, error) {
 	cfg, err := loadSourceConfig(sourceDir)
 	if err != nil {
@@ -100,28 +99,14 @@ func loadSourceConfig(sourceDir string) (*storageconfig.Config, error) {
 }
 
 // applyRing overlays the per-node ring state onto a Config parsed from the
-// ConfigMap YAML. It injects this node's local id into declared neighborhoods,
-// merges the discovered peer set with each neighborhood's declared peers, and
-// rebinds the TCP fabric address to the node's own routable address.
+// ConfigMap YAML. It injects this node's self peer name, merges the discovered
+// peer set with any declared peers, and rebinds the TCP fabric address to the
+// node's own routable address.
 func applyRing(cfg *storageconfig.Config, ring ringState) {
-	injected := false
-
-	for _, neighborhood := range cfg.Neighborhoods {
-		if neighborhood == nil {
-			continue
-		}
-
-		injected = true
-
-		// Preserve YAML-declared neighborhood scalars (fingers_per_node,
-		// local_tags, routing_plan); only stamp in the locally computed node id.
-		neighborhood.LocalNodeId = proto.Uint64(ring.localNodeID)
-		neighborhood.Peers = mergePeers(neighborhood.Peers, ring.peers, ring.localNodeID)
-	}
-
-	if !injected {
-		slog.Warn("ring discovery active but config declares no neighborhoods; discovered storage peers were not injected")
-	}
+	// Preserve YAML-declared routing knobs (fingers_per_node, routing_plan);
+	// only stamp in the locally computed self name and peer roster.
+	cfg.Self = ring.selfName
+	cfg.Peers = mergePeers(cfg.Peers, ring.peers)
 
 	if ring.selfListenAddr != "" {
 		if cfg.Startup == nil {
@@ -139,14 +124,12 @@ func applyRing(cfg *storageconfig.Config, ring ringState) {
 }
 
 // mergePeers combines the label-discovered peer set with any peers declared in
-// the ConfigMap YAML, deduplicated by peer id. Discovered peers are
-// authoritative: a YAML peer whose id collides with a discovered peer is
-// dropped. Any peer whose id equals the local node id is dropped (the daemon's
-// validate() rejects a self-peer, and discovery already excludes self). The
-// result is sorted by id so an unchanged input renders byte-for-byte
-// identically and never triggers a spurious config swap.
-func mergePeers(declared, discovered []*storageconfig.PeerSpec, localNodeID uint64) []*storageconfig.PeerSpec {
-	byID := make(map[uint64]*storageconfig.PeerSpec, len(declared)+len(discovered))
+// the ConfigMap YAML, deduplicated by peer name. Discovered peers are
+// authoritative: a YAML peer whose name collides with a discovered peer is
+// dropped. The result is sorted by name so an unchanged input renders
+// byte-for-byte identically and never triggers a spurious config swap.
+func mergePeers(declared, discovered []*storageconfig.PeerSpec) []*storageconfig.PeerSpec {
+	byName := make(map[string]*storageconfig.PeerSpec, len(declared)+len(discovered))
 
 	add := func(peers []*storageconfig.PeerSpec, fromYAML bool) {
 		for _, p := range peers {
@@ -154,34 +137,35 @@ func mergePeers(declared, discovered []*storageconfig.PeerSpec, localNodeID uint
 				continue
 			}
 
-			if p.GetId() == localNodeID {
-				slog.Warn("dropping peer whose id equals local node id", "id", p.GetId())
+			name := p.GetName()
+			if name == "" {
+				slog.Warn("dropping storage peer with empty name")
 
 				continue
 			}
 
-			if _, ok := byID[p.GetId()]; ok {
+			if _, ok := byName[name]; ok {
 				if fromYAML {
-					slog.Warn("dropping declared peer; id already discovered", "id", p.GetId())
+					slog.Warn("dropping declared peer; name already discovered", "name", name)
 				}
 
 				continue
 			}
 
-			byID[p.GetId()] = p
+			byName[name] = p
 		}
 	}
 
-	// Discovered first so they win id collisions against declared peers.
+	// Discovered first so they win name collisions against declared peers.
 	add(discovered, false)
 	add(declared, true)
 
-	merged := make([]*storageconfig.PeerSpec, 0, len(byID))
-	for _, p := range byID {
+	merged := make([]*storageconfig.PeerSpec, 0, len(byName))
+	for _, p := range byName {
 		merged = append(merged, p)
 	}
 
-	sort.Slice(merged, func(i, j int) bool { return merged[i].GetId() < merged[j].GetId() })
+	sort.Slice(merged, func(i, j int) bool { return merged[i].GetName() < merged[j].GetName() })
 
 	return merged
 }

--- a/internal/storagesupervisor/render_test.go
+++ b/internal/storagesupervisor/render_test.go
@@ -50,9 +50,9 @@ func decodeWithState(t *testing.T, dir string, state renderState) *storageconfig
 	return &cfg
 }
 
-func tcpPeer(id uint64, addr string) *storageconfig.PeerSpec {
+func tcpPeer(name, addr string) *storageconfig.PeerSpec {
 	return &storageconfig.PeerSpec{
-		Id: id,
+		Name: name,
 		Config: &storageconfig.PeerSpec_Tcp{
 			Tcp: &storageconfig.TcpPeerConfig{Addr: addr},
 		},
@@ -198,9 +198,9 @@ func TestRenderConfigInvalidValues(t *testing.T) {
 }
 
 func TestRenderConfigActiveRingOverlay(t *testing.T) {
-	// An active ring injects local_node_id + peers and overrides the
-	// ConfigMap's fabric addr with this node's own routable bind, while the
-	// rest of the startup settings still come from the source.
+	// An active ring injects self + peers and overrides the ConfigMap's fabric
+	// addr with this node's own routable bind, while the rest of the startup
+	// settings still come from the source.
 	dir := writeSource(t, `
 version: 3
 startup:
@@ -211,18 +211,19 @@ startup:
 backends:
   - name: origin
     fake: {}
-neighborhoods:
+caches:
   - name: edge
     source: origin
 `)
 
 	ring := ringState{
 		active:         true,
-		localNodeID:    42,
+		selfName:       "self",
 		selfListenAddr: "10.0.0.5:9000",
 		peers: []*storageconfig.PeerSpec{
-			tcpPeer(7, "10.0.0.6:9000"),
-			tcpPeer(9, "10.0.0.7:9000"),
+			tcpPeer("peer-a", "10.0.0.6:9000"),
+			tcpPeer("peer-b", "10.0.0.7:9000"),
+			tcpPeer("self", "10.0.0.5:9000"),
 		},
 	}
 
@@ -239,21 +240,20 @@ neighborhoods:
 	// addr is overridden with the node's own routable address.
 	assert.Equal(t, "10.0.0.5:9000", cfg.GetStartup().GetFabric().GetTcp().GetAddr())
 
-	require.Len(t, cfg.GetNeighborhoods(), 1)
-	neighborhood := cfg.GetNeighborhoods()[0]
-	assert.Equal(t, uint64(42), neighborhood.GetLocalNodeId())
-
-	require.Len(t, neighborhood.GetPeers(), 2)
-	assert.Equal(t, uint64(7), neighborhood.GetPeers()[0].GetId())
-	assert.Equal(t, "10.0.0.6:9000", neighborhood.GetPeers()[0].GetTcp().GetAddr())
-	assert.Equal(t, uint64(9), neighborhood.GetPeers()[1].GetId())
-	assert.Equal(t, "10.0.0.7:9000", neighborhood.GetPeers()[1].GetTcp().GetAddr())
+	assert.Equal(t, "self", cfg.GetSelf())
+	require.Len(t, cfg.GetPeers(), 3)
+	assert.Equal(t, "peer-a", cfg.GetPeers()[0].GetName())
+	assert.Equal(t, "10.0.0.6:9000", cfg.GetPeers()[0].GetTcp().GetAddr())
+	assert.Equal(t, "peer-b", cfg.GetPeers()[1].GetName())
+	assert.Equal(t, "10.0.0.7:9000", cfg.GetPeers()[1].GetTcp().GetAddr())
+	assert.Equal(t, "self", cfg.GetPeers()[2].GetName())
+	assert.Equal(t, "10.0.0.5:9000", cfg.GetPeers()[2].GetTcp().GetAddr())
 }
 
 func TestRenderConfigActiveRingMergesPeers(t *testing.T) {
 	// Peers declared in the YAML are merged with discovered peers, and
-	// YAML-declared neighborhood scalars (fingers_per_node, local_tags) are
-	// preserved while local_node_id is stamped in.
+	// YAML-declared routing scalars (fingers_per_node, routing_plan) are
+	// preserved while self is stamped in.
 	dir := writeSource(t, `
 startup:
   fabric:
@@ -262,24 +262,23 @@ startup:
 backends:
   - name: origin
     fake: {}
-neighborhoods:
-  - name: edge
-    source: origin
-    fingers_per_node: 5
-    local_tags: ["rack-a"]
-    peers:
-      - id: 100
-        tcp:
-          addr: "10.0.0.100:9000"
+fingers_per_node: 5
+routing_plan:
+  fingers: ["declared"]
+peers:
+  - name: declared
+    tcp:
+      addr: "10.0.0.100:9000"
 `)
 
 	ring := ringState{
 		active:         true,
-		localNodeID:    42,
+		selfName:       "self",
 		selfListenAddr: "10.0.0.5:9000",
 		peers: []*storageconfig.PeerSpec{
-			tcpPeer(9, "10.0.0.7:9000"),
-			tcpPeer(7, "10.0.0.6:9000"),
+			tcpPeer("peer-b", "10.0.0.7:9000"),
+			tcpPeer("peer-a", "10.0.0.6:9000"),
+			tcpPeer("self", "10.0.0.5:9000"),
 		},
 	}
 
@@ -290,24 +289,22 @@ neighborhoods:
 
 	require.NoError(t, proto.Unmarshal(data, &cfg))
 
-	require.Len(t, cfg.GetNeighborhoods(), 1)
-	neighborhood := cfg.GetNeighborhoods()[0]
+	// YAML routing scalars preserved; self injected.
+	assert.Equal(t, "self", cfg.GetSelf())
+	assert.NotNil(t, cfg.FingersPerNode)
+	assert.Equal(t, uint32(5), cfg.GetFingersPerNode())
+	assert.Equal(t, []string{"declared"}, cfg.GetRoutingPlan().GetFingers())
 
-	// YAML neighborhood scalars preserved; local id injected.
-	assert.Equal(t, uint64(42), neighborhood.GetLocalNodeId())
-	assert.NotNil(t, neighborhood.FingersPerNode)
-	assert.Equal(t, uint32(5), neighborhood.GetFingersPerNode())
-	assert.Equal(t, []string{"rack-a"}, neighborhood.GetLocalTags())
-
-	// Discovered {7,9} merged with declared {100}, sorted by id.
-	require.Len(t, neighborhood.GetPeers(), 3)
-	assert.Equal(t, uint64(7), neighborhood.GetPeers()[0].GetId())
-	assert.Equal(t, uint64(9), neighborhood.GetPeers()[1].GetId())
-	assert.Equal(t, uint64(100), neighborhood.GetPeers()[2].GetId())
-	assert.Equal(t, "10.0.0.100:9000", neighborhood.GetPeers()[2].GetTcp().GetAddr())
+	// Discovered peers merged with declared peers, sorted by name.
+	require.Len(t, cfg.GetPeers(), 4)
+	assert.Equal(t, "declared", cfg.GetPeers()[0].GetName())
+	assert.Equal(t, "10.0.0.100:9000", cfg.GetPeers()[0].GetTcp().GetAddr())
+	assert.Equal(t, "peer-a", cfg.GetPeers()[1].GetName())
+	assert.Equal(t, "peer-b", cfg.GetPeers()[2].GetName())
+	assert.Equal(t, "self", cfg.GetPeers()[3].GetName())
 }
 
-func TestRenderConfigActiveRingWarnsWithoutNeighborhoods(t *testing.T) {
+func TestRenderConfigActiveRingWorksWithoutDeclaredPeers(t *testing.T) {
 	dir := writeSource(t, `
 startup:
   fabric:
@@ -318,19 +315,12 @@ backends:
     fake: {}
 `)
 
-	var logs bytes.Buffer
-
-	previousLogger := slog.Default()
-
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
-	t.Cleanup(func() { slog.SetDefault(previousLogger) })
-
 	ring := ringState{
 		active:         true,
-		localNodeID:    42,
+		selfName:       "self",
 		selfListenAddr: "10.0.0.5:9000",
 		peers: []*storageconfig.PeerSpec{
-			tcpPeer(7, "10.0.0.6:9000"),
+			tcpPeer("peer-a", "10.0.0.6:9000"),
 		},
 	}
 
@@ -341,36 +331,33 @@ backends:
 
 	require.NoError(t, proto.Unmarshal(data, &cfg))
 
-	assert.Empty(t, cfg.GetNeighborhoods())
+	assert.Equal(t, "self", cfg.GetSelf())
+	require.Len(t, cfg.GetPeers(), 1)
+	assert.Equal(t, "peer-a", cfg.GetPeers()[0].GetName())
 	assert.Equal(t, "10.0.0.5:9000", cfg.GetStartup().GetFabric().GetTcp().GetAddr())
-	assert.Contains(t, logs.String(), "discovered storage peers were not injected")
 }
 
-func TestRenderConfigMergeDropsCollisionsAndSelf(t *testing.T) {
-	// A declared peer whose id collides with a discovered peer is dropped in
-	// favor of the discovered one; a declared peer whose id equals the local
-	// node id is dropped entirely.
+func TestRenderConfigMergeDropsNameCollisions(t *testing.T) {
+	// A declared peer whose name collides with a discovered peer is dropped in
+	// favor of the discovered one.
 	dir := writeSource(t, `
 backends:
   - name: origin
     fake: {}
-neighborhoods:
-  - name: edge
-    source: origin
-    peers:
-      - id: 7
-        tcp:
-          addr: "10.9.9.9:9000"
-      - id: 42
-        tcp:
-          addr: "10.9.9.42:9000"
+peers:
+  - name: peer-a
+    tcp:
+      addr: "10.9.9.9:9000"
+  - name: declared
+    tcp:
+      addr: "10.9.9.42:9000"
 `)
 
 	ring := ringState{
-		active:      true,
-		localNodeID: 42,
+		active:   true,
+		selfName: "self",
 		peers: []*storageconfig.PeerSpec{
-			tcpPeer(7, "10.0.0.6:9000"),
+			tcpPeer("peer-a", "10.0.0.6:9000"),
 		},
 	}
 
@@ -381,13 +368,14 @@ neighborhoods:
 
 	require.NoError(t, proto.Unmarshal(data, &cfg))
 
-	// Only the discovered peer 7 survives; its address wins the collision and
-	// the self-id peer (42) is gone.
-	require.Len(t, cfg.GetNeighborhoods(), 1)
-	peers := cfg.GetNeighborhoods()[0].GetPeers()
-	require.Len(t, peers, 1)
-	assert.Equal(t, uint64(7), peers[0].GetId())
-	assert.Equal(t, "10.0.0.6:9000", peers[0].GetTcp().GetAddr())
+	// The discovered peer-a address wins the collision; unrelated declared peers
+	// are preserved.
+	peers := cfg.GetPeers()
+	require.Len(t, peers, 2)
+	assert.Equal(t, "declared", peers[0].GetName())
+	assert.Equal(t, "10.9.9.42:9000", peers[0].GetTcp().GetAddr())
+	assert.Equal(t, "peer-a", peers[1].GetName())
+	assert.Equal(t, "10.0.0.6:9000", peers[1].GetTcp().GetAddr())
 }
 
 func TestRenderConfigInactiveRingPassesThrough(t *testing.T) {
@@ -401,21 +389,17 @@ startup:
 backends:
   - name: origin
     fake: {}
-neighborhoods:
-  - name: edge
-    source: origin
-    peers:
-      - id: 100
-        tcp:
-          addr: "10.0.0.100:9000"
+peers:
+  - name: declared
+    tcp:
+      addr: "10.0.0.100:9000"
 `)
 
 	cfg := decode(t, dir)
 
-	require.Len(t, cfg.GetNeighborhoods(), 1)
-	assert.Zero(t, cfg.GetNeighborhoods()[0].GetLocalNodeId())
-	require.Len(t, cfg.GetNeighborhoods()[0].GetPeers(), 1)
-	assert.Equal(t, uint64(100), cfg.GetNeighborhoods()[0].GetPeers()[0].GetId())
+	assert.Empty(t, cfg.GetSelf())
+	require.Len(t, cfg.GetPeers(), 1)
+	assert.Equal(t, "declared", cfg.GetPeers()[0].GetName())
 	assert.Equal(t, "0.0.0.0:0", cfg.GetStartup().GetFabric().GetTcp().GetAddr())
 }
 


### PR DESCRIPTION
- update unbounded-storage to the named-peer mesh config model
- add RDMA inventory/mesh support and storage loadgen paths
- add benchmark controls for force format and bypass options
- include minimal storage supervisor schema compatibility so repo-wide Go CI compiles against the updated protobuf schema