### PR TITLE
storage: use bufferpool cache for origin nodes

### DIFF
--- a/cmd/unbounded-storage/src/bufferpool/traits.rs
+++ b/cmd/unbounded-storage/src/bufferpool/traits.rs
@@ -44,9 +44,10 @@ pub trait Req {
     }
 
     /// Benchmark-only local-disk bypass. Unlike [`Req::bypass`], this
-    /// leaves peer routing enabled but skips the initiator's local disk
-    /// lookup/writeback. Peer handlers still consult their own local
-    /// store, so remote NVMe reads remain in the path.
+    /// leaves peer routing enabled but every bufferpool that serves the
+    /// request skips its local disk lookup/writeback. Remote owner reads
+    /// still use the normal peer/fabric path, without a separate RPC-side
+    /// disk path.
     fn skip_local_disk(&self) -> bool {
         false
     }

--- a/cmd/unbounded-storage/src/fabric/handler.rs
+++ b/cmd/unbounded-storage/src/fabric/handler.rs
@@ -3,7 +3,7 @@
 
 //! Server-side handler trait for fabric RPCs.
 //!
-//! A handler maps a typed request `R` to a stream of `PageRef`s the
+//! A handler maps a typed request `R` to a stream of pages the
 //! server should RMA-write into the client's destination MR. The
 //! stream surface is intentionally separate from
 //! `bufferpool::PageStream` so the server side can carry its own
@@ -14,10 +14,75 @@
 //! collection of canned handlers (`NPagesHandler`, `ErrorHandler`,
 //! `CancelObservingHandler`) used by `tests.rs`.
 
+use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::bufferpool::{BulkRef, PageRef, Req};
+
+use super::backing::MrHandle;
+
+/// Drop-owned token attached to a page write. The RPC layer holds it
+/// until the fabric write has completed or has been abandoned after a
+/// completion drain, so embedders can keep non-`Send` page guards pinned
+/// on their home shard while handing only a Send release token to fabric.
+pub type PageRelease = Box<dyn Send + 'static>;
+
+/// Registered source backing for a streamed RPC page.
+pub enum PageSource {
+    /// Use the server's default local MR passed to
+    /// [`crate::fabric::Fabric::start_rpc_server`]. This is the scratch
+    /// path used by forwarding and synthetic responses.
+    Default,
+    /// Use this registered MR for the source page and hold `release`
+    /// until the write no longer needs the bytes.
+    Registered {
+        mr: MrHandle,
+        release: Option<PageRelease>,
+    },
+}
+
+impl fmt::Debug for PageSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Default => f.write_str("Default"),
+            Self::Registered { mr, release } => f
+                .debug_struct("Registered")
+                .field("mr", mr)
+                .field("has_release", &release.is_some())
+                .finish(),
+        }
+    }
+}
+
+/// One page yielded by a server handler plus the backing it belongs to.
+#[derive(Debug)]
+pub struct FabricPage {
+    pub page: PageRef,
+    pub source: PageSource,
+}
+
+impl FabricPage {
+    pub fn default(page: PageRef) -> Self {
+        Self {
+            page,
+            source: PageSource::Default,
+        }
+    }
+
+    pub fn registered(page: PageRef, mr: MrHandle, release: Option<PageRelease>) -> Self {
+        Self {
+            page,
+            source: PageSource::Registered { mr, release },
+        }
+    }
+}
+
+impl From<PageRef> for FabricPage {
+    fn from(page: PageRef) -> Self {
+        Self::default(page)
+    }
+}
 
 /// Server-side stream produced by a `Handler`. Mirrors the
 /// `bufferpool::PageStream` shape but with a handler-defined error
@@ -27,7 +92,7 @@ pub trait HandlerStream {
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<PageRef, Self::Error>>>;
+    ) -> Poll<Option<Result<FabricPage, Self::Error>>>;
 }
 
 /// Handler for one request type `R`. Each invocation returns a fresh
@@ -56,7 +121,7 @@ mod test_handlers {
 
     use crate::bufferpool::{BulkRef, PageRef, Req};
 
-    use super::{Handler, HandlerStream};
+    use super::{FabricPage, Handler, HandlerStream};
 
     /// Handler that yields the configured pages in order, then ends.
     pub struct NPagesHandler {
@@ -73,11 +138,11 @@ mod test_handlers {
         fn poll_next(
             mut self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
-        ) -> Poll<Option<Result<PageRef, Infallible>>> {
+        ) -> Poll<Option<Result<FabricPage, Infallible>>> {
             if self.next < self.pages.len() {
                 let p = self.pages[self.next];
                 self.next += 1;
-                Poll::Ready(Some(Ok(p)))
+                Poll::Ready(Some(Ok(p.into())))
             } else {
                 Poll::Ready(None)
             }
@@ -136,7 +201,7 @@ mod test_handlers {
         fn poll_next(
             mut self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
-        ) -> Poll<Option<Result<PageRef, E>>> {
+        ) -> Poll<Option<Result<FabricPage, E>>> {
             if self.emitted {
                 Poll::Ready(None)
             } else {
@@ -197,11 +262,11 @@ mod test_handlers {
         fn poll_next(
             mut self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
-        ) -> Poll<Option<Result<PageRef, TestErr>>> {
+        ) -> Poll<Option<Result<FabricPage, TestErr>>> {
             if !self.yielded_first {
                 if let Some(p) = self.page {
                     self.yielded_first = true;
-                    return Poll::Ready(Some(Ok(p)));
+                    return Poll::Ready(Some(Ok(p.into())));
                 }
             }
             Poll::Pending

--- a/cmd/unbounded-storage/src/fabric/mod.rs
+++ b/cmd/unbounded-storage/src/fabric/mod.rs
@@ -39,7 +39,7 @@ pub use completion::{CompletionFuture, CompletionInfo, CompletionRegistry, Compl
 pub use config::{FabricConfig, Provider, apply_tcp_env_defaults, defaults_for};
 pub use error::{FabricError, Result, check};
 pub use fabric::{Fabric, provider_available};
-pub use handler::{Handler, HandlerStream};
+pub use handler::{FabricPage, Handler, HandlerStream, PageRelease, PageSource};
 pub use pool_handler::{PoolHandler, PoolHandlerError, PoolHandlerStream};
 pub use rpc::{
     MAX_HOPS, PageWritePlan, RequestHeader, RequestPlan, RpcServer, RpcServerHandle,

--- a/cmd/unbounded-storage/src/fabric/pool_handler.rs
+++ b/cmd/unbounded-storage/src/fabric/pool_handler.rs
@@ -44,7 +44,7 @@ use std::task::{Context, Poll};
 use crate::bufferpool::{BlockStore, BulkRef, PageRef, Req};
 use crate::memory::Backing;
 
-use super::handler::{Handler, HandlerStream};
+use super::handler::{FabricPage, Handler, HandlerStream};
 use super::scratch::ScratchBacking;
 
 /// Error surfaced by [`PoolHandler`]'s response stream.
@@ -161,7 +161,7 @@ impl<R: Req, S: BlockStore + Send + Sync + 'static> HandlerStream for PoolHandle
     fn poll_next(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<PageRef, PoolHandlerError>>> {
+    ) -> Poll<Option<Result<FabricPage, PoolHandlerError>>> {
         match self.state {
             StreamState::Done | StreamState::Ended => {
                 self.state = StreamState::Ended;
@@ -172,7 +172,7 @@ impl<R: Req, S: BlockStore + Send + Sync + 'static> HandlerStream for PoolHandle
                 match result {
                     Ok(page) => {
                         self.state = StreamState::Done;
-                        Poll::Ready(Some(Ok(page)))
+                        Poll::Ready(Some(Ok(page.into())))
                     }
                     Err(e) => {
                         self.state = StreamState::Ended;
@@ -346,7 +346,7 @@ mod tests {
         handler: &PoolHandler<S>,
         key: [u8; 32],
         len: u32,
-    ) -> Vec<Result<PageRef, PoolHandlerError>> {
+    ) -> Vec<Result<crate::fabric::FabricPage, PoolHandlerError>> {
         let req = KeyReq(StripeKey(key));
         let src = BulkRef {
             stripe: StripeKey(key),
@@ -382,10 +382,10 @@ mod tests {
         let out = drain(&handler, key, PAGE as u32);
         assert_eq!(out.len(), 1, "expected exactly one page yielded");
         let page = out[0].as_ref().expect("resident page must be Ok");
-        assert_eq!(page.len, PAGE as u32);
+        assert_eq!(page.page.len, PAGE as u32);
         // The yielded page index points into the filled scratch page.
         // SAFETY: page_idx is within the scratch backing.
-        let byte = unsafe { *base.add(page.page_idx as usize * PAGE) };
+        let byte = unsafe { *base.add(page.page.page_idx as usize * PAGE) };
         assert_eq!(byte, 0xAB, "scratch page was not filled from the store");
         assert_eq!(st.reads.load(Ordering::Relaxed), 1);
     }
@@ -430,7 +430,7 @@ mod tests {
 
         let out = drain(&handler, key, 1024);
         let page = out[0].as_ref().expect("ok");
-        assert_eq!(page.len, 1024, "handler must honor BulkRef.len window");
+        assert_eq!(page.page.len, 1024, "handler must honor BulkRef.len window");
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/fabric/rpc.rs
+++ b/cmd/unbounded-storage/src/fabric/rpc.rs
@@ -474,7 +474,9 @@ struct ServeOutcome {
 /// requester is still being established. The source bytes live in the
 /// server's long-lived registered backing. Pages that belong to a
 /// caller-managed backing can attach a drop-owned release token; the
-/// token is held here until the write completes or is drained.
+/// token is held here until the write completion is observed. If teardown
+/// gives up before the CQE arrives, the token is intentionally leaked so
+/// the source page cannot be recycled while the NIC may still read it.
 struct Inflight {
     fut: CompletionFuture,
     desc: *mut std::ffi::c_void,
@@ -483,7 +485,7 @@ struct Inflight {
     dest_addr: u64,
     dest_key: u64,
     data: u64,
-    _release: Option<PageRelease>,
+    release: Option<PageRelease>,
 }
 
 /// Drive one handler stream to completion, signalling each landed page
@@ -711,7 +713,7 @@ fn post_page(
         dest_addr: plan.dest_addr,
         dest_key: header.dest_mr_key,
         data,
-        _release: release,
+        release,
     })
 }
 
@@ -773,11 +775,13 @@ fn await_oldest(
     ep: EpPtr,
     deadline: std::time::Instant,
 ) -> FabResult<()> {
-    let inf = match inflight.pop_front() {
+    let mut inf = match inflight.pop_front() {
         Some(i) => i,
         None => return Ok(()),
     };
-    match block_on(inf.fut, Duration::from_secs(10), &shared.shutdown) {
+    let result = block_on(inf.fut, Duration::from_secs(10), &shared.shutdown);
+    leak_release_if_completion_unobserved(&mut inf.release, &result);
+    match result {
         Ok(_) => Ok(()),
         Err(FabricError::Cq { prov_errno, err })
             if prov_errno == ffi::ENOTCONN && std::time::Instant::now() < deadline =>
@@ -809,8 +813,9 @@ fn await_oldest(
 /// the request outcome has already been decided. Bounded by the server
 /// shutdown flag and per-op timeout inside `block_on`.
 fn drain_inflight(shared: &Arc<ServerShared>, inflight: &mut VecDeque<Inflight>) {
-    while let Some(inf) = inflight.pop_front() {
-        let _ = block_on(inf.fut, Duration::from_secs(10), &shared.shutdown);
+    while let Some(mut inf) = inflight.pop_front() {
+        let result = block_on(inf.fut, Duration::from_secs(10), &shared.shutdown);
+        leak_release_if_completion_unobserved(&mut inf.release, &result);
     }
 }
 
@@ -921,7 +926,7 @@ fn write_page(
     let ResolvedPageSource {
         mr,
         desc,
-        release: _release,
+        release: mut release,
     } = resolve_page_source(shared, page.source)?;
     let plan = plan_page_write(
         &mr,
@@ -960,7 +965,9 @@ fn write_page(
             }
             return Err(FabricError::Pkg("fi_write", rc as i32));
         }
-        match block_on(fut, Duration::from_secs(10), &shared.shutdown) {
+        let result = block_on(fut, Duration::from_secs(10), &shared.shutdown);
+        leak_release_if_completion_unobserved(&mut release, &result);
+        match result {
             Ok(_) => break,
             Err(FabricError::Cq { prov_errno, err })
                 if prov_errno == ffi::ENOTCONN && std::time::Instant::now() < deadline =>
@@ -974,6 +981,17 @@ fn write_page(
     }
 
     send_page_ack(shared, ep, header.request_id, plan.ack_page_idx)
+}
+
+fn leak_release_if_completion_unobserved(
+    release: &mut Option<PageRelease>,
+    result: &FabResult<CompletionInfo>,
+) {
+    if matches!(result, Err(FabricError::Timeout)) {
+        if let Some(release) = release.take() {
+            std::mem::forget(release);
+        }
+    }
 }
 
 struct ResolvedPageSource {
@@ -1270,6 +1288,41 @@ mod tests {
             op_context: 0,
             data: 0,
         }
+    }
+
+    fn counted_release(drops: Arc<std::sync::atomic::AtomicUsize>) -> PageRelease {
+        struct CountedRelease(Arc<std::sync::atomic::AtomicUsize>);
+
+        impl Drop for CountedRelease {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+
+        Box::new(CountedRelease(drops))
+    }
+
+    #[test]
+    fn unobserved_completion_leaks_page_release() {
+        let drops = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut release = Some(counted_release(drops.clone()));
+
+        leak_release_if_completion_unobserved(&mut release, &Err(FabricError::Timeout));
+
+        assert!(release.is_none());
+        assert_eq!(drops.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn observed_completion_keeps_page_release_drop_owned() {
+        let drops = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut release = Some(counted_release(drops.clone()));
+        let result = Ok(completion_info());
+
+        leak_release_if_completion_unobserved(&mut release, &result);
+        drop(release);
+
+        assert_eq!(drops.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/fabric/rpc.rs
+++ b/cmd/unbounded-storage/src/fabric/rpc.rs
@@ -66,7 +66,7 @@ use super::dispatch::{EpPtr, ReplyCtx, RequestSink};
 use super::error::{FabricError, Result as FabResult};
 use super::fabric::{Fabric, FabricInner};
 use super::ffi;
-use super::handler::{Handler, HandlerStream};
+use super::handler::{FabricPage, Handler, HandlerStream, PageRelease, PageSource};
 use super::rpc_queue::{Job, JobQueue};
 use super::wire::{MsgHeader, MsgKind};
 
@@ -217,9 +217,8 @@ fn classify_handler_error(error: &(dyn std::error::Error + 'static)) -> ErrorAck
 /// Per-server shared state held by the responder and each worker.
 struct ServerShared {
     fabric: Arc<FabricInner>,
-    /// MR covering the server's local backing. Used as the source MR
-    /// for `fi_write`s; if unset every request is failed with an
-    /// `ERROR_ACK`.
+    /// Default MR covering the server's local scratch backing. Handler
+    /// pages can override this with their own registered MR.
     local_mr: Option<MrHandle>,
     /// Page size used to compute source and destination offsets for
     /// streamed page writes. Supplied by the embedder via
@@ -432,27 +431,7 @@ fn run_worker<R, H>(
     // `hops_remaining` below and rejects only when it would actually
     // have to forward with no budget left (surfaced as a handler error
     // that becomes an `ERROR_ACK`).
-    let local_mr = match shared.local_mr {
-        Some(m) => m,
-        None => {
-            let _ = send_error_ack(
-                &shared,
-                ep,
-                header.request_id,
-                ErrorAck::generic("local backing not registered"),
-            );
-
-            if let Some(mut l) = log.take() {
-                l.finish_err("local backing not registered");
-            }
-
-            crate::metrics::fabric_rpc_served(crate::metrics::Outcome::Err);
-            crate::metrics::fabric_rpc_duration(started.elapsed().as_secs_f64());
-            return;
-        }
-    };
-
-    let outcome = serve_stream(&shared, &local_mr, ep, &header, &handler, &req);
+    let outcome = serve_stream(&shared, ep, &header, &handler, &req);
 
     if let Some(mut l) = log.take() {
         l.field("written", outcome.written);
@@ -493,17 +472,18 @@ struct ServeOutcome {
 /// Carries everything needed to re-post the write if its completion
 /// comes back with a transient `ENOTCONN` while the path back to the
 /// requester is still being established. The source bytes live in the
-/// server's long-lived registered backing (`local_mr`), so no page
-/// ownership needs to be held here; correctness instead relies on
-/// `serve_stream` draining every outstanding write before the handler
-/// stream is dropped.
+/// server's long-lived registered backing. Pages that belong to a
+/// caller-managed backing can attach a drop-owned release token; the
+/// token is held here until the write completes or is drained.
 struct Inflight {
     fut: CompletionFuture,
+    desc: *mut std::ffi::c_void,
     src_ptr: *const std::ffi::c_void,
     len: usize,
     dest_addr: u64,
     dest_key: u64,
     data: u64,
+    _release: Option<PageRelease>,
 }
 
 /// Drive one handler stream to completion, signalling each landed page
@@ -514,7 +494,6 @@ struct Inflight {
 /// falls back to an `fi_write` plus a framed `PageAck` send per page.
 fn serve_stream<R, H>(
     shared: &Arc<ServerShared>,
-    local_mr: &MrHandle,
     ep: EpPtr,
     header: &RequestHeader,
     handler: &Arc<H>,
@@ -525,9 +504,9 @@ where
     H: Handler<R>,
 {
     if shared.fabric.cfg.provider.supports_write_with_imm() {
-        serve_stream_writedata(shared, local_mr, ep, header, handler, req)
+        serve_stream_writedata(shared, ep, header, handler, req)
     } else {
-        serve_stream_framed(shared, local_mr, ep, header, handler, req)
+        serve_stream_framed(shared, ep, header, handler, req)
     }
 }
 
@@ -542,7 +521,6 @@ where
 /// response, `ERROR_ACK` on failure) before returning.
 fn serve_stream_writedata<R, H>(
     shared: &Arc<ServerShared>,
-    local_mr: &MrHandle,
     ep: EpPtr,
     header: &RequestHeader,
     handler: &Arc<H>,
@@ -567,10 +545,6 @@ where
     let mut task_cx = std::task::Context::from_waker(&waker);
 
     let depth = shared.fabric.cfg.write_pipeline_depth.max(1);
-    // SAFETY: local_mr.mr is owned by the live fabric for the duration of
-    // this request (the server handle joins workers before releasing the
-    // MR), so the descriptor stays valid across every posted write.
-    let desc = unsafe { ffi::ub_fi_mr_desc(local_mr.mr) };
     // Connection-establishment retry budget shared across the request:
     // the reverse-direction writes can transiently fail with -FI_EAGAIN
     // on submit or complete with prov_errno=ENOTCONN while the path back
@@ -601,7 +575,7 @@ where
         while !stream_done && inflight.len() < depth {
             match stream.as_mut().poll_next(&mut task_cx) {
                 std::task::Poll::Ready(Some(Ok(page))) => {
-                    match post_page(shared, local_mr, desc, ep, header, next_idx, page, deadline) {
+                    match post_page(shared, ep, header, next_idx, page, deadline) {
                         Ok(inf) => {
                             inflight.push_back(inf);
                             next_idx = next_idx.saturating_add(1);
@@ -671,7 +645,7 @@ where
 
         // Pipeline is full or the stream is drained: wait for the oldest
         // outstanding write to complete, then loop to refill.
-        if let Err(e) = await_oldest(shared, &mut inflight, desc, ep, deadline) {
+        if let Err(e) = await_oldest(shared, &mut inflight, ep, deadline) {
             drain_inflight(shared, &mut inflight);
             let msg = format!("write_page: {e}");
             if !shared.shutdown.load(Ordering::Acquire) {
@@ -697,19 +671,18 @@ where
 #[allow(clippy::too_many_arguments)]
 fn post_page(
     shared: &Arc<ServerShared>,
-    local_mr: &MrHandle,
-    desc: *mut std::ffi::c_void,
     ep: EpPtr,
     header: &RequestHeader,
     dest_idx: u32,
-    page: crate::bufferpool::PageRef,
+    page: FabricPage,
     deadline: std::time::Instant,
 ) -> FabResult<Inflight> {
+    let ResolvedPageSource { mr, desc, release } = resolve_page_source(shared, page.source)?;
     let plan = plan_page_write(
-        local_mr,
+        &mr,
         &RequestPlan::from(header),
         dest_idx,
-        page,
+        page.page,
         shared.page_size,
     )?;
     if plan.ack_page_idx > u16::MAX as u32 {
@@ -732,11 +705,13 @@ fn post_page(
     )?;
     Ok(Inflight {
         fut,
+        desc,
         src_ptr,
         len: plan.len,
         dest_addr: plan.dest_addr,
         dest_key: header.dest_mr_key,
         data,
+        _release: release,
     })
 }
 
@@ -795,7 +770,6 @@ fn post_writedata(
 fn await_oldest(
     shared: &Arc<ServerShared>,
     inflight: &mut VecDeque<Inflight>,
-    desc: *mut std::ffi::c_void,
     ep: EpPtr,
     deadline: std::time::Instant,
 ) -> FabResult<()> {
@@ -812,7 +786,7 @@ fn await_oldest(
             std::thread::sleep(Duration::from_millis(1));
             let fut = post_writedata(
                 shared,
-                desc,
+                inf.desc,
                 ep,
                 inf.src_ptr,
                 inf.len,
@@ -850,7 +824,6 @@ fn drain_inflight(shared: &Arc<ServerShared>, inflight: &mut VecDeque<Inflight>)
 /// throughput target. Terminator semantics match the writedata path.
 fn serve_stream_framed<R, H>(
     shared: &Arc<ServerShared>,
-    local_mr: &MrHandle,
     ep: EpPtr,
     header: &RequestHeader,
     handler: &Arc<H>,
@@ -887,7 +860,7 @@ where
 
         match stream.as_mut().poll_next(&mut task_cx) {
             std::task::Poll::Ready(Some(Ok(page))) => {
-                if let Err(e) = write_page(shared, local_mr, ep, header, next_idx, page) {
+                if let Err(e) = write_page(shared, ep, header, next_idx, page) {
                     let msg = format!("write_page: {e}");
                     if !shared.shutdown.load(Ordering::Acquire) {
                         let _ = send_error_ack(
@@ -940,23 +913,24 @@ where
 /// establishing) with a short backoff until a 10s deadline.
 fn write_page(
     shared: &Arc<ServerShared>,
-    local_mr: &MrHandle,
     ep: EpPtr,
     header: &RequestHeader,
     dest_idx: u32,
-    page: crate::bufferpool::PageRef,
+    page: FabricPage,
 ) -> FabResult<()> {
+    let ResolvedPageSource {
+        mr,
+        desc,
+        release: _release,
+    } = resolve_page_source(shared, page.source)?;
     let plan = plan_page_write(
-        local_mr,
+        &mr,
         &RequestPlan::from(header),
         dest_idx,
-        page,
+        page.page,
         shared.page_size,
     )?;
     let src_ptr = plan.src_addr as *const std::ffi::c_void;
-    // SAFETY: local_mr.mr is owned by the live fabric for the duration of
-    // this request, so the descriptor stays valid across the write.
-    let desc = unsafe { ffi::ub_fi_mr_desc(local_mr.mr) };
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
 
     loop {
@@ -1000,6 +974,33 @@ fn write_page(
     }
 
     send_page_ack(shared, ep, header.request_id, plan.ack_page_idx)
+}
+
+struct ResolvedPageSource {
+    mr: MrHandle,
+    desc: *mut std::ffi::c_void,
+    release: Option<PageRelease>,
+}
+
+fn resolve_page_source(
+    shared: &Arc<ServerShared>,
+    source: PageSource,
+) -> FabResult<ResolvedPageSource> {
+    let (mr, release) = match source {
+        PageSource::Default => (
+            shared
+                .local_mr
+                .ok_or(FabricError::BadConfig("local backing not registered"))?,
+            None,
+        ),
+        PageSource::Registered { mr, release } => (mr, release),
+    };
+    // SAFETY: source MRs are owned by the live fabric domain and remain
+    // registered for the lifetime of this server request. Any page-level
+    // pin lifetime is carried by `release`.
+    let desc = unsafe { ffi::ub_fi_mr_desc(mr.mr) };
+
+    Ok(ResolvedPageSource { mr, desc, release })
 }
 
 /// Frame and send a `MsgKind::PageAck` naming the landed destination
@@ -1456,7 +1457,7 @@ mod tests {
     /// do: serve a page, reject with an error ack, or end the response.
     #[derive(Debug)]
     enum FirstOutcome {
-        Served(crate::bufferpool::PageRef),
+        Served(crate::fabric::FabricPage),
         Rejected(String),
         Ended,
     }
@@ -1522,7 +1523,7 @@ mod tests {
     }
 
     struct RoutingStream {
-        outcome: Option<Result<crate::bufferpool::PageRef, HopLimit>>,
+        outcome: Option<Result<FabricPage, HopLimit>>,
     }
 
     impl HandlerStream for RoutingStream {
@@ -1530,7 +1531,7 @@ mod tests {
         fn poll_next(
             mut self: std::pin::Pin<&mut Self>,
             _cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<Result<crate::bufferpool::PageRef, HopLimit>>> {
+        ) -> std::task::Poll<Option<Result<FabricPage, HopLimit>>> {
             std::task::Poll::Ready(self.outcome.take())
         }
     }
@@ -1556,13 +1557,13 @@ mod tests {
             let outcome = if self.owns {
                 // Owner: serve from the local store regardless of the
                 // remaining hop budget.
-                Some(Ok(page))
+                Some(Ok(page.into()))
             } else if hops_remaining == 0 {
                 // Forward with no budget: the genuine hop-limit case.
                 Some(Err(HopLimit))
             } else {
                 // Forward with budget: relays a downstream page.
-                Some(Ok(page))
+                Some(Ok(page.into()))
             };
             RoutingStream { outcome }
         }

--- a/cmd/unbounded-storage/src/fabric/tests.rs
+++ b/cmd/unbounded-storage/src/fabric/tests.rs
@@ -276,7 +276,9 @@ use std::task::{Context, Poll};
 
 use crate::bufferpool::{BulkRef, PageRef, PageStream, Req, StripeKey, Transport};
 use crate::fabric::handler::{CancelObservingHandler, ErrorHandler, NPagesHandler, TestErr};
-use crate::fabric::{FabricTransport, Handler, HandlerStream, MrHandle, PoolHandler, StaticPeer};
+use crate::fabric::{
+    FabricPage, FabricTransport, Handler, HandlerStream, MrHandle, PoolHandler, StaticPeer,
+};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct TestReq {
@@ -315,7 +317,7 @@ impl HandlerStream for EmptyStream {
     fn poll_next(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<PageRef, Self::Error>>> {
+    ) -> Poll<Option<Result<FabricPage, Self::Error>>> {
         Poll::Ready(None)
     }
 }
@@ -958,29 +960,23 @@ fn pool_handler_reports_miss_for_non_resident_stripe() {
 //
 //   A (client) --static--> B (relay) --finger--> C (owner)
 //
-// A is a plain client whose `StaticPeer` router always targets B. B
-// owns no stripe for the requested key, so its finger table forwards
-// to C, RDMA-landing C's served page directly into B's scratch before
-// B relays it upstream to A. C owns the key and serves it from its
-// local store (or, on a miss, from the origin backend). This is the
-// only place the recursive forward path is exercised against a live
-// fabric; the per-node routing math is unit-tested in `p2p`.
-//
-// The finger tables are hand-crafted per node (B knows only C, C knows
-// only B) so the chain forwards exactly once at B and terminates at C.
-// A globally-consistent three-node ring would let B route straight to
-// C in one hop; the point here is to drive a genuine relay hop.
-//
-// Every test runtime-skips when the libfabric tcp provider is absent.
+// C serves owner pages through the same `FetchChannel` shape used by
+// shard-local bufferpool fanout. The fake service below emits only a
+// registered backing location and observes release commands; it never
+// hands page bytes to the RPC worker, preserving the zero-copy contract
+// the production `FetchService` provides.
 // ---------------------------------------------------------------
 
 use std::collections::HashMap;
 
-use crate::backend::{Backend, NullBackend};
-use crate::p2p::{
-    FingerTable, FingerTableConfig, NodeId, PeerEntry, RecursiveHandler, RingId, RouteTableHandle,
-    RoutingSnapshot, TopologyTags,
+use crate::fanout::{
+    FetchChannel, FetchChannelReceiver, FetchCommand, FetchEvent, FetchPage, PageLoc,
 };
+use crate::p2p::{
+    FingerTable, FingerTableConfig, NodeId, OwnerShardSource, OwnerShardTable, PeerEntry,
+    RecursiveHandler, RingId, RouteTableHandle, RoutingSnapshot, TopologyTags,
+};
+use crate::storage::StripeReq;
 
 /// Ring position the relay (B) forwards for and the owner (C) serves.
 /// Chosen to sit in the open arc `(B.ring, C.ring)` so B's finger
@@ -988,80 +984,68 @@ use crate::p2p::{
 const CHAIN_TARGET_RING: u64 = 150;
 const CHAIN_CACHE_ID: &str = "cache";
 
-/// Request whose stripe key's leading 8 bytes encode a ring id, so
-/// `stripe_to_ring(req.key())` is controllable from the test.
-#[derive(Clone, Serialize, Deserialize, Debug)]
-struct RingReq {
-    key_bytes: [u8; 32],
-    cache_id: Option<String>,
+#[derive(Copy, Clone)]
+enum OwnerFetchResult {
+    Page(u8),
+    Error(&'static str),
 }
 
-impl Req for RingReq {
-    fn key(&self) -> StripeKey {
-        StripeKey(self.key_bytes)
-    }
-
-    fn cache_id(&self) -> Option<&String> {
-        self.cache_id.as_ref()
-    }
+struct FetchStub {
+    stop: Arc<AtomicBool>,
+    join: Option<std::thread::JoinHandle<()>>,
 }
 
-/// Origin backend that fills its destination scratch page with a known
-/// byte then yields it once, standing in for an authoritative origin
-/// fetch on an owner-side store miss.
-struct FillBackend {
-    base: usize,
-    page_size: usize,
-    fill: u8,
-}
-
-// SAFETY: `base` points into a leaked scratch backing that outlives
-// the test; the page is only written from the RPC worker thread.
-unsafe impl Send for FillBackend {}
-unsafe impl Sync for FillBackend {}
-
-struct FillStream {
-    page: Option<PageRef>,
-}
-
-impl PageStream for FillStream {
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<PageRef, PoolError>>> {
-        match self.page.take() {
-            Some(p) => Poll::Ready(Some(Ok(p))),
-            None => Poll::Ready(None),
+impl Drop for FetchStub {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
         }
     }
 }
 
-impl Backend for FillBackend {
-    type Req = RingReq;
-    type Stream<'a> = FillStream;
-
-    fn bulk_get<'a>(
-        &'a self,
-        _req: &'a Self::Req,
-        _src: BulkRef,
-        dsts: &'a [PageRef],
-    ) -> Self::Stream<'a> {
-        let dst = dsts[0];
-        // SAFETY: dst.page_idx indexes the scratch backing at `base`.
-        unsafe {
-            let p = (self.base as *mut u8).add(dst.page_idx as usize * self.page_size);
-            std::ptr::write_bytes(p, self.fill, self.page_size);
+fn spawn_fetch_stub(
+    rx: FetchChannelReceiver,
+    page_byte_offset: u64,
+    len: u32,
+    result: OwnerFetchResult,
+) -> FetchStub {
+    let (cmd_rx, alive, _command_waker) = rx.into_parts();
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = stop.clone();
+    let join = std::thread::spawn(move || {
+        while !thread_stop.load(Ordering::Acquire) {
+            match cmd_rx.recv_timeout(Duration::from_millis(10)) {
+                Ok(FetchCommand::Fetch {
+                    fetch_id, events, ..
+                }) => match result {
+                    OwnerFetchResult::Page(_) => {
+                        events.push(Ok(FetchEvent::Page(FetchPage {
+                            ordinal: 0,
+                            pin_token: fetch_id + 1,
+                            loc: PageLoc {
+                                page_byte_offset,
+                                len,
+                            },
+                        })));
+                        events.push(Ok(FetchEvent::Done));
+                    }
+                    OwnerFetchResult::Error(msg) => events.push(Err(PoolError::from(msg))),
+                },
+                Ok(FetchCommand::Release { .. })
+                | Ok(FetchCommand::Sending { .. })
+                | Ok(FetchCommand::Cancel { .. }) => {}
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            }
         }
-        FillStream { page: Some(dst) }
-    }
-}
+        alive.store(false, Ordering::Release);
+    });
 
-/// Which origin backend the owner (C) consults on a store miss.
-enum OwnerBackend {
-    /// Inert backend: a store miss surfaces an error up the chain.
-    Null,
-    /// Origin fetch that fills the page with the given byte.
-    Fill(u8),
+    FetchStub {
+        stop,
+        join: Some(join),
+    }
 }
 
 /// Build a `PeerEntry` at an explicit ring position. The ring is set
@@ -1089,25 +1073,18 @@ fn key_for_ring(ring: u64) -> StripeKey {
 /// while the relay reads back from `PageRef.page_idx`.
 const RECURSIVE_SCRATCH_PAGES: usize = 8;
 
-/// Start a node running the production `RecursiveHandler` over a
-/// `RECURSIVE_SCRATCH_PAGES`-page scratch backing.
 #[allow(clippy::too_many_arguments)]
-fn start_recursive_node<B>(
+fn start_recursive_node(
     fabric: &Arc<Fabric>,
     scratch: Backing,
     scratch_mr: MrHandle,
     page_size: usize,
     fingers: Arc<FingerTable>,
     node_to_peer: Arc<HashMap<NodeId, PeerId>>,
-    store: Arc<MemBlockStore>,
-    backend: B,
-) -> crate::fabric::RpcServerHandle
-where
-    B: Backend<Req = RingReq> + 'static,
-{
+    owners: OwnerShardTable,
+) -> crate::fabric::RpcServerHandle {
     let handler = Arc::new(
         RecursiveHandler::with_routes(
-            store,
             scratch,
             RECURSIVE_SCRATCH_PAGES as u32,
             RouteTableHandle::new(
@@ -1124,29 +1101,24 @@ where
             fabric.clone(),
             scratch_mr,
             page_size,
-            backend,
+            owners,
         )
         .expect("RecursiveHandler::with_routes failed after provider availability gate"),
     );
-    Fabric::start_rpc_server::<RingReq, _>(fabric, handler, Some(scratch_mr), page_size)
+    Fabric::start_rpc_server::<StripeReq, _>(fabric, handler, Some(scratch_mr), page_size)
         .expect("start_rpc_server failed after provider availability gate")
 }
 
-/// Stand up the live A -> B -> C chain. `c_present` lists `(ring, fill)`
-/// entries resident in C's store; `owner` selects C's origin backend
-/// for the store-miss case. Returns the client transport, the client
-/// MR, the page size, both server handles, and the three fabrics. The
-/// handles and fabrics must be held for the lifetime of the test.
 #[allow(clippy::type_complexity)]
 fn recursive_chain(
-    c_present: &[(u64, u8)],
-    owner: OwnerBackend,
+    owner: OwnerFetchResult,
 ) -> (
-    FabricTransport<RingReq, StaticPeer>,
+    FabricTransport<StripeReq, StaticPeer>,
     MrHandle,
     usize,
     crate::fabric::RpcServerHandle,
     crate::fabric::RpcServerHandle,
+    FetchStub,
     Arc<Fabric>,
     Arc<Fabric>,
     Arc<Fabric>,
@@ -1167,22 +1139,25 @@ fn recursive_chain(
     let b_scratch = alloc(page_size * RECURSIVE_SCRATCH_PAGES);
     let c_scratch = alloc(page_size * RECURSIVE_SCRATCH_PAGES);
     let client_backing = alloc(page_size);
-    // Zero the client page so a populated byte proves an RMA landing.
-    // SAFETY: client_backing covers `page_size`.
+    let owner_backing = alloc(page_size);
+
+    // SAFETY: both heap backings cover `page_size` bytes.
     unsafe {
         std::ptr::write_bytes(client_backing.base, 0, page_size);
+        if let OwnerFetchResult::Page(fill) = owner {
+            std::ptr::write_bytes(owner_backing.base, fill, page_size);
+        }
     }
-
-    let b_base = b_scratch.base as usize;
-    let c_base = c_scratch.base as usize;
 
     let b_mr = b.register_backing(&b_scratch, None).expect("b scratch MR");
     let c_mr = c.register_backing(&c_scratch, None).expect("c scratch MR");
+    let owner_mr = c
+        .register_backing(&owner_backing, None)
+        .expect("c owner backing MR");
     let client_mr = a
         .register_backing(&client_backing, None)
         .expect("client MR");
 
-    // Global peer-id scheme: A=1, B=2, C=3 in every fabric's table.
     let a_addr = socket_addr_of(&a);
     let b_addr = socket_addr_of(&b);
     let c_addr = socket_addr_of(&c);
@@ -1215,8 +1190,6 @@ fn recursive_chain(
     })
     .expect("c -> b connection");
 
-    // B (ring 100) forwards CHAIN_TARGET_RING (150) to its successor C
-    // (ring 200); C owns it. Each table knows only the other node.
     let b_fingers = Arc::new(FingerTable::build(
         ring_peer(2, 100),
         std::slice::from_ref(&ring_peer(3, 200)),
@@ -1229,25 +1202,27 @@ fn recursive_chain(
     ));
     let b_n2p: Arc<HashMap<NodeId, PeerId>> =
         Arc::new([(NodeId(3), PeerId(3))].into_iter().collect());
-    // C never forwards for the target; mapping is present for symmetry.
     let c_n2p: Arc<HashMap<NodeId, PeerId>> =
         Arc::new([(NodeId(2), PeerId(2))].into_iter().collect());
 
-    let b_store = Arc::new(MemBlockStore {
-        base: b_base,
+    let empty_owners = OwnerShardTable::new(
+        Vec::new(),
+        crate::storage::disks::CacheDirectorySet::new(),
         page_size,
-        present: HashMap::new(),
-    });
-    let c_store = Arc::new(MemBlockStore {
-        base: c_base,
+    );
+    let (fetch_channel, fetch_rx) = FetchChannel::new();
+    let fetch_stub = spawn_fetch_stub(fetch_rx, 0, page_size as u32, owner);
+    let c_owners = OwnerShardTable::new(
+        vec![OwnerShardSource {
+            shard_index: 0,
+            channel: fetch_channel,
+            mr: owner_mr,
+            numa: None,
+        }],
+        crate::storage::disks::CacheDirectorySet::new(),
         page_size,
-        present: c_present
-            .iter()
-            .map(|&(ring, fill)| (key_for_ring(ring).0, fill))
-            .collect(),
-    });
+    );
 
-    // B always forwards: empty store, inert backend.
     let b_handle = start_recursive_node(
         &b,
         b_scratch,
@@ -1255,38 +1230,11 @@ fn recursive_chain(
         page_size,
         b_fingers,
         b_n2p,
-        b_store,
-        NullBackend::<RingReq>::new(),
+        empty_owners,
     );
-    // C owns the key; its backend depends on the scenario.
-    let c_handle = match owner {
-        OwnerBackend::Null => start_recursive_node(
-            &c,
-            c_scratch,
-            c_mr,
-            page_size,
-            c_fingers,
-            c_n2p,
-            c_store,
-            NullBackend::<RingReq>::new(),
-        ),
-        OwnerBackend::Fill(fill) => start_recursive_node(
-            &c,
-            c_scratch,
-            c_mr,
-            page_size,
-            c_fingers,
-            c_n2p,
-            c_store,
-            FillBackend {
-                base: c_base,
-                page_size,
-                fill,
-            },
-        ),
-    };
+    let c_handle = start_recursive_node(&c, c_scratch, c_mr, page_size, c_fingers, c_n2p, c_owners);
 
-    let transport = FabricTransport::<RingReq, _>::new(
+    let transport = FabricTransport::<StripeReq, _>::new(
         a.clone(),
         client_mr,
         StaticPeer { peer: PeerId(2) },
@@ -1294,24 +1242,22 @@ fn recursive_chain(
     )
     .expect("client FabricTransport::new failed after provider availability gate");
 
-    // Leak the client backing so it outlives the transport.
+    // Leak backings that outlive their direct owner in this test harness.
     Box::leak(Box::new(client_backing));
+    Box::leak(Box::new(owner_backing));
 
-    (transport, client_mr, page_size, b_handle, c_handle, a, b, c)
+    (
+        transport, client_mr, page_size, b_handle, c_handle, fetch_stub, a, b, c,
+    )
 }
 
-/// Issue the chain request for `CHAIN_TARGET_RING` against one client
-/// page and collect the stream results.
 fn run_chain_request(
-    transport: &FabricTransport<RingReq, StaticPeer>,
+    transport: &FabricTransport<StripeReq, StaticPeer>,
     page_size: usize,
     timeout: Duration,
 ) -> Vec<Result<PageRef, PoolError>> {
     let key = key_for_ring(CHAIN_TARGET_RING);
-    let req = RingReq {
-        key_bytes: key.0,
-        cache_id: Some(CHAIN_CACHE_ID.to_string()),
-    };
+    let req = StripeReq::new(key).with_cache_id(Some(CHAIN_CACHE_ID.to_string()));
     let dsts = vec![PageRef {
         page_idx: 0,
         offset: 0,
@@ -1329,13 +1275,13 @@ fn run_chain_request(
 }
 
 #[test]
-fn recursive_two_hop_owner_serves_from_store() {
+fn recursive_two_hop_owner_serves_from_fetch_channel() {
     if skip_ffi() {
         return;
     }
     let fill = 0xC7u8;
-    let (transport, client_mr, page_size, _bh, _ch, _a, _b, _c) =
-        recursive_chain(&[(CHAIN_TARGET_RING, fill)], OwnerBackend::Null);
+    let (transport, client_mr, page_size, _bh, _ch, _fetch, _a, _b, _c) =
+        recursive_chain(OwnerFetchResult::Page(fill));
 
     let results = run_chain_request(&transport, page_size, Duration::from_secs(30));
 
@@ -1345,9 +1291,6 @@ fn recursive_two_hop_owner_serves_from_store() {
         "unexpected stream error: {:?}",
         results[0]
     );
-
-    // The client page must hold C's store fill byte, proving the page
-    // traversed C -> B scratch -> A's MR over the live forward path.
     // SAFETY: client_mr.base is the live client mapping.
     unsafe {
         let byte = *(client_mr.base as *const u8);
@@ -1356,41 +1299,12 @@ fn recursive_two_hop_owner_serves_from_store() {
 }
 
 #[test]
-fn recursive_owner_miss_falls_through_to_backend() {
+fn recursive_owner_fetch_error_propagates() {
     if skip_ffi() {
         return;
     }
-    let fill = 0x3Bu8;
-    // C's store is empty for the key, so it falls through to the origin
-    // backend, which fills the page.
-    let (transport, client_mr, page_size, _bh, _ch, _a, _b, _c) =
-        recursive_chain(&[], OwnerBackend::Fill(fill));
-
-    let results = run_chain_request(&transport, page_size, Duration::from_secs(30));
-
-    assert_eq!(results.len(), 1, "expected one relayed page");
-    assert!(
-        results[0].is_ok(),
-        "unexpected stream error: {:?}",
-        results[0]
-    );
-
-    // SAFETY: client_mr.base is the live client mapping.
-    unsafe {
-        let byte = *(client_mr.base as *const u8);
-        assert_eq!(byte, fill, "client page not populated from origin backend");
-    }
-}
-
-#[test]
-fn recursive_owner_miss_null_backend_errors() {
-    if skip_ffi() {
-        return;
-    }
-    // C's store is empty and its origin backend is inert, so the miss
-    // surfaces as an error that propagates back through B to A.
-    let (transport, _client_mr, page_size, _bh, _ch, _a, _b, _c) =
-        recursive_chain(&[], OwnerBackend::Null);
+    let (transport, _client_mr, page_size, _bh, _ch, _fetch, _a, _b, _c) =
+        recursive_chain(OwnerFetchResult::Error("owner fetch failure"));
 
     let results = run_chain_request(&transport, page_size, Duration::from_secs(30));
 
@@ -1400,8 +1314,8 @@ fn recursive_owner_miss_null_backend_errors() {
     assert!(
         err_msg
             .as_deref()
-            .is_some_and(|m| m.contains("no backend configured")),
-        "expected owner-miss error to propagate up the chain, got {err_msg:?}",
+            .is_some_and(|m| m.contains("owner fetch failure")),
+        "expected owner-fetch error to propagate up the chain, got {err_msg:?}",
     );
 }
 

--- a/cmd/unbounded-storage/src/fabric_group.rs
+++ b/cmd/unbounded-storage/src/fabric_group.rs
@@ -21,15 +21,18 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use unbounded_storage::backend::{BackendRegistry, FixedRegion, OriginRing};
-use unbounded_storage::bufferpool::BlockStore;
 use unbounded_storage::config::{self, BackendSpec, RuntimePeer};
-use unbounded_storage::fabric::{self, ConnectionSpec, Fabric, PeerId, Provider, RpcServerHandle};
-use unbounded_storage::memory::{BackingKind, BackingRequest, HUGEPAGE_2MB, allocate};
-use unbounded_storage::p2p::{RecursiveHandler, RouteTableHandle, RouteTableSnapshot};
+use unbounded_storage::fabric::{
+    self, ConnectionSpec, Fabric, MrHandle, PeerId, Provider, RpcServerHandle,
+};
+use unbounded_storage::fanout::FetchChannel;
+use unbounded_storage::memory::{Backing, BackingKind, BackingRequest, HUGEPAGE_2MB, allocate};
+use unbounded_storage::p2p::{
+    OwnerShardSource, OwnerShardTable, RecursiveHandler, RouteTableHandle, RouteTableSnapshot,
+};
 use unbounded_storage::runtime::{Threading, WorkerIdx};
 use unbounded_storage::storage::StripeReq;
-use unbounded_storage::storage::disks::{CacheDirectorySet, ChainLocalStore};
+use unbounded_storage::storage::disks::CacheDirectorySet;
 use unbounded_storage::topology::{NicWorkerGroup, ServingShard};
 
 use crate::FabricStartup;
@@ -213,39 +216,54 @@ fn verbs_worker_for_device(
     (WorkerIdx(0), None)
 }
 
-/// A live fabric endpoint plus its shared RPC server and the
-/// reconcile-state for the shards mapped onto it.
+/// A shard phase-A publication needed by shared RPC workers.
+#[derive(Clone)]
+pub struct RpcShardPublish {
+    pub shard_index: usize,
+    pub fetch_channel: FetchChannel,
+    pub mr: MrHandle,
+    pub numa: Option<u16>,
+}
+
+/// A live fabric endpoint plus delayed RPC server state.
 ///
 /// Field order is drop order and mirrors the pre-lift per-shard teardown
 /// exactly: `rpc_server` drops first (it signals shutdown and joins its
-/// worker pool, releasing the `RecursiveHandler` it owns, which frees
-/// the scratch backing), then the registry and routing handle, then
-/// `fabric` last (closing every memory region registered against the
-/// domain: the shared scratch plus every assigned shard's data backing).
+/// worker pool), then scratch/routing, then `fabric` last (closing every
+/// memory region registered against the domain: the shared scratch plus
+/// every assigned shard's data backing).
 /// Closing the domain while a worker still touches it would be unsound,
 /// hence the order.
 ///
 /// The four teardown-ordered resources are type parameters defaulted to
 /// the production types, so the rest of the module refers to this as the
 /// plain `FabricUnit`. Bringing a real unit up needs a live libfabric
-/// domain, pinned backings, and RPC worker threads (what the smoke test
-/// covers), so the parameters exist solely so a unit test can substitute
-/// drop-logging stand-ins and lock this ordering hardware-free; see
+/// domain and pinned backings (what the smoke test covers), so the
+/// parameters exist solely so a unit test can substitute drop-logging
+/// stand-ins and lock this ordering hardware-free; see
 /// `fabric_unit_drops_resources_in_teardown_order`.
-struct FabricUnit<S = RpcServerHandle, Rg = BackendRegistry, Rt = RouteTableHandle, F = Arc<Fabric>>
-{
+struct FabricUnit<
+    S = Option<RpcServerHandle>,
+    Sc = Option<Backing>,
+    Rt = RouteTableHandle,
+    F = Arc<Fabric>,
+> {
     // Held only for its Drop: see the struct doc for the teardown order.
     #[allow(dead_code)]
     rpc_server: S,
-    handler_registry: Rg,
+    scratch: Sc,
     routes: Rt,
     fabric: F,
+    scratch_mr: MrHandle,
+    page_size: usize,
+    shards_assigned: Vec<usize>,
+    cache_directories: Arc<CacheDirectorySet>,
+    worker_idx: WorkerIdx,
     device_name: String,
     rdma: bool,
     self_addr: String,
     hca_numa: Option<u16>,
     applied_peers: HashMap<PeerId, ConnectionSpec>,
-    last_backends: HashMap<String, BackendSpec>,
 }
 
 /// The set of fabric endpoints serving a process, owning every shared
@@ -271,7 +289,7 @@ impl FabricGroup {
         plan: &FabricPlan,
         backing_kind: BackingKind,
         fabric_startup: &FabricStartup,
-        backend_specs: &[BackendSpec],
+        _backend_specs: &[BackendSpec],
         cache_directories: Arc<CacheDirectorySet>,
         routes: &RouteTableSnapshot,
         peers: &[RuntimePeer],
@@ -286,7 +304,6 @@ impl FabricGroup {
                 spec,
                 backing_kind,
                 fabric_startup,
-                backend_specs,
                 &cache_directories,
                 routes,
                 peers,
@@ -340,6 +357,69 @@ impl FabricGroup {
         }
     }
 
+    /// Start every shared RPC server after shards have published the
+    /// bufferpool MRs/fetch channels the owner path sources from.
+    pub fn start_rpc_servers(&mut self, shards: &[RpcShardPublish]) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+        for unit in &mut self.units {
+            if unit.rpc_server.is_some() {
+                continue;
+            }
+
+            let worker = unit.worker_idx.0;
+            let owner_entries: Vec<OwnerShardSource> = shards
+                .iter()
+                .filter(|shard| unit.shards_assigned.contains(&shard.shard_index))
+                .map(|shard| OwnerShardSource {
+                    shard_index: shard.shard_index,
+                    channel: shard.fetch_channel.clone(),
+                    mr: shard.mr,
+                    numa: shard.numa,
+                })
+                .collect();
+            let owners = OwnerShardTable::new(
+                owner_entries,
+                unit.cache_directories.clone(),
+                unit.page_size,
+            );
+            let Some(scratch) = unit.scratch.take() else {
+                errors.push(format!("worker={worker}: rpc scratch already consumed"));
+                continue;
+            };
+            let handler = match RecursiveHandler::with_routes(
+                scratch,
+                RPC_SCRATCH_PAGES,
+                unit.routes.clone(),
+                unit.fabric.clone(),
+                unit.scratch_mr,
+                unit.page_size,
+                owners,
+            ) {
+                Ok(handler) => Arc::new(handler),
+                Err(e) => {
+                    errors.push(format!(
+                        "worker={worker}: RecursiveHandler::with_routes: {e}"
+                    ));
+                    continue;
+                }
+            };
+            match unit.fabric.start_rpc_server::<StripeReq, _>(
+                handler,
+                Some(unit.scratch_mr),
+                unit.page_size,
+            ) {
+                Ok(server) => unit.rpc_server = Some(server),
+                Err(e) => errors.push(format!("worker={worker}: start_rpc_server: {e}")),
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
     /// Re-drive every endpoint's fabric connection table toward `peers`.
     /// Connections live at the fabric/address-vector level, so this runs
     /// once per endpoint rather than once per shard.
@@ -364,22 +444,9 @@ impl FabricGroup {
         }
     }
 
-    /// Re-drive every endpoint's RPC-side backend registry toward
-    /// `backends`. The shard-side transport registries are reconciled
-    /// separately in each shard's control drain.
-    pub fn reconcile_backends(&mut self, backends: &[BackendSpec]) {
-        for unit in &mut self.units {
-            let report = config::reconcile_backends(
-                &unit.handler_registry,
-                backends,
-                Some(&unit.last_backends),
-            );
-            unit.last_backends = report.applied;
-            for (id, err) in &report.failures {
-                eprintln!("fabric backend reconcile failed: id={id} err={err}");
-            }
-        }
-    }
+    /// RPC owner reads are served through shard bufferpools, whose
+    /// backend registries are reconciled by shard control broadcasts.
+    pub fn reconcile_backends(&mut self, _backends: &[BackendSpec]) {}
 }
 
 /// Bring up one fabric endpoint from its spec. Mirrors the pre-lift
@@ -392,7 +459,6 @@ fn build_unit(
     spec: &FabricUnitSpec,
     backing_kind: BackingKind,
     fabric_startup: &FabricStartup,
-    backend_specs: &[BackendSpec],
     cache_directories: &Arc<CacheDirectorySet>,
     routes: &RouteTableSnapshot,
     peers: &[RuntimePeer],
@@ -447,59 +513,11 @@ fn build_unit(
     })
     .map_err(|e| format!("worker={worker}: rpc scratch alloc: {e}"))?;
     let page_size = scratch.page_size;
-    let scratch_base = scratch.base;
     let scratch_mr = fabric
         .register_backing(&scratch, spec.numa)
         .map_err(|e| format!("worker={worker}: register rpc scratch: {e}"))?;
 
     let routes = RouteTableHandle::from_snapshot(routes.clone());
-
-    // The handler resolves disk reads into scratch pages, so it needs a
-    // `BlockStore` whose single registered backing IS the scratch
-    // region; it shares the same disk-channel directory as the shards'
-    // data-path stores but keeps page resolution unambiguous.
-    let rpc_store = ChainLocalStore::new(cache_directories.clone());
-    rpc_store
-        .register_pages(&scratch)
-        .map_err(|e| format!("worker={worker}: rpc scratch blockstore register: {e}"))?;
-
-    // The handler runs on a persistent RPC worker thread, so its origin
-    // backend must use a worker-local ring (not a shard ring another
-    // thread progresses) and memcpy origin bytes into the scratch
-    // region.
-    let handler_registry = BackendRegistry::new(
-        backend_specs,
-        OriginRing::WorkerLocal {
-            queue_depth: 256,
-            region: Some(FixedRegion {
-                base: scratch_base,
-                len: page_size * RPC_SCRATCH_PAGES as usize,
-            }),
-        },
-        page_size,
-        scratch_base,
-    )
-    .map_err(|e| format!("worker={worker}: build rpc backend registry: {e}"))?;
-
-    // `scratch` moves into the handler here; `scratch_mr` is a `Copy`
-    // value handle shared by copy between the handler's forwarding
-    // transport and the RPC server's `local_mr`.
-    let rpc_handler = Arc::new(
-        RecursiveHandler::with_routes(
-            rpc_store,
-            scratch,
-            RPC_SCRATCH_PAGES,
-            routes.clone(),
-            fabric.clone(),
-            scratch_mr,
-            page_size,
-            handler_registry.clone(),
-        )
-        .map_err(|e| format!("worker={worker}: RecursiveHandler::with_routes: {e}"))?,
-    );
-    let rpc_server = fabric
-        .start_rpc_server::<StripeReq, _>(rpc_handler, Some(scratch_mr), page_size)
-        .map_err(|e| format!("worker={worker}: start_rpc_server: {e}"))?;
 
     fabric.check_shared_domain_capacity(spec.expected_mr);
 
@@ -509,22 +527,22 @@ fn build_unit(
     // Seed the desired-peer set so the background reconnect thread can
     // retry any peer whose initial dial lost the startup race.
     fabric.set_desired_peers(desired_peers.clone());
-    let last_backends = backend_specs
-        .iter()
-        .map(|b| (b.name.clone(), b.clone()))
-        .collect();
 
     Ok(FabricUnit {
-        rpc_server,
-        handler_registry,
+        rpc_server: None,
+        scratch: Some(scratch),
         routes,
         fabric,
+        scratch_mr,
+        page_size,
+        shards_assigned: spec.shards_assigned.clone(),
+        cache_directories: cache_directories.clone(),
+        worker_idx: spec.worker_idx,
         device_name: spec.device_name.clone(),
         rdma: spec.provider == Provider::Verbs,
         self_addr,
         hca_numa: spec.numa,
         applied_peers,
-        last_backends,
     })
 }
 
@@ -801,7 +819,7 @@ mod tests {
         // A `FabricUnit`'s field order is its drop order, and that order
         // is the teardown contract: the RPC server (and the worker
         // threads it joins) must stop touching the domain before the
-        // fabric closes it, with the registry and route handle in
+        // fabric closes it, with scratch and the route handle in
         // between. Bringing a real unit up needs a live libfabric domain
         // (covered by the smoke test), so here we substitute drop-logging
         // tokens for the four hardware-bound resources. This binds to the
@@ -811,22 +829,32 @@ mod tests {
 
         let unit: FabricUnit<DropToken, DropToken, DropToken, DropToken> = FabricUnit {
             rpc_server: DropToken::new("rpc_server", &log),
-            handler_registry: DropToken::new("handler_registry", &log),
+            scratch: DropToken::new("scratch", &log),
             routes: DropToken::new("routes", &log),
             fabric: DropToken::new("fabric", &log),
+            scratch_mr: MrHandle {
+                mr: std::ptr::null_mut(),
+                remote_key: 0,
+                base: 0,
+                remote_base: 0,
+                len: 0,
+            },
+            page_size: 4096,
+            shards_assigned: Vec::new(),
+            cache_directories: CacheDirectorySet::new(),
+            worker_idx: WorkerIdx(0),
             device_name: "mlx5_0".to_string(),
             rdma: true,
             self_addr: "hex:01".to_string(),
             hca_numa: None,
             applied_peers: HashMap::new(),
-            last_backends: HashMap::new(),
         };
 
         drop(unit);
 
         assert_eq!(
             *log.borrow(),
-            vec!["rpc_server", "handler_registry", "routes", "fabric"],
+            vec!["rpc_server", "scratch", "routes", "fabric"],
         );
     }
 }

--- a/cmd/unbounded-storage/src/frontend/loadgen_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/loadgen_serve.rs
@@ -484,7 +484,7 @@ mod tests {
     use std::pin::Pin;
     use std::task::{RawWaker, RawWakerVTable, Waker};
 
-    use crate::bufferpool::{PageRef, Req};
+    use crate::bufferpool::Req;
     use crate::config::{HttpFrontendConfig, LoadgenFrontendConfig};
     use crate::p2p::{FingerTable, FingerTableConfig, NodeId, PeerEntry, RingId, TopologyTags};
 

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -20,7 +20,7 @@ use unbounded_storage::bufferpool::{Pool, PoolConfig, ShardDescriptor, StripeKey
 use unbounded_storage::config::{
     self, BackendSpec, Config, FrontendSpec, ResolvedFrontendBinding, frontend_spec,
 };
-use unbounded_storage::fabric::{self, Fabric, Provider};
+use unbounded_storage::fabric::{self, Fabric, MrHandle, Provider};
 use unbounded_storage::fanout::{
     FanoutPeer, FanoutTable, FetchChannel, FetchService, NumaShardTable,
 };
@@ -555,6 +555,7 @@ fn run_shard(
     ctrl_rx: mpsc::Receiver<config::ShardCommand>,
     peer_rx: mpsc::Receiver<Arc<Vec<PeerPublish>>>,
     phaseb_tx: mpsc::Sender<PhaseBReport>,
+    serve_start_rx: mpsc::Receiver<()>,
     layer_stop: Arc<AtomicBool>,
 ) {
     // The fabric endpoint is built and owned by the `FabricGroup` in the
@@ -658,13 +659,10 @@ fn run_shard(
     // Each request names its backend through the `OriginRef` the
     // frontend stamps, so the registry resolves the tier per fetch.
     //
-    // Two independent registries are needed (the pool transport and the
-    // RPC handler each own one) because they differ in which ring a
-    // cache-miss fetch drives (`OriginRing`) and which registered region
-    // origin bytes are copied into (`backing_base`). The pool transport
-    // runs on the shard thread and reuses the shard ring over the pool
-    // backing; the RPC handler serves on an ephemeral worker thread and
-    // must use a worker-local ring writing into the scratch backing.
+    // The registry runs on the shard thread, reuses the shard ring, and
+    // writes origin bytes into the pool backing. Recursive RPC owner
+    // serves go through this same pool/fetch-service path rather than a
+    // separate RPC-worker origin registry.
     log_backend_registry(widx, &backend_specs);
 
     // Route the pool's transport through the p2p finger table: a stripe
@@ -792,6 +790,7 @@ fn run_shard(
         publish: ShardPublish {
             backing_base: backing_base as usize,
             backing_len,
+            fabric_mr: mr,
             numa: shard.numa,
             fetch_channel,
             backing_keepalive,
@@ -1019,9 +1018,17 @@ fn run_shard(
         shard_loop.add_tick_hook(move || frontend_registry.progress());
     }
 
-    // PHASE B complete: peers registered, fan-out and frontend drivers
-    // built. Report readiness so the layer can finish bring-up.
+    // PHASE B complete: peers registered, fetch service installed, and
+    // frontend drivers built. Report readiness so the layer can start the
+    // shared recursive RPC servers, then wait until those handlers are
+    // installed before entering the shard loop. Without this barrier a
+    // loadgen/frontend tick can issue a remote read during the small
+    // window after phase-B reporting but before peer RPC handlers exist.
     phaseb_guard.report_ready();
+    match serve_start_rx.recv() {
+        Ok(()) => {}
+        Err(_) => return,
+    }
     metrics::shards_delta(1);
 
     // Drive the shard's cooperative future set until shutdown. The loop
@@ -1506,6 +1513,10 @@ enum ShardReady {
 struct ShardPublish {
     backing_base: usize,
     backing_len: usize,
+    /// Fabric memory region for this shard's pool backing. Shared RPC
+    /// workers use it to source owner responses directly from pinned
+    /// bufferpool pages.
+    fabric_mr: MrHandle,
     /// NUMA node this shard's cores and backing are pinned to (`None`
     /// when unpinned). Forwarded into [`PeerPublish`] so every shard can
     /// build its NUMA -> serving-shard table for NUMA-local fetch

--- a/cmd/unbounded-storage/src/p2p/handler.rs
+++ b/cmd/unbounded-storage/src/p2p/handler.rs
@@ -3,37 +3,17 @@
 
 //! Server-side recursive [`Handler`] for stripe reads.
 //!
-//! Where [`crate::fabric::PoolHandler`] serves only locally-resident
-//! pages and reports a miss otherwise, this handler *resolves* every
-//! request: it either owns the stripe (serve from the local
-//! [`BlockStore`], falling back to the topology-unaware origin
-//! [`Backend`] on a miss) or it is an intermediate hop (forward to the
-//! next hop over the fabric, landing the downstream page directly in
-//! this node's scratch via RDMA, then relay it upstream).
+//! The handler resolves Chord-routed peer requests. When this node owns
+//! the stripe, bytes are served from the shard-local bufferpool through
+//! [`crate::fanout::FetchService`]: the owner shard keeps the actual
+//! [`crate::bufferpool::PageGuard`] pinned, while the RPC worker receives
+//! only a registered-memory location and a drop-owned release token. This
+//! preserves zero-copy semantics and keeps the bufferpool cache as the
+//! only owner-side page cache.
 //!
-//! # Routing
-//!
-//! On each request the handler computes `stripe_to_ring(key)` and asks
-//! its [`FingerTable`] for the next hop:
-//!
-//! * `next_hop == None` - this node owns the stripe. Read it from the
-//!   local store; on a miss, fetch from the origin `Backend`.
-//! * `next_hop == Some(_)` and `hops_remaining > 0` - forward to the
-//!   next hop with a decremented TTL via the scratch-bound
-//!   [`FabricTransport`]. The downstream hop RDMA-writes its page into
-//!   this node's scratch page; the handler then yields that page so
-//!   the RPC layer relays it to the original requester.
-//! * `next_hop == Some(_)` and `hops_remaining == 0` - the hop budget
-//!   is exhausted; surface [`RecursiveHandlerError::HopLimitExceeded`].
-//!
-//! # Scratch backing
-//!
-//! Like [`crate::fabric::PoolHandler`], this handler owns a dedicated
-//! scratch [`Backing`] registered as its own fabric MR and as a
-//! [`BlockStore`] extra buffer. A shared scratch allocator hands out
-//! one zeroed scratch page per in-flight request; the page is reclaimed
-//! when the response stream drops, after the RPC layer has finished
-//! `fi_write`ing it to the peer.
+//! Forwarding still uses a dedicated scratch backing: an intermediate hop
+//! asks the next hop to RDMA-write into scratch, then relays that scratch
+//! page upstream.
 
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -43,16 +23,102 @@ use std::task::{Context, Poll};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use crate::backend::Backend;
-use crate::bufferpool::{BlockStore, BulkRef, PageRef, PageStream, Req, StripeKey};
-use crate::fabric::Result as FabResult;
+use crate::bufferpool::{BulkRef, Error as PoolError, PageRef, PageStream, Req, StripeKey};
 use crate::fabric::scratch::ScratchBacking;
-use crate::fabric::{Fabric, FabricTransport, Handler, HandlerStream, MrHandle, PeerId};
+use crate::fabric::{
+    Fabric, FabricPage, FabricTransport, Handler, HandlerStream, MrHandle, PeerId,
+};
+use crate::fanout::{FetchChannel, FetchEvent, FetchStream};
 use crate::memory::Backing;
 use crate::p2p::{
     ChainFingerRouter, FingerTable, NodeId, RingId, RouteTableHandle, RoutingHandle, stripe_to_ring,
 };
 use crate::runtime::{block_on_cooperative, noop_waker};
+use crate::storage::disks::CacheDirectorySet;
+use crate::storage::{StripeReq, disk_for};
+
+/// One local shard whose bufferpool backing may be used as an owner-side
+/// source for recursive RPC responses.
+#[derive(Clone)]
+pub struct OwnerShardSource {
+    pub shard_index: usize,
+    pub channel: FetchChannel,
+    pub mr: MrHandle,
+    pub numa: Option<u16>,
+}
+
+/// Owner-shard selector for one fabric unit.
+///
+/// The table is intentionally scoped to the shards assigned to the same
+/// fabric unit, so the RPC worker only sources memory regions registered
+/// with its own libfabric domain.
+#[derive(Clone)]
+pub struct OwnerShardTable {
+    entries: Arc<Vec<OwnerShardSource>>,
+    cache_directories: Arc<CacheDirectorySet>,
+    page_size: usize,
+}
+
+impl OwnerShardTable {
+    pub fn new(
+        entries: Vec<OwnerShardSource>,
+        cache_directories: Arc<CacheDirectorySet>,
+        page_size: usize,
+    ) -> Self {
+        Self {
+            entries: Arc::new(entries),
+            cache_directories,
+            page_size,
+        }
+    }
+
+    fn pick(&self, req: &StripeReq, src: BulkRef) -> Option<OwnerShardSource> {
+        let entries = self.entries.as_slice();
+        if entries.is_empty() {
+            return None;
+        }
+
+        let drive_numa = self.cache_directories.drive_numa(req.cache_id());
+        let target_numa = if drive_numa.is_empty() {
+            None
+        } else {
+            drive_numa
+                .get(disk_for(&req.key(), src.offset, drive_numa.len()))
+                .copied()
+                .flatten()
+        };
+
+        if let Some(numa) = target_numa {
+            let matches = entries
+                .iter()
+                .filter(|entry| entry.numa == Some(numa))
+                .count();
+            if matches > 0 {
+                let want = (shard_hash(req.key(), src.offset) as usize) % matches;
+                return entries
+                    .iter()
+                    .filter(|entry| entry.numa == Some(numa))
+                    .nth(want)
+                    .cloned();
+            }
+        }
+
+        let idx = (shard_hash(req.key(), src.offset) as usize) % entries.len();
+        entries.get(idx).cloned()
+    }
+
+    fn page_size(&self) -> usize {
+        self.page_size
+    }
+}
+
+fn shard_hash(key: StripeKey, stripe_off: u64) -> u64 {
+    let mut first = [0u8; 8];
+    let mut second = [0u8; 8];
+    first.copy_from_slice(&key.0[..8]);
+    second.copy_from_slice(&key.0[8..16]);
+    u64::from_le_bytes(first) ^ u64::from_le_bytes(second).rotate_left(17) ^ stripe_off
+}
 
 /// Error surfaced by [`RecursiveHandler`]'s response stream.
 #[derive(Debug)]
@@ -64,27 +130,24 @@ pub enum RecursiveHandlerError {
     /// This node is an intermediate hop but the request's hop budget
     /// is exhausted. The recursion is cut short to bound forwarding.
     HopLimitExceeded,
-    /// The local [`BlockStore::read_page`] returned an error.
-    BlockStore(crate::bufferpool::Error),
-    /// The origin [`Backend`] (consulted on an owner-side miss)
-    /// returned an error.
-    Backend(crate::bufferpool::Error),
-    /// Forwarding to the next hop over the fabric failed (downstream
-    /// server error or fabric transport error).
-    Forward(crate::bufferpool::Error),
+    /// This fabric unit has no local shard from which it may source an
+    /// owner response.
+    NoOwnerShard,
+    /// The owner shard's bufferpool/fetch service failed.
+    OwnerFetch(PoolError),
+    /// Forwarding to the next hop over the fabric failed.
+    Forward(PoolError),
 }
 
 impl std::fmt::Display for RecursiveHandlerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RecursiveHandlerError::NoScratchPage => {
-                write!(f, "no scratch page available")
-            }
+            RecursiveHandlerError::NoScratchPage => write!(f, "no scratch page available"),
             RecursiveHandlerError::HopLimitExceeded => {
                 write!(f, "recursive forward hop limit exceeded")
             }
-            RecursiveHandlerError::BlockStore(e) => write!(f, "block store: {e}"),
-            RecursiveHandlerError::Backend(e) => write!(f, "origin backend: {e}"),
+            RecursiveHandlerError::NoOwnerShard => write!(f, "no local owner shard available"),
+            RecursiveHandlerError::OwnerFetch(e) => write!(f, "owner fetch: {e}"),
             RecursiveHandlerError::Forward(e) => write!(f, "forward to next hop: {e}"),
         }
     }
@@ -93,58 +156,27 @@ impl std::fmt::Display for RecursiveHandlerError {
 impl std::error::Error for RecursiveHandlerError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            RecursiveHandlerError::BlockStore(e)
-            | RecursiveHandlerError::Backend(e)
-            | RecursiveHandlerError::Forward(e) => Some(e),
-            RecursiveHandlerError::NoScratchPage | RecursiveHandlerError::HopLimitExceeded => None,
+            RecursiveHandlerError::OwnerFetch(e) | RecursiveHandlerError::Forward(e) => Some(e),
+            RecursiveHandlerError::NoScratchPage
+            | RecursiveHandlerError::HopLimitExceeded
+            | RecursiveHandlerError::NoOwnerShard => None,
         }
     }
 }
 
 /// Recursive handler resolving stripe reads by routing through the
 /// finger table.
-///
-/// `S` is the shard's [`BlockStore`]; `B` is the topology-unaware
-/// origin [`Backend`]. Both must be `Send + Sync` because the handler
-/// runs on RPC worker threads. `forward` is a client transport bound
-/// to the scratch MR, used to forward to the next hop and land the
-/// downstream page directly in scratch.
-pub struct RecursiveHandler<S, B>
-where
-    S: BlockStore + Send + Sync + 'static,
-    B: Backend,
-{
-    store: Arc<S>,
+pub struct RecursiveHandler {
     scratch: Arc<ScratchBacking>,
     routes: RouteTableHandle,
-    forward: FabricTransport<B::Req, ChainFingerRouter>,
-    backend: B,
+    forward: FabricTransport<StripeReq, ChainFingerRouter>,
+    owners: OwnerShardTable,
 }
 
-impl<S, B> RecursiveHandler<S, B>
-where
-    S: BlockStore + Send + Sync + 'static,
-    B: Backend + 'static,
-    B::Req: Req + Serialize + DeserializeOwned + 'static,
-{
+impl RecursiveHandler {
     /// Build a recursive handler over a freshly-seeded routing surface.
-    ///
-    /// `scratch` is the dedicated backing whose pages are filled and
-    /// yielded; `scratch_mr` MUST be the same backing registered as
-    /// the forward transport's destination MR (so downstream
-    /// `fi_write`s land in scratch) and as a [`BlockStore`] extra
-    /// buffer (so the local disk read can DMA into it). `scratch_pages`
-    /// caps concurrent checkouts and must be `<= scratch.page_count`.
-    ///
-    /// The chosen signature threads the scratch backing, its MR, and
-    /// the page geometry separately because the backing (CPU view) and
-    /// the MR handle (NIC view) are distinct objects the embedder
-    /// registers out-of-band, mirroring `PoolHandler::new` plus
-    /// `FabricTransport::new`. Use [`Self::with_routing`] to share a
-    /// [`RoutingHandle`] with other consumers for live reload.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        store: Arc<S>,
         scratch: Backing,
         scratch_pages: u32,
         fingers: Arc<FingerTable>,
@@ -152,8 +184,8 @@ where
         fabric: Arc<Fabric>,
         scratch_mr: MrHandle,
         page_size: usize,
-        backend: B,
-    ) -> FabResult<Self> {
+        owners: OwnerShardTable,
+    ) -> crate::fabric::Result<Self> {
         let mut routes = HashMap::new();
         routes.insert(
             RouteTableHandle::LEGACY_ROUTE_ID.to_string(),
@@ -163,33 +195,27 @@ where
             },
         );
         Self::with_routes(
-            store,
             scratch,
             scratch_pages,
             RouteTableHandle::new(routes),
             fabric,
             scratch_mr,
             page_size,
-            backend,
+            owners,
         )
     }
 
     /// Build a recursive handler that shares `routing` with other
-    /// consumers. The forwarding `FabricTransport` is built with a
-    /// `FingerRouter` over a clone of the same handle, so a republish
-    /// through any clone reloads this handler's classify and forward
-    /// paths together.
-    #[allow(clippy::too_many_arguments)]
+    /// consumers.
     pub fn with_routing(
-        store: Arc<S>,
         scratch: Backing,
         scratch_pages: u32,
         routing: RoutingHandle,
         fabric: Arc<Fabric>,
         scratch_mr: MrHandle,
         page_size: usize,
-        backend: B,
-    ) -> FabResult<Self> {
+        owners: OwnerShardTable,
+    ) -> crate::fabric::Result<Self> {
         let snap = routing.snapshot();
         let mut routes = HashMap::new();
         routes.insert(
@@ -200,85 +226,79 @@ where
             },
         );
         Self::with_routes(
-            store,
             scratch,
             scratch_pages,
             RouteTableHandle::new(routes),
             fabric,
             scratch_mr,
             page_size,
-            backend,
+            owners,
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
+    /// Build a recursive handler over an existing route table.
     pub fn with_routes(
-        store: Arc<S>,
         scratch: Backing,
         scratch_pages: u32,
         routes: RouteTableHandle,
         fabric: Arc<Fabric>,
         scratch_mr: MrHandle,
         page_size: usize,
-        backend: B,
-    ) -> FabResult<Self> {
+        owners: OwnerShardTable,
+    ) -> crate::fabric::Result<Self> {
         let scratch = Arc::new(ScratchBacking::new(scratch, scratch_pages));
         let router = ChainFingerRouter::new(routes.clone());
         let forward = FabricTransport::new(fabric, scratch_mr, router, page_size)?;
         Ok(Self {
-            store,
             scratch,
             routes,
             forward,
-            backend,
+            owners,
         })
     }
 }
 
-impl<R, S, B> Handler<R> for RecursiveHandler<S, B>
-where
-    R: Req + Serialize + DeserializeOwned + Send + Sync + 'static,
-    S: BlockStore + Send + Sync + 'static,
-    B: Backend<Req = R> + 'static,
-{
+impl Handler<StripeReq> for RecursiveHandler {
     type Error = RecursiveHandlerError;
     type Stream<'a>
-        = RecursiveHandlerStream<'a, R, S, B>
+        = RecursiveHandlerStream<'a>
     where
-        Self: 'a,
-        R: 'a;
+        Self: 'a;
 
-    fn handle<'a>(&'a self, req: &'a R, src: BulkRef, hops_remaining: u32) -> Self::Stream<'a> {
+    fn handle<'a>(
+        &'a self,
+        req: &'a StripeReq,
+        src: BulkRef,
+        hops_remaining: u32,
+    ) -> Self::Stream<'a> {
         RecursiveHandlerStream {
-            store: self.store.clone(),
             scratch: self.scratch.clone(),
             fingers: self.routes.route_for_req(req).map(|route| route.fingers),
             forward: &self.forward,
-            backend: &self.backend,
+            owners: &self.owners,
             req,
+            owned_req: req.clone(),
             key: req.key(),
             src,
             hops_remaining,
             state: StreamState::Pending,
             page_idx: None,
+            owner_stream: None,
         }
     }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum StreamState {
-    /// Have not yet attempted to resolve the request.
     Pending,
-    /// Yielded the page; the next poll ends the stream.
     Done,
-    /// Already ended (page yielded or error emitted).
     Ended,
 }
 
 /// Where a request resolves on this node.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 enum Route {
-    /// This node owns the stripe; serve from store/backend.
+    /// This node owns the stripe; serve from a local shard bufferpool.
     Owner,
     /// This node is an intermediate hop; forward downstream.
     Forward,
@@ -298,40 +318,31 @@ fn classify(fingers: &FingerTable, target: RingId, hops_remaining: u32) -> Route
 }
 
 /// Response stream for one request. Resolves on first poll, yields
-/// exactly one page on success then ends, or yields the error then
-/// ends. The scratch page (if reserved) is returned to the allocator
-/// on drop, which happens after the RPC layer has finished
-/// `fi_write`ing it to the peer.
-pub struct RecursiveHandlerStream<'a, R, S, B>
-where
-    S: BlockStore + Send + Sync + 'static,
-    B: Backend<Req = R>,
-{
-    store: Arc<S>,
+/// exactly one page on success then ends, or yields the error then ends.
+pub struct RecursiveHandlerStream<'a> {
     scratch: Arc<ScratchBacking>,
     fingers: Option<Arc<FingerTable>>,
-    forward: &'a FabricTransport<R, ChainFingerRouter>,
-    backend: &'a B,
-    req: &'a R,
+    forward: &'a FabricTransport<StripeReq, ChainFingerRouter>,
+    owners: &'a OwnerShardTable,
+    req: &'a StripeReq,
+    owned_req: StripeReq,
     key: StripeKey,
     src: BulkRef,
     hops_remaining: u32,
     state: StreamState,
     page_idx: Option<u32>,
+    owner_stream: Option<FetchStream>,
 }
 
-impl<'a, R, S, B> HandlerStream for RecursiveHandlerStream<'a, R, S, B>
-where
-    R: Req + Serialize + DeserializeOwned + Send + Sync + 'static,
-    S: BlockStore + Send + Sync + 'static,
-    B: Backend<Req = R>,
-{
+impl Unpin for RecursiveHandlerStream<'_> {}
+
+impl HandlerStream for RecursiveHandlerStream<'_> {
     type Error = RecursiveHandlerError;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<PageRef, RecursiveHandlerError>>> {
+    ) -> Poll<Option<Result<FabricPage, RecursiveHandlerError>>> {
         match self.state {
             StreamState::Done | StreamState::Ended => {
                 self.state = StreamState::Ended;
@@ -351,20 +362,8 @@ where
     }
 }
 
-impl<'a, R, S, B> RecursiveHandlerStream<'a, R, S, B>
-where
-    R: Req + Serialize + DeserializeOwned + Send + Sync + 'static,
-    S: BlockStore + Send + Sync + 'static,
-    B: Backend<Req = R>,
-{
-    /// Resolve the request: own it (store/backend) or forward it.
-    /// Reserves one scratch page for the data-bearing paths and
-    /// records it in `page_idx` so `Drop` reclaims it. The inner async
-    /// work (`read_page`, the backend stream, the forward stream) is
-    /// driven to completion within this call so the stream holds no
-    /// future and is trivially `Send`; blocking here is acceptable
-    /// because RPC worker threads are separate from shard threads.
-    fn serve(&mut self) -> Result<PageRef, RecursiveHandlerError> {
+impl RecursiveHandlerStream<'_> {
+    fn serve(&mut self) -> Result<FabricPage, RecursiveHandlerError> {
         let page_size = self.scratch.page_size();
         if self.req.fabric_only() {
             crate::metrics::p2p_request(crate::metrics::Disposition::Local);
@@ -372,7 +371,7 @@ where
             let (idx, page) = serve_synthetic_page(&self.scratch, self.src, page_size)?;
             self.page_idx = Some(idx);
 
-            return Ok(page);
+            return Ok(page.into());
         }
 
         let target = stripe_to_ring(self.key);
@@ -388,14 +387,7 @@ where
             }
             Route::Owner => {
                 crate::metrics::p2p_request(crate::metrics::Disposition::Local);
-                let idx = self
-                    .scratch
-                    .take_zeroed()
-                    .ok_or(RecursiveHandlerError::NoScratchPage)?;
-                self.page_idx = Some(idx);
-                let dst = scratch_page(idx, page_size);
-                serve_owned(&self.store, self.backend, self.req, self.src, dst)?;
-                Ok(self.clamped_page(idx, page_size))
+                self.serve_owner()
             }
             Route::Forward => {
                 crate::metrics::p2p_request(crate::metrics::Disposition::Forward);
@@ -414,15 +406,59 @@ where
                     page_size,
                     dst,
                 )?;
-                Ok(self.clamped_page(idx, page_size))
+                Ok(self.clamped_page(idx, page_size).into())
             }
         }
     }
 
-    /// The yielded page, clamped to the requested intra-stripe window.
-    /// `BulkRef.len` is bounded by `page_size`; clamp defensively so a
-    /// malformed request can never make the RPC layer read past the
-    /// page.
+    fn serve_owner(&mut self) -> Result<FabricPage, RecursiveHandlerError> {
+        let owner = self
+            .owners
+            .pick(self.req, self.src)
+            .ok_or(RecursiveHandlerError::NoOwnerShard)?;
+        let mut stream = owner
+            .channel
+            .fetch(self.owned_req.clone(), self.src.offset, self.src.len as u64)
+            .map_err(RecursiveHandlerError::OwnerFetch)?;
+        let event =
+            block_on_local(stream.next_event()).map_err(RecursiveHandlerError::OwnerFetch)?;
+        let page = match event {
+            FetchEvent::Page(page) => page,
+            FetchEvent::Done => {
+                return Err(RecursiveHandlerError::OwnerFetch(PoolError::from(
+                    "owner fetch ended without a page",
+                )));
+            }
+        };
+
+        let hold = stream.pin_release_hold(page.pin_token);
+        let token = hold.token();
+        hold.close();
+
+        let byte_offset = page.loc.page_byte_offset as usize;
+        let page_size = self.owners.page_size();
+        let page_idx = u32::try_from(byte_offset / page_size)
+            .map_err(|_| RecursiveHandlerError::OwnerFetch(PoolError::PageOutOfRange))?;
+        let offset = u32::try_from(byte_offset % page_size)
+            .map_err(|_| RecursiveHandlerError::OwnerFetch(PoolError::OffsetOutOfRange))?;
+        let len = page.loc.len.min(self.src.len);
+
+        let page = FabricPage::registered(
+            PageRef {
+                page_idx,
+                offset,
+                len,
+            },
+            owner.mr,
+            Some(Box::new(token)),
+        );
+
+        self.owner_stream = Some(stream);
+
+        Ok(page)
+    }
+
+    /// The yielded scratch page, clamped to the requested intra-stripe window.
     fn clamped_page(&self, idx: u32, page_size: usize) -> PageRef {
         let len = (self.src.len as usize).min(page_size) as u32;
         PageRef {
@@ -433,11 +469,7 @@ where
     }
 }
 
-impl<'a, R, S, B> Drop for RecursiveHandlerStream<'a, R, S, B>
-where
-    S: BlockStore + Send + Sync + 'static,
-    B: Backend<Req = R>,
-{
+impl Drop for RecursiveHandlerStream<'_> {
     fn drop(&mut self) {
         if let Some(idx) = self.page_idx.take() {
             self.scratch.give(idx);
@@ -477,41 +509,8 @@ fn serve_synthetic_page(
     ))
 }
 
-/// Owner path: read the page from the local store, falling back to the
-/// origin backend on a miss. The page lands in `dst` (a scratch page).
-/// Factored out as a free function so it can be unit-tested without a
-/// live fabric (it never touches `forward`).
-fn serve_owned<R, S, B>(
-    store: &Arc<S>,
-    backend: &B,
-    req: &R,
-    src: BulkRef,
-    dst: PageRef,
-) -> Result<(), RecursiveHandlerError>
-where
-    R: Req,
-    S: BlockStore + Send + Sync + 'static,
-    B: Backend<Req = R>,
-{
-    let hit = block_on_local(store.read_page(req, src.offset, dst))
-        .map_err(RecursiveHandlerError::BlockStore)?;
-    if hit {
-        return Ok(());
-    }
-    let stream = backend.bulk_get(req, src, std::slice::from_ref(&dst));
-    drive_page_stream(stream).map_err(RecursiveHandlerError::Backend)
-}
-
 /// Forward path: hand the request to the next hop with TTL `ttl`,
 /// landing the downstream page in scratch slot `dst_idx` via RDMA.
-///
-/// The downstream hop RMA-writes the single response page at
-/// `dest_mr_base + ordinal * page_size`; since this relay reserved
-/// scratch slot `dst_idx` and later reads that exact slot back to
-/// relay upstream, the forward must shift the destination base by
-/// `dst_idx * page_size`. Passing only the full-page `dst` (ordinal 0)
-/// would land the page in slot 0 and the relay would ship stale bytes
-/// from slot `dst_idx`.
 fn serve_forward<R>(
     forward: &FabricTransport<R, ChainFingerRouter>,
     req: &R,
@@ -529,11 +528,10 @@ where
     drive_page_stream(stream).map_err(RecursiveHandlerError::Forward)
 }
 
-/// Drive a [`PageStream`] to completion with a noop waker on the
-/// current thread, returning the first error if any. Page payloads
-/// land in the caller-provided `dst` via the stream's side effects, so
-/// the yielded `PageRef`s themselves are not inspected here.
-fn drive_page_stream<P: PageStream>(stream: P) -> Result<(), crate::bufferpool::Error> {
+/// Drive a [`PageStream`] to completion with a noop waker on the current
+/// thread. Page payloads land in the caller-provided `dst` via stream
+/// side effects, so yielded [`PageRef`]s are not inspected here.
+fn drive_page_stream<P: PageStream>(stream: P) -> Result<(), PoolError> {
     let mut stream = std::pin::pin!(stream);
     let waker = noop_waker();
     let mut cx = Context::from_waker(&waker);
@@ -547,10 +545,6 @@ fn drive_page_stream<P: PageStream>(stream: P) -> Result<(), crate::bufferpool::
     }
 }
 
-/// Drive a non-`Send`-bounded future to completion on the current
-/// thread with a noop waker. Mirrors [`crate::fabric::PoolHandler`]'s
-/// spin-poller; the underlying disk I/O makes progress on its own
-/// io_uring threads while this spins.
 fn block_on_local<F: std::future::Future>(fut: F) -> F::Output {
     block_on_cooperative(fut, || {
         std::thread::sleep(std::time::Duration::from_micros(50))
@@ -560,127 +554,10 @@ fn block_on_local<F: std::future::Future>(fut: F) -> F::Output {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::NullBackend;
-    use crate::bufferpool::Error;
     use crate::p2p::{FingerTableConfig, PeerEntry, TopologyTags, node_to_ring};
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     const PAGE: usize = 4096;
-    const SCRATCH_PAGES: usize = 2;
-
-    struct TestReq(StripeKey);
-
-    impl Req for TestReq {
-        fn key(&self) -> StripeKey {
-            self.0
-        }
-    }
-
-    /// In-memory `BlockStore` mock: holds page bytes keyed by stripe.
-    /// `read_page` copies the recorded fill byte into the destination
-    /// scratch page when present (`Ok(true)`); otherwise returns a
-    /// miss (`Ok(false)`) or, for a poisoned key, an error.
-    struct MemStore {
-        base: *mut u8,
-        page_size: usize,
-        present: std::collections::HashMap<[u8; 32], u8>,
-        poison: std::collections::HashSet<[u8; 32]>,
-        reads: AtomicUsize,
-    }
-
-    // SAFETY: the test drives the mock from a single thread; the raw
-    // base pointer refers to a leaked heap allocation that outlives
-    // the test.
-    unsafe impl Send for MemStore {}
-    unsafe impl Sync for MemStore {}
-
-    impl BlockStore for MemStore {
-        fn register_pages(&self, _backing: &Backing) -> Result<(), Error> {
-            Ok(())
-        }
-
-        async fn read_page<R: Req + ?Sized>(
-            &self,
-            req: &R,
-            _stripe_off: u64,
-            dst: PageRef,
-        ) -> Result<bool, Error> {
-            let key = req.key();
-            self.reads.fetch_add(1, Ordering::Relaxed);
-            if self.poison.contains(&key.0) {
-                return Err(Error::Io(libc::EIO));
-            }
-            match self.present.get(&key.0) {
-                Some(&fill) => {
-                    // SAFETY: dst.page_idx is within the backing the
-                    // test allocated.
-                    unsafe {
-                        let p = self.base.add(dst.page_idx as usize * self.page_size);
-                        std::ptr::write_bytes(p, fill, self.page_size);
-                    }
-                    Ok(true)
-                }
-                None => Ok(false),
-            }
-        }
-
-        async fn write_page<R: Req + ?Sized>(
-            &self,
-            _req: &R,
-            _stripe_off: u64,
-            _page: PageRef,
-        ) -> Result<(), Error> {
-            Ok(())
-        }
-    }
-
-    /// Origin backend that fills the destination page with a known
-    /// byte then yields it once, mimicking a real origin fetch.
-    struct FillBackend {
-        base: *mut u8,
-        page_size: usize,
-        fill: u8,
-    }
-
-    // SAFETY: single-threaded test; base outlives the test.
-    unsafe impl Send for FillBackend {}
-    unsafe impl Sync for FillBackend {}
-
-    struct FillStream {
-        page: Option<PageRef>,
-    }
-
-    impl PageStream for FillStream {
-        fn poll_next(
-            mut self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Option<Result<PageRef, Error>>> {
-            match self.page.take() {
-                Some(p) => Poll::Ready(Some(Ok(p))),
-                None => Poll::Ready(None),
-            }
-        }
-    }
-
-    impl Backend for FillBackend {
-        type Req = TestReq;
-        type Stream<'a> = FillStream;
-
-        fn bulk_get<'a>(
-            &'a self,
-            _req: &'a Self::Req,
-            _src: BulkRef,
-            dsts: &'a [PageRef],
-        ) -> Self::Stream<'a> {
-            let dst = dsts[0];
-            // SAFETY: dst.page_idx is within the test backing.
-            unsafe {
-                let p = self.base.add(dst.page_idx as usize * self.page_size);
-                std::ptr::write_bytes(p, self.fill, self.page_size);
-            }
-            FillStream { page: Some(dst) }
-        }
-    }
+    const SCRATCH_PAGES: usize = 4;
 
     fn scratch_backing() -> (Backing, *mut u8) {
         let buf = vec![0u8; PAGE * SCRATCH_PAGES].into_boxed_slice();
@@ -692,21 +569,6 @@ mod tests {
             keepalive: std::sync::Arc::new(()),
         };
         (backing, base)
-    }
-
-    fn mem_store(base: *mut u8, present: &[([u8; 32], u8)], poison: &[[u8; 32]]) -> Arc<MemStore> {
-        Arc::new(MemStore {
-            base,
-            page_size: PAGE,
-            present: present.iter().copied().collect(),
-            poison: poison.iter().copied().collect(),
-            reads: AtomicUsize::new(0),
-        })
-    }
-
-    fn page_byte(base: *mut u8, idx: u32) -> u8 {
-        // SAFETY: idx is within the test backing.
-        unsafe { *base.add(idx as usize * PAGE) }
     }
 
     fn peer(node: u64) -> PeerEntry {
@@ -730,8 +592,6 @@ mod tests {
             len: PAGE as u32,
         }
     }
-
-    // --- classify (routing decision, no fabric) ---
 
     #[test]
     fn classify_single_node_owns_everything() {
@@ -773,73 +633,55 @@ mod tests {
         assert_eq!(classify(&fingers, target, 0), Route::HopLimit);
     }
 
-    // --- serve_owned (owner path, no fabric) ---
-
     #[test]
-    fn owner_resident_stripe_yields_store_page() {
-        let (_backing, base) = scratch_backing();
-        let key = key_for_ring(42);
-        let store = mem_store(base, &[(key.0, 0xAB)], &[]);
-        let backend = NullBackend::<TestReq>::new();
-        let req = TestReq(key);
-        let dst = scratch_page(0, PAGE);
-
-        serve_owned(&store, &backend, &req, src_for(key), dst).expect("resident read must succeed");
-        assert_eq!(page_byte(base, 0), 0xAB, "store did not fill the page");
-        assert_eq!(store.reads.load(Ordering::Relaxed), 1);
-    }
-
-    #[test]
-    fn owner_miss_falls_back_to_backend_fill() {
-        let (_backing, base) = scratch_backing();
-        let key = key_for_ring(7);
-        // store has no entry -> read_page returns Ok(false) (miss).
-        let store = mem_store(base, &[], &[]);
-        let backend = FillBackend {
-            base,
-            page_size: PAGE,
-            fill: 0xCD,
+    fn owner_table_prefers_drive_numa_within_unit() {
+        let (ch0, _rx0) = FetchChannel::new();
+        let (ch1, _rx1) = FetchChannel::new();
+        let mr = MrHandle {
+            mr: std::ptr::null_mut(),
+            remote_key: 0,
+            base: 0,
+            remote_base: 0,
+            len: PAGE,
         };
-        let req = TestReq(key);
-        let dst = scratch_page(1, PAGE);
+        let directories = CacheDirectorySet::new();
+        directories.apply_channels(
+            "cache-a",
+            vec![(
+                std::path::PathBuf::from("/a"),
+                dummy_page_channel(),
+                Some(1),
+                true,
+            )],
+        );
+        let table = OwnerShardTable::new(
+            vec![
+                OwnerShardSource {
+                    shard_index: 0,
+                    channel: ch0,
+                    mr,
+                    numa: Some(0),
+                },
+                OwnerShardSource {
+                    shard_index: 1,
+                    channel: ch1,
+                    mr,
+                    numa: Some(1),
+                },
+            ],
+            directories,
+            PAGE,
+        );
+        let key = key_for_ring(7);
+        let req = StripeReq::new(key).with_cache_id(Some("cache-a".to_string()));
 
-        serve_owned(&store, &backend, &req, src_for(key), dst)
-            .expect("backend fallback must succeed");
-        assert_eq!(page_byte(base, 1), 0xCD, "backend did not fill the page");
+        let picked = table.pick(&req, src_for(key)).expect("owner shard");
+
+        assert_eq!(picked.shard_index, 1);
     }
 
     #[test]
-    fn owner_miss_with_null_backend_errors() {
-        let (_backing, base) = scratch_backing();
-        let key = key_for_ring(9);
-        let store = mem_store(base, &[], &[]);
-        let backend = NullBackend::<TestReq>::new();
-        let req = TestReq(key);
-        let dst = scratch_page(0, PAGE);
-
-        match serve_owned(&store, &backend, &req, src_for(key), dst) {
-            Err(RecursiveHandlerError::Backend(_)) => {}
-            other => panic!("expected Backend error, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn owner_block_store_error_propagates() {
-        let (_backing, base) = scratch_backing();
-        let key = key_for_ring(3);
-        let store = mem_store(base, &[], &[key.0]);
-        let backend = NullBackend::<TestReq>::new();
-        let req = TestReq(key);
-        let dst = scratch_page(0, PAGE);
-
-        match serve_owned(&store, &backend, &req, src_for(key), dst) {
-            Err(RecursiveHandlerError::BlockStore(_)) => {}
-            other => panic!("expected BlockStore error, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn fabric_only_request_yields_zeroed_scratch_without_store_or_backend() {
+    fn fabric_only_request_yields_zeroed_scratch() {
         let (backing, base) = scratch_backing();
         let key = key_for_ring(11);
         let scratch = ScratchBacking::new(backing, SCRATCH_PAGES as u32);
@@ -854,37 +696,15 @@ mod tests {
         assert!(page_all(base, page.page_idx).iter().all(|&b| b == 0));
     }
 
-    // --- scratch recycling (cross-request leak guard) ---
-
-    fn fill_page(base: *mut u8, idx: u32, byte: u8) {
-        // SAFETY: idx is within the test backing.
-        unsafe {
-            std::ptr::write_bytes(base.add(idx as usize * PAGE), byte, PAGE);
-        }
-    }
-
-    fn dirty_scratch_slot(base: *mut u8, idx: u32, byte: u8) {
-        fill_page(base, idx, byte);
-    }
-
-    fn page_all(base: *mut u8, idx: u32) -> Vec<u8> {
-        // SAFETY: idx is within the test backing.
-        unsafe { std::slice::from_raw_parts(base.add(idx as usize * PAGE), PAGE).to_vec() }
-    }
-
     #[test]
     fn recycled_scratch_page_is_zeroed_on_checkout() {
         let (backing, base) = scratch_backing();
         let scratch = ScratchBacking::new(backing, 1);
 
-        // A prior request leaves a recognizable non-zero pattern across
-        // the full extent of the slot, then returns it to the allocator.
         let idx = scratch.take_zeroed().expect("slot available");
-        dirty_scratch_slot(base, idx, 0xEE);
+        fill_page(base, idx, 0xEE);
         scratch.give(idx);
 
-        // Re-acquiring through the zeroing checkout must hand back a
-        // clean page with no residual bytes from the prior request.
         let idx = scratch.take_zeroed().expect("slot available");
         assert!(
             page_all(base, idx).iter().all(|&b| b == 0),
@@ -894,22 +714,13 @@ mod tests {
 
     #[test]
     fn short_fill_does_not_relay_prior_bytes() {
-        // The store fill writes the whole page here, but the guarantee
-        // we exercise is that the unwritten tail of a recycled page is
-        // zero: dirty the slot, then drive an owner read whose fill we
-        // restrict to the page head, and assert the tail is zero rather
-        // than the prior pattern.
         let (backing, base) = scratch_backing();
         let scratch = ScratchBacking::new(backing, 1);
 
-        // Prior request dirties the entire slot.
         let idx = scratch.take_zeroed().expect("slot available");
-        dirty_scratch_slot(base, idx, 0xEE);
+        fill_page(base, idx, 0xEE);
         scratch.give(idx);
 
-        // New checkout zeroes the slot; a short fill (head only) leaves
-        // the tail untouched, so the tail must read as zero rather than
-        // the prior 0xEE pattern.
         let idx = scratch.take_zeroed().expect("slot available");
         fill_page_head(base, idx, 0x11, 64);
 
@@ -921,10 +732,27 @@ mod tests {
         );
     }
 
+    fn dummy_page_channel() -> crate::storage::PageChannel {
+        let (tx, _rx) = crate::storage::PageChannel::new();
+        tx
+    }
+
+    fn fill_page(base: *mut u8, idx: u32, byte: u8) {
+        // SAFETY: idx is within the test backing.
+        unsafe {
+            std::ptr::write_bytes(base.add(idx as usize * PAGE), byte, PAGE);
+        }
+    }
+
     fn fill_page_head(base: *mut u8, idx: u32, byte: u8, n: usize) {
         // SAFETY: idx is within the test backing and n <= PAGE.
         unsafe {
             std::ptr::write_bytes(base.add(idx as usize * PAGE), byte, n);
         }
+    }
+
+    fn page_all(base: *mut u8, idx: u32) -> Vec<u8> {
+        // SAFETY: idx is within the test backing.
+        unsafe { std::slice::from_raw_parts(base.add(idx as usize * PAGE), PAGE).to_vec() }
     }
 }

--- a/cmd/unbounded-storage/src/p2p/mod.rs
+++ b/cmd/unbounded-storage/src/p2p/mod.rs
@@ -25,7 +25,10 @@ pub use finger_router::{ChainFingerRouter, FingerRouter};
 pub use fingers::{
     FingerTable, FingerTableConfig, TopologyPrefixWeight, TopologySelection, TopologyWeighting,
 };
-pub use handler::{RecursiveHandler, RecursiveHandlerError, RecursiveHandlerStream};
+pub use handler::{
+    OwnerShardSource, OwnerShardTable, RecursiveHandler, RecursiveHandlerError,
+    RecursiveHandlerStream,
+};
 pub use ring::{node_id_from_name, node_to_ring, splitmix64, stripe_to_ring};
 pub use routing_handle::{RouteTableHandle, RouteTableSnapshot, RoutingHandle, RoutingSnapshot};
 pub use transport::{RoutedStream, RoutedTransport};

--- a/cmd/unbounded-storage/src/shard_layer.rs
+++ b/cmd/unbounded-storage/src/shard_layer.rs
@@ -34,14 +34,14 @@ use unbounded_storage::config::{
     self, ApplyError, Config, ConfigApplyTarget, ConfigDiff, ShardControlGroup,
 };
 use unbounded_storage::fabric::PeerId;
-use unbounded_storage::p2p::{NodeId, RouteTableHandle};
+use unbounded_storage::p2p::RouteTableHandle;
 use unbounded_storage::runtime::{JoinHandle, Threading, WorkerIdx};
 use unbounded_storage::storage::StripeReq;
 use unbounded_storage::storage::disks::{CacheDirectorySet, DiskRegistrySet, UringDiskTarget};
 use unbounded_storage::topology::ServingShard;
 
 use crate::StartupSettings;
-use crate::fabric_group::{FabricGroup, FabricPlan, FabricUnitAddress};
+use crate::fabric_group::{FabricGroup, FabricPlan, FabricUnitAddress, RpcShardPublish};
 
 /// Inputs that are constant across the life of the process and used to
 /// spawn the shard layer. Cloned cheaply into every shard thread.
@@ -143,9 +143,9 @@ pub fn spawn_shard_layer(
 
     // Bring up the shared fabric endpoints before spawning any shards:
     // each shard registers its data backing against the endpoint it maps
-    // onto, so the fabrics (and their RPC servers) must exist first. On
-    // failure nothing has spawned yet, so there is nothing to retire.
-    let fabric_group = FabricGroup::new(
+    // onto. RPC servers start after shards publish their pool MRs/fetch
+    // channels because owner responses source those bufferpool pages.
+    let mut fabric_group = FabricGroup::new(
         &deps.runtime,
         &deps.fabric_plan,
         settings.backing_kind,
@@ -170,6 +170,7 @@ pub fn spawn_shard_layer(
     // when bring-up fails before the broadcast.
     let mut peer_txs: Vec<mpsc::Sender<Arc<Vec<crate::PeerPublish>>>> =
         Vec::with_capacity(worker_count);
+    let mut serve_start_txs = Vec::with_capacity(worker_count);
 
     for (i, (shard, _)) in deps.workers.iter().enumerate() {
         let widx = WorkerIdx(u16::try_from(i).expect("worker index fits in u16"));
@@ -177,6 +178,8 @@ pub fn spawn_shard_layer(
         control_senders.push((widx, ctrl_tx));
         let (peer_tx, peer_rx) = mpsc::channel::<Arc<Vec<crate::PeerPublish>>>();
         peer_txs.push(peer_tx);
+        let (serve_start_tx, serve_start_rx) = mpsc::channel::<()>();
+        serve_start_txs.push(serve_start_tx);
         let phaseb_tx = phaseb_tx.clone();
 
         let shard = *shard;
@@ -211,6 +214,7 @@ pub fn spawn_shard_layer(
                         ctrl_rx,
                         peer_rx,
                         phaseb_tx,
+                        serve_start_rx,
                         layer_stop,
                     );
                 });
@@ -256,6 +260,7 @@ pub fn spawn_shard_layer(
         // Dropping the peer senders unblocks any up-shard parked on
         // `peer_rx.recv()` so it can exit and be joined.
         drop(peer_txs);
+        drop(serve_start_txs);
         layer_stop.store(true, Ordering::Relaxed);
         for h in joins.into_iter().rev() {
             let _ = h.join();
@@ -274,19 +279,34 @@ pub fn spawn_shard_layer(
     // into the broadcast `PeerPublish` set (which deliberately carries
     // only base/len, not ownership).
     let mut backing_keepalives: Vec<Arc<dyn Send + Sync>> = Vec::with_capacity(publishes.len());
+    let mut rpc_shards = Vec::with_capacity(publishes.len());
     let peer_list: Arc<Vec<crate::PeerPublish>> = Arc::new(
         publishes
             .into_iter()
             .enumerate()
             .map(|(shard_index, (worker_idx, publish))| {
-                backing_keepalives.push(publish.backing_keepalive);
+                let crate::ShardPublish {
+                    backing_base,
+                    backing_len,
+                    fabric_mr,
+                    numa,
+                    fetch_channel,
+                    backing_keepalive,
+                } = publish;
+                backing_keepalives.push(backing_keepalive);
+                rpc_shards.push(RpcShardPublish {
+                    shard_index,
+                    fetch_channel: fetch_channel.clone(),
+                    mr: fabric_mr,
+                    numa,
+                });
                 crate::PeerPublish {
                     shard_index,
                     worker_idx,
-                    backing_base: publish.backing_base,
-                    backing_len: publish.backing_len,
-                    channel: publish.fetch_channel,
-                    numa: publish.numa,
+                    backing_base,
+                    backing_len,
+                    channel: fetch_channel,
+                    numa,
                 }
             })
             .collect(),
@@ -318,10 +338,32 @@ pub fn spawn_shard_layer(
     }
     if !phaseb_errors.is_empty() {
         layer_stop.store(true, Ordering::Relaxed);
+        drop(serve_start_txs);
         for h in joins.into_iter().rev() {
             let _ = h.join();
         }
         return Err(phaseb_errors);
+    }
+
+    if let Err(mut rpc_errors) = fabric_group.start_rpc_servers(&rpc_shards) {
+        layer_stop.store(true, Ordering::Relaxed);
+        drop(serve_start_txs);
+        for h in joins.into_iter().rev() {
+            let _ = h.join();
+        }
+        phaseb_errors.append(&mut rpc_errors);
+        return Err(phaseb_errors);
+    }
+    for tx in serve_start_txs {
+        if tx.send(()).is_err() {
+            layer_stop.store(true, Ordering::Relaxed);
+            for h in joins.into_iter().rev() {
+                let _ = h.join();
+            }
+            return Err(vec![
+                "shard exited before recursive RPC servers were ready".to_string(),
+            ]);
+        }
     }
 
     descriptors.sort_by_key(|d| d.worker_idx.0);
@@ -506,6 +548,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use unbounded_storage::p2p::NodeId;
 
     fn graph_with_self_peer(self_peer_id: PeerId) -> config::RuntimeGraph {
         config::RuntimeGraph {

--- a/cmd/unbounded-storage/src/storage/origin.rs
+++ b/cmd/unbounded-storage/src/storage/origin.rs
@@ -169,13 +169,10 @@ pub struct StripeReq {
     /// loadgen run can measure fabric RPC/RMA capacity without disk or
     /// origin work in the server path.
     fabric_only: bool,
-    /// Local-only benchmark flag. Never serialized: the initiating
-    /// bufferpool skips its own disk lookup/writeback when this is set,
-    /// but peer handlers still use their local NVMe-backed cache after
-    /// decoding the request from the fabric. This keeps measurements
-    /// focused on remote NVMe + RDMA without short-circuiting on the
-    /// requester's disk.
-    #[serde(skip)]
+    /// Benchmark-only flag carried over the fabric. Every bufferpool that
+    /// serves the request skips local NVMe lookup/writeback so loadgen can
+    /// isolate remote RAM/backend + RDMA behavior without falling back to
+    /// either node's disk cache.
     skip_local_disk: bool,
 }
 
@@ -512,16 +509,14 @@ mod tests {
     }
 
     #[test]
-    fn stripe_req_skip_local_disk_is_not_serialized() {
-        // `skip_local_disk` is local to the requester: peer handlers must
-        // still read from their own NVMe cache after decoding the request.
+    fn stripe_req_skip_local_disk_round_trips_through_bincode() {
         let origin = OriginRef::new("primary-s3", "models/llama.bin", 7);
         let req = StripeReq::new(origin.stripe_key())
             .with_origin(origin)
             .with_skip_local_disk(true);
         let bytes = bincode::serialize(&req).unwrap();
         let back: StripeReq = bincode::deserialize(&bytes).unwrap();
-        assert!(!back.skip_local_disk());
+        assert!(back.skip_local_disk());
     }
 
     #[test]

--- a/cmd/unbounded-storage/tests/bufferpool/mocks.rs
+++ b/cmd/unbounded-storage/tests/bufferpool/mocks.rs
@@ -21,7 +21,7 @@ use std::task::{Context, Poll};
 
 use rand::Rng;
 use unbounded_storage::bufferpool::{
-    BlockStore, BulkRef, Error, PageRef, PageStream, Req, StripeKey, Transport,
+    BlockStore, BulkRef, Error, PageCachePolicy, PageRef, PageStream, Req, StripeKey, Transport,
 };
 use unbounded_storage::memory::Backing;
 
@@ -31,7 +31,6 @@ use crate::framework::executor::{with_sim, yield_n};
 /// framework's [`SimState`]. Held behind an `Rc` so both mocks plus
 /// the workload driver can share a single configuration instance
 /// without leaking knowledge into the framework crate.
-#[derive(Default)]
 pub struct MockSimConfig {
     /// Maximum number of `yield_once` pends an I/O mock will emit
     /// before completing. The actual count per call is drawn from
@@ -42,6 +41,19 @@ pub struct MockSimConfig {
     /// happy-path regime); positive values exercise the
     /// leader-error / `ParkOutcome::Error` paths in `pool.rs`.
     pub io_fault_rate: Cell<u32>,
+    /// Whether fetched pages may be retained in the bufferpool's RAM
+    /// page cache once all consumers drop their guards.
+    pub page_cache_enabled: Cell<bool>,
+}
+
+impl Default for MockSimConfig {
+    fn default() -> Self {
+        Self {
+            max_io_delay: Cell::new(0),
+            io_fault_rate: Cell::new(0),
+            page_cache_enabled: Cell::new(true),
+        }
+    }
 }
 
 impl MockSimConfig {
@@ -309,6 +321,10 @@ impl DstBlockStore {
     pub fn set_hit_rate(&self, pct: u32) {
         self.hit_rate.set(pct.min(100));
     }
+
+    pub fn set_page_cache_enabled(&self, enabled: bool) {
+        self.cfg.page_cache_enabled.set(enabled);
+    }
 }
 
 impl BlockStore for DstBlockStore {
@@ -316,6 +332,14 @@ impl BlockStore for DstBlockStore {
         self.base.set(Some(backing.base));
         self.page_size.set(backing.page_size);
         Ok(())
+    }
+
+    fn page_cache_policy<R: Req + ?Sized>(&self, _req: &R) -> PageCachePolicy {
+        if self.cfg.page_cache_enabled.get() {
+            PageCachePolicy::Enabled
+        } else {
+            PageCachePolicy::Disabled
+        }
     }
 
     async fn read_page<R: Req + ?Sized>(

--- a/cmd/unbounded-storage/tests/bufferpool/tests.rs
+++ b/cmd/unbounded-storage/tests/bufferpool/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -97,8 +97,17 @@ proptest! {
     #[test]
     fn invariant_page_accounting_at_quiescence(seed in any::<u64>(), w in workload_strategy()) {
         let page_count = w.page_count;
+        let page_cache_enabled = w.page_cache_enabled;
         let report = run_workload(seed, w).expect("run completed");
         assert_quiescent_accounting(&report, page_count)?;
+        if !page_cache_enabled {
+            prop_assert_eq!(
+                report.cached_pages_at_end,
+                0,
+                "disabled page cache retained {} pages",
+                report.cached_pages_at_end,
+            );
+        }
         prop_assert_eq!(
             report.prefetch_inflight_at_end, 0,
             "prefetch budget not released: {} pages still reserved",
@@ -295,8 +304,17 @@ proptest! {
         w in pipelined_workload_strategy(),
     ) {
         let page_count = w.page_count;
+        let page_cache_enabled = w.page_cache_enabled;
         let report = run_workload(seed, w).expect("run completed");
         assert_quiescent_accounting(&report, page_count)?;
+        if !page_cache_enabled {
+            prop_assert_eq!(
+                report.cached_pages_at_end,
+                0,
+                "disabled page cache retained {} pages",
+                report.cached_pages_at_end,
+            );
+        }
         prop_assert_eq!(
             report.prefetch_inflight_at_end, 0,
             "prefetch budget not released: {} pages still reserved",
@@ -363,6 +381,7 @@ fn stream_limit_rejects_excess_concurrent_reads() {
         max_io_delay: 4,
         io_fault_rate: 0,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1,
         max_inflight_pages: 4,
         key_count: 1,
@@ -467,6 +486,7 @@ fn regression_freelist_deadlock_under_faults() {
         max_io_delay: 1,
         io_fault_rate: 3,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 4,
         key_count: 2,
@@ -523,6 +543,7 @@ fn smoke() {
         max_io_delay: 2,
         io_fault_rate: 0,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 4,
         key_count: 2,
@@ -575,6 +596,7 @@ fn all_cache_hits_skip_bulk_get_and_tee() {
         max_io_delay: 2,
         io_fault_rate: 0,
         cache_hit_rate: 100,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 4,
         key_count: 2,
@@ -617,6 +639,124 @@ fn all_cache_hits_skip_bulk_get_and_tee() {
         match o {
             ClientOutcome::Ok { got, expected } => assert_eq!(got, expected),
             other => panic!("unexpected outcome: {other:?}"),
+        }
+    }
+}
+
+/// Scenario test: a live page-cache drain invalidates the policy
+/// snapshot held by an already admitted stream. Pages fetched after the
+/// drain must still be delivered correctly but must not be retained in
+/// the RAM page cache. This pins the branch's `page_cache_drain_epoch`
+/// path under deterministic scheduler interleavings instead of only the
+/// synchronous module tests.
+#[test]
+fn drain_page_cache_during_active_stream_disables_retention() {
+    const PAGE_SIZE: usize = 128;
+    const PAGE_COUNT: usize = 4;
+
+    for seed in [0u64, 1, 7, 42, 1234, 99999] {
+        let backing = heap_backing(PAGE_SIZE, PAGE_COUNT);
+        let counts = Rc::new(CallCounts::default());
+        let mock_cfg = MockSimConfig::new();
+        mock_cfg.max_io_delay.set(3);
+        let stripes: Stripes = Rc::new(RefCell::new(HashMap::new()));
+        let key = StripeKey([0xDA; 32]);
+        let expected: Vec<u8> = (0..PAGE_SIZE * 3)
+            .map(|i| ((i + 0x31) & 0xff) as u8)
+            .collect();
+        stripes.borrow_mut().insert(key, expected.clone());
+
+        let transport = DstTransport::new(
+            stripes.clone(),
+            counts.clone(),
+            mock_cfg.clone(),
+            backing.base,
+            backing.page_size,
+        );
+        let blockstore = DstBlockStore::new(counts.clone(), stripes, mock_cfg);
+        blockstore.set_page_cache_enabled(true);
+        let pool = Rc::new(
+            Pool::new(
+                PoolConfig {
+                    max_concurrent_streams: 1024,
+                    max_inflight_pages: 3,
+                },
+                backing,
+                transport,
+                blockstore,
+            )
+            .expect("pool construction must succeed"),
+        );
+
+        let mut exec = Executor::new(seed);
+        let first_page_seen = Rc::new(Cell::new(false));
+        let drain_done = Rc::new(Cell::new(false));
+        let outcomes: Rc<RefCell<Vec<ClientOutcome>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let p = pool.clone();
+        let first_page_seen_reader = first_page_seen.clone();
+        let outcomes_reader = outcomes.clone();
+        let expected_reader = expected.clone();
+        exec.spawn(async move {
+            let req = TestReq { key };
+            let mut read = p
+                .read_windowed(&req, 0, (PAGE_SIZE * 3) as u64, 3)
+                .expect("windowed read");
+            let mut got = Vec::new();
+            let first = read.next_page().await.unwrap().unwrap();
+            got.extend_from_slice(first.as_slice());
+            first_page_seen_reader.set(true);
+            yield_n(4).await;
+            drop(first);
+            while let Some(page) = read.next_page().await {
+                got.extend_from_slice(page.unwrap().as_slice());
+            }
+            outcomes_reader.borrow_mut().push(ClientOutcome::Ok {
+                got,
+                expected: expected_reader,
+            });
+        });
+
+        let p = pool.clone();
+        let first_page_seen_drainer = first_page_seen.clone();
+        let drain_done_task = drain_done.clone();
+        exec.spawn(async move {
+            while !first_page_seen_drainer.get() {
+                yield_n(1).await;
+            }
+            p.drain_page_cache();
+            drain_done_task.set(true);
+        });
+
+        exec.run(5_000)
+            .expect("active drain scenario must complete");
+        assert!(drain_done.get(), "seed {seed}: drain task ran");
+        assert_eq!(
+            pool.cached_pages(),
+            0,
+            "seed {seed}: drained stream must not retain RAM cache pages",
+        );
+        assert_eq!(
+            pool.free_pages(),
+            PAGE_COUNT,
+            "seed {seed}: all pages returned to free list",
+        );
+        assert_eq!(
+            pool.active_inflight_entries(),
+            0,
+            "seed {seed}: active entries must drain",
+        );
+        assert_eq!(
+            counts.bulk_get.get(),
+            3,
+            "seed {seed}: every page fetched exactly once",
+        );
+
+        let outcomes = outcomes.borrow();
+        assert_eq!(outcomes.len(), 1, "seed {seed}: reader finished");
+        match &outcomes[0] {
+            ClientOutcome::Ok { got, expected } => assert_eq!(got, expected),
+            other => panic!("seed {seed}: unexpected outcome {other:?}"),
         }
     }
 }
@@ -867,6 +1007,7 @@ fn cancellation_drains_to_clean_state() {
         max_io_delay: 2,
         io_fault_rate: 0,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 4,
         key_count: 2,
@@ -940,6 +1081,7 @@ fn windowed_read_in_order_and_drains() {
         max_io_delay: 3,
         io_fault_rate: 0,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 4,
         key_count: 1,
@@ -990,6 +1132,7 @@ fn regression_windowed_cancel_under_pressure() {
         max_io_delay: 3,
         io_fault_rate: 0,
         cache_hit_rate: 10,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 1,
         key_count: 2,
@@ -1053,6 +1196,7 @@ fn windowed_under_free_list_pressure_drains() {
         max_io_delay: 3,
         io_fault_rate: 0,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 3,
         key_count: 2,
@@ -1127,6 +1271,7 @@ fn regression_windowed_speculation_starves_head() {
         max_io_delay: 2,
         io_fault_rate: 0,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 5,
         key_count: 2,
@@ -1181,6 +1326,7 @@ fn pipelined_multi_stripe_in_order_and_drains() {
         max_io_delay: 3,
         io_fault_rate: 0,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 6,
         key_count: 3,
@@ -1242,6 +1388,7 @@ fn pipelined_under_free_list_pressure_drains() {
         max_io_delay: 3,
         io_fault_rate: 0,
         cache_hit_rate: 0,
+        page_cache_enabled: true,
         max_concurrent_streams: 1024,
         max_inflight_pages: 4,
         key_count: 3,

--- a/cmd/unbounded-storage/tests/bufferpool/workload.rs
+++ b/cmd/unbounded-storage/tests/bufferpool/workload.rs
@@ -44,6 +44,9 @@ pub struct Workload {
     /// is the miss-only regime where every fetch goes through the
     /// transport.
     pub cache_hit_rate: u32,
+    /// Whether pages fetched by the pool may be retained in the RAM
+    /// page cache after their consumers drop them.
+    pub page_cache_enabled: bool,
     /// `PoolConfig::max_concurrent_streams`. Defaults set this high
     /// enough to never trigger; the strategy occasionally chooses a
     /// small value so `Pool::read` returns `Error::StreamLimit` and
@@ -244,6 +247,10 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
         3 => 1u32..=80,     // mixed hits / misses
         1 => Just(100u32),  // all hits: tee never runs
     ];
+    let page_cache_enabled = prop_oneof![
+        8 => Just(true),
+        2 => Just(false),
+    ];
     // Default to a limit well above the client count so most cases
     // exercise the happy path; a meaningful minority drops it low
     // enough that some `Pool::read` calls must be rejected with
@@ -269,6 +276,7 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
         max_io_delay,
         io_fault_rate,
         cache_hit_rate,
+        page_cache_enabled,
         max_concurrent_streams,
         max_inflight_pages,
         key_count,
@@ -281,6 +289,7 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
                 max_io_delay,
                 io_fault_rate,
                 cache_hit_rate,
+                page_cache_enabled,
                 max_concurrent_streams,
                 max_inflight_pages,
                 key_count,
@@ -291,6 +300,7 @@ pub fn workload_strategy() -> impl Strategy<Value = Workload> {
                 max_io_delay,
                 io_fault_rate,
                 cache_hit_rate,
+                page_cache_enabled,
                 max_concurrent_streams,
                 max_inflight_pages,
                 key_count,
@@ -356,6 +366,10 @@ pub fn pipelined_workload_strategy() -> impl Strategy<Value = Workload> {
         3 => 1u32..=80,
         1 => Just(100u32),
     ];
+    let page_cache_enabled = prop_oneof![
+        8 => Just(true),
+        2 => Just(false),
+    ];
     let max_inflight_pages = 1usize..=8;
     let key_count = 1u8..=3;
     let pipelines = vec(pipeline_strategy(), 1..=4);
@@ -366,6 +380,7 @@ pub fn pipelined_workload_strategy() -> impl Strategy<Value = Workload> {
         max_io_delay,
         io_fault_rate,
         cache_hit_rate,
+        page_cache_enabled,
         max_inflight_pages,
         key_count,
         pipelines,
@@ -377,6 +392,7 @@ pub fn pipelined_workload_strategy() -> impl Strategy<Value = Workload> {
                 max_io_delay,
                 io_fault_rate,
                 cache_hit_rate,
+                page_cache_enabled,
                 max_inflight_pages,
                 key_count,
                 pipelines,
@@ -386,6 +402,7 @@ pub fn pipelined_workload_strategy() -> impl Strategy<Value = Workload> {
                 max_io_delay,
                 io_fault_rate,
                 cache_hit_rate,
+                page_cache_enabled,
                 // Pinned high: pipelined admission must not be
                 // rejected, so every plan slice gets a stream.
                 max_concurrent_streams: 1024,
@@ -527,6 +544,7 @@ pub fn run_workload(seed: u64, w: Workload) -> Result<RunReport, RunError> {
     );
     let blockstore = DstBlockStore::new(counts.clone(), stripes.clone(), mock_cfg.clone());
     blockstore.set_hit_rate(w.cache_hit_rate);
+    blockstore.set_page_cache_enabled(w.page_cache_enabled);
 
     let pool = Rc::new(
         Pool::new(


### PR DESCRIPTION
Previously the bufferpool cache was only used for serving "hops" through neighbor nodes.