### PR TITLE
Adjust docs main padding

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -790,7 +790,6 @@ a:hover {
   flex: 1;
   min-width: 0;
   padding-left: 6rem;
-  padding-right: 6rem;
 }
 
 /* Strip centering/padding from inner containers inside docs-layout */


### PR DESCRIPTION
## Summary
- remove the right padding declaration from the docs layout main content area

## Testing
- not run; CSS-only change