### PR TITLE
ci: enable merge queue workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 # Cancel in-progress runs for the same branch/PR to avoid wasted runner time.

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add the `merge_group` trigger to the required CI workflow.
- Add the `merge_group` trigger to the CodeQL workflow used by code scanning.

## Expected behavior
- Pull requests continue to run the existing `pull_request` checks as they do today.
- When a PR enters the merge queue, GitHub creates a temporary merge group commit.
- The required CI checks run again on that merge group commit via `merge_group: checks_requested`.
- CodeQL also runs on the merge group commit so the existing code scanning rule can evaluate the queued merge.
- Optional/path-filtered PR workflows, such as agent e2e and metalman smoke, remain PR-only unless they are explicitly made required later.

## Testing
- Not run locally; workflow trigger-only change.