### PR TITLE
storage-supervisor: render node annotations

### DIFF
--- a/deploy/unbounded-storage-supervisor/02-configmap.yaml.tmpl
+++ b/deploy/unbounded-storage-supervisor/02-configmap.yaml.tmpl
@@ -19,12 +19,11 @@ metadata:
 # its proto3 zero value, which the daemon promotes to the documented default.
 #
 # Per-node sections are supervisor-injected when a storage ring is active:
-# startup.fabric.binds.tcp.addr is overridden per node, and every declared
-# neighborhood gets its local_node_id plus label-discovered peers merged into
-# neighborhoods[].peers (discovered peers win id collisions). Declare
-# neighborhoods here when this deployment should participate in a P2P ring; the
-# supervisor will not invent one because each neighborhood needs an explicit
-# source backend.
+# startup.fabric.binds.tcp.addr is overridden per node, self is set to the local
+# Kubernetes node name, and label-discovered peers are merged into peers
+# (discovered peers win name collisions). Declare caches here when this
+# deployment should participate in P2P caching; the supervisor only supplies the
+# ring roster.
 #
 # Disks are declared in disks[]. Explicit disks are preserved, while an absent
 # or empty disks list is filled from this node's annotations.
@@ -35,7 +34,7 @@ metadata:
 # /var/lib/unbounded-storage/cache.disk sized by
 # unbounded-cloud.io/storage-file-size-bytes, defaulting to 2 GiB. The shared
 # disk set is available to every cache; the supervisor does not
-# invent caches, backends, frontends, or neighborhoods.
+# invent caches, backends, or frontends.
 data:
   config.yaml: |
     # Operator-assigned config version (opaque counter; 0 means unversioned).

--- a/deploy/unbounded-storage-supervisor/03-rbac.yaml.tmpl
+++ b/deploy/unbounded-storage-supervisor/03-rbac.yaml.tmpl
@@ -3,9 +3,10 @@
 
 # ServiceAccount + RBAC for the unbounded-storage supervisor's run container.
 # The run supervisor watches cluster Nodes to read this node's storage disk
-# annotations and discover storage-ring peers by label, so it needs
-# cluster-wide list/watch on nodes. The install initContainer does not use the
-# API and so does not need these grants.
+# annotations and discover storage-ring peers by label. It also publishes this
+# node's RDMA inventory back onto its Node annotation, so it needs get/list/watch
+# plus patch on nodes. The install initContainer does not use the API and so does
+# not need these grants.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -24,10 +25,11 @@ metadata:
     app.kubernetes.io/name: unbounded-storage-supervisor
     app.kubernetes.io/component: storage
 rules:
-  # Nodes - list/watch to read storage annotations and discover peers by label.
+  # Nodes - list/watch to read storage annotations and discover peers by label;
+  # get/patch to publish this node's RDMA HCA inventory annotation.
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list", "watch"]
+    verbs: ["get", "list", "watch", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/internal/storagesupervisor/config.go
+++ b/internal/storagesupervisor/config.go
@@ -95,6 +95,9 @@ type Config struct {
 	// means in-cluster service-account discovery. This is the developer/test
 	// path; in production the run container relies on the in-cluster config.
 	Kubeconfig string
+	// RdmaInventoryURL, when set, is polled for the daemon's local RDMA HCA
+	// inventory JSON and published onto this Node for peer discovery.
+	RdmaInventoryURL string
 	// StorageArgs are extra arguments appended to the daemon ExecStart line.
 	StorageArgs string
 	// Arch is the normalized target architecture ("amd64" or "arm64").
@@ -104,6 +107,9 @@ type Config struct {
 	// Hugepages, when > 0, reserves an explicit number of 2 MiB hugepages
 	// instead of deriving the count from PoolBytes.
 	Hugepages int64
+	// NoHugepages skips the systemd hugepage reservation preflight. Use this
+	// when the daemon config sets startup.memory.no_hugepages.
+	NoHugepages bool
 	// NoEnable, when true, installs the unit but does not enable/start it.
 	NoEnable bool
 
@@ -144,6 +150,7 @@ func LoadConfig() (Config, error) {
 	cfg.NodeName = os.Getenv("NODE_NAME")
 	cfg.StorageRingLabel = envOr("STORAGE_RING_LABEL", defaultStorageRingLabel)
 	cfg.Kubeconfig = os.Getenv("KUBECONFIG")
+	cfg.RdmaInventoryURL = os.Getenv("STORAGE_RDMA_INVENTORY_URL")
 
 	// SOURCE takes precedence; LOCAL_TARBALL is honored for backward
 	// compatibility with the shell installer when SOURCE is unset.
@@ -155,6 +162,7 @@ func LoadConfig() (Config, error) {
 	cfg.SourceMode = classifySource(cfg.Source)
 
 	cfg.NoEnable = os.Getenv("NO_ENABLE") == "1"
+	cfg.NoHugepages = os.Getenv("NO_HUGEPAGES") == "1"
 
 	if len(cfg.Systemctl) == 0 {
 		return Config{}, fmt.Errorf("SYSTEMCTL must not be empty")

--- a/internal/storagesupervisor/config_test.go
+++ b/internal/storagesupervisor/config_test.go
@@ -18,7 +18,8 @@ func clearConfigEnv(t *testing.T) {
 	for _, name := range []string{
 		"REPO", "VERSION", "PREFIX", "SERVICE_NAME", "CONFIG_PATH",
 		"CONFIG_SOURCE_DIR", "STORAGE_ARGS", "HOST_ROOT", "SYSTEMCTL", "SOURCE", "LOCAL_TARBALL",
-		"NO_ENABLE", "ARCH", "POOL_BYTES", "HUGEPAGES",
+		"NO_ENABLE", "NO_HUGEPAGES", "ARCH", "POOL_BYTES", "HUGEPAGES", "NODE_NAME", "STORAGE_RING_LABEL", "KUBECONFIG",
+		"STORAGE_RDMA_INVENTORY_URL",
 	} {
 		t.Setenv(name, "")
 	}
@@ -43,6 +44,7 @@ func TestLoadConfigDefaults(t *testing.T) {
 	assert.Equal(t, int64(defaultPoolBytes), cfg.PoolBytes)
 	assert.Equal(t, int64(0), cfg.Hugepages)
 	assert.False(t, cfg.NoEnable)
+	assert.False(t, cfg.NoHugepages)
 	assert.Equal(t, SourceRelease, cfg.SourceMode)
 }
 
@@ -61,6 +63,11 @@ func TestLoadConfigOverrides(t *testing.T) {
 	t.Setenv("ARCH", "aarch64")
 	t.Setenv("POOL_BYTES", "262144000")
 	t.Setenv("HUGEPAGES", "512")
+	t.Setenv("NO_HUGEPAGES", "1")
+	t.Setenv("NODE_NAME", "node-a")
+	t.Setenv("STORAGE_RING_LABEL", "storage.example/ring")
+	t.Setenv("KUBECONFIG", "/tmp/kubeconfig")
+	t.Setenv("STORAGE_RDMA_INVENTORY_URL", "http://127.0.0.1:9100/inventory/rdma")
 
 	cfg, err := LoadConfig()
 	require.NoError(t, err)
@@ -78,6 +85,11 @@ func TestLoadConfigOverrides(t *testing.T) {
 	assert.Equal(t, "arm64", cfg.Arch)
 	assert.Equal(t, int64(262144000), cfg.PoolBytes)
 	assert.Equal(t, int64(512), cfg.Hugepages)
+	assert.True(t, cfg.NoHugepages)
+	assert.Equal(t, "node-a", cfg.NodeName)
+	assert.Equal(t, "storage.example/ring", cfg.StorageRingLabel)
+	assert.Equal(t, "/tmp/kubeconfig", cfg.Kubeconfig)
+	assert.Equal(t, "http://127.0.0.1:9100/inventory/rdma", cfg.RdmaInventoryURL)
 }
 
 func TestLoadConfigSourceClassification(t *testing.T) {

--- a/internal/storagesupervisor/loadgen.go
+++ b/internal/storagesupervisor/loadgen.go
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package storagesupervisor
+
+import (
+	"log/slog"
+	"math"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	storageconfig "github.com/Azure/unbounded/api/unbounded-storage"
+)
+
+const (
+	storageLoadgenAnnotation = "unbounded-cloud.io/storage-loadgen"
+
+	loadgenOptionSource          = "source"
+	loadgenOptionWorkers         = "workers"
+	loadgenOptionSeed            = "seed"
+	loadgenOptionKeyspaceObjects = "keyspace_objects"
+	loadgenOptionObjectSizeBytes = "object_size_bytes"
+	loadgenOptionReadBytes       = "read_bytes"
+	loadgenOptionZipfExponent    = "zipf_exponent"
+	loadgenOptionVerify          = "verify"
+	loadgenOptionRemoteOnly      = "remote_only"
+	loadgenOptionFabricOnly      = "fabric_only"
+	loadgenOptionLocalOnly       = "local_only"
+	loadgenOptionSkipLocalDisk   = "skip_local_disk"
+)
+
+func applyLoadgenOverlay(cfg *storageconfig.Config, annotations map[string]string) {
+	frontends := annotationLoadgenFrontends(annotations[storageLoadgenAnnotation], declaredFrontendNames(cfg))
+	if len(frontends) == 0 {
+		return
+	}
+
+	cfg.Frontends = append(cfg.Frontends, frontends...)
+}
+
+func annotationLoadgenFrontends(raw string, existingNames map[string]struct{}) []*storageconfig.FrontendSpec {
+	entries := strings.Split(raw, ",")
+	frontends := make([]*storageconfig.FrontendSpec, 0, len(entries))
+	seenNames := make(map[string]struct{}, len(entries))
+
+	for _, entry := range entries {
+		frontend := annotationLoadgenFrontend(entry)
+		if frontend == nil {
+			continue
+		}
+
+		name := frontend.GetName()
+		if _, exists := existingNames[name]; exists {
+			slog.Warn("skipping annotated storage loadgen because frontend name is already declared", "name", name)
+
+			continue
+		}
+
+		if _, exists := seenNames[name]; exists {
+			slog.Warn("skipping duplicate annotated storage loadgen frontend", "name", name)
+
+			continue
+		}
+
+		seenNames[name] = struct{}{}
+		frontends = append(frontends, frontend)
+	}
+
+	return frontends
+}
+
+func annotationLoadgenFrontend(raw string) *storageconfig.FrontendSpec {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ";")
+	name := strings.TrimSpace(parts[0])
+	if name == "" {
+		slog.Warn("skipping annotated storage loadgen with empty name", "value", raw)
+
+		return nil
+	}
+
+	frontend := &storageconfig.FrontendSpec{
+		Name: name,
+		Config: &storageconfig.FrontendSpec_Loadgen{
+			Loadgen: &storageconfig.LoadgenFrontendConfig{},
+		},
+	}
+	seenOptions := make(map[string]struct{}, len(parts)-1)
+
+	for _, part := range parts[1:] {
+		applyLoadgenOption(frontend, strings.TrimSpace(part), seenOptions, name)
+	}
+
+	if frontend.GetSource() == "" {
+		slog.Warn("skipping annotated storage loadgen without source", "name", name)
+
+		return nil
+	}
+
+	return frontend
+}
+
+func applyLoadgenOption(frontend *storageconfig.FrontendSpec, raw string, seen map[string]struct{}, name string) {
+	if raw == "" {
+		slog.Warn("ignoring empty storage loadgen option", "name", name)
+
+		return
+	}
+
+	key, value, ok := strings.Cut(raw, "=")
+	if !ok {
+		slog.Warn("ignoring storage loadgen option without key=value", "name", name, "option", raw)
+
+		return
+	}
+
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" || value == "" {
+		slog.Warn("ignoring storage loadgen option with empty key or value", "name", name, "option", raw)
+
+		return
+	}
+
+	if _, exists := seen[key]; exists {
+		slog.Warn("ignoring duplicate storage loadgen option", "name", name, "key", key)
+
+		return
+	}
+
+	loadgen := frontend.GetLoadgen()
+
+	switch key {
+	case loadgenOptionSource:
+		frontend.Source = value
+	case loadgenOptionWorkers:
+		v, ok := parseLoadgenUint32Option(name, key, value)
+		if !ok {
+			return
+		}
+
+		loadgen.Workers = proto.Uint32(v)
+	case loadgenOptionSeed:
+		v, ok := parseLoadgenUint64Option(name, key, value)
+		if !ok {
+			return
+		}
+
+		loadgen.Seed = proto.Uint64(v)
+	case loadgenOptionKeyspaceObjects:
+		v, ok := parseLoadgenUint64Option(name, key, value)
+		if !ok {
+			return
+		}
+
+		loadgen.KeyspaceObjects = proto.Uint64(v)
+	case loadgenOptionObjectSizeBytes:
+		v, ok := parseLoadgenUint64Option(name, key, value)
+		if !ok {
+			return
+		}
+
+		loadgen.ObjectSizeBytes = proto.Uint64(v)
+	case loadgenOptionReadBytes:
+		v, ok := parseLoadgenUint64Option(name, key, value)
+		if !ok {
+			return
+		}
+
+		loadgen.ReadBytes = proto.Uint64(v)
+	case loadgenOptionZipfExponent:
+		v, err := strconv.ParseFloat(value, 64)
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
+			slog.Warn("ignoring invalid storage loadgen float option", "name", name, "key", key, "value", value)
+
+			return
+		}
+
+		loadgen.ZipfExponent = proto.Float64(v)
+	case loadgenOptionVerify:
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage loadgen bool option", "name", name, "key", key, "value", value)
+
+			return
+		}
+
+		loadgen.Verify = v
+	case loadgenOptionRemoteOnly:
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage loadgen bool option", "name", name, "key", key, "value", value)
+
+			return
+		}
+
+		loadgen.RemoteOnly = v
+	case loadgenOptionFabricOnly:
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage loadgen bool option", "name", name, "key", key, "value", value)
+
+			return
+		}
+
+		loadgen.FabricOnly = v
+	case loadgenOptionLocalOnly:
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage loadgen bool option", "name", name, "key", key, "value", value)
+
+			return
+		}
+
+		loadgen.LocalOnly = v
+	case loadgenOptionSkipLocalDisk:
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			slog.Warn("ignoring invalid storage loadgen bool option", "name", name, "key", key, "value", value)
+
+			return
+		}
+
+		loadgen.SkipLocalDisk = v
+	default:
+		slog.Warn("ignoring unknown storage loadgen option", "name", name, "key", key)
+
+		return
+	}
+
+	seen[key] = struct{}{}
+}
+
+func parseLoadgenUint32Option(name, key, raw string) (uint32, bool) {
+	v, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		slog.Warn("ignoring invalid storage loadgen uint32 option", "name", name, "key", key, "value", raw)
+
+		return 0, false
+	}
+
+	return uint32(v), true
+}
+
+func parseLoadgenUint64Option(name, key, raw string) (uint64, bool) {
+	v, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		slog.Warn("ignoring invalid storage loadgen uint64 option", "name", name, "key", key, "value", raw)
+
+		return 0, false
+	}
+
+	return v, true
+}
+
+func declaredFrontendNames(cfg *storageconfig.Config) map[string]struct{} {
+	names := map[string]struct{}{}
+
+	for _, frontend := range cfg.GetFrontends() {
+		if frontend.GetName() != "" {
+			names[frontend.GetName()] = struct{}{}
+		}
+	}
+
+	return names
+}

--- a/internal/storagesupervisor/loadgen.go
+++ b/internal/storagesupervisor/loadgen.go
@@ -65,6 +65,7 @@ func annotationLoadgenFrontends(raw string, existingNames map[string]struct{}) [
 		}
 
 		seenNames[name] = struct{}{}
+
 		frontends = append(frontends, frontend)
 	}
 
@@ -78,6 +79,7 @@ func annotationLoadgenFrontend(raw string) *storageconfig.FrontendSpec {
 	}
 
 	parts := strings.Split(raw, ";")
+
 	name := strings.TrimSpace(parts[0])
 	if name == "" {
 		slog.Warn("skipping annotated storage loadgen with empty name", "value", raw)
@@ -121,6 +123,7 @@ func applyLoadgenOption(frontend *storageconfig.FrontendSpec, raw string, seen m
 	}
 
 	key = strings.TrimSpace(key)
+
 	value = strings.TrimSpace(value)
 	if key == "" || value == "" {
 		slog.Warn("ignoring storage loadgen option with empty key or value", "name", name, "option", raw)

--- a/internal/storagesupervisor/peers.go
+++ b/internal/storagesupervisor/peers.go
@@ -29,6 +29,14 @@ import (
 // leaving the peer set stale.
 const nodeInformerResync = 30 * time.Second
 
+// placeholderRdmaSelfAddr is only used before a node's daemon has published
+// live RDMA inventory. Config validation requires each peer to carry a valid
+// address, while the daemon needs self set on the first render because peer
+// identity is startup-fixed. This native address is never dialed: runtime
+// projection removes the self peer from the remote peer set, and a later render
+// replaces it with the daemon's real inventory address.
+const placeholderRdmaSelfAddr = "hex:00"
+
 // ringState is a pure snapshot of the storage ring this node belongs to,
 // computed from the watched Node set and the fabric port. It is the seam
 // between the Kubernetes node watch (peerWatcher) and the pure renderer
@@ -158,14 +166,7 @@ func (w *peerWatcher) signal() {
 // returned when the ring is inactive.
 func (w *peerWatcher) snapshot(port int, portOK bool) renderState {
 	objs := w.informer.GetStore().List()
-
-	nodes := make([]*corev1.Node, 0, len(objs))
-
-	for _, obj := range objs {
-		if n, ok := obj.(*corev1.Node); ok {
-			nodes = append(nodes, n)
-		}
-	}
+	nodes := nodesFromInformerObjects(objs)
 
 	state := renderState{annotations: selfAnnotations(nodes, w.selfName)}
 	if !portOK || port == 0 {
@@ -178,6 +179,32 @@ func (w *peerWatcher) snapshot(port int, portOK bool) renderState {
 	state.ring = computeRing(nodes, w.selfName, w.ringLabel, port)
 
 	return state
+}
+
+// snapshotRdma computes render state for RDMA fabrics. Local bind addresses are
+// owned by the daemon's auto-RDMA/explicit-RDMA startup config, so unlike TCP
+// this does not override startup.fabric; it only injects self and peer RDMA
+// addresses published by other supervisors.
+func (w *peerWatcher) snapshotRdma() renderState {
+	objs := w.informer.GetStore().List()
+	nodes := nodesFromInformerObjects(objs)
+
+	return renderState{
+		annotations: selfAnnotations(nodes, w.selfName),
+		ring:        computeRDMARing(nodes, w.selfName, w.ringLabel),
+	}
+}
+
+func nodesFromInformerObjects(objs []any) []*corev1.Node {
+	nodes := make([]*corev1.Node, 0, len(objs))
+
+	for _, obj := range objs {
+		if n, ok := obj.(*corev1.Node); ok {
+			nodes = append(nodes, n)
+		}
+	}
+
+	return nodes
 }
 
 // computeRing is the pure core of peer discovery: given the ring-labelled
@@ -255,6 +282,143 @@ func computeRing(nodes []*corev1.Node, selfName, ringLabel string, port int) rin
 	sort.Slice(ring.peers, func(i, j int) bool { return ring.peers[i].Name < ring.peers[j].Name })
 
 	return ring
+}
+
+// computeRDMARing mirrors computeRing's label-membership rules, but peers are
+// dialed through their published RDMA HCA inventory annotation. The daemon
+// config currently models one RDMA address per peer name, so discovery chooses
+// the first address from each peer's full HCA inventory.
+func computeRDMARing(nodes []*corev1.Node, selfName, ringLabel string) ringState {
+	var self *corev1.Node
+
+	for _, n := range nodes {
+		if n.Name == selfName {
+			self = n
+
+			break
+		}
+	}
+
+	if self == nil {
+		slog.Warn("storage ring inactive: this node not found among watched nodes", "node", selfName)
+
+		return ringState{}
+	}
+
+	ringValue, ok := self.Labels[ringLabel]
+	if !ok || ringValue == "" {
+		return ringState{}
+	}
+
+	ring := ringState{
+		active:   true,
+		selfName: selfName,
+	}
+	seen := map[string]struct{}{}
+
+	for _, n := range nodes {
+		if n.Labels[ringLabel] != ringValue {
+			continue
+		}
+		if _, dup := seen[n.Name]; dup {
+			continue
+		}
+
+		addrs, err := rdmaInventoryAddrs(n.Annotations[storageRdmaHcasAnnotation])
+		if err != nil {
+			if n.Name == selfName {
+				slog.Warn("storage ring inactive: this node has invalid rdma inventory", "node", selfName, "ring", ringValue, "error", err)
+
+				return ringState{}
+			}
+
+			slog.Warn("skipping storage ring peer with invalid rdma inventory", "peer", n.Name, "ring", ringValue, "error", err)
+
+			continue
+		}
+
+		addr := ""
+		if len(addrs) > 0 {
+			addr = addrs[0]
+		}
+		if addr == "" {
+			if n.Name != selfName {
+				slog.Warn("skipping storage ring peer with no rdma address", "peer", n.Name, "ring", ringValue)
+
+				continue
+			}
+
+			// The daemon's local peer identity is startup-fixed, but RDMA
+			// inventory is only available after the daemon has started. Emit a
+			// valid placeholder for self so the first render locks in the peer
+			// name; later renders replace it with the daemon-published address.
+			addr = placeholderRdmaSelfAddr
+		}
+		addr, ok = rdmaPeerDialAddr(addr, n)
+		if !ok {
+			if n.Name == selfName {
+				slog.Warn("storage ring inactive: this node has wildcard rdma address but no InternalIP", "node", selfName, "ring", ringValue)
+
+				return ringState{}
+			}
+
+			slog.Warn("skipping storage ring peer with wildcard rdma address but no InternalIP", "peer", n.Name, "ring", ringValue)
+
+			continue
+		}
+		if len(addrs) == 0 {
+			addrs = []string{addr}
+		} else {
+			addrs = rewriteRdmaPeerDialAddrs(addrs, n)
+			addrs[0] = addr
+		}
+
+		seen[n.Name] = struct{}{}
+		ring.peers = append(ring.peers, &storageconfig.PeerSpec{
+			Name: n.Name,
+			Config: &storageconfig.PeerSpec_Rdma{
+				Rdma: &storageconfig.RdmaPeerConfig{Addr: addr, Addrs: addrs},
+			},
+		})
+	}
+
+	sort.Slice(ring.peers, func(i, j int) bool { return ring.peers[i].Name < ring.peers[j].Name })
+
+	return ring
+}
+
+func rewriteRdmaPeerDialAddrs(addrs []string, node *corev1.Node) []string {
+	rewritten := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr == "" {
+			continue
+		}
+
+		if dialAddr, ok := rdmaPeerDialAddr(addr, node); ok {
+			rewritten = append(rewritten, dialAddr)
+		}
+	}
+
+	return rewritten
+}
+
+func rdmaPeerDialAddr(addr string, node *corev1.Node) (string, bool) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr, true
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsUnspecified() {
+		return addr, true
+	}
+
+	internal := internalIP(node)
+	if internal == "" {
+		return "", false
+	}
+
+	return net.JoinHostPort(internal, port), true
 }
 
 func selfAnnotations(nodes []*corev1.Node, selfName string) map[string]string {

--- a/internal/storagesupervisor/peers.go
+++ b/internal/storagesupervisor/peers.go
@@ -320,6 +320,7 @@ func computeRDMARing(nodes []*corev1.Node, selfName, ringLabel string) ringState
 		if n.Labels[ringLabel] != ringValue {
 			continue
 		}
+
 		if _, dup := seen[n.Name]; dup {
 			continue
 		}
@@ -341,6 +342,7 @@ func computeRDMARing(nodes []*corev1.Node, selfName, ringLabel string) ringState
 		if len(addrs) > 0 {
 			addr = addrs[0]
 		}
+
 		if addr == "" {
 			if n.Name != selfName {
 				slog.Warn("skipping storage ring peer with no rdma address", "peer", n.Name, "ring", ringValue)
@@ -354,6 +356,7 @@ func computeRDMARing(nodes []*corev1.Node, selfName, ringLabel string) ringState
 			// name; later renders replace it with the daemon-published address.
 			addr = placeholderRdmaSelfAddr
 		}
+
 		addr, ok = rdmaPeerDialAddr(addr, n)
 		if !ok {
 			if n.Name == selfName {
@@ -366,6 +369,7 @@ func computeRDMARing(nodes []*corev1.Node, selfName, ringLabel string) ringState
 
 			continue
 		}
+
 		if len(addrs) == 0 {
 			addrs = []string{addr}
 		} else {

--- a/internal/storagesupervisor/peers_test.go
+++ b/internal/storagesupervisor/peers_test.go
@@ -202,6 +202,7 @@ func TestComputeRDMARingMembership(t *testing.T) {
 
 	got := map[string]string{}
 	gotAll := map[string][]string{}
+
 	for _, p := range ring.peers {
 		got[p.GetName()] = p.GetRdma().GetAddr()
 		gotAll[p.GetName()] = p.GetRdma().GetAddrs()
@@ -230,8 +231,10 @@ func TestComputeRDMARingRewritesWildcardSocketAddresses(t *testing.T) {
 
 	require.True(t, ring.active)
 	require.Len(t, ring.peers, 3)
+
 	got := map[string]string{}
 	gotAll := map[string][]string{}
+
 	for _, p := range ring.peers {
 		got[p.GetName()] = p.GetRdma().GetAddr()
 		gotAll[p.GetName()] = p.GetRdma().GetAddrs()
@@ -259,7 +262,9 @@ func TestComputeRDMARingPreservesAllPeerAddresses(t *testing.T) {
 
 	require.True(t, ring.active)
 	require.Len(t, ring.peers, 2)
+
 	got := map[string][]string{}
+
 	for _, p := range ring.peers {
 		got[p.GetName()] = p.GetRdma().GetAddrs()
 	}
@@ -282,7 +287,9 @@ func TestComputeRDMARingKeepsNativeAndRoutableSocketAddresses(t *testing.T) {
 
 	require.True(t, ring.active)
 	require.Len(t, ring.peers, 2)
+
 	got := map[string]string{}
+
 	for _, p := range ring.peers {
 		got[p.GetName()] = p.GetRdma().GetAddr()
 	}
@@ -304,7 +311,9 @@ func TestComputeRDMARingUsesSelfPlaceholderUntilInventoryPublishes(t *testing.T)
 	require.True(t, ring.active)
 	assert.Equal(t, "self", ring.selfName)
 	require.Len(t, ring.peers, 2)
+
 	got := map[string]string{}
+
 	for _, p := range ring.peers {
 		got[p.GetName()] = p.GetRdma().GetAddr()
 	}

--- a/internal/storagesupervisor/peers_test.go
+++ b/internal/storagesupervisor/peers_test.go
@@ -85,7 +85,7 @@ func TestComputeRingMembership(t *testing.T) {
 
 	require.Len(t, ring.peers, 3)
 	// Peers are sorted by name; verify all red peers are present with their
-	// names and InternalIP:port sockets, including self.
+	// InternalIP:port sockets, including self.
 	got := map[string]string{}
 	for _, p := range ring.peers {
 		got[p.GetName()] = p.GetTcp().GetAddr()
@@ -160,7 +160,7 @@ func TestComputeRingSkipsPeerWithoutInternalIP(t *testing.T) {
 
 func TestComputeRingSingleMember(t *testing.T) {
 	// A lone ring member still activates so its fabric addr is made routable,
-	// with itself in the peer roster.
+	// with self in the peer roster.
 	nodes := []*corev1.Node{node("self", "red", "10.0.0.1")}
 
 	ring := computeRing(nodes, "self", testRingLabel, 9000)
@@ -169,7 +169,174 @@ func TestComputeRingSingleMember(t *testing.T) {
 	assert.Equal(t, "10.0.0.1:9000", ring.selfListenAddr)
 	require.Len(t, ring.peers, 1)
 	assert.Equal(t, "self", ring.peers[0].GetName())
-	assert.Equal(t, "10.0.0.1:9000", ring.peers[0].GetTcp().GetAddr())
+}
+
+func TestComputeRDMARingMembership(t *testing.T) {
+	nodes := []*corev1.Node{
+		nodeWithAnnotations("self", "red", "10.0.0.1", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:self"]}]}`,
+		}),
+		nodeWithAnnotations("peer-a", "red", "10.0.0.2", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:a"]}]}`,
+		}),
+		nodeWithAnnotations("peer-b", "red", "10.0.0.3", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_1","addrs":["hex:b1","hex:b2"]}]}`,
+		}),
+		nodeWithAnnotations("no-rdma", "red", "10.0.0.4", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[]}`,
+		}),
+		nodeWithAnnotations("invalid", "red", "10.0.0.5", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":2,"hcas":[]}`,
+		}),
+		nodeWithAnnotations("other", "blue", "10.0.0.6", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:other"]}]}`,
+		}),
+	}
+
+	ring := computeRDMARing(nodes, "self", testRingLabel)
+
+	require.True(t, ring.active)
+	assert.Equal(t, "self", ring.selfName)
+	assert.Empty(t, ring.selfListenAddr)
+	require.Len(t, ring.peers, 3)
+
+	got := map[string]string{}
+	gotAll := map[string][]string{}
+	for _, p := range ring.peers {
+		got[p.GetName()] = p.GetRdma().GetAddr()
+		gotAll[p.GetName()] = p.GetRdma().GetAddrs()
+	}
+
+	assert.Equal(t, "hex:self", got["self"])
+	assert.Equal(t, "hex:a", got["peer-a"])
+	assert.Equal(t, "hex:b1", got["peer-b"])
+	assert.Equal(t, []string{"hex:b1", "hex:b2"}, gotAll["peer-b"])
+}
+
+func TestComputeRDMARingRewritesWildcardSocketAddresses(t *testing.T) {
+	nodes := []*corev1.Node{
+		nodeWithAnnotations("self", "red", "10.0.0.1", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["0.0.0.0:40000"]}]}`,
+		}),
+		nodeWithAnnotations("peer-a", "red", "10.0.0.2", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["0.0.0.0:50000"]}]}`,
+		}),
+		nodeWithAnnotations("peer-b", "red", "fd00::3", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["[::]:60000"]}]}`,
+		}),
+	}
+
+	ring := computeRDMARing(nodes, "self", testRingLabel)
+
+	require.True(t, ring.active)
+	require.Len(t, ring.peers, 3)
+	got := map[string]string{}
+	gotAll := map[string][]string{}
+	for _, p := range ring.peers {
+		got[p.GetName()] = p.GetRdma().GetAddr()
+		gotAll[p.GetName()] = p.GetRdma().GetAddrs()
+	}
+
+	assert.Equal(t, "10.0.0.1:40000", got["self"])
+	assert.Equal(t, "10.0.0.2:50000", got["peer-a"])
+	assert.Equal(t, "[fd00::3]:60000", got["peer-b"])
+	assert.Equal(t, []string{"10.0.0.1:40000"}, gotAll["self"])
+	assert.Equal(t, []string{"10.0.0.2:50000"}, gotAll["peer-a"])
+	assert.Equal(t, []string{"[fd00::3]:60000"}, gotAll["peer-b"])
+}
+
+func TestComputeRDMARingPreservesAllPeerAddresses(t *testing.T) {
+	nodes := []*corev1.Node{
+		nodeWithAnnotations("self", "red", "10.0.0.1", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:self0"]},{"name":"mlx5_1","addrs":["hex:self1"]}]}`,
+		}),
+		nodeWithAnnotations("peer-a", "red", "10.0.0.2", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:a0"]},{"name":"mlx5_1","addrs":["hex:a1"]}]}`,
+		}),
+	}
+
+	ring := computeRDMARing(nodes, "self", testRingLabel)
+
+	require.True(t, ring.active)
+	require.Len(t, ring.peers, 2)
+	got := map[string][]string{}
+	for _, p := range ring.peers {
+		got[p.GetName()] = p.GetRdma().GetAddrs()
+	}
+
+	assert.Equal(t, []string{"hex:self0", "hex:self1"}, got["self"])
+	assert.Equal(t, []string{"hex:a0", "hex:a1"}, got["peer-a"])
+}
+
+func TestComputeRDMARingKeepsNativeAndRoutableSocketAddresses(t *testing.T) {
+	nodes := []*corev1.Node{
+		nodeWithAnnotations("self", "red", "10.0.0.1", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:self"]}]}`,
+		}),
+		nodeWithAnnotations("peer-a", "red", "10.0.0.2", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["10.0.0.9:50000"]}]}`,
+		}),
+	}
+
+	ring := computeRDMARing(nodes, "self", testRingLabel)
+
+	require.True(t, ring.active)
+	require.Len(t, ring.peers, 2)
+	got := map[string]string{}
+	for _, p := range ring.peers {
+		got[p.GetName()] = p.GetRdma().GetAddr()
+	}
+
+	assert.Equal(t, "hex:self", got["self"])
+	assert.Equal(t, "10.0.0.9:50000", got["peer-a"])
+}
+
+func TestComputeRDMARingUsesSelfPlaceholderUntilInventoryPublishes(t *testing.T) {
+	nodes := []*corev1.Node{
+		nodeWithAnnotations("self", "red", "10.0.0.1", nil),
+		nodeWithAnnotations("peer-a", "red", "10.0.0.2", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:a"]}]}`,
+		}),
+	}
+
+	ring := computeRDMARing(nodes, "self", testRingLabel)
+
+	require.True(t, ring.active)
+	assert.Equal(t, "self", ring.selfName)
+	require.Len(t, ring.peers, 2)
+	got := map[string]string{}
+	for _, p := range ring.peers {
+		got[p.GetName()] = p.GetRdma().GetAddr()
+	}
+
+	assert.Equal(t, placeholderRdmaSelfAddr, got["self"])
+	assert.Equal(t, "hex:a", got["peer-a"])
+}
+
+func TestComputeRDMARingInactiveWhenSelfInvalidInventory(t *testing.T) {
+	nodes := []*corev1.Node{
+		nodeWithAnnotations("self", "red", "10.0.0.1", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":2,"hcas":[]}`,
+		}),
+	}
+
+	ring := computeRDMARing(nodes, "self", testRingLabel)
+
+	assert.False(t, ring.active)
+}
+
+func TestComputeRDMARingSingleMember(t *testing.T) {
+	nodes := []*corev1.Node{nodeWithAnnotations("self", "red", "", map[string]string{
+		storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:self"]}]}`,
+	})}
+
+	ring := computeRDMARing(nodes, "self", testRingLabel)
+
+	require.True(t, ring.active)
+	assert.Equal(t, "self", ring.selfName)
+	require.Len(t, ring.peers, 1)
+	assert.Equal(t, "self", ring.peers[0].GetName())
+	assert.Equal(t, "hex:self", ring.peers[0].GetRdma().GetAddr())
 }
 
 func TestNewPeerWatcherDisabledWithoutNodeName(t *testing.T) {
@@ -232,6 +399,39 @@ func TestPeerWatcherSnapshotFromInformer(t *testing.T) {
 	assert.Equal(t, "10.0.0.2:9000", ring.peers[0].GetTcp().GetAddr())
 	assert.Equal(t, "self", ring.peers[1].GetName())
 	assert.Equal(t, "10.0.0.1:9000", ring.peers[1].GetTcp().GetAddr())
+}
+
+func TestPeerWatcherSnapshotRdmaFromInformer(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		nodeWithAnnotations("self", "red", "10.0.0.1", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:self"]}]}`,
+		}),
+		nodeWithAnnotations("peer-a", "red", "10.0.0.2", map[string]string{
+			storageRdmaHcasAnnotation: `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:a"]}]}`,
+		}),
+	)
+
+	w, err := newPeerWatcher(Config{
+		NodeName:         "self",
+		StorageRingLabel: testRingLabel,
+	}, cs)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+
+	defer w.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, w.Start(ctx))
+
+	state := w.snapshotRdma()
+	require.True(t, state.ring.active)
+	require.Len(t, state.ring.peers, 2)
+	assert.Equal(t, "peer-a", state.ring.peers[0].GetName())
+	assert.Equal(t, "hex:a", state.ring.peers[0].GetRdma().GetAddr())
+	assert.Equal(t, "self", state.ring.peers[1].GetName())
+	assert.Equal(t, "hex:self", state.ring.peers[1].GetRdma().GetAddr())
 }
 
 func TestPeerWatcherSnapshotIncludesSelfAnnotations(t *testing.T) {

--- a/internal/storagesupervisor/rdma_inventory.go
+++ b/internal/storagesupervisor/rdma_inventory.go
@@ -201,6 +201,7 @@ func rdmaInventoryAddrs(value string) ([]string, error) {
 	}
 
 	var addrs []string
+
 	for _, hca := range inv.HCAs {
 		for _, addr := range hca.Addrs {
 			if addr != "" {

--- a/internal/storagesupervisor/rdma_inventory.go
+++ b/internal/storagesupervisor/rdma_inventory.go
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package storagesupervisor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	storageRdmaHcasAnnotation = "storage.unbounded-cloud.io/rdma-hcas"
+	rdmaInventoryPollInterval = 30 * time.Second
+	rdmaInventoryHTTPTimeout  = 5 * time.Second
+)
+
+type rdmaInventory struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	HCAs          []rdmaHCA `json:"hcas"`
+}
+
+type rdmaHCA struct {
+	Name  string   `json:"name"`
+	Addrs []string `json:"addrs"`
+}
+
+type rdmaInventoryPublisher struct {
+	clientset  kubernetes.Interface
+	nodeName   string
+	url        string
+	interval   time.Duration
+	httpClient *http.Client
+	signal     func()
+}
+
+func startRdmaInventoryPublisher(ctx context.Context, cfg Config, cs kubernetes.Interface, signal func()) {
+	if cfg.RdmaInventoryURL == "" {
+		return
+	}
+
+	if cfg.NodeName == "" {
+		slog.Warn("rdma inventory publishing disabled: NODE_NAME is not set", "url", cfg.RdmaInventoryURL)
+
+		return
+	}
+
+	p := &rdmaInventoryPublisher{
+		clientset: cs,
+		nodeName:  cfg.NodeName,
+		url:       cfg.RdmaInventoryURL,
+		interval:  rdmaInventoryPollInterval,
+		httpClient: &http.Client{
+			Timeout: rdmaInventoryHTTPTimeout,
+		},
+		signal: signal,
+	}
+
+	go p.run(ctx)
+}
+
+func (p *rdmaInventoryPublisher) run(ctx context.Context) {
+	p.poll(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.poll(ctx)
+		}
+	}
+}
+
+func (p *rdmaInventoryPublisher) poll(ctx context.Context) {
+	changed, err := p.publishOnce(ctx)
+	if err != nil {
+		slog.Warn("rdma inventory publish failed", "node", p.nodeName, "url", p.url, "error", err)
+
+		return
+	}
+
+	if changed && p.signal != nil {
+		p.signal()
+	}
+}
+
+func (p *rdmaInventoryPublisher) publishOnce(ctx context.Context) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.url, nil)
+	if err != nil {
+		return false, fmt.Errorf("build inventory request: %w", err)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("fetch inventory: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("fetch inventory: status %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return false, fmt.Errorf("read inventory response: %w", err)
+	}
+
+	jsonValue, _, err := normalizeRdmaInventoryJSON(body)
+	if err != nil {
+		return false, fmt.Errorf("validate inventory response: %w", err)
+	}
+
+	return patchNodeAnnotationIfChanged(ctx, p.clientset, p.nodeName, storageRdmaHcasAnnotation, jsonValue)
+}
+
+func patchNodeAnnotationIfChanged(
+	ctx context.Context,
+	cs kubernetes.Interface,
+	nodeName string,
+	key string,
+	value string,
+) (bool, error) {
+	node, err := cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("get node %q: %w", nodeName, err)
+	}
+
+	if node.Annotations[key] == value {
+		return false, nil
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{key: value},
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("build node annotation patch: %w", err)
+	}
+
+	if _, err := cs.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return false, fmt.Errorf("patch node %q annotation %q: %w", nodeName, key, err)
+	}
+
+	return true, nil
+}
+
+func normalizeRdmaInventoryJSON(raw []byte) (string, *rdmaInventory, error) {
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, bytes.TrimSpace(raw)); err != nil {
+		return "", nil, err
+	}
+
+	var inv rdmaInventory
+	if err := json.Unmarshal(compact.Bytes(), &inv); err != nil {
+		return "", nil, err
+	}
+
+	if inv.SchemaVersion != 1 {
+		return "", nil, fmt.Errorf("unsupported schemaVersion %d", inv.SchemaVersion)
+	}
+
+	if inv.HCAs == nil {
+		return "", nil, fmt.Errorf("hcas field is required")
+	}
+
+	return compact.String(), &inv, nil
+}
+
+func firstRdmaInventoryAddr(value string) (string, error) {
+	addrs, err := rdmaInventoryAddrs(value)
+	if err != nil || len(addrs) == 0 {
+		return "", err
+	}
+
+	return addrs[0], nil
+}
+
+func rdmaInventoryAddrs(value string) ([]string, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	_, inv, err := normalizeRdmaInventoryJSON([]byte(value))
+	if err != nil {
+		return nil, err
+	}
+
+	var addrs []string
+	for _, hca := range inv.HCAs {
+		for _, addr := range hca.Addrs {
+			if addr != "" {
+				addrs = append(addrs, addr)
+			}
+		}
+	}
+
+	return addrs, nil
+}

--- a/internal/storagesupervisor/rdma_inventory_test.go
+++ b/internal/storagesupervisor/rdma_inventory_test.go
@@ -65,8 +65,10 @@ func TestPatchNodeAnnotationIfChanged(t *testing.T) {
 func TestRdmaInventoryPublisherPublishesMinifiedJSON(t *testing.T) {
 	ctx := context.Background()
 	cs := fake.NewSimpleClientset(node("self", "red", "10.0.0.1"))
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/inventory/rdma", r.URL.Path)
+
 		_, _ = w.Write([]byte(`{"schemaVersion": 1, "hcas": []}`))
 	}))
 	defer server.Close()

--- a/internal/storagesupervisor/rdma_inventory_test.go
+++ b/internal/storagesupervisor/rdma_inventory_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package storagesupervisor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNormalizeRdmaInventoryJSON(t *testing.T) {
+	got, inv, err := normalizeRdmaInventoryJSON([]byte(`{
+		"schemaVersion": 1,
+		"hcas": [{"name": "mlx5_0", "addrs": ["hex:01"]}]
+	}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, `{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":["hex:01"]}]}`, got)
+	require.Len(t, inv.HCAs, 1)
+	assert.Equal(t, "mlx5_0", inv.HCAs[0].Name)
+}
+
+func TestNormalizeRdmaInventoryJSONRejectsInvalidSchema(t *testing.T) {
+	_, _, err := normalizeRdmaInventoryJSON([]byte(`{"schemaVersion":2,"hcas":[]}`))
+	require.Error(t, err)
+
+	_, _, err = normalizeRdmaInventoryJSON([]byte(`{"schemaVersion":1}`))
+	require.Error(t, err)
+}
+
+func TestFirstRdmaInventoryAddr(t *testing.T) {
+	addr, err := firstRdmaInventoryAddr(`{"schemaVersion":1,"hcas":[{"name":"mlx5_0","addrs":[]},{"name":"mlx5_1","addrs":["hex:02","hex:03"]}]}`)
+	require.NoError(t, err)
+	assert.Equal(t, "hex:02", addr)
+
+	addr, err = firstRdmaInventoryAddr(`{"schemaVersion":1,"hcas":[]}`)
+	require.NoError(t, err)
+	assert.Empty(t, addr)
+}
+
+func TestPatchNodeAnnotationIfChanged(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset(node("self", "red", "10.0.0.1"))
+
+	changed, err := patchNodeAnnotationIfChanged(ctx, cs, "self", storageRdmaHcasAnnotation, `{"schemaVersion":1,"hcas":[]}`)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	n, err := cs.CoreV1().Nodes().Get(ctx, "self", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, `{"schemaVersion":1,"hcas":[]}`, n.Annotations[storageRdmaHcasAnnotation])
+
+	changed, err = patchNodeAnnotationIfChanged(ctx, cs, "self", storageRdmaHcasAnnotation, `{"schemaVersion":1,"hcas":[]}`)
+	require.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestRdmaInventoryPublisherPublishesMinifiedJSON(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset(node("self", "red", "10.0.0.1"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/inventory/rdma", r.URL.Path)
+		_, _ = w.Write([]byte(`{"schemaVersion": 1, "hcas": []}`))
+	}))
+	defer server.Close()
+
+	p := &rdmaInventoryPublisher{
+		clientset:  cs,
+		nodeName:   "self",
+		url:        server.URL + "/inventory/rdma",
+		httpClient: server.Client(),
+	}
+
+	changed, err := p.publishOnce(ctx)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	n, err := cs.CoreV1().Nodes().Get(ctx, "self", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, `{"schemaVersion":1,"hcas":[]}`, n.Annotations[storageRdmaHcasAnnotation])
+}

--- a/internal/storagesupervisor/render.go
+++ b/internal/storagesupervisor/render.go
@@ -39,7 +39,8 @@ type renderState struct {
 // in the YAML (discovered peers win on name collision). TCP rings also override
 // startup.fabric.tcp.addr with the node's own routable bind. The default disk
 // set is populated from the self node's storage disk annotations, or from a
-// default file-backed disk when no valid annotation disks are present.
+// default file-backed disk when no valid annotation disks are present. Loadgen
+// annotations append synthetic frontends for this node.
 func RenderConfig(sourceDir string, state renderState) ([]byte, error) {
 	cfg, err := loadSourceConfig(sourceDir)
 	if err != nil {
@@ -51,6 +52,12 @@ func RenderConfig(sourceDir string, state renderState) ([]byte, error) {
 	}
 
 	if err := applyDiskOverlay(cfg, state.annotations); err != nil {
+		return nil, err
+	}
+
+	applyLoadgenOverlay(cfg, state.annotations)
+
+	if err := validateRenderedConfig(cfg); err != nil {
 		return nil, err
 	}
 
@@ -98,10 +105,74 @@ func loadSourceConfig(sourceDir string) (*storageconfig.Config, error) {
 	return cfg, nil
 }
 
+func validateRenderedConfig(cfg *storageconfig.Config) error {
+	components := make(map[string]string)
+
+	backends, err := collectComponentNames(components, "backend", cfg.GetBackends(), func(spec *storageconfig.BackendSpec) string {
+		return spec.GetName()
+	})
+	if err != nil {
+		return err
+	}
+
+	caches, err := collectComponentNames(components, "cache", cfg.GetCaches(), func(spec *storageconfig.CacheSpec) string {
+		return spec.GetName()
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = collectComponentNames(components, "frontend", cfg.GetFrontends(), func(spec *storageconfig.FrontendSpec) string {
+		return spec.GetName()
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, cache := range cfg.GetCaches() {
+		if _, ok := backends[cache.GetSource()]; !ok {
+			return fmt.Errorf("validate rendered config: cache %q references unknown backend source %q", cache.GetName(), cache.GetSource())
+		}
+	}
+
+	for _, frontend := range cfg.GetFrontends() {
+		if _, ok := backends[frontend.GetSource()]; ok {
+			continue
+		}
+
+		if _, ok := caches[frontend.GetSource()]; ok {
+			continue
+		}
+
+		return fmt.Errorf("validate rendered config: frontend %q references unknown source %q", frontend.GetName(), frontend.GetSource())
+	}
+
+	return nil
+}
+
+func collectComponentNames[T any](components map[string]string, kind string, specs []T, nameOf func(T) string) (map[string]struct{}, error) {
+	names := make(map[string]struct{}, len(specs))
+	for _, spec := range specs {
+		name := nameOf(spec)
+		if name == "" {
+			return nil, fmt.Errorf("validate rendered config: %s name must not be empty", kind)
+		}
+
+		if existingKind, exists := components[name]; exists {
+			return nil, fmt.Errorf("validate rendered config: duplicate component name %q while adding %s; already used by %s", name, kind, existingKind)
+		}
+
+		components[name] = kind
+		names[name] = struct{}{}
+	}
+
+	return names, nil
+}
+
 // applyRing overlays the per-node ring state onto a Config parsed from the
 // ConfigMap YAML. It injects this node's self peer name, merges the discovered
 // peer set with any declared peers, and rebinds the TCP fabric address to the
-// node's own routable address.
+// node's own routable address when the ring includes a TCP selfListenAddr.
 func applyRing(cfg *storageconfig.Config, ring ringState) {
 	// Preserve YAML-declared routing knobs (fingers_per_node, routing_plan);
 	// only stamp in the locally computed self name and peer roster.

--- a/internal/storagesupervisor/render_test.go
+++ b/internal/storagesupervisor/render_test.go
@@ -809,7 +809,9 @@ frontends:
 `)
 
 	var logs bytes.Buffer
+
 	previousLogger := slog.Default()
+
 	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
 	t.Cleanup(func() { slog.SetDefault(previousLogger) })
 

--- a/internal/storagesupervisor/render_test.go
+++ b/internal/storagesupervisor/render_test.go
@@ -59,6 +59,15 @@ func tcpPeer(name, addr string) *storageconfig.PeerSpec {
 	}
 }
 
+func rdmaPeer(name, addr string) *storageconfig.PeerSpec {
+	return &storageconfig.PeerSpec{
+		Name: name,
+		Config: &storageconfig.PeerSpec_Rdma{
+			Rdma: &storageconfig.RdmaPeerConfig{Addr: addr},
+		},
+	}
+}
+
 func TestRenderConfigFullSchema(t *testing.T) {
 	dir := writeSource(t, `
 version: 7
@@ -197,10 +206,76 @@ func TestRenderConfigInvalidValues(t *testing.T) {
 	}
 }
 
+func TestRenderConfigRejectsDanglingRenderedBindings(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "frontend source",
+			yaml: `
+frontends:
+  - name: f
+    source: ghost
+    loadgen: {}
+`,
+			wantErr: `frontend "f" references unknown source "ghost"`,
+		},
+		{
+			name: "cache source",
+			yaml: `
+caches:
+  - name: c
+    source: ghost
+`,
+			wantErr: `cache "c" references unknown backend source "ghost"`,
+		},
+		{
+			name: "duplicate backend cache component name",
+			yaml: `
+backends:
+  - name: same
+    fake: {}
+caches:
+  - name: same
+    source: same
+`,
+			wantErr: `duplicate component name "same" while adding cache`,
+		},
+		{
+			name: "duplicate cache frontend component name",
+			yaml: `
+backends:
+  - name: origin
+    fake: {}
+caches:
+  - name: same
+    source: origin
+frontends:
+  - name: same
+    source: same
+    loadgen: {}
+`,
+			wantErr: `duplicate component name "same" while adding frontend`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := writeSource(t, tt.yaml)
+
+			_, err := RenderConfig(dir, renderState{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestRenderConfigActiveRingOverlay(t *testing.T) {
-	// An active ring injects self + peers and overrides the ConfigMap's fabric
-	// addr with this node's own routable bind, while the rest of the startup
-	// settings still come from the source.
+	// An active ring injects self + peers and overrides the
+	// ConfigMap's fabric addr with this node's own routable bind, while the
+	// rest of the startup settings still come from the source.
 	dir := writeSource(t, `
 version: 3
 startup:
@@ -211,19 +286,16 @@ startup:
 backends:
   - name: origin
     fake: {}
-caches:
-  - name: edge
-    source: origin
 `)
 
 	ring := ringState{
 		active:         true,
-		selfName:       "self",
+		selfName:       "node-a",
 		selfListenAddr: "10.0.0.5:9000",
 		peers: []*storageconfig.PeerSpec{
-			tcpPeer("peer-a", "10.0.0.6:9000"),
-			tcpPeer("peer-b", "10.0.0.7:9000"),
-			tcpPeer("self", "10.0.0.5:9000"),
+			tcpPeer("node-a", "10.0.0.5:9000"),
+			tcpPeer("node-b", "10.0.0.6:9000"),
+			tcpPeer("node-c", "10.0.0.7:9000"),
 		},
 	}
 
@@ -240,21 +312,22 @@ caches:
 	// addr is overridden with the node's own routable address.
 	assert.Equal(t, "10.0.0.5:9000", cfg.GetStartup().GetFabric().GetTcp().GetAddr())
 
-	assert.Equal(t, "self", cfg.GetSelf())
+	assert.Equal(t, "node-a", cfg.GetSelf())
+
 	require.Len(t, cfg.GetPeers(), 3)
-	assert.Equal(t, "peer-a", cfg.GetPeers()[0].GetName())
-	assert.Equal(t, "10.0.0.6:9000", cfg.GetPeers()[0].GetTcp().GetAddr())
-	assert.Equal(t, "peer-b", cfg.GetPeers()[1].GetName())
-	assert.Equal(t, "10.0.0.7:9000", cfg.GetPeers()[1].GetTcp().GetAddr())
-	assert.Equal(t, "self", cfg.GetPeers()[2].GetName())
-	assert.Equal(t, "10.0.0.5:9000", cfg.GetPeers()[2].GetTcp().GetAddr())
+	assert.Equal(t, "node-a", cfg.GetPeers()[0].GetName())
+	assert.Equal(t, "10.0.0.5:9000", cfg.GetPeers()[0].GetTcp().GetAddr())
+	assert.Equal(t, "node-b", cfg.GetPeers()[1].GetName())
+	assert.Equal(t, "10.0.0.6:9000", cfg.GetPeers()[1].GetTcp().GetAddr())
+	assert.Equal(t, "node-c", cfg.GetPeers()[2].GetName())
+	assert.Equal(t, "10.0.0.7:9000", cfg.GetPeers()[2].GetTcp().GetAddr())
 }
 
 func TestRenderConfigActiveRingMergesPeers(t *testing.T) {
 	// Peers declared in the YAML are merged with discovered peers, and
-	// YAML-declared routing scalars (fingers_per_node, routing_plan) are
-	// preserved while self is stamped in.
+	// YAML-declared routing knobs are preserved while self is stamped in.
 	dir := writeSource(t, `
+fingers_per_node: 5
 startup:
   fabric:
     tcp:
@@ -262,23 +335,20 @@ startup:
 backends:
   - name: origin
     fake: {}
-fingers_per_node: 5
-routing_plan:
-  fingers: ["declared"]
 peers:
-  - name: declared
+  - name: node-z
     tcp:
       addr: "10.0.0.100:9000"
 `)
 
 	ring := ringState{
 		active:         true,
-		selfName:       "self",
+		selfName:       "node-a",
 		selfListenAddr: "10.0.0.5:9000",
 		peers: []*storageconfig.PeerSpec{
-			tcpPeer("peer-b", "10.0.0.7:9000"),
-			tcpPeer("peer-a", "10.0.0.6:9000"),
-			tcpPeer("self", "10.0.0.5:9000"),
+			tcpPeer("node-c", "10.0.0.7:9000"),
+			tcpPeer("node-a", "10.0.0.5:9000"),
+			tcpPeer("node-b", "10.0.0.6:9000"),
 		},
 	}
 
@@ -289,22 +359,53 @@ peers:
 
 	require.NoError(t, proto.Unmarshal(data, &cfg))
 
-	// YAML routing scalars preserved; self injected.
-	assert.Equal(t, "self", cfg.GetSelf())
+	// YAML routing knobs preserved; self injected.
+	assert.Equal(t, "node-a", cfg.GetSelf())
 	assert.NotNil(t, cfg.FingersPerNode)
 	assert.Equal(t, uint32(5), cfg.GetFingersPerNode())
-	assert.Equal(t, []string{"declared"}, cfg.GetRoutingPlan().GetFingers())
 
-	// Discovered peers merged with declared peers, sorted by name.
+	// Discovered peers merge with declared node-z and are sorted by name.
 	require.Len(t, cfg.GetPeers(), 4)
-	assert.Equal(t, "declared", cfg.GetPeers()[0].GetName())
-	assert.Equal(t, "10.0.0.100:9000", cfg.GetPeers()[0].GetTcp().GetAddr())
-	assert.Equal(t, "peer-a", cfg.GetPeers()[1].GetName())
-	assert.Equal(t, "peer-b", cfg.GetPeers()[2].GetName())
-	assert.Equal(t, "self", cfg.GetPeers()[3].GetName())
+	assert.Equal(t, "node-a", cfg.GetPeers()[0].GetName())
+	assert.Equal(t, "node-b", cfg.GetPeers()[1].GetName())
+	assert.Equal(t, "node-c", cfg.GetPeers()[2].GetName())
+	assert.Equal(t, "node-z", cfg.GetPeers()[3].GetName())
+	assert.Equal(t, "10.0.0.100:9000", cfg.GetPeers()[3].GetTcp().GetAddr())
 }
 
-func TestRenderConfigActiveRingWorksWithoutDeclaredPeers(t *testing.T) {
+func TestRenderConfigActiveRDMARingPreservesStartupFabric(t *testing.T) {
+	dir := writeSource(t, `
+startup:
+  fabric:
+    auto_rdma:
+      hcas_per_numa_node: 2
+    max_inflight: 2048
+backends:
+  - name: origin
+    fake: {}
+`)
+
+	ring := ringState{
+		active:   true,
+		selfName: "node-a",
+		peers: []*storageconfig.PeerSpec{
+			rdmaPeer("node-a", "hex:self"),
+			rdmaPeer("node-b", "hex:peer"),
+		},
+	}
+
+	cfg := decodeWithState(t, dir, renderState{ring: ring})
+
+	assert.NotNil(t, cfg.GetStartup().GetFabric().GetAutoRdma())
+	assert.Equal(t, uint64(2), cfg.GetStartup().GetFabric().GetAutoRdma().GetHcasPerNumaNode())
+	assert.Nil(t, cfg.GetStartup().GetFabric().GetTcp())
+	assert.Equal(t, "node-a", cfg.GetSelf())
+	require.Len(t, cfg.GetPeers(), 2)
+	assert.Equal(t, "hex:self", cfg.GetPeers()[0].GetRdma().GetAddr())
+	assert.Equal(t, "hex:peer", cfg.GetPeers()[1].GetRdma().GetAddr())
+}
+
+func TestRenderConfigActiveRingInjectsMeshWithoutDeclaredPeers(t *testing.T) {
 	dir := writeSource(t, `
 startup:
   fabric:
@@ -315,12 +416,20 @@ backends:
     fake: {}
 `)
 
+	var logs bytes.Buffer
+
+	previousLogger := slog.Default()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
 	ring := ringState{
 		active:         true,
-		selfName:       "self",
+		selfName:       "node-a",
 		selfListenAddr: "10.0.0.5:9000",
 		peers: []*storageconfig.PeerSpec{
-			tcpPeer("peer-a", "10.0.0.6:9000"),
+			tcpPeer("node-a", "10.0.0.5:9000"),
+			tcpPeer("node-b", "10.0.0.6:9000"),
 		},
 	}
 
@@ -331,33 +440,37 @@ backends:
 
 	require.NoError(t, proto.Unmarshal(data, &cfg))
 
-	assert.Equal(t, "self", cfg.GetSelf())
-	require.Len(t, cfg.GetPeers(), 1)
-	assert.Equal(t, "peer-a", cfg.GetPeers()[0].GetName())
+	assert.Equal(t, "node-a", cfg.GetSelf())
+	require.Len(t, cfg.GetPeers(), 2)
+	assert.Equal(t, "node-a", cfg.GetPeers()[0].GetName())
+	assert.Equal(t, "node-b", cfg.GetPeers()[1].GetName())
 	assert.Equal(t, "10.0.0.5:9000", cfg.GetStartup().GetFabric().GetTcp().GetAddr())
+	assert.NotContains(t, logs.String(), "discovered storage peers were not injected")
 }
 
 func TestRenderConfigMergeDropsNameCollisions(t *testing.T) {
 	// A declared peer whose name collides with a discovered peer is dropped in
-	// favor of the discovered one.
+	// favor of the discovered one. Self remains in the roster because the daemon
+	// uses it to derive the local fabric/ring identity.
 	dir := writeSource(t, `
 backends:
   - name: origin
     fake: {}
 peers:
-  - name: peer-a
+  - name: node-b
     tcp:
       addr: "10.9.9.9:9000"
-  - name: declared
+  - name: node-z
     tcp:
       addr: "10.9.9.42:9000"
 `)
 
 	ring := ringState{
 		active:   true,
-		selfName: "self",
+		selfName: "node-a",
 		peers: []*storageconfig.PeerSpec{
-			tcpPeer("peer-a", "10.0.0.6:9000"),
+			tcpPeer("node-a", "10.0.0.5:9000"),
+			tcpPeer("node-b", "10.0.0.6:9000"),
 		},
 	}
 
@@ -368,20 +481,20 @@ peers:
 
 	require.NoError(t, proto.Unmarshal(data, &cfg))
 
-	// The discovered peer-a address wins the collision; unrelated declared peers
-	// are preserved.
+	// Discovered node-b wins the collision and declared node-z is preserved.
 	peers := cfg.GetPeers()
-	require.Len(t, peers, 2)
-	assert.Equal(t, "declared", peers[0].GetName())
-	assert.Equal(t, "10.9.9.42:9000", peers[0].GetTcp().GetAddr())
-	assert.Equal(t, "peer-a", peers[1].GetName())
+	require.Len(t, peers, 3)
+	assert.Equal(t, "node-a", peers[0].GetName())
+	assert.Equal(t, "node-b", peers[1].GetName())
 	assert.Equal(t, "10.0.0.6:9000", peers[1].GetTcp().GetAddr())
+	assert.Equal(t, "node-z", peers[2].GetName())
 }
 
 func TestRenderConfigInactiveRingPassesThrough(t *testing.T) {
-	// An inactive ring leaves the YAML-declared per-node sections untouched and
+	// An inactive ring leaves the YAML-declared mesh fields untouched and
 	// the ConfigMap's fabric addr unchanged.
 	dir := writeSource(t, `
+self: manual
 startup:
   fabric:
     tcp:
@@ -390,16 +503,16 @@ backends:
   - name: origin
     fake: {}
 peers:
-  - name: declared
+  - name: manual
     tcp:
       addr: "10.0.0.100:9000"
 `)
 
 	cfg := decode(t, dir)
 
-	assert.Empty(t, cfg.GetSelf())
+	assert.Equal(t, "manual", cfg.GetSelf())
 	require.Len(t, cfg.GetPeers(), 1)
-	assert.Equal(t, "declared", cfg.GetPeers()[0].GetName())
+	assert.Equal(t, "manual", cfg.GetPeers()[0].GetName())
 	assert.Equal(t, "0.0.0.0:0", cfg.GetStartup().GetFabric().GetTcp().GetAddr())
 }
 
@@ -410,7 +523,7 @@ version: 1
 
 	cfg := decodeWithState(t, dir, renderState{
 		annotations: map[string]string{
-			storageDisksAnnotation: "/dev/nvme1n1;queue_depth=256;page_size_bytes=4096;numa=0;skip_recovery_scan=true",
+			storageDisksAnnotation: "/dev/nvme1n1;queue_depth=256;page_size_bytes=4096;numa=0;skip_recovery_scan=true;force_format=true;bypass_admission=true;bypass_index_read=true;bypass_checksum=true",
 		},
 	})
 
@@ -425,6 +538,10 @@ version: 1
 	assert.NotNil(t, disk.GetBlock().Numa)
 	assert.Equal(t, uint32(0), disk.GetBlock().GetNuma())
 	assert.True(t, disk.GetSkipRecoveryScan())
+	assert.True(t, disk.GetForceFormat())
+	assert.True(t, disk.GetBypassAdmission())
+	assert.True(t, disk.GetBypassIndexRead())
+	assert.True(t, disk.GetBypassChecksum())
 }
 
 func TestRenderConfigInjectsMultipleAnnotatedBlockDisks(t *testing.T) {
@@ -459,7 +576,7 @@ version: 1
 
 	cfg := decodeWithState(t, dir, renderState{
 		annotations: map[string]string{
-			storageDisksAnnotation: "/dev/nvme1n1;unknown=x;queue_depth=0;queue_depth=512;queue_depth=1024;page_size_bytes=bad;skip_recovery_scan=maybe;numa=bad;empty=;=value;missing",
+			storageDisksAnnotation: "/dev/nvme1n1;unknown=x;queue_depth=0;queue_depth=512;queue_depth=1024;page_size_bytes=bad;skip_recovery_scan=maybe;force_format=maybe;bypass_admission=maybe;bypass_index_read=maybe;bypass_checksum=maybe;numa=bad;empty=;=value;missing",
 		},
 	})
 
@@ -471,6 +588,10 @@ version: 1
 	assert.Nil(t, disk.PageSizeBytes)
 	assert.Nil(t, disk.GetBlock().Numa)
 	assert.False(t, disk.GetSkipRecoveryScan())
+	assert.False(t, disk.GetForceFormat())
+	assert.False(t, disk.GetBypassAdmission())
+	assert.False(t, disk.GetBypassIndexRead())
+	assert.False(t, disk.GetBypassChecksum())
 	assert.Contains(t, logs.String(), "ignoring unknown storage disk option")
 	assert.Contains(t, logs.String(), "ignoring duplicate storage disk option")
 }
@@ -590,11 +711,14 @@ disks:
 
 func TestRenderConfigCachesUntouched(t *testing.T) {
 	dir := writeSource(t, `
+backends:
+  - name: origin
+    fake: {}
 caches:
   - name: cache-a
-    source: p2p
+    source: origin
   - name: cache-b
-    source: p2p
+    source: origin
 `)
 
 	cfg := decode(t, dir)
@@ -616,6 +740,120 @@ version: 1
 
 	require.Len(t, cfg.GetDisks(), 1)
 	assert.Equal(t, "/dev/nvme1n1", cfg.GetDisks()[0].GetBlock().GetPath())
+}
+
+func TestRenderConfigInjectsAnnotatedLoadgenFrontends(t *testing.T) {
+	dir := writeSource(t, `
+backends:
+  - name: origin
+    fake: {}
+caches:
+  - name: cache
+    source: origin
+frontends:
+  - name: http
+    source: cache
+    http:
+      addr: "0.0.0.0:8080"
+`)
+
+	cfg := decodeWithState(t, dir, renderState{
+		annotations: map[string]string{
+			storageLoadgenAnnotation: "lg;source=cache;workers=32;seed=1234;keyspace_objects=1000000;object_size_bytes=4194304;read_bytes=262144;zipf_exponent=1.1;verify=true;remote_only=true;fabric_only=true;local_only=true;skip_local_disk=true,lg2;source=origin",
+		},
+	})
+
+	require.Len(t, cfg.GetFrontends(), 3)
+	assert.Equal(t, "http", cfg.GetFrontends()[0].GetName())
+
+	frontend := cfg.GetFrontends()[1]
+	assert.Equal(t, "lg", frontend.GetName())
+	assert.Equal(t, "cache", frontend.GetSource())
+	loadgen := frontend.GetLoadgen()
+	require.NotNil(t, loadgen)
+	assert.NotNil(t, loadgen.Workers)
+	assert.Equal(t, uint32(32), loadgen.GetWorkers())
+	assert.NotNil(t, loadgen.Seed)
+	assert.Equal(t, uint64(1234), loadgen.GetSeed())
+	assert.NotNil(t, loadgen.KeyspaceObjects)
+	assert.Equal(t, uint64(1000000), loadgen.GetKeyspaceObjects())
+	assert.NotNil(t, loadgen.ObjectSizeBytes)
+	assert.Equal(t, uint64(4194304), loadgen.GetObjectSizeBytes())
+	assert.NotNil(t, loadgen.ReadBytes)
+	assert.Equal(t, uint64(262144), loadgen.GetReadBytes())
+	assert.NotNil(t, loadgen.ZipfExponent)
+	assert.Equal(t, 1.1, loadgen.GetZipfExponent())
+	assert.True(t, loadgen.GetVerify())
+	assert.True(t, loadgen.GetRemoteOnly())
+	assert.True(t, loadgen.GetFabricOnly())
+	assert.True(t, loadgen.GetLocalOnly())
+	assert.True(t, loadgen.GetSkipLocalDisk())
+
+	assert.Equal(t, "lg2", cfg.GetFrontends()[2].GetName())
+	assert.Equal(t, "origin", cfg.GetFrontends()[2].GetSource())
+}
+
+func TestRenderConfigSkipsInvalidAnnotatedLoadgenFrontends(t *testing.T) {
+	dir := writeSource(t, `
+backends:
+  - name: origin
+    fake: {}
+caches:
+  - name: cache
+    source: origin
+frontends:
+  - name: existing
+    source: cache
+    http:
+      addr: "0.0.0.0:8080"
+`)
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	cfg := decodeWithState(t, dir, renderState{
+		annotations: map[string]string{
+			storageLoadgenAnnotation: "existing;source=cache,missing-source;workers=1,valid;source=cache;workers=bad;workers=2;zipf_exponent=NaN;zipf_exponent=1.3;verify=maybe;verify=true;remote_only=maybe;remote_only=true;fabric_only=maybe;fabric_only=true;local_only=maybe;local_only=true;skip_local_disk=maybe;skip_local_disk=true,valid;source=origin",
+		},
+	})
+
+	require.Len(t, cfg.GetFrontends(), 2)
+	assert.Equal(t, "existing", cfg.GetFrontends()[0].GetName())
+	assert.Equal(t, "valid", cfg.GetFrontends()[1].GetName())
+	loadgen := cfg.GetFrontends()[1].GetLoadgen()
+	require.NotNil(t, loadgen)
+	assert.Equal(t, uint32(2), loadgen.GetWorkers())
+	assert.Equal(t, 1.3, loadgen.GetZipfExponent())
+	assert.True(t, loadgen.GetVerify())
+	assert.True(t, loadgen.GetRemoteOnly())
+	assert.True(t, loadgen.GetFabricOnly())
+	assert.True(t, loadgen.GetLocalOnly())
+	assert.True(t, loadgen.GetSkipLocalDisk())
+	assert.Contains(t, logs.String(), "frontend name is already declared")
+	assert.Contains(t, logs.String(), "without source")
+	assert.Contains(t, logs.String(), "invalid storage loadgen uint32 option")
+	assert.Contains(t, logs.String(), "invalid storage loadgen float option")
+	assert.Contains(t, logs.String(), "invalid storage loadgen bool option")
+	assert.Contains(t, logs.String(), "duplicate annotated storage loadgen frontend")
+}
+
+func TestRenderConfigRejectsAnnotatedLoadgenWithUnknownSource(t *testing.T) {
+	dir := writeSource(t, `
+backends:
+  - name: origin
+    fake: {}
+`)
+
+	_, err := RenderConfig(dir, renderState{
+		annotations: map[string]string{
+			storageLoadgenAnnotation: "lg;source=ghost",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `frontend "lg" references unknown source "ghost"`)
 }
 
 func TestWriteConfigAtomic(t *testing.T) {

--- a/internal/storagesupervisor/run.go
+++ b/internal/storagesupervisor/run.go
@@ -50,6 +50,7 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 
 		slog.Info("watching nodes for storage ring peers", "node", cfg.NodeName, "label", cfg.StorageRingLabel)
+		startRdmaInventoryPublisher(ctx, cfg, watcher.clientset, watcher.signal)
 	}
 
 	slog.Info("rendering initial config", "source", cfg.SourceDir, "dest", cfg.ConfigPath)
@@ -173,11 +174,11 @@ func reconcile(cfg Config, peers *peerWatcher) error {
 }
 
 // currentRenderState resolves the current node annotations and ring state from
-// the node watch, reading the shared fabric port from the ConfigMap's TCP fabric
-// bind. It returns the zero value when node watching is disabled. A source that
-// cannot be loaded yields an inactive ring; the subsequent RenderConfig surfaces
-// the same error in reconcile, which keeps the previously rendered config in
-// place.
+// the node watch. TCP configs use the fixed ConfigMap fabric port; RDMA configs
+// use peer-published HCA inventory annotations. It returns the zero value when
+// node watching is disabled. A source that cannot be loaded yields an inactive
+// ring; the subsequent RenderConfig surfaces the same error in reconcile, which
+// keeps the previously rendered config in place.
 func currentRenderState(cfg Config, peers *peerWatcher) renderState {
 	if peers == nil {
 		return renderState{}
@@ -188,7 +189,12 @@ func currentRenderState(cfg Config, peers *peerWatcher) renderState {
 		return peers.snapshot(0, false)
 	}
 
-	port, ok := parseFabricPort(sc.GetStartup().GetFabric().GetTcp().GetAddr())
+	fabric := sc.GetStartup().GetFabric()
+	if fabric.GetRdma() != nil || fabric.GetAutoRdma() != nil {
+		return peers.snapshotRdma()
+	}
+
+	port, ok := parseFabricPort(fabric.GetTcp().GetAddr())
 
 	return peers.snapshot(port, ok)
 }

--- a/internal/storagesupervisor/systemd.go
+++ b/internal/storagesupervisor/systemd.go
@@ -105,6 +105,11 @@ func renderUnit(cfg Config) string {
 		execStart += " " + cfg.StorageArgs
 	}
 
+	hugepagePreStart := fmt.Sprintf("ExecStartPre=+/bin/sh -c '%s'\n", hugepageReserveCmd(cfg))
+	if cfg.NoHugepages {
+		hugepagePreStart = ""
+	}
+
 	return fmt.Sprintf(`[Unit]
 Description=unbounded-storage daemon
 Documentation=https://github.com/%[1]s
@@ -116,8 +121,7 @@ Type=simple
 User=root
 Group=root
 Environment=LD_LIBRARY_PATH=%[2]s/current/lib
-ExecStartPre=+/bin/sh -c '%[3]s'
-ExecStartPre=+/bin/sh -c '%[4]s'
+%[3]sExecStartPre=+/bin/sh -c '%[4]s'
 ExecStart=%[5]s
 Restart=always
 RestartSec=2s
@@ -135,7 +139,7 @@ TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target
-`, cfg.Repo, cfg.Prefix, hugepageReserveCmd(cfg), configEnsureCmd(cfg), execStart)
+`, cfg.Repo, cfg.Prefix, hugepagePreStart, configEnsureCmd(cfg), execStart)
 }
 
 // hugepageReserveCmd builds the shell one-liner used as an ExecStartPre to

--- a/internal/storagesupervisor/systemd_test.go
+++ b/internal/storagesupervisor/systemd_test.go
@@ -129,6 +129,20 @@ func TestRenderUnitHugepageOverride(t *testing.T) {
 	assert.Contains(t, unit, "want=256")
 }
 
+func TestRenderUnitNoHugepages(t *testing.T) {
+	cfg := Config{
+		Repo:        "Azure/unbounded-kube",
+		Prefix:      "/opt/unbounded-storage",
+		ConfigPath:  "/etc/unbounded-storage/config.binpb",
+		NoHugepages: true,
+	}
+
+	unit := renderUnit(cfg)
+	assert.NotContains(t, unit, "hugepages-2048kB")
+	assert.Contains(t, unit, `mkdir -p "$d" "/var/lib/unbounded-storage"`)
+	assert.Contains(t, unit, "ExecStart=/opt/unbounded-storage/current/bin/unbounded-storage --config /etc/unbounded-storage/config.binpb")
+}
+
 func TestWriteUnit(t *testing.T) {
 	hostRoot := t.TempDir()
 	cfg := Config{


### PR DESCRIPTION
- render storage disk, loadgen, and benchmark options from node annotations
- advertise and consume RDMA HCA inventory annotations