### PR TITLE
metalman: fix concurrent operations

### DIFF
--- a/internal/metalman/machineops/controller.go
+++ b/internal/metalman/machineops/controller.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,14 +33,13 @@ const (
 
 	conditionCompleted = "Completed"
 
-	reasonSucceeded                = "Succeeded"
-	reasonInvalidTargetScope       = "InvalidTargetScope"
-	reasonNoMatchingOwnedMachines  = "NoMatchingOwnedMachines"
-	reasonMachineNotFound          = "MachineNotFound"
-	reasonUnsupportedTarget        = "UnsupportedTarget"
-	reasonTargetNoLongerOwned      = "TargetNoLongerOwned"
-	reasonExecutionFailed          = "ExecutionFailed"
-	reasonWaitingForOlderOperation = "WaitingForOlderOperation"
+	reasonSucceeded               = "Succeeded"
+	reasonInvalidTargetScope      = "InvalidTargetScope"
+	reasonNoMatchingOwnedMachines = "NoMatchingOwnedMachines"
+	reasonMachineNotFound         = "MachineNotFound"
+	reasonUnsupportedTarget       = "UnsupportedTarget"
+	reasonTargetNoLongerOwned     = "TargetNoLongerOwned"
+	reasonExecutionFailed         = "ExecutionFailed"
 )
 
 // PowerClient is the Redfish power operation subset used by MachineOperation reconciliation.
@@ -121,7 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	if older, err := r.olderActiveOperation(ctx, &op); err != nil {
+	if older, err := r.olderConflictingOperation(ctx, &op); err != nil {
 		return ctrl.Result{}, err
 	} else if older != "" {
 		message := fmt.Sprintf("waiting for older host operation %s", older)
@@ -684,22 +684,44 @@ func (r *Reconciler) aggregateStatus(op *v1alpha3.MachineOperation) {
 	setCompletedCondition(op, metav1.ConditionFalse, "InProgress", message)
 }
 
-func (r *Reconciler) olderActiveOperation(ctx context.Context, op *v1alpha3.MachineOperation) (string, error) {
+func (r *Reconciler) olderConflictingOperation(ctx context.Context, op *v1alpha3.MachineOperation) (string, error) {
+	opKeys, err := r.operationConflictKeys(ctx, op)
+	if err != nil {
+		return "", err
+	}
+
+	if len(opKeys) == 0 {
+		return "", nil
+	}
+
 	var list v1alpha3.MachineOperationList
 	if err := r.List(ctx, &list); err != nil {
 		return "", fmt.Errorf("list MachineOperations: %w", err)
 	}
+
+	candidates := make([]v1alpha3.MachineOperation, 0, len(list.Items))
 
 	for _, candidate := range list.Items {
 		if candidate.Name == op.Name || candidate.Status.IsTerminal() || !isHostOperation(candidate.Spec.OperationKind) {
 			continue
 		}
 
-		if !r.operationBelongsToSite(ctx, &candidate) {
+		if !operationBefore(&candidate, op) {
 			continue
 		}
 
-		if operationBefore(&candidate, op) {
+		candidates = append(candidates, candidate)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool { return operationBefore(&candidates[i], &candidates[j]) })
+
+	for _, candidate := range candidates {
+		candidateKeys, err := r.operationConflictKeys(ctx, &candidate)
+		if err != nil {
+			return "", err
+		}
+
+		if conflictSetsOverlap(opKeys, candidateKeys) {
 			return candidate.Name, nil
 		}
 	}
@@ -707,32 +729,96 @@ func (r *Reconciler) olderActiveOperation(ctx context.Context, op *v1alpha3.Mach
 	return "", nil
 }
 
-func (r *Reconciler) operationBelongsToSite(ctx context.Context, op *v1alpha3.MachineOperation) bool {
+func (r *Reconciler) operationConflictKeys(ctx context.Context, op *v1alpha3.MachineOperation) (map[string]struct{}, error) {
+	keys := map[string]struct{}{}
 	if len(op.Status.Targets) > 0 {
 		for _, target := range op.Status.Targets {
-			var machine v1alpha3.Machine
-			if err := r.Get(ctx, client.ObjectKey{Name: target.MachineRef}, &machine); err == nil && r.ownsMachine(&machine) {
-				return true
+			if isTerminalTarget(target) {
+				continue
+			}
+
+			if err := r.addTargetConflictKeys(ctx, keys, target.MachineRef); err != nil {
+				return nil, err
 			}
 		}
 
-		return false
+		return keys, nil
 	}
 
-	if op.Spec.MachineRef != "" {
-		var machine v1alpha3.Machine
-		if err := r.Get(ctx, client.ObjectKey{Name: op.Spec.MachineRef}, &machine); err != nil {
-			return false
+	targets, err := r.resolveTargets(ctx, op)
+	if err != nil {
+		var opErr operationError
+		if errors.As(err, &opErr) {
+			return keys, nil
 		}
 
-		return r.ownsMachine(&machine)
+		return nil, err
 	}
 
-	if op.Spec.MachineSelector != nil && r.Site != "" {
-		return r.validateSelectorScope(op.Spec.MachineSelector) == nil
+	for i := range targets {
+		addMachineConflictKeys(keys, &targets[i])
+	}
+
+	return keys, nil
+}
+
+func (r *Reconciler) addTargetConflictKeys(ctx context.Context, keys map[string]struct{}, machineName string) error {
+	if machineName == "" {
+		return nil
+	}
+
+	keys["machine:"+machineName] = struct{}{}
+
+	var machine v1alpha3.Machine
+	if err := r.Get(ctx, client.ObjectKey{Name: machineName}, &machine); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("get Machine %s for operation conflict detection: %w", machineName, err)
+	}
+
+	if !r.ownsMachine(&machine) {
+		delete(keys, "machine:"+machineName)
+
+		return nil
+	}
+
+	addMachineConflictKeys(keys, &machine)
+
+	return nil
+}
+
+func addMachineConflictKeys(keys map[string]struct{}, machine *v1alpha3.Machine) {
+	keys["machine:"+machine.Name] = struct{}{}
+
+	if machine.Spec.PXE == nil || machine.Spec.PXE.Redfish == nil || machine.Spec.PXE.Redfish.URL == "" {
+		return
+	}
+
+	keys["redfish:"+normalizeRedfishURL(machine.Spec.PXE.Redfish.URL)] = struct{}{}
+}
+
+func isTerminalTarget(target v1alpha3.MachineOperationTargetStatus) bool {
+	return target.Phase == v1alpha3.OperationPhaseComplete || target.Phase == v1alpha3.OperationPhaseFailed
+}
+
+func conflictSetsOverlap(a, b map[string]struct{}) bool {
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+
+	for key := range a {
+		if _, ok := b[key]; ok {
+			return true
+		}
 	}
 
 	return false
+}
+
+func normalizeRedfishURL(raw string) string {
+	return strings.TrimRight(raw, "/")
 }
 
 func operationBefore(a, b *v1alpha3.MachineOperation) bool {

--- a/internal/metalman/machineops/controller.go
+++ b/internal/metalman/machineops/controller.go
@@ -731,6 +731,7 @@ func (r *Reconciler) olderConflictingOperation(ctx context.Context, op *v1alpha3
 
 func (r *Reconciler) operationConflictKeys(ctx context.Context, op *v1alpha3.MachineOperation) (map[string]struct{}, error) {
 	keys := map[string]struct{}{}
+
 	if len(op.Status.Targets) > 0 {
 		for _, target := range op.Status.Targets {
 			if isTerminalTarget(target) {

--- a/internal/metalman/machineops/controller_test.go
+++ b/internal/metalman/machineops/controller_test.go
@@ -364,6 +364,151 @@ func TestReconcilerWaitsForOlderOperation(t *testing.T) {
 	require.Contains(t, updated.Status.Message, "waiting for older host operation op-a")
 }
 
+func TestReconcilerStartsDisjointHostReplaceWhileOlderReplaceInProgress(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machineA := testBareMetalMachine("machine-a", "rack-a")
+	machineA.Spec.PXE.Redfish.URL = "https://bmc-a.example.com"
+	machineB := testBareMetalMachine("machine-b", "rack-a")
+	machineB.Spec.PXE.Redfish.URL = "https://bmc-b.example.com"
+	older := testOperation("op-a", v1alpha3.OperationHostReplace)
+	older.CreationTimestamp = metav1.NewTime(fixedNow().Add(-time.Minute))
+	older.Spec.MachineRef = machineA.Name
+	older.Status.Phase = v1alpha3.OperationPhaseInProgress
+	older.Status.Targets = []v1alpha3.MachineOperationTargetStatus{{
+		MachineRef:       machineA.Name,
+		Phase:            v1alpha3.OperationPhaseInProgress,
+		Stage:            v1alpha3.OperationStageWaitingRepave,
+		TargetOperations: &v1alpha3.OperationsStatus{RebootCounter: 1, RepaveCounter: 1},
+	}}
+	newer := testOperation("op-b", v1alpha3.OperationHostReplace)
+	newer.CreationTimestamp = fixedNow()
+	newer.Spec.MachineRef = machineB.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machineA, machineB, older, newer, testRedfishSecret()).WithStatusSubresource(older, newer, machineB).Build()
+	reconciler := testReconciler(c, &recordingPowerClient{}, "rack-a")
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: newer.Name}})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: newer.Name}})
+	require.NoError(t, err)
+
+	var updated v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: newer.Name}, &updated))
+	require.NotEqual(t, v1alpha3.OperationPhasePending, updated.Status.Phase)
+	require.NotContains(t, updated.Status.Message, "waiting for older host operation")
+	require.Equal(t, []string{machineB.Name}, targetNames(updated.Status.Targets))
+	require.Equal(t, v1alpha3.OperationStageRepaveRequested, updated.Status.Targets[0].Stage)
+	require.Equal(t, int64(1), updated.Status.Targets[0].TargetOperations.RebootCounter)
+	require.Equal(t, int64(1), updated.Status.Targets[0].TargetOperations.RepaveCounter)
+
+	var patched v1alpha3.Machine
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: machineB.Name}, &patched))
+	require.Equal(t, int64(1), patched.Spec.Operations.RebootCounter)
+	require.Equal(t, int64(1), patched.Spec.Operations.RepaveCounter)
+}
+
+func TestReconcilerWaitsForOlderHostReplaceSelectorOverlap(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machineA := testBareMetalMachine("machine-a", "rack-a")
+	machineA.Spec.PXE.Redfish.URL = "https://bmc-a.example.com"
+	machineB := testBareMetalMachine("machine-b", "rack-a")
+	machineB.Spec.PXE.Redfish.URL = "https://bmc-b.example.com"
+	older := testOperation("op-a", v1alpha3.OperationHostReplace)
+	older.CreationTimestamp = metav1.NewTime(fixedNow().Add(-time.Minute))
+	older.Spec.MachineSelector = &metav1.LabelSelector{MatchLabels: map[string]string{siteLabel: "rack-a"}}
+	older.Status.Phase = v1alpha3.OperationPhaseInProgress
+	newer := testOperation("op-b", v1alpha3.OperationHostReplace)
+	newer.CreationTimestamp = fixedNow()
+	newer.Spec.MachineRef = machineB.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machineA, machineB, older, newer, testRedfishSecret()).WithStatusSubresource(older, newer).Build()
+	reconciler := testReconciler(c, &recordingPowerClient{}, "rack-a")
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: newer.Name}})
+	require.NoError(t, err)
+
+	var updated v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: newer.Name}, &updated))
+	require.Equal(t, v1alpha3.OperationPhasePending, updated.Status.Phase)
+	require.Contains(t, updated.Status.Message, "waiting for older host operation op-a")
+}
+
+func TestReconcilerStartsDisjointHostReplaceSelector(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machineA := testBareMetalMachine("machine-a", "rack-a")
+	machineA.Labels["pool"] = "a"
+	machineA.Spec.PXE.Redfish.URL = "https://bmc-a.example.com"
+	machineB := testBareMetalMachine("machine-b", "rack-a")
+	machineB.Labels["pool"] = "b"
+	machineB.Spec.PXE.Redfish.URL = "https://bmc-b.example.com"
+	older := testOperation("op-a", v1alpha3.OperationHostReplace)
+	older.CreationTimestamp = metav1.NewTime(fixedNow().Add(-time.Minute))
+	older.Spec.MachineSelector = &metav1.LabelSelector{MatchLabels: map[string]string{siteLabel: "rack-a", "pool": "a"}}
+	older.Status.Phase = v1alpha3.OperationPhaseInProgress
+	newer := testOperation("op-b", v1alpha3.OperationHostReplace)
+	newer.CreationTimestamp = fixedNow()
+	newer.Spec.MachineSelector = &metav1.LabelSelector{MatchLabels: map[string]string{siteLabel: "rack-a", "pool": "b"}}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machineA, machineB, older, newer, testRedfishSecret()).WithStatusSubresource(older, newer, machineB).Build()
+	reconciler := testReconciler(c, &recordingPowerClient{}, "rack-a")
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: newer.Name}})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: newer.Name}})
+	require.NoError(t, err)
+
+	var updated v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: newer.Name}, &updated))
+	require.NotEqual(t, v1alpha3.OperationPhasePending, updated.Status.Phase)
+	require.NotContains(t, updated.Status.Message, "waiting for older host operation")
+	require.Equal(t, []string{machineB.Name}, targetNames(updated.Status.Targets))
+
+	var patched v1alpha3.Machine
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: machineB.Name}, &patched))
+	require.Equal(t, int64(1), patched.Spec.Operations.RebootCounter)
+	require.Equal(t, int64(1), patched.Spec.Operations.RepaveCounter)
+}
+
+func TestReconcilerWaitsForOlderHostReplaceSharedRedfishEndpoint(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machineA := testBareMetalMachine("machine-a", "rack-a")
+	machineA.Spec.PXE.Redfish.URL = "https://bmc.example.com/"
+	machineB := testBareMetalMachine("machine-b", "rack-a")
+	machineB.Spec.PXE.Redfish.URL = "https://bmc.example.com"
+	older := testOperation("op-a", v1alpha3.OperationHostReplace)
+	older.CreationTimestamp = metav1.NewTime(fixedNow().Add(-time.Minute))
+	older.Spec.MachineRef = machineA.Name
+	older.Status.Phase = v1alpha3.OperationPhaseInProgress
+	older.Status.Targets = []v1alpha3.MachineOperationTargetStatus{{
+		MachineRef:       machineA.Name,
+		Phase:            v1alpha3.OperationPhaseInProgress,
+		Stage:            v1alpha3.OperationStageWaitingRepave,
+		TargetOperations: &v1alpha3.OperationsStatus{RebootCounter: 1, RepaveCounter: 1},
+	}}
+	newer := testOperation("op-b", v1alpha3.OperationHostReplace)
+	newer.CreationTimestamp = fixedNow()
+	newer.Spec.MachineRef = machineB.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machineA, machineB, older, newer, testRedfishSecret()).WithStatusSubresource(older, newer).Build()
+	reconciler := testReconciler(c, &recordingPowerClient{}, "rack-a")
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: newer.Name}})
+	require.NoError(t, err)
+
+	var updated v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: newer.Name}, &updated))
+	require.Equal(t, v1alpha3.OperationPhasePending, updated.Status.Phase)
+	require.Contains(t, updated.Status.Message, "waiting for older host operation op-a")
+}
+
 func testReconciler(c client.Client, power PowerClientFactory, site string) *Reconciler {
 	return &Reconciler{
 		Client:                c,


### PR DESCRIPTION
Currently only a single metalman `MachineOperation` is processed per site. This change adds conflict detection so it's safe to run concurrent provisioning operations.