### PR TITLE
playpen: a testing tool for metalman

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -40,6 +40,7 @@ jobs:
       tag: ${{ steps.resolve.outputs.tag }}
       file: ${{ steps.resolve.outputs.file }}
       platforms: ${{ steps.resolve.outputs.platforms }}
+      should_build: ${{ steps.resolve.outputs.should_build }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -61,6 +62,12 @@ jobs:
 
           file="images/${name}/Containerfile"
 
+          if [[ ( "$name" == playpen || "$name" == playpen-* ) && "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            echo "::notice::Skipping ${name}; playpen images are manual-only. Dispatch this workflow with image=${name}."
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ ! -f "$file" ]]; then
             echo "::error::No Containerfile found at ${file}"
             exit 1
@@ -76,6 +83,7 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "file=${file}" >> "$GITHUB_OUTPUT"
           echo "platforms=${platforms}" >> "$GITHUB_OUTPUT"
+          echo "should_build=true" >> "$GITHUB_OUTPUT"
 
           echo "Image: ${name}:${tag}"
           echo "Containerfile: ${file}"
@@ -86,6 +94,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build:
     needs: resolve
+    if: needs.resolve.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Normalize container registry

--- a/.github/workflows/playpen-e2e.yaml
+++ b/.github/workflows/playpen-e2e.yaml
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: playpen e2e
+
+on:
+  pull_request:
+    paths:
+      - cmd/playpen-operator/**
+      - cmd/playpen-runner/**
+      - internal/playpen/**
+      - deploy/playpen/**
+      - images/playpen/**
+      - e2e/playpen/**
+      - go.mod
+      - go.sum
+      - Makefile
+      - .github/workflows/playpen-e2e.yaml
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "23 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  playpen-e2e:
+    name: playpen e2e
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Install kind
+        run: go install sigs.k8s.io/kind@v0.30.0
+
+      - name: Install network prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iproute2 kmod wireguard-tools
+          sudo modprobe wireguard || true
+          ip -V
+          wg --version
+
+      - name: Run playpen e2e
+        run: make e2e-playpen

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ METALMAN_BIN=bin/metalman
 METALMAN_CMD=./cmd/metalman
 NETBOOT_IMAGE ?= $(CONTAINER_REGISTRY)/netboot:$(VERSION)
 
+PLAYPEN_TAG ?= $(subst /,-,$(VERSION))
+PLAYPEN_IMAGE ?= $(CONTAINER_REGISTRY)/playpen:$(PLAYPEN_TAG)
+
 KUBECTL_UNBOUNDED_BIN=bin/kubectl-unbounded
 KUBECTL_UNBOUNDED_CMD=./cmd/kubectl-unbounded
 
@@ -206,9 +209,9 @@ NET_FRONTEND_CACHE_FILE    := $(NET_FRONTEND_DIST_DIR)/.frontend-build-key
 # Frontend build toggle (dev builds produce unminified output with sourcemaps).
 REACT_DEV ?= false
 
-.PHONY: all help fmt lint test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build install-tools install-protoc generate kubectl-unbounded forge orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build
+.PHONY: all help fmt lint test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build install-tools install-protoc generate kubectl-unbounded forge orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push playpen-manifests e2e-playpen gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build
 .PHONY: net-frontend net-frontend-clean net-ebpf-build net-ebpf-generate net-ebpf-verify net-manifests release-manifests
-.PHONY: image-machina-local image-machine-ops-controller-local image-metalman-local image-net-controller-local image-net-node-local image-gantry-local image-gantry-push images-local
+.PHONY: image-machina-local image-machine-ops-controller-local image-metalman-local image-playpen-local image-net-controller-local image-net-node-local image-gantry-local image-gantry-push images-local
 .PHONY: image-net-controller-push image-net-node-push images-net-all images-net-all-push
 .PHONY: unbounded-storage unbounded-storage-build unbounded-storage-smoke unbounded-storage-tarball unbounded-storage-push bench unbounded-storage-test unbounded-storage-check unbounded-storage-model-check libfabric openssl
 .PHONY: unbounded-storage-supervisor unbounded-storage-supervisor-build unbounded-storage-supervisor-manifests image-unbounded-storage-supervisor-local image-unbounded-storage-supervisor-push
@@ -287,6 +290,7 @@ help: ## Show this help
 	@echo "  image-machina-local              Build machina image with \$$(CONTAINER_ENGINE)"
 	@echo "  image-machine-ops-controller-local Build machine-ops-controller image"
 	@echo "  image-metalman-local             Build metalman image"
+	@echo "  image-playpen-local              Build playpen image"
 	@echo "  image-net-controller-local       Build unbounded-net-controller image"
 	@echo "  image-net-controller-push        Build and push unbounded-net-controller image"
 	@echo "  image-net-node-local             Build unbounded-net-node image"
@@ -421,24 +425,27 @@ lint: ## Run golangci-lint (matches CI; run `make fmt` to auto-fix)
 ifdef CI
 # In CI each job is independent; skip chained prerequisites.
 
-test: machina-manifests net-manifests ## Run all tests with race detector
+test: machina-manifests machine-ops-manifests playpen-manifests net-manifests ## Run all tests with race detector
 	$(GOTEST) -race $(GO_PACKAGES)
 
 else
 # Locally, chain test -> lint for convenience.
 
-test: lint machina-manifests net-manifests ## Run all tests (implies lint)
+test: lint machina-manifests machine-ops-manifests playpen-manifests net-manifests ## Run all tests (implies lint)
 	$(GOTEST) $(GO_PACKAGES)
 
 endif
 
-build: machina-manifests net-manifests ## Build all Go packages
+e2e-playpen: ## Run the kind-based playpen e2e suite
+	$(GOTEST) -tags=e2e ./e2e/playpen -v -timeout=10m
+
+build: machina-manifests machine-ops-manifests playpen-manifests net-manifests ## Build all Go packages
 	$(GOBUILD) $(GO_PACKAGES)
 
 generate: install-protoc ## Run go generate for API types (deepcopy, CRDs) and protobuf
 	PATH="$(PROTOC_DIR)/bin:$$PATH" $(GOCMD) generate $(GO_PACKAGES)
 
-vulncheck: machina-manifests net-manifests ## Run govulncheck for known vulnerabilities
+vulncheck: machina-manifests machine-ops-manifests playpen-manifests net-manifests ## Run govulncheck for known vulnerabilities
 	@# GO-2024-3218 (libp2p/go-libp2p-kad-dht): all versions affected, no fix
 	@# available. Theoretical DHT content-censorship attack, not exploitable in
 	@# gantry's private-cluster deployment model. Tracked upstream at
@@ -938,6 +945,18 @@ MACHINE_OPS_NAMESPACE ?= unbounded-kube
 MACHINE_OPS_API_SERVER_ENDPOINT ?=
 MACHINE_OPS_MANIFEST_TEMPLATES_DIR := deploy/machine-ops
 MACHINE_OPS_MANIFEST_RENDERED_DIR  := deploy/machine-ops/rendered
+PLAYPEN_NAMESPACE ?= playpen
+PLAYPEN_AMD64_RUNNERS ?= 2
+PLAYPEN_ARM64_RUNNERS ?= 2
+PLAYPEN_RUNNER_WIREGUARD_HOST_PORT_START ?= 51820
+PLAYPEN_RUNNER_WIREGUARD_HOST_PORT_END ?= 51899
+PLAYPEN_CONTROL_PLANE_COUNT ?= 1
+PLAYPEN_CONTROL_PLANE_VERSIONS ?= v1.33.0
+PLAYPEN_CONTROL_PLANE_IMAGE ?= rancher/k3s:{version}-k3s1
+PLAYPEN_CONTROL_PLANE_API_SERVER_HOST_PORT_START ?= 16443
+PLAYPEN_CONTROL_PLANE_API_SERVER_HOST_PORT_END ?= 16499
+PLAYPEN_MANIFEST_TEMPLATES_DIR := deploy/playpen
+PLAYPEN_MANIFEST_RENDERED_DIR  := deploy/playpen/rendered
 
 machina-manifests: ## Render machina deployment manifests into deploy/machina/rendered
 	@mkdir -p $(MACHINA_MANIFEST_RENDERED_DIR)
@@ -966,6 +985,25 @@ machine-ops-manifests: ## Render machine-ops-controller manifests into deploy/ma
 		--set APIServerEndpoint=$(MACHINE_OPS_API_SERVER_ENDPOINT)
 	@echo "Rendered machine-ops manifests into $(MACHINE_OPS_MANIFEST_RENDERED_DIR) (image: $(MACHINE_OPS_CONTROLLER_IMAGE))"
 
+playpen-manifests: ## Render playpen operator and runner manifests into deploy/playpen/rendered
+	@mkdir -p $(PLAYPEN_MANIFEST_RENDERED_DIR)
+	@find $(PLAYPEN_MANIFEST_RENDERED_DIR) -mindepth 1 -not -name .gitignore -delete
+	$(GOCMD) run ./hack/cmd/render-manifests \
+		--templates-dir $(PLAYPEN_MANIFEST_TEMPLATES_DIR) \
+		--output-dir $(PLAYPEN_MANIFEST_RENDERED_DIR) \
+		--set Namespace=$(PLAYPEN_NAMESPACE) \
+		--set PlaypenImage=$(PLAYPEN_IMAGE) \
+		--set RunnerAMD64Count=$(PLAYPEN_AMD64_RUNNERS) \
+		--set RunnerARM64Count=$(PLAYPEN_ARM64_RUNNERS) \
+		--set RunnerWireGuardHostPortStart=$(PLAYPEN_RUNNER_WIREGUARD_HOST_PORT_START) \
+		--set RunnerWireGuardHostPortEnd=$(PLAYPEN_RUNNER_WIREGUARD_HOST_PORT_END) \
+		--set ControlPlaneCount=$(PLAYPEN_CONTROL_PLANE_COUNT) \
+		--set ControlPlaneVersions=$(PLAYPEN_CONTROL_PLANE_VERSIONS) \
+		--set ControlPlaneImage=$(PLAYPEN_CONTROL_PLANE_IMAGE) \
+		--set ControlPlaneAPIServerHostPortStart=$(PLAYPEN_CONTROL_PLANE_API_SERVER_HOST_PORT_START) \
+		--set ControlPlaneAPIServerHostPortEnd=$(PLAYPEN_CONTROL_PLANE_API_SERVER_HOST_PORT_END)
+	@echo "Rendered playpen manifests into $(PLAYPEN_MANIFEST_RENDERED_DIR) (image: $(PLAYPEN_IMAGE))"
+
 machina-run: machina ## Replace the in-cluster machina with a locally built binary
 	kubectl scale deployment/machina-controller --replicas=0 -n unbounded-kube
 	kubectl get configmap machina-config -n unbounded-kube -o jsonpath='{.data.config\.yaml}' > hack/machina-config.yaml
@@ -985,6 +1023,15 @@ metalman-oci: image-metalman-local ## Alias for image-metalman-local
 
 metalman-oci-push: metalman-oci ## Build and push the metalman container image
 	$(CONTAINER_ENGINE) push $(METALMAN_IMAGE)
+
+image-playpen-local: ## Build the playpen container image locally (single-arch)
+	$(CONTAINER_ENGINE) build \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg BUILD_TIME=$(BUILD_TIME) \
+		-t playpen:$(PLAYPEN_TAG) -t $(PLAYPEN_IMAGE) \
+		-f ./images/playpen/Containerfile .
+	$(call trivy-maybe,$(PLAYPEN_IMAGE))
 
 image-gantry-local: ## Build the gantry container image locally (single-arch)
 	$(CONTAINER_ENGINE) build \

--- a/cmd/playpen-operator/README.md
+++ b/cmd/playpen-operator/README.md
@@ -1,0 +1,99 @@
+# playpen-operator
+
+`playpen-operator` serves the aggregated Kubernetes API for playpen runner pods.
+It runs next to a pool of `playpen-runner` pods and allocates one idle runner to
+a client that presents a WireGuard public key.
+
+The operator maintains the runner pod pool itself. It assigns each runner a
+unique WireGuard UDP `hostPort`, and on alloc patches the selected pod with the
+client key and returns the endpoint, network, VXLAN, and Redfish details needed
+to use the playpen VM.
+
+The returned guest network metadata is intended for a VM whose default gateway is
+configured on the client side of the tunnel. The runner pod exposes only the VM's
+L2 path into VXLAN; VM egress is routed and NATed by the client tunnel namespace.
+
+The same runner image is also used for pooled k3s control-plane pods. Those pods
+run k3s plus `playpen-runner control-plane`, which publishes the kubeconfig and
+guest API server metadata consumed by control-plane allocations.
+
+The operator does not proxy Redfish or console traffic. Clients reach Redfish and
+the serial console stream on the runner through the WireGuard tunnel. The alloc
+response includes the runner Redfish URL, the system URL, and the OEM serial
+console stream URI for convenience.
+
+## API
+
+The operator is registered as `v1alpha1.playpen.unbounded-cloud.io` and is meant
+to be reached through the Kubernetes API server, not by calling the operator
+Service directly. It trusts only Kubernetes front-proxy client certificates and
+authorizes requests with `SubjectAccessReview`.
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/apis/playpen.unbounded-cloud.io` | `GET` | API group discovery |
+| `/apis/playpen.unbounded-cloud.io/v1alpha1` | `GET` | API version discovery |
+| `/apis/playpen.unbounded-cloud.io/v1alpha1/allocs` | `POST` | Allocate an idle runner pod |
+| `/apis/playpen.unbounded-cloud.io/v1alpha1/deallocs` | `POST` | Deallocate by idempotency key and delete the runner pod |
+| `/healthz` | `GET` | Liveness probe |
+| `/readyz` | `GET` | Readiness probe |
+
+Alloc and dealloc share one RBAC action. Both handlers authorize `create` on
+`allocs.playpen.unbounded-cloud.io`, so granting that action grants both API
+operations together.
+
+Alloc requests require an idempotency key and a valid WireGuard public key. The
+idempotency key can be passed in the `Idempotency-Key` header or, for `kubectl`
+clients without a header flag, as `idempotencyKey` in the JSON body:
+
+```bash
+kubectl create --raw /apis/playpen.unbounded-cloud.io/v1alpha1/allocs \
+	-f - <<'EOF'
+{"idempotencyKey":"smoke-test-1","wireGuardPublicKey":"<client-wireguard-public-key>"}
+EOF
+```
+
+The same idempotency key can be retried with the same request body. Reusing the
+key with a different WireGuard public key returns `409 Conflict`.
+
+Dealloc uses the same idempotency key and is idempotent:
+
+```bash
+kubectl create --raw /apis/playpen.unbounded-cloud.io/v1alpha1/deallocs \
+	-f - <<'EOF'
+{"idempotencyKey":"smoke-test-1"}
+EOF
+```
+
+## Kubernetes Behavior
+
+- Runner pods are created in `--runner-namespace` from `--runner-image`.
+- `--runner-amd64-count` and `--runner-arm64-count` set the desired idle pool
+  size for each architecture.
+- `--runner-wireguard-host-port-start` and
+  `--runner-wireguard-host-port-end` define the cluster-wide UDP hostPort range
+  used for runner WireGuard endpoints.
+- Runner pods are selected from `--runner-namespace` using
+  `--runner-label-selector` for allocation and reconciliation.
+- An alloc writes pod annotations for the client key, request hash, idempotency
+  key hash, and allocation time, then labels the pod with an allocation ID.
+- The alloc response uses the runner node's `ExternalIP` and the runner pod's
+  WireGuard `hostPort` as the externally reachable endpoint. If the runner node
+  has no `ExternalIP`, allocs fail with `503 Service Unavailable`.
+- `--playpen-ttl` is the only playpen pod TTL enforcement point. It deletes
+  expired allocated pods. Deallocs also delete the allocated pod. The operator
+  replaces deleted allocated pods during runner pool reconciliation.
+- On startup, the operator ensures the operator TLS Secret exists, then injects
+  the serving certificate into the APIService `caBundle`.
+
+## Run
+
+For local development against the current Kubernetes context:
+
+```bash
+go run ./cmd/playpen-operator --listen-addr=:8443
+```
+
+For the in-cluster deployment, build the shared playpen image with
+`make image-playpen-local`, render manifests with `make playpen-manifests`, and
+apply the files under `deploy/playpen/rendered`.

--- a/cmd/playpen-operator/main.go
+++ b/cmd/playpen-operator/main.go
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	apiregclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/Azure/unbounded/internal/playpen/operator"
+	"github.com/Azure/unbounded/internal/version"
+)
+
+func main() {
+	cfg := operator.DefaultConfig()
+	cmd := &cobra.Command{
+		Use:   "playpen-operator",
+		Short: "Aggregated Kubernetes API allocator for playpen runner pods",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+
+			return run(ctx, cfg)
+		},
+		Version: version.Version + " (commit: " + version.GitCommit + ")",
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&cfg.ListenAddr, "listen-addr", cfg.ListenAddr, "HTTPS listen address")
+	flags.StringVar(&cfg.Namespace, "namespace", cfg.Namespace, "operator namespace")
+	flags.StringVar(&cfg.ServiceName, "service-name", cfg.ServiceName, "operator Service name used by the aggregated APIService")
+	flags.StringVar(&cfg.TLSSecretName, "tls-secret-name", cfg.TLSSecretName, "Secret storing the operator HTTPS serving certificate")
+	flags.StringVar(&cfg.RunnerNamespace, "runner-namespace", cfg.RunnerNamespace, "namespace containing playpen-runner pods")
+	flags.StringVar(&cfg.RunnerLabelSelector, "runner-label-selector", cfg.RunnerLabelSelector, "label selector for playpen-runner pods")
+	flags.StringVar(&cfg.RunnerImage, "runner-image", cfg.RunnerImage, "container image used for operator-managed playpen-runner pods")
+	flags.StringVar(&cfg.RunnerImagePullPolicy, "runner-image-pull-policy", cfg.RunnerImagePullPolicy, "imagePullPolicy used for operator-managed playpen-runner pods")
+	flags.StringVar(&cfg.RunnerServiceAccountName, "runner-service-account-name", cfg.RunnerServiceAccountName, "ServiceAccount used for operator-managed playpen-runner pods")
+	flags.IntVar(&cfg.RunnerAMD64Count, "runner-amd64-count", cfg.RunnerAMD64Count, "desired number of idle amd64 playpen-runner pods")
+	flags.IntVar(&cfg.RunnerARM64Count, "runner-arm64-count", cfg.RunnerARM64Count, "desired number of idle arm64 playpen-runner pods")
+	flags.Int32Var(&cfg.RunnerWireGuardHostPortStart, "runner-wireguard-host-port-start", cfg.RunnerWireGuardHostPortStart, "first UDP hostPort available for runner WireGuard endpoints")
+	flags.Int32Var(&cfg.RunnerWireGuardHostPortEnd, "runner-wireguard-host-port-end", cfg.RunnerWireGuardHostPortEnd, "last UDP hostPort available for runner WireGuard endpoints")
+	flags.BoolVar(&cfg.RunnerRequireKVM, "runner-require-kvm", cfg.RunnerRequireKVM, "mount /dev/kvm into operator-managed playpen-runner pods")
+	flags.BoolVar(&cfg.RunnerControlPlaneToleration, "runner-control-plane-tolerations", cfg.RunnerControlPlaneToleration, "allow operator-managed playpen-runner pods to schedule on control-plane nodes")
+	flags.IntVar(&cfg.ControlPlaneCount, "control-plane-count", cfg.ControlPlaneCount, "desired number of idle k3s control-plane pods per Kubernetes version")
+	flags.StringSliceVar(&cfg.ControlPlaneVersions, "control-plane-versions", cfg.ControlPlaneVersions, "Kubernetes versions available for k3s control-plane allocations")
+	flags.StringVar(&cfg.ControlPlaneImage, "control-plane-image", cfg.ControlPlaneImage, "k3s image template for control-plane pods; {version} is replaced with the Kubernetes version")
+	flags.StringVar(&cfg.ControlPlaneServiceAccountName, "control-plane-service-account-name", cfg.ControlPlaneServiceAccountName, "ServiceAccount used for operator-managed control-plane pods")
+	flags.Int32Var(&cfg.ControlPlaneAPIServerHostPortStart, "control-plane-apiserver-host-port-start", cfg.ControlPlaneAPIServerHostPortStart, "first TCP hostPort available for control-plane API servers")
+	flags.Int32Var(&cfg.ControlPlaneAPIServerHostPortEnd, "control-plane-apiserver-host-port-end", cfg.ControlPlaneAPIServerHostPortEnd, "last TCP hostPort available for control-plane API servers")
+	flags.DurationVar(&cfg.PlaypenTTL, "playpen-ttl", cfg.PlaypenTTL, "maximum lifetime for an allocated playpen pod; disabled when non-positive")
+	flags.DurationVar(&cfg.ReconcileInterval, "reconcile-interval", cfg.ReconcileInterval, "runner cleanup reconciliation interval")
+	flags.StringVar(&cfg.Runner.ListenAddr, "runner-listen-addr", cfg.Runner.ListenAddr, "runner HTTPS listen address returned in allocs")
+	flags.StringVar(&cfg.Runner.PublicRedfishURL, "runner-public-redfish-url", cfg.Runner.PublicRedfishURL, "runner Redfish URL returned in allocs; defaults to the runner WireGuard server address")
+	flags.StringVar(&cfg.Runner.WireGuard.Interface, "runner-wireguard-interface", cfg.Runner.WireGuard.Interface, "runner WireGuard interface")
+	flags.StringVar(&cfg.Runner.WireGuard.ServerAddress, "runner-wireguard-server-address", cfg.Runner.WireGuard.ServerAddress, "runner WireGuard address with prefix")
+	flags.StringVar(&cfg.Runner.WireGuard.ClientAddress, "runner-wireguard-client-address", cfg.Runner.WireGuard.ClientAddress, "client WireGuard address with prefix")
+	flags.IntVar(&cfg.Runner.WireGuard.ListenPort, "runner-wireguard-listen-port", cfg.Runner.WireGuard.ListenPort, "runner WireGuard UDP listen port")
+	flags.StringVar(&cfg.Runner.VXLAN.Interface, "runner-vxlan-interface", cfg.Runner.VXLAN.Interface, "runner VXLAN interface")
+	flags.IntVar(&cfg.Runner.VXLAN.VNI, "runner-vxlan-vni", cfg.Runner.VXLAN.VNI, "runner VXLAN network identifier")
+	flags.IntVar(&cfg.Runner.VXLAN.Port, "runner-vxlan-port", cfg.Runner.VXLAN.Port, "runner VXLAN UDP destination port")
+	flags.StringVar(&cfg.Runner.Guest.MAC, "runner-guest-mac", cfg.Runner.Guest.MAC, "guest MAC returned in allocs")
+	flags.StringVar(&cfg.Runner.Guest.IPv4, "runner-guest-ipv4", cfg.Runner.Guest.IPv4, "guest IPv4 returned in allocs")
+	flags.StringVar(&cfg.Runner.Guest.SubnetMask, "runner-guest-subnet-mask", cfg.Runner.Guest.SubnetMask, "guest subnet mask returned in allocs")
+	flags.StringVar(&cfg.Runner.Guest.Gateway, "runner-guest-gateway", cfg.Runner.Guest.Gateway, "guest gateway returned in allocs")
+	flags.StringSliceVar(&cfg.Runner.Guest.DNS, "runner-guest-dns", cfg.Runner.Guest.DNS, "guest DNS servers returned in allocs")
+	flags.StringVar(&cfg.Runner.Redfish.Username, "runner-redfish-username", cfg.Runner.Redfish.Username, "Redfish username returned in allocs")
+	flags.StringVar(&cfg.Runner.Redfish.Password, "runner-redfish-password", cfg.Runner.Redfish.Password, "Redfish password returned in allocs")
+	flags.StringVar(&cfg.Runner.Redfish.DeviceID, "runner-redfish-device-id", cfg.Runner.Redfish.DeviceID, "Redfish device ID returned in allocs")
+
+	cmd.CompletionOptions.DisableDefaultCmd = true
+	cmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, cfg operator.Config) error {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	scheme := runtimeScheme()
+	restConfig := ctrl.GetConfigOrDie()
+
+	kubeClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return err
+	}
+
+	kubeClientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	apiRegClient, err := apiregclient.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	op := &operator.Operator{Client: kubeClient, KubeClient: kubeClientset, APIRegClient: apiRegClient, Config: cfg, Scheme: scheme}
+
+	return op.Run(ctx)
+}
+
+func runtimeScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	return scheme
+}

--- a/cmd/playpen-runner/README.md
+++ b/cmd/playpen-runner/README.md
@@ -1,0 +1,109 @@
+# playpen-runner
+
+`playpen-runner` hosts one disposable VM for metalman playpen smoke tests. It
+serves a small HTTPS Redfish endpoint, reports connection metadata, and, by
+default, builds the WireGuard/VXLAN/tap network path that connects a remote
+client to the VM NIC.
+
+The same binary also provides the `control-plane` subcommand used as the helper
+container for pooled k3s control-plane pods.
+
+## Services
+
+The runner listens on `--listen-addr` (default `:8443`) using a self-signed
+certificate stored in `--data-dir`.
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/redfish/v1/` | Minimal Redfish service for VM power, boot control, and serial console discovery |
+| `/redfish/v1/Systems/1/Oem/Unbounded/SerialConsole/Stream` | Authenticated read-only VM serial console WebSocket stream |
+| `/playpen/v1/info` | WireGuard, VXLAN, guest network, and Redfish metadata |
+| `/healthz` | Liveness probe |
+| `/readyz` | Readiness probe |
+
+The Redfish implementation supports session tokens and basic authentication. It
+can report power state, set boot override, and handle `ComputerSystem.Reset`:
+`On` starts QEMU and `ForceOff` stops it. The default boot target is PXE.
+
+The `ComputerSystem` resource advertises the VM serial console through the
+standard `SerialConsole` property. The byte stream itself is an OEM WebSocket
+protocol exposed under the same Redfish service and marked with
+`ConnectTypesSupported: ["OEM"]`. The stream is read-only, requires Redfish auth,
+and is reachable through the default public Redfish URL, normally the WireGuard
+tunnel address `https://10.88.0.1:8443`.
+
+## Networking
+
+With `--configure-network=true`, startup creates these interfaces:
+
+| Interface | Default | Purpose |
+|-----------|---------|---------|
+| WireGuard | `wg0` | Secure tunnel to the client |
+| VXLAN | `vxlan0` | L2 overlay carried inside WireGuard |
+| Bridge | `br0` | Connects VXLAN to the VM tap |
+| Tap | `tap0` | QEMU NIC backend |
+
+The runner reads or creates its WireGuard private key at
+`--wireguard-private-key-file` and publishes the corresponding public key to its
+pod's `playpen.unbounded-cloud.io/server-wireguard-public-key` annotation. A
+client peer can be configured immediately with `--wireguard-client-public-key`.
+In Kubernetes, the operator writes the client key into the runner pod's
+`playpen.unbounded-cloud.io/client-wireguard-public-key` annotation and the
+runner configures the peer after observing that annotation. In delayed mode,
+`/readyz` returns `503` until the peer is configured.
+
+The runner side is L2-only for the VM: it connects QEMU's tap to the bridge and
+VXLAN, but does not assign the guest gateway address, enable forwarding, or NAT
+guest traffic through the runner pod. The guest can only emit frames onto the
+VXLAN overlay.
+
+The default WireGuard addresses are `10.88.0.1/24` for the runner and
+`10.88.0.2/32` for the client. The default guest metadata is MAC
+`52:54:00:aa:bb:01`, IPv4 `192.168.200.10`, gateway `192.168.200.1`, and DNS
+`8.8.8.8`. The client tunnel configures that gateway address on its side of the
+VXLAN and NATs guest egress through the client's network namespace.
+
+## VM Lifecycle
+
+QEMU state lives in `--data-dir` (default `/var/lib/playpen-runner`). The runner
+creates a qcow2 disk, copies OVMF vars, and starts `qemu-system-x86_64` on the
+Redfish `On` reset action. By default, the VM has 2 vCPUs, 4096 MiB of memory, a
+20G disk, UEFI firmware, and a software TPM. QEMU, serial, and swtpm logs are
+written under the data directory.
+
+The runner does not enforce a lifetime limit. In the Kubernetes playpen
+deployment, the operator owns pod TTL enforcement: it deletes claimed pods on
+release or `--playpen-ttl` expiration so the Deployment can create fresh runners.
+
+## Run
+
+Local HTTP and Redfish development can disable host networking setup:
+
+```bash
+go run ./cmd/playpen-runner \
+  --configure-network=false \
+  --listen-addr=127.0.0.1:8443 \
+  --public-redfish-url=https://127.0.0.1:8443 \
+  --redfish-username=admin \
+  --redfish-password=secret
+```
+
+The full Kubernetes deployment runs this binary in a privileged container with
+access to `/dev/kvm` and `/dev/net/tun`; see `deploy/playpen/04-runner.yaml.tmpl`.
+
+## Control Plane Helper
+
+The operator also runs `playpen-runner control-plane` next to each pooled k3s
+server. The helper waits for the child API server, ensures minimal Kubernetes
+discovery objects exist, and publishes the admin kubeconfig and guest-reachable
+API server URL onto the parent pod annotations used during allocation.
+
+```bash
+playpen-runner control-plane \
+  --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+  --guest-server=https://192.168.200.1:6443 \
+  --kubernetes-version=v1.33.0
+```
+
+In Kubernetes, `POD_NAME` and `POD_NAMESPACE` must be provided through the
+downward API so the helper can patch its own pod metadata.

--- a/cmd/playpen-runner/control_plane.go
+++ b/cmd/playpen-runner/control_plane.go
@@ -1,0 +1,232 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/unbounded/internal/playpen/meta"
+)
+
+type controlPlaneConfig struct {
+	kubeconfig        string
+	guestServer       string
+	kubernetesVersion string
+	podName           string
+	podNamespace      string
+}
+
+func newControlPlaneCommand() *cobra.Command {
+	cfg := controlPlaneConfig{podName: os.Getenv("POD_NAME"), podNamespace: os.Getenv("POD_NAMESPACE")}
+
+	cmd := &cobra.Command{
+		Use:   "control-plane",
+		Short: "Publish pooled k3s control-plane allocation metadata",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runControlPlane(cmd.Context(), cfg)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&cfg.kubeconfig, "kubeconfig", "/etc/rancher/k3s/k3s.yaml", "k3s admin kubeconfig path")
+	flags.StringVar(&cfg.guestServer, "guest-server", "", "API server URL reachable from allocated playpen guests")
+	flags.StringVar(&cfg.kubernetesVersion, "kubernetes-version", "", "Kubernetes version served by this control plane")
+
+	return cmd
+}
+
+func runControlPlane(ctx context.Context, cfg controlPlaneConfig) error {
+	if strings.TrimSpace(cfg.podName) == "" || strings.TrimSpace(cfg.podNamespace) == "" {
+		return fmt.Errorf("POD_NAME and POD_NAMESPACE are required")
+	}
+
+	if strings.TrimSpace(cfg.guestServer) == "" {
+		return fmt.Errorf("guest server is required")
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	parentClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("create parent Kubernetes client: %w", err)
+	}
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		if err := publishControlPlaneOnce(ctx, parentClient, cfg); err != nil {
+			slog.Warn("control-plane metadata publish failed", "error", err)
+		} else {
+			slog.Info("control-plane metadata published")
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func publishControlPlaneOnce(ctx context.Context, parentClient client.Client, cfg controlPlaneConfig) error {
+	rawKubeconfig, err := os.ReadFile(cfg.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("read k3s kubeconfig: %w", err)
+	}
+
+	childConfig, err := clientcmd.RESTConfigFromKubeConfig(rawKubeconfig)
+	if err != nil {
+		return fmt.Errorf("build child REST config: %w", err)
+	}
+
+	childClient, err := kubernetes.NewForConfig(childConfig)
+	if err != nil {
+		return fmt.Errorf("create child Kubernetes client: %w", err)
+	}
+
+	if _, err := childClient.Discovery().ServerVersion(); err != nil {
+		return fmt.Errorf("child API server is not ready: %w", err)
+	}
+
+	guestKubeconfig, err := rewriteKubeconfigServer(rawKubeconfig, cfg.guestServer, "")
+	if err != nil {
+		return err
+	}
+
+	if err := ensureKubeDNS(ctx, childClient); err != nil {
+		return err
+	}
+
+	if err := ensureClusterInfo(ctx, childClient, guestKubeconfig); err != nil {
+		return err
+	}
+
+	pod := &corev1.Pod{}
+
+	key := types.NamespacedName{Namespace: cfg.podNamespace, Name: cfg.podName}
+	if err := parentClient.Get(ctx, key, pod); err != nil {
+		return fmt.Errorf("get parent pod: %w", err)
+	}
+
+	base := pod.DeepCopy()
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+
+	pod.Annotations[meta.AnnotationControlPlaneKubeconfig] = string(rawKubeconfig)
+	pod.Annotations[meta.AnnotationControlPlaneGuestServer] = cfg.guestServer
+
+	if err := parentClient.Patch(ctx, pod, client.MergeFrom(base)); err != nil {
+		return fmt.Errorf("patch parent pod annotations: %w", err)
+	}
+
+	return nil
+}
+
+func ensureKubeDNS(ctx context.Context, childClient kubernetes.Interface) error {
+	services := childClient.CoreV1().Services("kube-system")
+
+	_, err := services.Get(ctx, "kube-dns", metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get kube-dns service: %w", err)
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{Name: "dns", Protocol: corev1.ProtocolUDP, Port: 53},
+				{Name: "dns-tcp", Protocol: corev1.ProtocolTCP, Port: 53},
+			},
+			Selector: map[string]string{"k8s-app": "kube-dns"},
+		},
+	}
+
+	if _, err := services.Create(ctx, service, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create kube-dns service: %w", err)
+	}
+
+	return nil
+}
+
+func ensureClusterInfo(ctx context.Context, childClient kubernetes.Interface, kubeconfig string) error {
+	configMaps := childClient.CoreV1().ConfigMaps("kube-public")
+
+	current, err := configMaps.Get(ctx, "cluster-info", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = configMaps.Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-info", Namespace: "kube-public"},
+			Data:       map[string]string{"kubeconfig": kubeconfig},
+		}, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create cluster-info ConfigMap: %w", err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("get cluster-info ConfigMap: %w", err)
+	}
+
+	if current.Data == nil {
+		current.Data = map[string]string{}
+	}
+
+	if current.Data["kubeconfig"] == kubeconfig {
+		return nil
+	}
+
+	current.Data["kubeconfig"] = kubeconfig
+	if _, err := configMaps.Update(ctx, current, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update cluster-info ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+func rewriteKubeconfigServer(raw []byte, server, tlsServerName string) (string, error) {
+	cfg, err := clientcmd.Load(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse kubeconfig: %w", err)
+	}
+
+	for _, cluster := range cfg.Clusters {
+		cluster.Server = server
+		cluster.TLSServerName = tlsServerName
+	}
+
+	data, err := clientcmd.Write(*cfg)
+	if err != nil {
+		return "", fmt.Errorf("write kubeconfig: %w", err)
+	}
+
+	return string(data), nil
+}

--- a/cmd/playpen-runner/main.go
+++ b/cmd/playpen-runner/main.go
@@ -95,6 +95,7 @@ func main() {
 
 	root.CompletionOptions.DisableDefaultCmd = true
 	root.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
+
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/playpen-runner/main.go
+++ b/cmd/playpen-runner/main.go
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/unbounded/internal/playpen/runner"
+	"github.com/Azure/unbounded/internal/version"
+)
+
+func main() {
+	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
+
+	cfg := runner.DefaultConfig()
+	cfg.PodName = os.Getenv("POD_NAME")
+
+	cfg.PodNamespace = os.Getenv("POD_NAMESPACE")
+	if cfg.PodName != "" && cfg.PodNamespace != "" {
+		scheme := runtime.NewScheme()
+		utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+		utilruntime.Must(corev1.AddToScheme(scheme))
+
+		kubeClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+		if err != nil {
+			slog.Error("create Kubernetes client", "error", err)
+			os.Exit(1)
+		}
+
+		cfg.KubernetesClient = kubeClient
+	}
+
+	root := &cobra.Command{
+		Use:   "playpen-runner",
+		Short: "Standalone VM runner and k3s control-plane helper for playpen tests",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runner.Run(cmd.Context(), cfg)
+		},
+		Version: version.Version + " (commit: " + version.GitCommit + ")",
+	}
+
+	flags := root.Flags()
+	flags.StringVar(&cfg.ListenAddr, "listen-addr", cfg.ListenAddr, "HTTPS Redfish and info listen address")
+	flags.StringVar(&cfg.PublicRedfishURL, "public-redfish-url", cfg.PublicRedfishURL, "Redfish URL returned by /playpen/v1/info; defaults to the WireGuard server address")
+	flags.StringVar(&cfg.DataDir, "data-dir", cfg.DataDir, "runner state directory")
+	flags.StringVar(&cfg.Architecture, "architecture", cfg.Architecture, "runner VM architecture: amd64 or arm64")
+	flags.BoolVar(&cfg.ConfigureNetwork, "configure-network", cfg.ConfigureNetwork, "configure WireGuard, VXLAN, bridge, and tap interfaces")
+	flags.StringVar(&cfg.WireGuard.PrivateKeyFile, "wireguard-private-key-file", cfg.WireGuard.PrivateKeyFile, "path to the runner WireGuard private key")
+	flags.StringVar(&cfg.WireGuard.ClientPublicKey, "wireguard-client-public-key", cfg.WireGuard.ClientPublicKey, "client WireGuard public key")
+	flags.StringVar(&cfg.WireGuard.Interface, "wireguard-interface", cfg.WireGuard.Interface, "WireGuard interface name")
+	flags.StringVar(&cfg.WireGuard.ServerAddress, "wireguard-server-address", cfg.WireGuard.ServerAddress, "runner WireGuard address with prefix")
+	flags.StringVar(&cfg.WireGuard.ClientAddress, "wireguard-client-address", cfg.WireGuard.ClientAddress, "client WireGuard address with prefix")
+	flags.IntVar(&cfg.WireGuard.ListenPort, "wireguard-listen-port", cfg.WireGuard.ListenPort, "WireGuard UDP listen port")
+	flags.StringVar(&cfg.VXLAN.Interface, "vxlan-interface", cfg.VXLAN.Interface, "VXLAN interface name")
+	flags.IntVar(&cfg.VXLAN.VNI, "vxlan-vni", cfg.VXLAN.VNI, "VXLAN network identifier")
+	flags.IntVar(&cfg.VXLAN.Port, "vxlan-port", cfg.VXLAN.Port, "VXLAN UDP destination port")
+	flags.StringVar(&cfg.BridgeName, "bridge", cfg.BridgeName, "bridge interface name")
+	flags.StringVar(&cfg.TapName, "tap", cfg.TapName, "tap interface name")
+	flags.StringVar(&cfg.Guest.MAC, "guest-mac", cfg.Guest.MAC, "guest NIC MAC address")
+	flags.StringVar(&cfg.Guest.IPv4, "guest-ipv4", cfg.Guest.IPv4, "guest DHCP IPv4 address returned by info endpoint")
+	flags.StringVar(&cfg.Guest.SubnetMask, "guest-subnet-mask", cfg.Guest.SubnetMask, "guest DHCP subnet mask returned by info endpoint")
+	flags.StringVar(&cfg.Guest.Gateway, "guest-gateway", cfg.Guest.Gateway, "guest DHCP gateway returned by info endpoint")
+	flags.StringSliceVar(&cfg.Guest.DNS, "guest-dns", cfg.Guest.DNS, "guest DNS servers returned by info endpoint")
+	flags.StringVar(&cfg.Redfish.Username, "redfish-username", cfg.Redfish.Username, "Redfish username")
+	flags.StringVar(&cfg.Redfish.Password, "redfish-password", cfg.Redfish.Password, "Redfish password")
+	flags.StringVar(&cfg.Redfish.DeviceID, "redfish-device-id", cfg.Redfish.DeviceID, "Redfish system device ID")
+	flags.StringVar(&cfg.QEMU.Binary, "qemu-binary", cfg.QEMU.Binary, "qemu-system binary")
+	flags.StringVar(&cfg.QEMU.ImgBinary, "qemu-img-binary", cfg.QEMU.ImgBinary, "qemu-img binary")
+	flags.StringVar(&cfg.QEMU.SWTPMBinary, "swtpm-binary", cfg.QEMU.SWTPMBinary, "swtpm binary")
+	flags.BoolVar(&cfg.QEMU.EnableTPM, "enable-tpm", cfg.QEMU.EnableTPM, "attach a software TPM to the VM")
+	flags.StringVar(&cfg.QEMU.Machine, "qemu-machine", cfg.QEMU.Machine, "QEMU machine type")
+	flags.StringVar(&cfg.QEMU.CPU, "qemu-cpu", cfg.QEMU.CPU, "QEMU CPU model")
+	flags.StringVar(&cfg.QEMU.NICDevice, "qemu-nic-device", cfg.QEMU.NICDevice, "QEMU network device")
+	flags.StringVar(&cfg.QEMU.SerialDevice, "qemu-serial-device", cfg.QEMU.SerialDevice, "QEMU virtio serial device")
+	flags.StringVar(&cfg.QEMU.TPMDevice, "qemu-tpm-device", cfg.QEMU.TPMDevice, "QEMU TPM device")
+	flags.StringVar(&cfg.QEMU.OVMFCodeFile, "ovmf-code-file", cfg.QEMU.OVMFCodeFile, "OVMF code pflash image")
+	flags.StringVar(&cfg.QEMU.OVMFVarsTemplate, "ovmf-vars-template", cfg.QEMU.OVMFVarsTemplate, "OVMF vars template copied per runner")
+	flags.StringVar(&cfg.QEMU.DiskSize, "disk-size", cfg.QEMU.DiskSize, "VM disk size passed to qemu-img create")
+	flags.IntVar(&cfg.QEMU.MemoryMiB, "memory-mib", cfg.QEMU.MemoryMiB, "VM memory in MiB")
+	flags.IntVar(&cfg.QEMU.CPUs, "cpus", cfg.QEMU.CPUs, "VM vCPU count")
+
+	root.AddCommand(newControlPlaneCommand())
+	root.AddCommand(version.Command())
+
+	root.CompletionOptions.DisableDefaultCmd = true
+	root.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/deploy/playpen/00-namespace.yaml.tmpl
+++ b/deploy/playpen/00-namespace.yaml.tmpl
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen

--- a/deploy/playpen/01-serviceaccount.yaml.tmpl
+++ b/deploy/playpen/01-serviceaccount.yaml.tmpl
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: playpen-operator
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: playpen-runner
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-runner
+    app.kubernetes.io/component: runner
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: playpen-control-plane
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-control-plane
+    app.kubernetes.io/component: control-plane

--- a/deploy/playpen/02-rbac.yaml.tmpl
+++ b/deploy/playpen/02-rbac.yaml.tmpl
@@ -1,0 +1,143 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: playpen-operator
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    resourceNames: ["v1alpha1.playpen.unbounded-cloud.io"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: playpen-operator
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: playpen-operator
+subjects:
+  - kind: ServiceAccount
+    name: playpen-operator
+    namespace: {{ default "playpen" .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: playpen-operator
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["extension-apiserver-authentication"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: playpen-operator
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: playpen-operator
+subjects:
+  - kind: ServiceAccount
+    name: playpen-operator
+    namespace: {{ default "playpen" .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: playpen-operator
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: playpen-operator
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: playpen-operator
+subjects:
+  - kind: ServiceAccount
+    name: playpen-operator
+    namespace: {{ default "playpen" .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: playpen-runner
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-runner
+    app.kubernetes.io/component: runner
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: playpen-runner
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-runner
+    app.kubernetes.io/component: runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: playpen-runner
+subjects:
+  - kind: ServiceAccount
+    name: playpen-runner
+    namespace: {{ default "playpen" .Namespace }}
+  - kind: ServiceAccount
+    name: playpen-control-plane
+    namespace: {{ default "playpen" .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: playpen-user
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups: ["playpen.unbounded-cloud.io"]
+    resources: ["allocs", "deallocs"]
+    verbs: ["create"]

--- a/deploy/playpen/03-operator.yaml.tmpl
+++ b/deploy/playpen/03-operator.yaml.tmpl
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: playpen-operator
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: playpen-operator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: playpen-operator
+        app.kubernetes.io/component: operator
+      annotations:
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
+    spec:
+      serviceAccountName: playpen-operator
+      containers:
+        - name: operator
+          image: {{ default "ghcr.io/azure/playpen:latest" .PlaypenImage }}
+          imagePullPolicy: Always
+          command:
+            - /unbounded/bin/playpen-operator
+          args:
+            - --listen-addr=:8443
+            - --namespace={{ default "playpen" .Namespace }}
+            - --service-name=playpen-operator
+            - --runner-namespace={{ default "playpen" .Namespace }}
+            - --runner-label-selector=app.kubernetes.io/name=playpen-runner
+            - --runner-image={{ default (default "ghcr.io/azure/playpen:latest" .PlaypenImage) .RunnerImage }}
+            - --runner-image-pull-policy={{ default "Always" .RunnerImagePullPolicy }}
+            - --runner-service-account-name=playpen-runner
+            - --runner-amd64-count={{ default "2" .RunnerAMD64Count }}
+            - --runner-arm64-count={{ default "2" .RunnerARM64Count }}
+            - --runner-wireguard-host-port-start={{ default "51820" .RunnerWireGuardHostPortStart }}
+            - --runner-wireguard-host-port-end={{ default "51899" .RunnerWireGuardHostPortEnd }}
+            - --runner-require-kvm={{ default "true" .RunnerRequireKVM }}
+            - --runner-control-plane-tolerations={{ default "false" .RunnerControlPlaneTolerations }}
+            - --control-plane-count={{ default "1" .ControlPlaneCount }}
+            - --control-plane-versions={{ default "v1.33.0" .ControlPlaneVersions }}
+            - --control-plane-image={{ default "rancher/k3s:{version}-k3s1" .ControlPlaneImage }}
+            - --control-plane-service-account-name=playpen-control-plane
+            - --control-plane-apiserver-host-port-start={{ default "16443" .ControlPlaneAPIServerHostPortStart }}
+            - --control-plane-apiserver-host-port-end={{ default "16499" .ControlPlaneAPIServerHostPortEnd }}
+            - --playpen-ttl={{ default "1h" .PlaypenTTL }}
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "4"
+              memory: 8Gi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - ALL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: playpen-operator
+  namespace: {{ default "playpen" .Namespace }}
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: playpen-operator
+  ports:
+    - name: https
+      port: 443
+      targetPort: https
+      protocol: TCP

--- a/deploy/playpen/05-apiservice.yaml.tmpl
+++ b/deploy/playpen/05-apiservice.yaml.tmpl
@@ -1,0 +1,17 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.playpen.unbounded-cloud.io
+  labels:
+    app.kubernetes.io/name: playpen-operator
+    app.kubernetes.io/component: operator
+spec:
+  group: playpen.unbounded-cloud.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  insecureSkipTLSVerify: false
+  service:
+    name: playpen-operator
+    namespace: {{ default "playpen" .Namespace }}
+    port: 443

--- a/deploy/playpen/rendered/.gitignore
+++ b/deploy/playpen/rendered/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/e2e/playpen/kind-config.yaml
+++ b/e2e/playpen/kind-config.yaml
@@ -1,0 +1,6 @@
+# kind cluster topology for the playpen e2e suite.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: playpen-e2e
+nodes:
+  - role: control-plane

--- a/e2e/playpen/playpen_e2e_test.go
+++ b/e2e/playpen/playpen_e2e_test.go
@@ -1,0 +1,892 @@
+//go:build e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package playpen
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	playpenclient "github.com/Azure/unbounded/internal/playpen/client"
+	"github.com/Azure/unbounded/internal/playpen/operator"
+	"github.com/Azure/unbounded/internal/playpen/runner"
+)
+
+const (
+	clusterName = "playpen-e2e"
+	imageTag    = "playpen:e2e"
+	namespace   = "playpen"
+)
+
+type harness struct {
+	t           *testing.T
+	repoRoot    string
+	artifacts   string
+	keepCluster bool
+
+	restConfig *rest.Config
+	kubeClient kubernetes.Interface
+}
+
+type operatorTransport struct {
+	op *operator.Operator
+}
+
+func (t operatorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	switch req.URL.Path {
+	case "/apis/playpen.unbounded-cloud.io/v1alpha1/allocs":
+		return t.allocate(req)
+	case "/apis/playpen.unbounded-cloud.io/v1alpha1/deallocs":
+		return t.deallocate(req)
+	default:
+		return jsonResponse(req, http.StatusNotFound, map[string]string{"error": "not found"})
+	}
+}
+
+func (t operatorTransport) allocate(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodPost {
+		return jsonResponse(req, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+
+	var allocReq operator.AllocRequest
+	if err := json.NewDecoder(req.Body).Decode(&allocReq); err != nil {
+		return jsonResponse(req, http.StatusBadRequest, map[string]string{"error": "invalid JSON request"})
+	}
+
+	allocResp, status, err := t.op.Alloc(req.Context(), req.Header.Get("Idempotency-Key"), allocReq)
+	if err != nil {
+		return jsonResponse(req, status, map[string]string{"error": err.Error()})
+	}
+	return jsonResponse(req, status, allocResp)
+}
+
+func (t operatorTransport) deallocate(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodPost {
+		return jsonResponse(req, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+
+	status, err := t.op.Dealloc(req.Context(), req.Header.Get("Idempotency-Key"))
+	if err != nil {
+		return jsonResponse(req, status, map[string]string{"error": err.Error()})
+	}
+
+	return jsonResponse(req, status, nil)
+}
+
+func jsonResponse(req *http.Request, status int, value any) (*http.Response, error) {
+	var body []byte
+
+	if value != nil {
+		var err error
+
+		body, err = json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Request:    req,
+	}, nil
+}
+
+func TestPlaypenBasicLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	h := newHarness(t)
+	h.checkPrereqs()
+	h.bootCluster(ctx)
+
+	if !h.keepCluster {
+		t.Cleanup(func() { h.teardown(context.Background()) })
+	}
+
+	h.buildAndLoadImage(ctx)
+	h.renderManifests(ctx)
+	h.applyManifests(ctx)
+	h.patchNodeExternalIPs(ctx)
+	h.waitForRollouts(ctx)
+	h.patchNodeExternalIPs(ctx)
+	h.waitForReadyRunner(ctx)
+
+	client, err := h.newPlaypenClient()
+	if err != nil {
+		t.Fatalf("create playpen client: %v", err)
+	}
+
+	allocated, err := client.Allocate(ctx, playpenclient.AllocateOptions{Architecture: runner.ArchitectureAMD64})
+	if err != nil {
+		t.Fatalf("allocate playpen: %v", err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+
+		if err := allocated.Close(closeCtx); err != nil {
+			t.Logf("close playpen during cleanup: %v", err)
+		}
+	})
+
+	if allocated.Metadata.Pod.Namespace != namespace || allocated.Metadata.Pod.Name == "" {
+		t.Fatalf("allocation returned unexpected pod metadata: %#v", allocated.Metadata.Pod)
+	}
+
+	if allocated.Metadata.Endpoint.Host == "" || allocated.Metadata.Endpoint.WireGuardUDPPort == 0 {
+		t.Fatalf("allocation returned incomplete endpoint metadata: %#v", allocated.Metadata.Endpoint)
+	}
+
+	if allocated.Metadata.WireGuard.ServerPublicKey == "" || allocated.Metadata.WireGuard.ClientAddress == "" {
+		t.Fatalf("allocation returned incomplete wireguard metadata: %#v", allocated.Metadata.WireGuard)
+	}
+
+	if allocated.Metadata.VXLAN.VNI == 0 || allocated.Metadata.VXLAN.UDPPort == 0 {
+		t.Fatalf("allocation returned incomplete vxlan metadata: %#v", allocated.Metadata.VXLAN)
+	}
+
+	h.waitForPodAnnotation(ctx, allocated.Metadata.Pod.Name, operator.AnnotationIdempotencyKeyHash, true)
+
+	if err := allocated.ConfigureTunnel(ctx); err != nil {
+		t.Fatalf("configure tunnel: %v", err)
+	}
+
+	h.verifyTunnelInterfaces(ctx, allocated)
+	h.verifyTunnelConnectivity(ctx, allocated)
+
+	if err := allocated.Close(ctx); err != nil {
+		t.Fatalf("close playpen: %v", err)
+	}
+
+	h.waitForPodDeleted(ctx, allocated.Metadata.Pod.Name)
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	repoRoot := filepath.Dir(filepath.Dir(wd))
+
+	artifacts := filepath.Join(wd, ".artifacts")
+	if err := os.MkdirAll(artifacts, 0o755); err != nil {
+		t.Fatalf("mkdir artifacts: %v", err)
+	}
+
+	return &harness{t: t, repoRoot: repoRoot, artifacts: artifacts, keepCluster: os.Getenv("E2E_KEEP") == "1"}
+}
+
+func (h *harness) checkPrereqs() {
+	h.t.Helper()
+
+	for _, bin := range []string{"bridge", "docker", "ip", "iptables", "kind", "kubectl", "sysctl", "wg"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			h.t.Skipf("e2e prereq %q missing on PATH; skipping suite", bin)
+		}
+	}
+
+	if os.Geteuid() != 0 {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			h.t.Skipf("e2e prereq %q missing on PATH; skipping suite", "sudo")
+		}
+
+		if err := h.run(context.Background(), "sudo", "-n", "true"); err != nil {
+			h.t.Skipf("passwordless sudo unavailable (%v); skipping suite", err)
+		}
+	}
+
+	if err := h.run(context.Background(), "docker", "info"); err != nil {
+		h.t.Skipf("docker engine unreachable (%v); skipping suite", err)
+	}
+}
+
+func (h *harness) bootCluster(ctx context.Context) {
+	h.t.Helper()
+
+	if !h.keepCluster && h.clusterExists(ctx) {
+		h.teardown(ctx)
+	}
+
+	if h.clusterExists(ctx) {
+		h.initClients()
+
+		return
+	}
+
+	cfg := filepath.Join(h.repoRoot, "e2e", "playpen", "kind-config.yaml")
+	if err := h.run(ctx, "kind", "create", "cluster", "--name", clusterName, "--config", cfg, "--wait", "120s"); err != nil {
+		h.t.Fatalf("kind create cluster: %v", err)
+	}
+
+	h.initClients()
+}
+
+func (h *harness) clusterExists(ctx context.Context) bool {
+	out, err := h.runOut(ctx, "kind", "get", "clusters")
+	if err != nil {
+		return false
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == clusterName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (h *harness) initClients() {
+	h.t.Helper()
+
+	kubeconfig, err := h.runOut(context.Background(), "kind", "get", "kubeconfig", "--name", clusterName)
+	if err != nil {
+		h.t.Fatalf("kind get kubeconfig: %v", err)
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
+	if err != nil {
+		h.t.Fatalf("parse kubeconfig: %v", err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		h.t.Fatalf("create kubernetes client: %v", err)
+	}
+
+	h.restConfig = restConfig
+	h.kubeClient = kubeClient
+}
+
+func (h *harness) newPlaypenClient() (*playpenclient.Client, error) {
+	h.t.Helper()
+
+	scheme := k8sruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	kubeClient, err := ctrlclient.New(h.restConfig, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("create operator client: %w", err)
+	}
+
+	cfg := operator.DefaultConfig()
+	cfg.Namespace = namespace
+	cfg.RunnerNamespace = namespace
+	cfg.RunnerLabelSelector = "app.kubernetes.io/name=playpen-runner"
+
+	op := &operator.Operator{
+		Client:     kubeClient,
+		KubeClient: h.kubeClient,
+		Config:     cfg,
+		Scheme:     scheme,
+	}
+
+	return playpenclient.New(playpenclient.Config{
+		RESTConfig: &rest.Config{Host: "http://playpen-e2e.local"},
+		HTTPClient: &http.Client{Transport: operatorTransport{op: op}},
+	})
+}
+
+func (h *harness) buildAndLoadImage(ctx context.Context) {
+	h.t.Helper()
+
+	platform := fmt.Sprintf("linux/%s", goArchForDocker(runtime.GOARCH))
+	if err := h.run(ctx, "docker", "build", "--platform", platform, "-t", imageTag, "-f", filepath.Join(h.repoRoot, "images", "playpen", "Containerfile"), h.repoRoot); err != nil {
+		h.t.Fatalf("build playpen image: %v", err)
+	}
+
+	if err := h.run(ctx, "kind", "load", "docker-image", imageTag, "--name", clusterName); err != nil {
+		h.t.Fatalf("kind load playpen image: %v", err)
+	}
+}
+
+func (h *harness) renderManifests(ctx context.Context) {
+	h.t.Helper()
+
+	manifestDir := filepath.Join(h.artifacts, "rendered")
+	if err := os.RemoveAll(manifestDir); err != nil {
+		h.t.Fatalf("clean rendered manifests: %v", err)
+	}
+
+	if err := h.run(
+		ctx,
+		"go", "run", "./hack/cmd/render-manifests",
+		"--templates-dir", filepath.Join(h.repoRoot, "deploy", "playpen"),
+		"--output-dir", manifestDir,
+		"--set", "Namespace="+namespace,
+		"--set", "PlaypenImage="+imageTag,
+		"--set", "RunnerImagePullPolicy=IfNotPresent",
+		"--set", "RunnerAMD64Count=1",
+		"--set", "RunnerARM64Count=0",
+		"--set", "ControlPlaneCount=0",
+		"--set", "RunnerRequireKVM=false",
+		"--set", "RunnerControlPlaneTolerations=true",
+	); err != nil {
+		h.t.Fatalf("render playpen manifests: %v", err)
+	}
+}
+
+func (h *harness) applyManifests(ctx context.Context) {
+	h.t.Helper()
+
+	manifestDir := filepath.Join(h.artifacts, "rendered")
+	if err := h.run(ctx, "kubectl", "apply", "-f", manifestDir); err != nil {
+		h.t.Fatalf("apply playpen manifests: %v", err)
+	}
+
+	operatorPatch := map[string]any{
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"tolerations": controlPlaneTolerations(),
+					"containers": []map[string]any{{
+						"name":            "operator",
+						"imagePullPolicy": "IfNotPresent",
+						"env": []map[string]any{
+							{"name": "KUBERNETES_SERVICE_HOST", "value": h.controlPlaneIP(ctx)},
+							{"name": "KUBERNETES_SERVICE_PORT", "value": "6443"},
+							{"name": "KUBERNETES_SERVICE_PORT_HTTPS", "value": "6443"},
+						},
+					}},
+				},
+			},
+		},
+	}
+	h.patchDeployment(ctx, "playpen-operator", operatorPatch)
+}
+
+func controlPlaneTolerations() []map[string]any {
+	return []map[string]any{
+		{
+			"key":      "node-role.kubernetes.io/control-plane",
+			"operator": "Exists",
+			"effect":   "NoSchedule",
+		},
+		{
+			"key":      "node-role.kubernetes.io/master",
+			"operator": "Exists",
+			"effect":   "NoSchedule",
+		},
+	}
+}
+
+func (h *harness) patchDeployment(ctx context.Context, name string, patch map[string]any) {
+	h.t.Helper()
+
+	data, err := json.Marshal(patch)
+	if err != nil {
+		h.t.Fatalf("marshal deployment patch: %v", err)
+	}
+
+	if _, err := h.kubeClient.AppsV1().Deployments(namespace).Patch(ctx, name, types.StrategicMergePatchType, data, metav1.PatchOptions{}); err != nil {
+		h.t.Fatalf("patch deployment %s: %v", name, err)
+	}
+}
+
+func (h *harness) patchNodeExternalIPs(ctx context.Context) {
+	h.t.Helper()
+
+	if err := wait(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
+		nodes, err := h.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		ready := true
+
+		for i := range nodes.Items {
+			node := nodes.Items[i]
+
+			internalIP := nodeAddress(node, corev1.NodeInternalIP)
+			if internalIP == "" {
+				continue
+			}
+
+			if nodeAddress(node, corev1.NodeExternalIP) != "" {
+				continue
+			}
+
+			ready = false
+			patch := []map[string]any{{
+				"op":    "add",
+				"path":  "/status/addresses/-",
+				"value": map[string]string{"type": string(corev1.NodeExternalIP), "address": internalIP},
+			}}
+
+			data, err := json.Marshal(patch)
+			if err != nil {
+				return false, err
+			}
+
+			if _, err := h.kubeClient.CoreV1().Nodes().Patch(ctx, node.Name, types.JSONPatchType, data, metav1.PatchOptions{}, "status"); err != nil {
+				return false, err
+			}
+		}
+
+		return ready, nil
+	}); err != nil {
+		h.t.Fatalf("patch node ExternalIPs: %v", err)
+	}
+}
+
+func nodeAddress(node corev1.Node, addressType corev1.NodeAddressType) string {
+	for _, address := range node.Status.Addresses {
+		if address.Type == addressType {
+			return address.Address
+		}
+	}
+
+	return ""
+}
+
+func (h *harness) controlPlaneIP(ctx context.Context) string {
+	h.t.Helper()
+
+	nodes, err := h.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/control-plane"})
+	if err != nil {
+		h.t.Fatalf("list control-plane nodes: %v", err)
+	}
+
+	if len(nodes.Items) == 0 {
+		h.t.Fatal("no control-plane node found")
+	}
+
+	address := nodeAddress(nodes.Items[0], corev1.NodeInternalIP)
+	if address == "" {
+		h.t.Fatalf("control-plane node %s has no InternalIP", nodes.Items[0].Name)
+	}
+
+	return address
+}
+
+func (h *harness) waitForRollouts(ctx context.Context) {
+	h.t.Helper()
+
+	for _, name := range []string{"playpen-operator"} {
+		if err := h.run(ctx, "kubectl", "rollout", "status", "deployment/"+name, "-n", namespace, "--timeout=180s"); err != nil {
+			h.dumpDiagnostics(context.Background())
+			h.t.Fatalf("rollout %s: %v", name, err)
+		}
+	}
+}
+
+func (h *harness) waitForReadyRunner(ctx context.Context) {
+	h.t.Helper()
+
+	if err := wait(ctx, 60*time.Second, func(ctx context.Context) (bool, error) {
+		pods, err := h.kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=playpen-runner,playpen.unbounded-cloud.io/architecture=amd64"})
+		if err != nil {
+			return false, err
+		}
+
+		for i := range pods.Items {
+			pod := pods.Items[i]
+			if !pod.DeletionTimestamp.IsZero() || pod.Status.Phase != corev1.PodRunning || pod.Spec.NodeName == "" {
+				continue
+			}
+
+			if pod.Annotations[operator.AnnotationIdempotencyKeyHash] != "" || pod.Annotations[operator.AnnotationServerWireGuardPublicKey] == "" {
+				continue
+			}
+
+			ready := len(pod.Status.ContainerStatuses) > 0
+			for _, status := range pod.Status.ContainerStatuses {
+				ready = ready && status.Ready && status.State.Running != nil
+			}
+
+			if !ready {
+				continue
+			}
+
+			node, err := h.kubeClient.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+
+			if nodeAddress(*node, corev1.NodeExternalIP) != "" {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}); err != nil {
+		h.dumpDiagnostics(context.Background())
+		h.t.Fatalf("wait for ready playpen runner: %v", err)
+	}
+}
+
+func (h *harness) waitForPodAnnotation(ctx context.Context, podName, annotation string, wantPresent bool) {
+	h.t.Helper()
+
+	if err := wait(ctx, 60*time.Second, func(ctx context.Context) (bool, error) {
+		pod, err := h.kubeClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		_, present := pod.Annotations[annotation]
+
+		return present == wantPresent, nil
+	}); err != nil {
+		h.t.Fatalf("wait for pod %s annotation %s presence=%t: %v", podName, annotation, wantPresent, err)
+	}
+}
+
+func (h *harness) waitForPodDeleted(ctx context.Context, podName string) {
+	h.t.Helper()
+
+	if err := wait(ctx, 90*time.Second, func(ctx context.Context) (bool, error) {
+		_, err := h.kubeClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+
+		return err != nil, nil
+	}); err != nil {
+		h.t.Fatalf("wait for pod %s deletion: %v", podName, err)
+	}
+}
+
+func (h *harness) verifyTunnelInterfaces(ctx context.Context, allocated *playpenclient.Playpen) {
+	h.t.Helper()
+
+	cfg := allocated.TunnelConfig()
+	if err := allocated.Run(ctx, "ip", "link", "show", "dev", cfg.WireGuardInterface); err != nil {
+		h.t.Fatalf("show wireguard interface %s: %v", cfg.WireGuardInterface, err)
+	}
+
+	if err := allocated.Run(ctx, "ip", "-d", "link", "show", "dev", cfg.VXLANInterface); err != nil {
+		h.t.Fatalf("show vxlan interface %s: %v", cfg.VXLANInterface, err)
+	}
+
+	peers, err := h.runPlaypenOut(ctx, allocated, "wg", "show", cfg.WireGuardInterface, "peers")
+	if err != nil {
+		h.t.Fatalf("show wireguard peers for %s: %v", cfg.WireGuardInterface, err)
+	}
+
+	if !strings.Contains(peers, allocated.Metadata.WireGuard.ServerPublicKey) {
+		h.t.Fatalf("wireguard peers for %s do not include server public key %s: %s", cfg.WireGuardInterface, allocated.Metadata.WireGuard.ServerPublicKey, peers)
+	}
+
+	guestGateway := guestGatewayPrefix(h.t, allocated.Metadata.Network)
+	vxlanAddr, err := h.runPlaypenOut(ctx, allocated, "ip", "addr", "show", "dev", cfg.VXLANInterface)
+	if err != nil {
+		h.t.Fatalf("show vxlan address for %s: %v", cfg.VXLANInterface, err)
+	}
+
+	if !strings.Contains(vxlanAddr, guestGateway) {
+		h.t.Fatalf("vxlan interface %s missing guest gateway %s:\n%s", cfg.VXLANInterface, guestGateway, vxlanAddr)
+	}
+
+	guestSubnet := guestSubnetCIDR(h.t, allocated.Metadata.Network)
+	natRules, err := h.runPlaypenOut(ctx, allocated, "iptables", "-t", "nat", "-S", "POSTROUTING")
+	if err != nil {
+		h.t.Fatalf("show playpen namespace NAT rules: %v", err)
+	}
+
+	wantNAT := "-A POSTROUTING -s " + guestSubnet + " -o " + cfg.ManagementNamespaceInterface + " -j MASQUERADE"
+	if !strings.Contains(natRules, wantNAT) {
+		h.t.Fatalf("playpen namespace NAT rules missing %q:\n%s", wantNAT, natRules)
+	}
+}
+
+func guestGatewayPrefix(t *testing.T, network operator.NetworkResponse) string {
+	t.Helper()
+
+	gatewayIP, err := netip.ParseAddr(network.GatewayIPv4)
+	if err != nil {
+		t.Fatalf("parse gateway IPv4 %q: %v", network.GatewayIPv4, err)
+	}
+
+	return netip.PrefixFrom(gatewayIP, subnetMaskPrefixLength(t, network.SubnetMask)).String()
+}
+
+func guestSubnetCIDR(t *testing.T, network operator.NetworkResponse) string {
+	t.Helper()
+
+	guestIP, err := netip.ParseAddr(network.GuestIPv4)
+	if err != nil {
+		t.Fatalf("parse guest IPv4 %q: %v", network.GuestIPv4, err)
+	}
+
+	return netip.PrefixFrom(guestIP, subnetMaskPrefixLength(t, network.SubnetMask)).Masked().String()
+}
+
+func subnetMaskPrefixLength(t *testing.T, subnetMask string) int {
+	t.Helper()
+
+	mask := net.ParseIP(subnetMask).To4()
+	if mask == nil {
+		t.Fatalf("parse subnet mask %q", subnetMask)
+	}
+
+	ones, bits := net.IPMask(mask).Size()
+	if bits != 32 {
+		t.Fatalf("subnet mask %q is not contiguous", subnetMask)
+	}
+
+	return ones
+}
+
+func (h *harness) verifyTunnelConnectivity(ctx context.Context, allocated *playpenclient.Playpen) {
+	h.t.Helper()
+
+	readyURL := strings.TrimRight(allocated.Metadata.Redfish["url"], "/") + "/readyz"
+	if _, err := url.ParseRequestURI(readyURL); err != nil {
+		h.t.Fatalf("parse redfish ready URL %q: %v", readyURL, err)
+	}
+
+	if err := wait(ctx, 45*time.Second, func(ctx context.Context) (bool, error) {
+		cmd, err := allocated.Command(ctx, os.Args[0], "-test.run", "^TestPlaypenRedfishReadyProbe$", "-test.count=1")
+		if err != nil {
+			return false, err
+		}
+
+		cmd.Dir = h.repoRoot
+		cmd.Env = append(
+			os.Environ(),
+			"PLAYPEN_REDFISH_PROBE_URL="+readyURL,
+			"PLAYPEN_REDFISH_PROBE_CERT_PEM="+strings.TrimSpace(allocated.Metadata.Redfish["certPEM"]),
+		)
+
+		_, err = h.runPlaypenCmdOut(cmd)
+		if err != nil {
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		h.dumpTunnelDiagnostics(context.Background(), allocated)
+		h.t.Fatalf("verify tunnel connectivity to %s: %v", readyURL, err)
+	}
+}
+
+func (h *harness) dumpTunnelDiagnostics(ctx context.Context, allocated *playpenclient.Playpen) {
+	cfg := allocated.TunnelConfig()
+	for _, args := range [][]string{
+		{"addr", "show", "dev", cfg.WireGuardInterface},
+		{"route", "get", "10.88.0.1"},
+		{"-d", "link", "show", "dev", cfg.VXLANInterface},
+	} {
+		out, err := h.runPlaypenOut(ctx, allocated, "ip", args...)
+		if err != nil {
+			h.t.Logf("ip %s failed: %v", strings.Join(args, " "), err)
+			continue
+		}
+
+		h.t.Logf("ip %s\n%s", strings.Join(args, " "), out)
+	}
+
+	for _, args := range [][]string{
+		{"show", cfg.WireGuardInterface},
+		{"show", cfg.WireGuardInterface, "endpoints"},
+		{"show", cfg.WireGuardInterface, "latest-handshakes"},
+	} {
+		out, err := h.runPlaypenOut(ctx, allocated, "wg", args...)
+		if err != nil {
+			h.t.Logf("wg %s failed: %v", strings.Join(args, " "), err)
+			continue
+		}
+
+		h.t.Logf("wg %s\n%s", strings.Join(args, " "), out)
+	}
+
+	for _, args := range [][]string{
+		{"get", "pod", allocated.Metadata.Pod.Name, "-n", namespace, "-o", "yaml"},
+		{"logs", "-n", namespace, allocated.Metadata.Pod.Name, "--tail=200"},
+	} {
+		out, err := h.runOut(ctx, "kubectl", args...)
+		if err != nil {
+			h.t.Logf("kubectl %s failed: %v", strings.Join(args, " "), err)
+			continue
+		}
+
+		h.t.Logf("kubectl %s\n%s", strings.Join(args, " "), out)
+	}
+}
+
+func TestPlaypenRedfishReadyProbe(t *testing.T) {
+	readyURL := os.Getenv("PLAYPEN_REDFISH_PROBE_URL")
+	certPEM := os.Getenv("PLAYPEN_REDFISH_PROBE_CERT_PEM")
+	if readyURL == "" && certPEM == "" {
+		t.Skip("helper process only")
+	}
+
+	if readyURL == "" || certPEM == "" {
+		t.Fatal("PLAYPEN_REDFISH_PROBE_URL and PLAYPEN_REDFISH_PROBE_CERT_PEM are required")
+	}
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM([]byte(certPEM)) {
+		t.Fatal("invalid Redfish certificate PEM")
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots}
+	client := &http.Client{Timeout: 5 * time.Second, Transport: transport}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, readyURL, http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // Test cleanup only.
+
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck // Test response drain only.
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+}
+
+func (h *harness) teardown(ctx context.Context) {
+	if err := h.run(ctx, "kind", "delete", "cluster", "--name", clusterName); err != nil {
+		h.t.Logf("kind delete cluster: %v", err)
+	}
+}
+
+func (h *harness) dumpDiagnostics(ctx context.Context) {
+	for _, args := range [][]string{
+		{"get", "pods", "-n", namespace, "-o", "wide"},
+		{"describe", "pods", "-n", namespace},
+		{"logs", "-n", namespace, "deployment/playpen-operator"},
+		{"logs", "-n", namespace, "-l", "app.kubernetes.io/name=playpen-runner", "--tail=200"},
+		{"get", "apiservice", "v1alpha1.playpen.unbounded-cloud.io", "-o", "yaml"},
+	} {
+		out, err := h.runOut(ctx, "kubectl", args...)
+		if err != nil {
+			h.t.Logf("kubectl %s failed: %v", strings.Join(args, " "), err)
+			continue
+		}
+
+		h.t.Logf("kubectl %s\n%s", strings.Join(args, " "), out)
+	}
+}
+
+func (h *harness) run(ctx context.Context, name string, args ...string) error {
+	_, err := h.runCaptured(ctx, name, nil, args...)
+
+	return err
+}
+
+func (h *harness) runOut(ctx context.Context, name string, args ...string) (string, error) {
+	out, err := h.runCaptured(ctx, name, nil, args...)
+
+	return out, err
+}
+
+func (h *harness) runPlaypenOut(ctx context.Context, allocated *playpenclient.Playpen, name string, args ...string) (string, error) {
+	h.t.Helper()
+
+	cmd, err := allocated.Command(ctx, name, args...)
+	if err != nil {
+		return "", err
+	}
+
+	cmd.Dir = h.repoRoot
+
+	return h.runPlaypenCmdOut(cmd)
+}
+
+func (h *harness) runPlaypenCmdOut(cmd *exec.Cmd) (string, error) {
+	h.t.Helper()
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%s %s: %w\n%s", cmd.Path, strings.Join(cmd.Args[1:], " "), err, out.String())
+	}
+
+	return out.String(), nil
+}
+
+func (h *harness) runCaptured(ctx context.Context, name string, stdin io.Reader, args ...string) (string, error) {
+	h.t.Helper()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = h.repoRoot
+	cmd.Stdin = stdin
+
+	var out bytes.Buffer
+
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%s %s: %w\n%s", name, strings.Join(args, " "), err, out.String())
+	}
+
+	return out.String(), nil
+}
+
+func wait(ctx context.Context, timeout time.Duration, condition func(context.Context) (bool, error)) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		ok, err := condition(ctx)
+		if ok || err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func goArchForDocker(arch string) string {
+	switch arch {
+	case "amd64", "arm64":
+		return arch
+	case "arm":
+		return "arm/v7"
+	default:
+		return arch
+	}
+}

--- a/images/playpen/Containerfile
+++ b/images/playpen/Containerfile
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.4-trixie AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    make \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV CGO_ENABLED=0
+ENV GOPATH=/go
+ENV GOTOOLCHAIN=auto
+ENV PATH=$PATH:/go/bin
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=
+ARG BUILD_TIME=
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build \
+      -ldflags "-X github.com/Azure/unbounded/internal/version.Version=${VERSION} -X github.com/Azure/unbounded/internal/version.GitCommit=${GIT_COMMIT} -X github.com/Azure/unbounded/internal/version.BuildTime=${BUILD_TIME}" \
+      -o bin/playpen-runner \
+      ./cmd/playpen-runner && \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build \
+      -ldflags "-X github.com/Azure/unbounded/internal/version.Version=${VERSION} -X github.com/Azure/unbounded/internal/version.GitCommit=${GIT_COMMIT} -X github.com/Azure/unbounded/internal/version.BuildTime=${BUILD_TIME}" \
+      -o bin/playpen-operator \
+      ./cmd/playpen-operator
+
+FROM ubuntu:noble
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    iproute2 \
+    ovmf \
+    qemu-efi-aarch64 \
+    qemu-system-arm \
+    qemu-system-x86 \
+    qemu-utils \
+    swtpm \
+    wireguard-tools \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /unbounded/bin /var/lib/playpen-runner /etc/playpen/wireguard
+COPY --from=builder /src/bin/playpen-runner /unbounded/bin/playpen-runner
+COPY --from=builder /src/bin/playpen-operator /unbounded/bin/playpen-operator
+
+ENV PATH="/unbounded/bin:${PATH}"
+WORKDIR /unbounded

--- a/internal/playpen/client/client.go
+++ b/internal/playpen/client/client.go
@@ -1,0 +1,369 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"k8s.io/client-go/rest"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/Azure/unbounded/internal/playpen/operator"
+)
+
+const (
+	idempotencyKeyHeader = "Idempotency-Key"
+	allocsPath           = "/apis/playpen.unbounded-cloud.io/v1alpha1/allocs"
+	deallocsPath         = "/apis/playpen.unbounded-cloud.io/v1alpha1/deallocs"
+)
+
+// Config contains settings for connecting to the playpen aggregated API.
+type Config struct {
+	// RESTConfig connects to the Kubernetes API server hosting the playpen aggregated API.
+	RESTConfig *rest.Config
+	// HTTPClient overrides the client built from RESTConfig. It is intended for tests.
+	HTTPClient *http.Client
+	cmd        commander
+}
+
+// Client is a high-level client for allocating and releasing playpens.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	cmd        commander
+}
+
+// AllocateOptions controls one playpen allocation.
+type AllocateOptions struct {
+	// Architecture optionally requests a runner architecture. Empty defaults to amd64.
+	Architecture string
+	// KubernetesVersion optionally requests a control-plane Kubernetes version.
+	KubernetesVersion string
+	// WireGuardPrivateKey is the client's WireGuard private key. If empty, one is generated.
+	WireGuardPrivateKey string
+	// Tunnel optionally overrides local tunnel settings.
+	Tunnel TunnelConfig
+}
+
+// Playpen represents one allocated playpen runner pod and its local resources.
+type Playpen struct {
+	client              *Client
+	mu                  sync.Mutex
+	idempotencyKey      string
+	wireGuardPrivateKey string
+	closed              bool
+	tunnel              *tunnel
+
+	Metadata operator.AllocResponse
+}
+
+// ControlPlane represents one allocated playpen Kubernetes control plane.
+type ControlPlane struct {
+	client         *Client
+	mu             sync.Mutex
+	idempotencyKey string
+	closed         bool
+
+	Metadata operator.AllocResponse
+}
+
+// New returns a client configured to use the Kubernetes aggregated API server.
+func New(cfg Config) (*Client, error) {
+	if cfg.RESTConfig == nil {
+		return nil, fmt.Errorf("REST config is required")
+	}
+
+	restConfig := rest.CopyConfig(cfg.RESTConfig)
+
+	baseURL := strings.TrimRight(strings.TrimSpace(restConfig.Host), "/")
+	if baseURL == "" {
+		return nil, fmt.Errorf("REST config host is required")
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		var err error
+
+		httpClient, err = rest.HTTPClientFor(restConfig)
+		if err != nil {
+			return nil, fmt.Errorf("create Kubernetes HTTP client: %w", err)
+		}
+	}
+
+	cmd := cfg.cmd
+	if cmd == nil {
+		cmd = osCommander{}
+	}
+
+	return &Client{baseURL: baseURL, httpClient: httpClient, cmd: cmd}, nil
+}
+
+// Allocate allocates an idle playpen runner and returns its metadata.
+func (c *Client) Allocate(ctx context.Context, opts AllocateOptions) (*Playpen, error) {
+	privateKey := strings.TrimSpace(opts.WireGuardPrivateKey)
+	if privateKey == "" {
+		key, err := wgtypes.GeneratePrivateKey()
+		if err != nil {
+			return nil, fmt.Errorf("generate wireguard key: %w", err)
+		}
+
+		privateKey = key.String()
+	}
+
+	key, err := wgtypes.ParseKey(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse wireguard private key: %w", err)
+	}
+
+	idempotencyKey, err := randomHex(32)
+	if err != nil {
+		return nil, fmt.Errorf("generate idempotency key: %w", err)
+	}
+
+	body, err := json.Marshal(operator.AllocRequest{WireGuardPublicKey: key.PublicKey().String(), Architecture: opts.Architecture})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.newRequest(ctx, http.MethodPost, allocsPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set(idempotencyKeyHeader, idempotencyKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	var resp operator.AllocResponse
+	if err := c.doJSON(req, http.StatusOK, &resp); err != nil {
+		return nil, err
+	}
+
+	return &Playpen{
+		client:              c,
+		idempotencyKey:      idempotencyKey,
+		wireGuardPrivateKey: privateKey,
+		Metadata:            resp,
+		tunnel: newTunnel(c.cmd, privateKey, resp, tunnelConfigWithDefaults(
+			opts.Tunnel,
+			idempotencyKey,
+		)),
+	}, nil
+}
+
+// AllocateControlPlane allocates an idle Kubernetes control plane and returns its metadata.
+func (c *Client) AllocateControlPlane(ctx context.Context, opts AllocateOptions) (*ControlPlane, error) {
+	idempotencyKey, err := randomHex(32)
+	if err != nil {
+		return nil, fmt.Errorf("generate idempotency key: %w", err)
+	}
+
+	body, err := json.Marshal(operator.AllocRequest{ResourceType: operator.ResourceTypeControlPlane, KubernetesVersion: opts.KubernetesVersion})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.newRequest(ctx, http.MethodPost, allocsPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set(idempotencyKeyHeader, idempotencyKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	var resp operator.AllocResponse
+	if err := c.doJSON(req, http.StatusOK, &resp); err != nil {
+		return nil, err
+	}
+
+	return &ControlPlane{client: c, idempotencyKey: idempotencyKey, Metadata: resp}, nil
+}
+
+func (c *Client) deallocate(ctx context.Context, idempotencyKey string) error {
+	req, err := c.newRequest(ctx, http.MethodPost, deallocsPath, http.NoBody)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set(idempotencyKeyHeader, strings.TrimSpace(idempotencyKey))
+
+	return c.doJSON(req, http.StatusNoContent, nil)
+}
+
+// WireGuardPrivateKey returns the client's WireGuard private key for this playpen.
+func (p *Playpen) WireGuardPrivateKey() string {
+	return p.wireGuardPrivateKey
+}
+
+// TunnelConfig returns the local tunnel settings for this playpen.
+func (p *Playpen) TunnelConfig() TunnelConfig {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.tunnel.cfg
+}
+
+// OverrideEndpoint replaces the WireGuard endpoint used by future tunnel setup.
+func (p *Playpen) OverrideEndpoint(host string, port int32) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.Metadata.Endpoint.Host = strings.TrimSpace(host)
+	p.Metadata.Endpoint.WireGuardUDPPort = port
+	p.tunnel.metadata.Endpoint.Host = p.Metadata.Endpoint.Host
+	p.tunnel.metadata.Endpoint.WireGuardUDPPort = p.Metadata.Endpoint.WireGuardUDPPort
+}
+
+// ConfigureTunnel creates the local WireGuard and VXLAN resources for this playpen.
+func (p *Playpen) ConfigureTunnel(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return fmt.Errorf("playpen is closed")
+	}
+
+	return p.tunnel.Setup(ctx)
+}
+
+// Run executes a command inside the playpen network namespace.
+func (p *Playpen) Run(ctx context.Context, name string, args ...string) error {
+	cmd, err := p.Command(ctx, name, args...)
+	if err != nil {
+		return err
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// Command returns a command configured to execute inside the playpen network namespace.
+func (p *Playpen) Command(ctx context.Context, name string, args ...string) (*exec.Cmd, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, fmt.Errorf("playpen is closed")
+	}
+
+	namespace := strings.TrimSpace(p.tunnel.cfg.NetworkNamespace)
+	if namespace == "" {
+		return nil, fmt.Errorf("network namespace is required")
+	}
+
+	cmdArgs := append([]string{"netns", "exec", namespace, name}, args...)
+
+	cmdName := "ip"
+	if os.Geteuid() != 0 {
+		cmdArgs = append([]string{"-n", cmdName}, cmdArgs...)
+		cmdName = "sudo"
+	}
+
+	return exec.CommandContext(ctx, cmdName, cmdArgs...), nil
+}
+
+// Close tears down local tunnel resources and releases the playpen.
+func (p *Playpen) Close(ctx context.Context) error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+
+		return nil
+	}
+
+	p.closed = true
+	tunnel := p.tunnel
+	idempotencyKey := p.idempotencyKey
+	client := p.client
+	p.mu.Unlock()
+
+	var closeErr error
+	if tunnel != nil {
+		closeErr = tunnel.Teardown(ctx)
+	}
+
+	if err := client.deallocate(ctx, idempotencyKey); err != nil && closeErr == nil {
+		closeErr = err
+	}
+
+	return closeErr
+}
+
+// Kubeconfig returns the host-reachable kubeconfig for this control plane.
+func (cp *ControlPlane) Kubeconfig() string {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	return cp.Metadata.ControlPlane.Kubeconfig
+}
+
+// Close releases the control-plane allocation.
+func (cp *ControlPlane) Close(ctx context.Context) error {
+	cp.mu.Lock()
+	if cp.closed {
+		cp.mu.Unlock()
+
+		return nil
+	}
+
+	cp.closed = true
+	idempotencyKey := cp.idempotencyKey
+	client := cp.client
+	cp.mu.Unlock()
+
+	return client.deallocate(ctx, idempotencyKey)
+}
+
+func (c *Client) newRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (c *Client) doJSON(req *http.Request, wantStatus int, out any) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck // Best-effort close of HTTP response body.
+
+	if resp.StatusCode != wantStatus {
+		data, _ := io.ReadAll(resp.Body) //nolint:errcheck // Best-effort error body read.
+
+		return fmt.Errorf("%s %s returned %d: %s", req.Method, req.URL.Path, resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+
+	if out == nil {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck // Best-effort drain of response body.
+
+		return nil
+	}
+
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func randomHex(bytesLen int) (string, error) {
+	b := make([]byte, bytesLen)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(b), nil
+}

--- a/internal/playpen/client/client_test.go
+++ b/internal/playpen/client/client_test.go
@@ -1,0 +1,420 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"k8s.io/client-go/rest"
+
+	"github.com/Azure/unbounded/internal/playpen/operator"
+)
+
+func TestAllocateGeneratesIdempotencyKeyAndSendsPublicKeyToAggregatedAPI(t *testing.T) {
+	privateKey, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotKey, gotPublicKey, gotArchitecture string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != allocsPath {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+
+		gotKey = r.Header.Get(idempotencyKeyHeader)
+
+		var req operator.AllocRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+
+		gotPublicKey = req.WireGuardPublicKey
+		gotArchitecture = req.Architecture
+
+		writeJSON(t, w, testAllocResponse())
+	}))
+	defer server.Close()
+
+	c, err := New(Config{RESTConfig: &rest.Config{Host: server.URL}, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := c.Allocate(t.Context(), AllocateOptions{Architecture: operator.ArchitectureARM64, WireGuardPrivateKey: privateKey.String()})
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+
+	if gotKey == "" {
+		t.Fatal("idempotency key was not sent")
+	}
+
+	if gotPublicKey != privateKey.PublicKey().String() {
+		t.Fatalf("public key = %q, want %q", gotPublicKey, privateKey.PublicKey().String())
+	}
+
+	if gotArchitecture != operator.ArchitectureARM64 {
+		t.Fatalf("architecture = %q, want %q", gotArchitecture, operator.ArchitectureARM64)
+	}
+
+	if p.Metadata.Pod.Name != "runner-1" {
+		t.Fatalf("pod name = %q", p.Metadata.Pod.Name)
+	}
+}
+
+func TestAllocateControlPlaneSendsResourceTypeAndVersion(t *testing.T) {
+	var gotKey, gotResourceType, gotVersion, gotPublicKey string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != allocsPath {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+
+		gotKey = r.Header.Get(idempotencyKeyHeader)
+
+		var req operator.AllocRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+
+		gotResourceType = req.ResourceType
+		gotVersion = req.KubernetesVersion
+		gotPublicKey = req.WireGuardPublicKey
+
+		writeJSON(t, w, testControlPlaneAllocResponse())
+	}))
+	defer server.Close()
+
+	c, err := New(Config{RESTConfig: &rest.Config{Host: server.URL}, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := c.AllocateControlPlane(t.Context(), AllocateOptions{KubernetesVersion: "v1.33.1"})
+	if err != nil {
+		t.Fatalf("allocate control plane: %v", err)
+	}
+
+	if gotKey == "" {
+		t.Fatal("idempotency key was not sent")
+	}
+
+	if gotResourceType != operator.ResourceTypeControlPlane {
+		t.Fatalf("resourceType = %q, want %q", gotResourceType, operator.ResourceTypeControlPlane)
+	}
+
+	if gotVersion != "v1.33.1" {
+		t.Fatalf("kubernetesVersion = %q, want v1.33.1", gotVersion)
+	}
+
+	if gotPublicKey != "" {
+		t.Fatalf("wireGuardPublicKey = %q, want empty", gotPublicKey)
+	}
+
+	if cp.Kubeconfig() != "host-kubeconfig" {
+		t.Fatalf("kubeconfig = %q", cp.Kubeconfig())
+	}
+}
+
+func TestNewRequiresRESTConfig(t *testing.T) {
+	_, err := New(Config{})
+	if err == nil || !strings.Contains(err.Error(), "REST config") {
+		t.Fatalf("error = %v, want REST config requirement", err)
+	}
+
+	_, err = New(Config{RESTConfig: &rest.Config{}})
+	if err == nil || !strings.Contains(err.Error(), "host") {
+		t.Fatalf("error = %v, want host requirement", err)
+	}
+}
+
+func TestNewUsesKubernetesAuthTransport(t *testing.T) {
+	var gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c, err := New(Config{RESTConfig: &rest.Config{Host: server.URL, BearerToken: "test-token"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.deallocate(t.Context(), "alloc-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotAuth != "Bearer test-token" {
+		t.Fatalf("authorization header = %q, want bearer token", gotAuth)
+	}
+}
+
+func TestCloseTearsDownTunnelBeforeDeallocateAndIsIdempotent(t *testing.T) {
+	fake := &fakeCommander{}
+
+	var deallocCount int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case allocsPath:
+			writeJSON(t, w, testAllocResponse())
+		case deallocsPath:
+			deallocCount++
+
+			if len(fake.commands) == 0 || !containsCommand(fake.commands, "ip netns delete ppns") {
+				t.Fatalf("dealloc happened before tunnel teardown: %#v", fake.commands)
+			}
+
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	c, err := New(Config{RESTConfig: &rest.Config{Host: server.URL}, HTTPClient: server.Client(), cmd: fake})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := c.Allocate(t.Context(), AllocateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.ConfigureTunnel(t.Context()); err != nil {
+		t.Fatalf("configure tunnel: %v", err)
+	}
+
+	if err := p.Close(t.Context()); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if err := p.Close(t.Context()); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+
+	if deallocCount != 1 {
+		t.Fatalf("dealloc count = %d, want 1", deallocCount)
+	}
+}
+
+func TestDeallocateSendsIdempotencyKey(t *testing.T) {
+	var gotKey string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != deallocsPath {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+
+		gotKey = r.Header.Get(idempotencyKeyHeader)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c, err := New(Config{RESTConfig: &rest.Config{Host: server.URL}, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.deallocate(t.Context(), "alloc-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotKey != "alloc-key" {
+		t.Fatalf("idempotency key = %q", gotKey)
+	}
+}
+
+func TestControlPlaneCloseDeallocatesOnce(t *testing.T) {
+	var deallocCount int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case allocsPath:
+			writeJSON(t, w, testControlPlaneAllocResponse())
+		case deallocsPath:
+			deallocCount++
+
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	c, err := New(Config{RESTConfig: &rest.Config{Host: server.URL}, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := c.AllocateControlPlane(t.Context(), AllocateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cp.Close(t.Context()); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if err := cp.Close(t.Context()); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+
+	if deallocCount != 1 {
+		t.Fatalf("dealloc count = %d, want 1", deallocCount)
+	}
+}
+
+func TestPlaypenCommandExecutesInNetworkNamespace(t *testing.T) {
+	p := &Playpen{
+		tunnel: newTunnel(&fakeCommander{}, "private-key", testAllocResponse(), TunnelConfig{NetworkNamespace: "ns-playpen"}),
+	}
+
+	cmd, err := p.Command(t.Context(), "ip", "addr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " ")
+	if os.Geteuid() == 0 {
+		if !strings.Contains(got, "ip netns exec ns-playpen ip addr") {
+			t.Fatalf("command = %q", got)
+		}
+
+		return
+	}
+
+	if !strings.Contains(got, "sudo -n ip netns exec ns-playpen ip addr") {
+		t.Fatalf("command = %q", got)
+	}
+}
+
+func TestOverrideEndpointUpdatesTunnelMetadata(t *testing.T) {
+	metadata := testAllocResponse()
+	p := &Playpen{
+		Metadata: metadata,
+		tunnel:   newTunnel(&fakeCommander{}, "private-key", metadata, TunnelConfig{}),
+	}
+
+	p.OverrideEndpoint("  lb.example.test  ", 51820)
+
+	if p.Metadata.Endpoint.Host != "lb.example.test" || p.Metadata.Endpoint.WireGuardUDPPort != 51820 {
+		t.Fatalf("metadata endpoint = %s:%d", p.Metadata.Endpoint.Host, p.Metadata.Endpoint.WireGuardUDPPort)
+	}
+
+	if p.tunnel.metadata.Endpoint.Host != "lb.example.test" || p.tunnel.metadata.Endpoint.WireGuardUDPPort != 51820 {
+		t.Fatalf("tunnel endpoint = %s:%d", p.tunnel.metadata.Endpoint.Host, p.tunnel.metadata.Endpoint.WireGuardUDPPort)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testAllocResponse() operator.AllocResponse {
+	return operator.AllocResponse{
+		ResourceType: operator.ResourceTypeRunner,
+		Pod: operator.PodResponse{
+			Namespace:    "playpen",
+			Name:         "runner-1",
+			NodeName:     "node-1",
+			ResourceType: operator.ResourceTypeRunner,
+			Architecture: operator.ArchitectureAMD64,
+		},
+		Endpoint: operator.EndpointResponse{
+			Host:             "20.30.40.50",
+			WireGuardUDPPort: 32000,
+		},
+		WireGuard: operator.WireGuardResponse{
+			ServerPublicKey: testPublicKey(),
+			ServerAddress:   "10.88.0.1/24",
+			ClientAddress:   "10.88.0.2/32",
+		},
+		VXLAN: operator.VXLANResponse{
+			VNI:     12001,
+			UDPPort: 4789,
+		},
+		Network: operator.NetworkResponse{
+			GuestMAC:    "52:54:00:aa:bb:01",
+			GuestIPv4:   "192.168.200.10",
+			SubnetMask:  "255.255.255.0",
+			GatewayIPv4: "192.168.200.1",
+			DNS:         []string{"8.8.8.8"},
+		},
+		Redfish: map[string]string{
+			"url":                    "https://10.88.0.1:8443",
+			"username":               "admin",
+			"password":               "secret",
+			"serialConsoleStreamURI": "/redfish/v1/Systems/1/Oem/Unbounded/SerialConsole/Stream",
+		},
+	}
+}
+
+func testControlPlaneAllocResponse() operator.AllocResponse {
+	return operator.AllocResponse{
+		ResourceType: operator.ResourceTypeControlPlane,
+		Pod: operator.PodResponse{
+			Namespace:         "playpen",
+			Name:              "control-plane-1",
+			NodeName:          "node-1",
+			ResourceType:      operator.ResourceTypeControlPlane,
+			KubernetesVersion: "v1.33.1",
+		},
+		Endpoint: operator.EndpointResponse{Host: "20.30.40.50", APIServerTCPPort: 16443},
+		ControlPlane: operator.ControlPlaneResponse{
+			KubernetesVersion: "v1.33.1",
+			Kubeconfig:        "host-kubeconfig",
+			APIServerURL:      "https://20.30.40.50:16443",
+			GuestAPIServerURL: "https://10.88.0.1:6443",
+		},
+	}
+}
+
+func testPublicKey() string {
+	key, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		panic(err)
+	}
+
+	return key.PublicKey().String()
+}
+
+type fakeCommander struct {
+	commands []string
+}
+
+func (f *fakeCommander) Run(_ context.Context, name string, args ...string) error {
+	f.commands = append(f.commands, strings.Join(append([]string{name}, args...), " "))
+
+	return nil
+}
+
+func containsCommand(commands []string, want string) bool {
+	for _, command := range commands {
+		if strings.Contains(command, want) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/playpen/client/console.go
+++ b/internal/playpen/client/console.go
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// StreamConsoleLogs asynchronously streams serial console logs into dst until
+// ctx is canceled or the stream fails. The returned channel receives one error.
+func (p *Playpen) StreamConsoleLogs(ctx context.Context, dst io.Writer) <-chan error {
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- p.streamConsoleLogs(ctx, dst)
+
+		close(errCh)
+	}()
+
+	return errCh
+}
+
+func (p *Playpen) streamConsoleLogs(ctx context.Context, dst io.Writer) error {
+	if dst == nil {
+		return fmt.Errorf("writer is required")
+	}
+
+	streamURL, err := consoleStreamURL(p.Metadata.Redfish)
+	if err != nil {
+		return err
+	}
+
+	header := http.Header{}
+	if user := p.Metadata.Redfish["username"]; user != "" {
+		header.Set("Authorization", "Basic "+basicAuth(user, p.Metadata.Redfish["password"]))
+	}
+
+	conn, _, err := websocket.Dial(ctx, streamURL, &websocket.DialOptions{
+		HTTPClient: redfishWebSocketHTTPClient(p.Metadata.Redfish),
+		HTTPHeader: header,
+	})
+	if err != nil {
+		return err
+	}
+	defer conn.CloseNow() //nolint:errcheck // Connection cleanup only.
+
+	for {
+		messageType, data, err := conn.Read(ctx)
+		if err != nil {
+			return err
+		}
+
+		if messageType != websocket.MessageBinary && messageType != websocket.MessageText {
+			continue
+		}
+
+		if _, err := dst.Write(data); err != nil {
+			return err
+		}
+	}
+}
+
+func consoleStreamURL(redfish map[string]string) (string, error) {
+	base := strings.TrimRight(redfish["url"], "/")
+
+	path := redfish["serialConsoleStreamURI"]
+	if base == "" || path == "" {
+		return "", fmt.Errorf("redfish url and serialConsoleStreamURI are required")
+	}
+
+	parsed, err := url.Parse(base + path)
+	if err != nil {
+		return "", err
+	}
+
+	switch parsed.Scheme {
+	case "https":
+		parsed.Scheme = "wss"
+	case "http":
+		parsed.Scheme = "ws"
+	case "ws", "wss":
+	default:
+		return "", fmt.Errorf("unsupported redfish URL scheme %q", parsed.Scheme)
+	}
+
+	return parsed.String(), nil
+}
+
+func redfishWebSocketHTTPClient(redfish map[string]string) *http.Client {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return http.DefaultClient
+	}
+
+	clonedTransport := transport.Clone()
+
+	if certPEM := strings.TrimSpace(redfish["certPEM"]); certPEM != "" {
+		roots := x509.NewCertPool()
+		if roots.AppendCertsFromPEM([]byte(certPEM)) {
+			clonedTransport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots}
+		}
+	}
+
+	return &http.Client{
+		Timeout:   0,
+		Transport: clonedTransport,
+	}
+}
+
+func basicAuth(user, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(user + ":" + password))
+}

--- a/internal/playpen/client/console_test.go
+++ b/internal/playpen/client/console_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func TestStreamConsoleLogsAsync(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Basic "+basicAuth("admin", "secret") {
+			t.Fatalf("authorization = %q", got)
+		}
+
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{OriginPatterns: []string{"*"}})
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow() //nolint:errcheck // Test cleanup.
+
+		if err := conn.Write(r.Context(), websocket.MessageBinary, []byte("booting\n")); err != nil {
+			t.Fatal(err)
+		}
+
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	metadata := testAllocResponse()
+	metadata.Redfish["url"] = server.URL
+	p := &Playpen{Metadata: metadata}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	buf := &lockedBuffer{}
+
+	errCh := p.StreamConsoleLogs(ctx, buf)
+	for !strings.Contains(buf.String(), "booting\n") {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("stream: %v", err)
+			}
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	cancel()
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
+}
+
+var _ io.Writer = (*lockedBuffer)(nil)
+
+func TestConsoleStreamURL(t *testing.T) {
+	got, err := consoleStreamURL(map[string]string{
+		"url":                    "https://10.88.0.1:8443",
+		"serialConsoleStreamURI": "/redfish/v1/Systems/1/Oem/Unbounded/SerialConsole/Stream",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got != "wss://10.88.0.1:8443/redfish/v1/Systems/1/Oem/Unbounded/SerialConsole/Stream" {
+		t.Fatalf("url = %q", got)
+	}
+}

--- a/internal/playpen/client/network.go
+++ b/internal/playpen/client/network.go
@@ -1,0 +1,379 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package client
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Azure/unbounded/internal/playpen/operator"
+)
+
+// commander runs local network configuration commands.
+type commander interface {
+	Run(ctx context.Context, name string, args ...string) error
+}
+
+type osCommander struct{}
+
+func (osCommander) Run(ctx context.Context, name string, args ...string) error {
+	if os.Geteuid() != 0 {
+		args = append([]string{"-n", name}, args...)
+		name = "sudo"
+	}
+
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil && len(out) > 0 {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	return err
+}
+
+// TunnelConfig controls local interface names and WireGuard settings.
+type TunnelConfig struct {
+	NetworkNamespace             string
+	WireGuardInterface           string
+	VXLANInterface               string
+	ManagementHostInterface      string
+	ManagementNamespaceInterface string
+	ManagementHostAddress        string
+	ManagementNamespaceAddress   string
+	WireGuardListenPort          int
+	PersistentKeepalive          int
+	PrivateKeyFile               string
+}
+
+type tunnel struct {
+	cmd                 commander
+	privateKey          string
+	metadata            operator.AllocResponse
+	cfg                 TunnelConfig
+	createdPrivateKey   bool
+	createdPrivateKeyAt string
+}
+
+func newTunnel(cmd commander, privateKey string, metadata operator.AllocResponse, cfg TunnelConfig) *tunnel {
+	return &tunnel{cmd: cmd, privateKey: privateKey, metadata: metadata, cfg: cfg}
+}
+
+func (t *tunnel) Setup(ctx context.Context) error {
+	if err := t.validate(); err != nil {
+		return err
+	}
+
+	t.Teardown(ctx) //nolint:errcheck // Setup is idempotent and recreates network resources below.
+
+	serverWG, err := addressIP(t.metadata.WireGuard.ServerAddress)
+	if err != nil {
+		return fmt.Errorf("parse server wireguard address: %w", err)
+	}
+
+	clientWG, err := addressIP(t.metadata.WireGuard.ClientAddress)
+	if err != nil {
+		return fmt.Errorf("parse client wireguard address: %w", err)
+	}
+
+	privateKeyFile, err := t.privateKeyFile()
+	if err != nil {
+		return err
+	}
+
+	endpoint := net.JoinHostPort(t.metadata.Endpoint.Host, fmt.Sprint(t.metadata.Endpoint.WireGuardUDPPort))
+
+	commands, err := t.setupCommands(privateKeyFile, endpoint, serverWG, clientWG)
+	if err != nil {
+		return err
+	}
+
+	for _, c := range commands {
+		if err := t.cmd.Run(ctx, c[0], c[1:]...); err != nil {
+			return fmt.Errorf("run %q: %w", joinCommand(c), err)
+		}
+	}
+
+	return nil
+}
+
+func (t *tunnel) setupCommands(privateKeyFile, endpoint string, serverWG, clientWG netip.Addr) ([][]string, error) {
+	hostManagementIP, err := addressIP(t.cfg.ManagementHostAddress)
+	if err != nil {
+		return nil, fmt.Errorf("parse management host address: %w", err)
+	}
+
+	namespaceManagementIP, err := addressIP(t.cfg.ManagementNamespaceAddress)
+	if err != nil {
+		return nil, fmt.Errorf("parse management namespace address: %w", err)
+	}
+
+	guestGatewayPrefix, guestSubnetCIDR, err := guestNetworkPrefixes(t.metadata.Network)
+	if err != nil {
+		return nil, err
+	}
+
+	commands := [][]string{
+		{"ip", "netns", "add", t.cfg.NetworkNamespace},
+		{"ip", "link", "add", t.cfg.ManagementHostInterface, "type", "veth", "peer", "name", t.cfg.ManagementNamespaceInterface},
+		{"ip", "link", "set", t.cfg.ManagementNamespaceInterface, "netns", t.cfg.NetworkNamespace},
+		{"ip", "addr", "add", t.cfg.ManagementHostAddress, "dev", t.cfg.ManagementHostInterface},
+		{"ip", "link", "set", t.cfg.ManagementHostInterface, "up"},
+		{"ip", "-n", t.cfg.NetworkNamespace, "link", "set", "lo", "up"},
+		{"ip", "-n", t.cfg.NetworkNamespace, "addr", "add", t.cfg.ManagementNamespaceAddress, "dev", t.cfg.ManagementNamespaceInterface},
+		{"ip", "-n", t.cfg.NetworkNamespace, "link", "set", t.cfg.ManagementNamespaceInterface, "up"},
+		{"ip", "-n", t.cfg.NetworkNamespace, "route", "add", "default", "via", hostManagementIP.String(), "dev", t.cfg.ManagementNamespaceInterface},
+		{"sysctl", "-w", "net.ipv4.ip_forward=1"},
+		{"iptables", "-A", "FORWARD", "-i", t.cfg.ManagementHostInterface, "-j", "ACCEPT"},
+		{"iptables", "-A", "FORWARD", "-o", t.cfg.ManagementHostInterface, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+		{"iptables", "-t", "nat", "-A", "POSTROUTING", "-s", singleIPCIDR(namespaceManagementIP), "-j", "MASQUERADE"},
+		{"ip", "link", "add", t.cfg.WireGuardInterface, "type", "wireguard"},
+		{"ip", "link", "set", t.cfg.WireGuardInterface, "netns", t.cfg.NetworkNamespace},
+		{
+			"ip", "netns", "exec", t.cfg.NetworkNamespace,
+			"wg", "set", t.cfg.WireGuardInterface,
+			"private-key", privateKeyFile,
+			"listen-port", fmt.Sprint(t.cfg.WireGuardListenPort),
+			"peer", t.metadata.WireGuard.ServerPublicKey,
+			"endpoint", endpoint,
+			"allowed-ips", singleIPCIDR(serverWG),
+			"persistent-keepalive", fmt.Sprint(t.cfg.PersistentKeepalive),
+		},
+		{"ip", "-n", t.cfg.NetworkNamespace, "addr", "add", t.metadata.WireGuard.ClientAddress, "dev", t.cfg.WireGuardInterface},
+		{"ip", "-n", t.cfg.NetworkNamespace, "link", "set", t.cfg.WireGuardInterface, "up"},
+		{"ip", "-n", t.cfg.NetworkNamespace, "route", "add", singleIPCIDR(serverWG), "dev", t.cfg.WireGuardInterface},
+		{
+			"ip", "-n", t.cfg.NetworkNamespace, "link", "add", t.cfg.VXLANInterface,
+			"type", "vxlan",
+			"id", fmt.Sprint(t.metadata.VXLAN.VNI),
+			"dev", t.cfg.WireGuardInterface,
+			"local", clientWG.String(),
+			"remote", serverWG.String(),
+			"dstport", fmt.Sprint(t.metadata.VXLAN.UDPPort),
+			"nolearning",
+		},
+		{"ip", "netns", "exec", t.cfg.NetworkNamespace, "bridge", "fdb", "append", "00:00:00:00:00:00", "dev", t.cfg.VXLANInterface, "dst", serverWG.String()},
+	}
+
+	commands = append(commands, []string{"ip", "-n", t.cfg.NetworkNamespace, "link", "set", t.cfg.VXLANInterface, "up"})
+	commands = append(
+		commands,
+		[]string{"ip", "-n", t.cfg.NetworkNamespace, "addr", "add", guestGatewayPrefix, "dev", t.cfg.VXLANInterface},
+		[]string{"ip", "netns", "exec", t.cfg.NetworkNamespace, "sysctl", "-w", "net.ipv4.ip_forward=1"},
+		[]string{"ip", "netns", "exec", t.cfg.NetworkNamespace, "iptables", "-A", "FORWARD", "-i", t.cfg.VXLANInterface, "-o", t.cfg.ManagementNamespaceInterface, "-j", "ACCEPT"},
+		[]string{"ip", "netns", "exec", t.cfg.NetworkNamespace, "iptables", "-A", "FORWARD", "-i", t.cfg.ManagementNamespaceInterface, "-o", t.cfg.VXLANInterface, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+		[]string{"ip", "netns", "exec", t.cfg.NetworkNamespace, "iptables", "-t", "nat", "-A", "POSTROUTING", "-s", guestSubnetCIDR, "-o", t.cfg.ManagementNamespaceInterface, "-j", "MASQUERADE"},
+	)
+
+	return commands, nil
+}
+
+func (t *tunnel) Teardown(ctx context.Context) error {
+	if t.cfg.ManagementNamespaceAddress != "" {
+		if namespaceManagementIP, err := addressIP(t.cfg.ManagementNamespaceAddress); err == nil {
+			t.cmd.Run(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING", "-s", singleIPCIDR(namespaceManagementIP), "-j", "MASQUERADE") //nolint:errcheck // Teardown is best-effort for idempotency.
+		}
+	}
+
+	if t.cfg.ManagementHostInterface != "" {
+		t.cmd.Run(ctx, "iptables", "-D", "FORWARD", "-o", t.cfg.ManagementHostInterface, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT") //nolint:errcheck // Teardown is best-effort for idempotency.
+		t.cmd.Run(ctx, "iptables", "-D", "FORWARD", "-i", t.cfg.ManagementHostInterface, "-j", "ACCEPT")                                                        //nolint:errcheck // Teardown is best-effort for idempotency.
+		t.cmd.Run(ctx, "ip", "link", "delete", t.cfg.ManagementHostInterface)                                                                                   //nolint:errcheck // Teardown is best-effort for idempotency.
+	}
+
+	if t.cfg.NetworkNamespace != "" {
+		t.cmd.Run(ctx, "ip", "netns", "delete", t.cfg.NetworkNamespace) //nolint:errcheck // Teardown is best-effort for idempotency.
+	}
+
+	if t.cfg.WireGuardInterface != "" {
+		t.cmd.Run(ctx, "ip", "link", "delete", t.cfg.WireGuardInterface) //nolint:errcheck // Teardown is best-effort for idempotency.
+	}
+
+	if t.createdPrivateKeyAt != "" {
+		os.Remove(t.createdPrivateKeyAt) //nolint:errcheck // Temporary key cleanup is best-effort.
+		t.createdPrivateKeyAt = ""
+		t.createdPrivateKey = false
+	}
+
+	return nil
+}
+
+func (t *tunnel) validate() error {
+	if t.cmd == nil {
+		return fmt.Errorf("commander is required")
+	}
+
+	if strings.TrimSpace(t.privateKey) == "" {
+		return fmt.Errorf("wireguard private key is required")
+	}
+
+	if strings.TrimSpace(t.metadata.WireGuard.ServerPublicKey) == "" {
+		return fmt.Errorf("server wireguard public key is required")
+	}
+
+	if strings.TrimSpace(t.metadata.Endpoint.Host) == "" || t.metadata.Endpoint.WireGuardUDPPort == 0 {
+		return fmt.Errorf("wireguard endpoint host and port are required")
+	}
+
+	if strings.TrimSpace(t.cfg.NetworkNamespace) == "" || strings.TrimSpace(t.cfg.WireGuardInterface) == "" || strings.TrimSpace(t.cfg.VXLANInterface) == "" {
+		return fmt.Errorf("network namespace, wireguard interface, and vxlan interface names are required")
+	}
+
+	if strings.TrimSpace(t.cfg.ManagementHostInterface) == "" || strings.TrimSpace(t.cfg.ManagementNamespaceInterface) == "" {
+		return fmt.Errorf("management host and namespace interface names are required")
+	}
+
+	if strings.TrimSpace(t.cfg.ManagementHostAddress) == "" || strings.TrimSpace(t.cfg.ManagementNamespaceAddress) == "" {
+		return fmt.Errorf("management host and namespace addresses are required")
+	}
+
+	return nil
+}
+
+func (t *tunnel) privateKeyFile() (string, error) {
+	if t.cfg.PrivateKeyFile != "" {
+		return t.cfg.PrivateKeyFile, os.WriteFile(t.cfg.PrivateKeyFile, []byte(t.privateKey+"\n"), 0o600)
+	}
+
+	file, err := os.CreateTemp("", "playpen-wireguard-*")
+	if err != nil {
+		return "", err
+	}
+
+	path := file.Name()
+	if _, err := file.WriteString(t.privateKey + "\n"); err != nil {
+		err = errors.Join(err, file.Close(), os.Remove(path))
+
+		return "", err
+	}
+
+	if err := file.Close(); err != nil {
+		err = errors.Join(err, os.Remove(path))
+
+		return "", err
+	}
+
+	t.createdPrivateKey = true
+	t.createdPrivateKeyAt = path
+
+	return path, nil
+}
+
+func tunnelConfigWithDefaults(cfg TunnelConfig, idempotencyKey string) TunnelConfig {
+	suffix := shortHash(idempotencyKey)
+	if cfg.NetworkNamespace == "" {
+		cfg.NetworkNamespace = "ppns" + suffix
+	}
+
+	if cfg.WireGuardInterface == "" {
+		cfg.WireGuardInterface = "ppwg" + suffix
+	}
+
+	if cfg.VXLANInterface == "" {
+		cfg.VXLANInterface = "ppvx" + suffix
+	}
+
+	if cfg.ManagementHostInterface == "" {
+		cfg.ManagementHostInterface = "ppmh" + suffix
+	}
+
+	if cfg.ManagementNamespaceInterface == "" {
+		cfg.ManagementNamespaceInterface = "ppmn" + suffix
+	}
+
+	if cfg.ManagementHostAddress == "" || cfg.ManagementNamespaceAddress == "" {
+		hostAddress, namespaceAddress := defaultManagementAddresses(idempotencyKey)
+		if cfg.ManagementHostAddress == "" {
+			cfg.ManagementHostAddress = hostAddress
+		}
+
+		if cfg.ManagementNamespaceAddress == "" {
+			cfg.ManagementNamespaceAddress = namespaceAddress
+		}
+	}
+
+	if cfg.PersistentKeepalive == 0 {
+		cfg.PersistentKeepalive = 25
+	}
+
+	return cfg
+}
+
+func addressIP(value string) (netip.Addr, error) {
+	if prefix, err := netip.ParsePrefix(value); err == nil {
+		return prefix.Addr(), nil
+	}
+
+	return netip.ParseAddr(value)
+}
+
+func singleIPCIDR(addr netip.Addr) string {
+	if addr.Is4() {
+		return netip.PrefixFrom(addr, 32).String()
+	}
+
+	return netip.PrefixFrom(addr, 128).String()
+}
+
+func guestNetworkPrefixes(network operator.NetworkResponse) (string, string, error) {
+	guestIP, err := netip.ParseAddr(network.GuestIPv4)
+	if err != nil {
+		return "", "", fmt.Errorf("parse guest IPv4 address %q: %w", network.GuestIPv4, err)
+	}
+
+	if !guestIP.Is4() {
+		return "", "", fmt.Errorf("guest address %s is not IPv4", guestIP)
+	}
+
+	gatewayIP, err := netip.ParseAddr(network.GatewayIPv4)
+	if err != nil {
+		return "", "", fmt.Errorf("parse guest gateway IPv4 address %q: %w", network.GatewayIPv4, err)
+	}
+
+	if !gatewayIP.Is4() {
+		return "", "", fmt.Errorf("guest gateway %s is not IPv4", gatewayIP)
+	}
+
+	mask := net.ParseIP(network.SubnetMask).To4()
+	if mask == nil {
+		return "", "", fmt.Errorf("parse guest subnet mask %q", network.SubnetMask)
+	}
+
+	ones, bits := net.IPMask(mask).Size()
+	if bits != 32 {
+		return "", "", fmt.Errorf("guest subnet mask %q is not contiguous", network.SubnetMask)
+	}
+
+	guestSubnet := netip.PrefixFrom(guestIP, ones).Masked()
+	if !guestSubnet.Contains(gatewayIP) {
+		return "", "", fmt.Errorf("guest gateway %s is outside guest subnet %s", gatewayIP, guestSubnet)
+	}
+
+	return netip.PrefixFrom(gatewayIP, ones).String(), guestSubnet.String(), nil
+}
+
+func defaultManagementAddresses(idempotencyKey string) (string, string) {
+	h := sha256.Sum256([]byte(idempotencyKey))
+	fourthOctet := int(h[3] & 0xfc)
+
+	return fmt.Sprintf("169.254.%d.%d/30", h[2], fourthOctet+1), fmt.Sprintf("169.254.%d.%d/30", h[2], fourthOctet+2)
+}
+
+func shortHash(value string) string {
+	h := sha256.Sum256([]byte(value))
+
+	return hex.EncodeToString(h[:4])
+}
+
+func joinCommand(parts []string) string {
+	return strings.Join(parts, " ")
+}

--- a/internal/playpen/client/network_test.go
+++ b/internal/playpen/client/network_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/Azure/unbounded/internal/playpen/operator"
+)
+
+func TestTunnelSetupCommands(t *testing.T) {
+	key, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeCommander{}
+	metadata := testAllocResponse()
+	tunnel := newTunnel(fake, key.String(), metadata, TunnelConfig{
+		NetworkNamespace:             "ns-playpen",
+		WireGuardInterface:           "wg-playpen",
+		VXLANInterface:               "vx-playpen",
+		ManagementHostInterface:      "mh-playpen",
+		ManagementNamespaceInterface: "mn-playpen",
+		ManagementHostAddress:        "169.254.10.1/30",
+		ManagementNamespaceAddress:   "169.254.10.2/30",
+		PersistentKeepalive:          25,
+	})
+
+	if err := tunnel.Setup(t.Context()); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	commands := strings.Join(fake.commands, "\n")
+	for _, want := range []string{
+		"iptables -t nat -D POSTROUTING -s 169.254.10.2/32 -j MASQUERADE",
+		"iptables -D FORWARD -o mh-playpen -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
+		"iptables -D FORWARD -i mh-playpen -j ACCEPT",
+		"ip link delete mh-playpen",
+		"ip netns delete ns-playpen",
+		"ip link delete wg-playpen",
+		"ip netns add ns-playpen",
+		"ip link add mh-playpen type veth peer name mn-playpen",
+		"ip link set mn-playpen netns ns-playpen",
+		"ip addr add 169.254.10.1/30 dev mh-playpen",
+		"ip -n ns-playpen addr add 169.254.10.2/30 dev mn-playpen",
+		"ip -n ns-playpen route add default via 169.254.10.1 dev mn-playpen",
+		"sysctl -w net.ipv4.ip_forward=1",
+		"iptables -A FORWARD -i mh-playpen -j ACCEPT",
+		"iptables -A FORWARD -o mh-playpen -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
+		"iptables -t nat -A POSTROUTING -s 169.254.10.2/32 -j MASQUERADE",
+		"ip link add wg-playpen type wireguard",
+		"ip link set wg-playpen netns ns-playpen",
+		"ip netns exec ns-playpen wg set wg-playpen private-key",
+		"peer " + metadata.WireGuard.ServerPublicKey,
+		"endpoint 20.30.40.50:32000",
+		"allowed-ips 10.88.0.1/32",
+		"persistent-keepalive 25",
+		"ip -n ns-playpen addr add 10.88.0.2/32 dev wg-playpen",
+		"ip -n ns-playpen route add 10.88.0.1/32 dev wg-playpen",
+		"ip -n ns-playpen link add vx-playpen type vxlan id 12001 dev wg-playpen local 10.88.0.2 remote 10.88.0.1 dstport 4789 nolearning",
+		"ip netns exec ns-playpen bridge fdb append 00:00:00:00:00:00 dev vx-playpen dst 10.88.0.1",
+		"ip -n ns-playpen link set vx-playpen up",
+		"ip -n ns-playpen addr add 192.168.200.1/24 dev vx-playpen",
+		"ip netns exec ns-playpen sysctl -w net.ipv4.ip_forward=1",
+		"ip netns exec ns-playpen iptables -A FORWARD -i vx-playpen -o mn-playpen -j ACCEPT",
+		"ip netns exec ns-playpen iptables -A FORWARD -i mn-playpen -o vx-playpen -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
+		"ip netns exec ns-playpen iptables -t nat -A POSTROUTING -s 192.168.200.0/24 -o mn-playpen -j MASQUERADE",
+	} {
+		if !strings.Contains(commands, want) {
+			t.Fatalf("commands missing %q:\n%s", want, commands)
+		}
+	}
+}
+
+func TestGuestNetworkPrefixes(t *testing.T) {
+	metadata := testAllocResponse()
+
+	gatewayPrefix, guestSubnet, err := guestNetworkPrefixes(metadata.Network)
+	if err != nil {
+		t.Fatalf("guest network prefixes: %v", err)
+	}
+
+	if gatewayPrefix != "192.168.200.1/24" {
+		t.Fatalf("gateway prefix = %q, want 192.168.200.1/24", gatewayPrefix)
+	}
+
+	if guestSubnet != "192.168.200.0/24" {
+		t.Fatalf("guest subnet = %q, want 192.168.200.0/24", guestSubnet)
+	}
+}
+
+func TestGuestNetworkPrefixesRejectsInvalidMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*operator.NetworkResponse)
+	}{
+		{
+			name: "guest IP",
+			mutate: func(network *operator.NetworkResponse) {
+				network.GuestIPv4 = "not-an-ip"
+			},
+		},
+		{
+			name: "gateway IP",
+			mutate: func(network *operator.NetworkResponse) {
+				network.GatewayIPv4 = "not-an-ip"
+			},
+		},
+		{
+			name: "subnet mask",
+			mutate: func(network *operator.NetworkResponse) {
+				network.SubnetMask = "255.0.255.0"
+			},
+		},
+		{
+			name: "gateway outside subnet",
+			mutate: func(network *operator.NetworkResponse) {
+				network.GatewayIPv4 = "192.168.201.1"
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := testAllocResponse()
+			tt.mutate(&metadata.Network)
+
+			if _, _, err := guestNetworkPrefixes(metadata.Network); err == nil {
+				t.Fatal("guest network prefixes succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestDefaultTunnelInterfaceNamesAreShort(t *testing.T) {
+	cfg := tunnelConfigWithDefaults(TunnelConfig{}, "claim-key")
+	if !strings.HasPrefix(cfg.NetworkNamespace, "ppns") || len(cfg.NetworkNamespace) > 15 {
+		t.Fatalf("network namespace = %q", cfg.NetworkNamespace)
+	}
+
+	if !strings.HasPrefix(cfg.WireGuardInterface, "ppwg") || len(cfg.WireGuardInterface) > 15 {
+		t.Fatalf("wireguard interface = %q", cfg.WireGuardInterface)
+	}
+
+	if !strings.HasPrefix(cfg.VXLANInterface, "ppvx") || len(cfg.VXLANInterface) > 15 {
+		t.Fatalf("vxlan interface = %q", cfg.VXLANInterface)
+	}
+
+	if !strings.HasPrefix(cfg.ManagementHostInterface, "ppmh") || len(cfg.ManagementHostInterface) > 15 {
+		t.Fatalf("management host interface = %q", cfg.ManagementHostInterface)
+	}
+
+	if !strings.HasPrefix(cfg.ManagementNamespaceInterface, "ppmn") || len(cfg.ManagementNamespaceInterface) > 15 {
+		t.Fatalf("management namespace interface = %q", cfg.ManagementNamespaceInterface)
+	}
+
+	if cfg.ManagementHostAddress == "" || cfg.ManagementNamespaceAddress == "" {
+		t.Fatalf("management addresses were not defaulted: %#v", cfg)
+	}
+}

--- a/internal/playpen/meta/metadata.go
+++ b/internal/playpen/meta/metadata.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package meta
+
+const (
+	AnnotationClientWireGuardPublicKey = "playpen.unbounded-cloud.io/client-wireguard-public-key"
+	AnnotationServerWireGuardPublicKey = "playpen.unbounded-cloud.io/server-wireguard-public-key"
+	AnnotationRedfishCertPEM           = "playpen.unbounded-cloud.io/redfish-cert-pem"
+	AnnotationIdempotencyKeyHash       = "playpen.unbounded-cloud.io/idempotency-key-hash"
+	AnnotationRequestHash              = "playpen.unbounded-cloud.io/request-hash"
+	AnnotationClaimedAt                = "playpen.unbounded-cloud.io/claimed-at"
+	AnnotationControlPlaneKubeconfig   = "playpen.unbounded-cloud.io/control-plane-kubeconfig"
+	AnnotationControlPlaneGuestServer  = "playpen.unbounded-cloud.io/control-plane-guest-server"
+
+	LabelAllocated         = "playpen.unbounded-cloud.io/allocated"
+	LabelArchitecture      = "playpen.unbounded-cloud.io/architecture"
+	LabelResourceType      = "playpen.unbounded-cloud.io/resource-type"
+	LabelKubernetesVersion = "playpen.unbounded-cloud.io/kubernetes-version"
+
+	ArchitectureAMD64 = "amd64"
+	ArchitectureARM64 = "arm64"
+
+	ResourceTypeRunner       = "runner"
+	ResourceTypeControlPlane = "controlPlane"
+)

--- a/internal/playpen/operator/config.go
+++ b/internal/playpen/operator/config.go
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"time"
+
+	"github.com/Azure/unbounded/internal/playpen/meta"
+	"github.com/Azure/unbounded/internal/playpen/runner"
+)
+
+const (
+	AnnotationClientWireGuardPublicKey = meta.AnnotationClientWireGuardPublicKey
+	AnnotationServerWireGuardPublicKey = meta.AnnotationServerWireGuardPublicKey
+	AnnotationRedfishCertPEM           = meta.AnnotationRedfishCertPEM
+	AnnotationIdempotencyKeyHash       = meta.AnnotationIdempotencyKeyHash
+	AnnotationRequestHash              = meta.AnnotationRequestHash
+	AnnotationClaimedAt                = meta.AnnotationClaimedAt
+	AnnotationControlPlaneKubeconfig   = meta.AnnotationControlPlaneKubeconfig
+	AnnotationControlPlaneGuestServer  = meta.AnnotationControlPlaneGuestServer
+
+	LabelAllocated         = meta.LabelAllocated
+	LabelArchitecture      = meta.LabelArchitecture
+	LabelResourceType      = meta.LabelResourceType
+	LabelKubernetesVersion = meta.LabelKubernetesVersion
+
+	ArchitectureAMD64 = meta.ArchitectureAMD64
+	ArchitectureARM64 = meta.ArchitectureARM64
+
+	ResourceTypeRunner       = meta.ResourceTypeRunner
+	ResourceTypeControlPlane = meta.ResourceTypeControlPlane
+)
+
+type Config struct {
+	ListenAddr                         string
+	Namespace                          string
+	ServiceName                        string
+	TLSSecretName                      string
+	RunnerNamespace                    string
+	RunnerLabelSelector                string
+	RunnerImage                        string
+	RunnerImagePullPolicy              string
+	RunnerServiceAccountName           string
+	RunnerAMD64Count                   int
+	RunnerARM64Count                   int
+	RunnerWireGuardHostPortStart       int32
+	RunnerWireGuardHostPortEnd         int32
+	RunnerRequireKVM                   bool
+	RunnerControlPlaneToleration       bool
+	ControlPlaneCount                  int
+	ControlPlaneVersions               []string
+	ControlPlaneImage                  string
+	ControlPlaneServiceAccountName     string
+	ControlPlaneAPIServerHostPortStart int32
+	ControlPlaneAPIServerHostPortEnd   int32
+	PlaypenTTL                         time.Duration
+	ReconcileInterval                  time.Duration
+	Runner                             runner.Config
+}
+
+func DefaultConfig() Config {
+	runnerCfg := runner.DefaultConfig()
+
+	return Config{
+		ListenAddr:                         ":8443",
+		Namespace:                          "playpen",
+		ServiceName:                        "playpen-operator",
+		TLSSecretName:                      "playpen-operator-tls",
+		RunnerNamespace:                    "playpen",
+		RunnerLabelSelector:                "app.kubernetes.io/name=playpen-runner",
+		RunnerImage:                        "ghcr.io/azure/playpen:latest",
+		RunnerImagePullPolicy:              "Always",
+		RunnerServiceAccountName:           "playpen-runner",
+		RunnerAMD64Count:                   1,
+		RunnerARM64Count:                   1,
+		RunnerWireGuardHostPortStart:       51820,
+		RunnerWireGuardHostPortEnd:         51899,
+		RunnerRequireKVM:                   true,
+		RunnerControlPlaneToleration:       false,
+		ControlPlaneCount:                  0,
+		ControlPlaneVersions:               []string{"v1.33.0"},
+		ControlPlaneImage:                  "rancher/k3s:{version}-k3s1",
+		ControlPlaneServiceAccountName:     "playpen-control-plane",
+		ControlPlaneAPIServerHostPortStart: 16443,
+		ControlPlaneAPIServerHostPortEnd:   16499,
+		PlaypenTTL:                         time.Hour,
+		ReconcileInterval:                  30 * time.Second,
+		Runner:                             runnerCfg,
+	}
+}

--- a/internal/playpen/operator/operator.go
+++ b/internal/playpen/operator/operator.go
@@ -1778,6 +1778,7 @@ func latestConfiguredKubernetesVersion(versions []string) (string, error) {
 	}
 
 	latest := ""
+
 	var latestParts kubernetesVersionParts
 
 	for _, version := range versions {
@@ -1804,6 +1805,7 @@ func parseKubernetesVersionParts(version string) (kubernetesVersionParts, error)
 	trimmed := strings.TrimPrefix(strings.TrimSpace(version), "v")
 	trimmed = strings.SplitN(trimmed, "-", 2)[0]
 	trimmed = strings.SplitN(trimmed, "+", 2)[0]
+
 	fields := strings.Split(trimmed, ".")
 	if len(fields) != 3 {
 		return kubernetesVersionParts{}, fmt.Errorf("kubernetes version %q must be major.minor.patch", version)
@@ -1831,6 +1833,7 @@ func compareKubernetesVersionParts(a, b kubernetesVersionParts) int {
 	if a.major != b.major {
 		return a.major - b.major
 	}
+
 	if a.minor != b.minor {
 		return a.minor - b.minor
 	}

--- a/internal/playpen/operator/operator.go
+++ b/internal/playpen/operator/operator.go
@@ -1,0 +1,2057 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	apiregclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/unbounded/internal/playpen/runner"
+)
+
+const (
+	idempotencyKeyHeader = "Idempotency-Key"
+
+	apiGroup        = "playpen.unbounded-cloud.io"
+	apiVersion      = "v1alpha1"
+	apiGroupVersion = apiGroup + "/" + apiVersion
+	apiServiceName  = apiVersion + "." + apiGroup
+
+	aggregatedAPIGroupPath   = "/apis/" + apiGroup
+	aggregatedAPIVersionPath = aggregatedAPIGroupPath + "/" + apiVersion
+	allocsPath               = aggregatedAPIVersionPath + "/allocs"
+	deallocsPath             = aggregatedAPIVersionPath + "/deallocs"
+
+	extensionAuthNamespace       = "kube-system"
+	extensionAuthConfigMapName   = "extension-apiserver-authentication"
+	extensionAuthClientCAKey     = "requestheader-client-ca-file"
+	extensionAuthAllowedNamesKey = "requestheader-allowed-names"
+	remoteUserHeader             = "X-Remote-User"
+	remoteGroupHeader            = "X-Remote-Group"
+
+	runnerAppName        = "playpen-runner"
+	runnerComponent      = "runner"
+	runnerHostPortLabel  = "playpen.unbounded-cloud.io/host-port"
+	runnerContainerName  = "runner"
+	runnerWireGuardPort  = "wireguard"
+	runnerHTTPSPort      = "https"
+	runnerKubeFQDNAnnot  = "kubernetes.azure.com/set-kube-service-host-fqdn"
+	runnerDataMountPath  = "/var/lib/playpen-runner"
+	runnerWGMountPath    = "/etc/playpen/wireguard"
+	runnerKVMPath        = "/dev/kvm"
+	runnerTunPath        = "/dev/net/tun"
+	runnerHTTPSContainer = int32(8443)
+
+	controlPlaneAppName       = "playpen-control-plane"
+	controlPlaneComponent     = "control-plane"
+	controlPlaneContainerName = "k3s"
+	controlPlaneHelperName    = "helper"
+	controlPlaneAPIPort       = "apiserver"
+	controlPlaneKubeconfig    = "/etc/rancher/k3s/k3s.yaml"
+	controlPlaneDataMountPath = "/var/lib/rancher/k3s"
+	controlPlaneKubeMountPath = "/etc/rancher/k3s"
+)
+
+type Operator struct {
+	Client       client.Client
+	KubeClient   kubernetes.Interface
+	APIRegClient apiregclient.Interface
+	Config       Config
+	Scheme       *runtime.Scheme
+
+	aggregatedMu               sync.RWMutex
+	aggregatedClientCAs        *x509.CertPool
+	aggregatedClientAllowedCNs map[string]struct{}
+}
+
+type AllocRequest struct {
+	IdempotencyKey     string `json:"idempotencyKey,omitempty"`
+	ResourceType       string `json:"resourceType,omitempty"`
+	KubernetesVersion  string `json:"kubernetesVersion,omitempty"`
+	WireGuardPublicKey string `json:"wireGuardPublicKey,omitempty"`
+	Architecture       string `json:"architecture,omitempty"`
+}
+
+type DeallocRequest struct {
+	IdempotencyKey string `json:"idempotencyKey,omitempty"`
+}
+
+type AllocResponse struct {
+	ResourceType string               `json:"resourceType"`
+	Pod          PodResponse          `json:"pod"`
+	Endpoint     EndpointResponse     `json:"endpoint"`
+	WireGuard    WireGuardResponse    `json:"wireGuard"`
+	VXLAN        VXLANResponse        `json:"vxlan"`
+	Network      NetworkResponse      `json:"network"`
+	Redfish      map[string]string    `json:"redfish"`
+	ControlPlane ControlPlaneResponse `json:"controlPlane,omitempty"`
+}
+
+type PodResponse struct {
+	Namespace         string `json:"namespace"`
+	Name              string `json:"name"`
+	NodeName          string `json:"nodeName"`
+	NodePublicIP      string `json:"nodePublicIP"`
+	ResourceType      string `json:"resourceType"`
+	Architecture      string `json:"architecture"`
+	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
+}
+
+type EndpointResponse struct {
+	Host                  string `json:"host"`
+	WireGuardUDPPort      int32  `json:"wireGuardUDPPort"`
+	APIServerTCPPort      int32  `json:"apiServerTCPPort,omitempty"`
+	ExternalTrafficPolicy string `json:"externalTrafficPolicy"`
+}
+
+type ControlPlaneResponse struct {
+	KubernetesVersion string `json:"kubernetesVersion"`
+	Kubeconfig        string `json:"kubeconfig"`
+	APIServerURL      string `json:"apiServerURL"`
+	GuestAPIServerURL string `json:"guestAPIServerURL"`
+}
+
+type WireGuardResponse struct {
+	Interface       string `json:"interface"`
+	ServerPublicKey string `json:"serverPublicKey"`
+	ServerAddress   string `json:"serverAddress"`
+	ClientAddress   string `json:"clientAddress"`
+	ListenPort      int    `json:"listenPort"`
+}
+
+type VXLANResponse struct {
+	Interface     string `json:"interface"`
+	VNI           int    `json:"vni"`
+	UDPPort       int    `json:"udpPort"`
+	ServerAddress string `json:"serverAddress"`
+	ClientAddress string `json:"clientAddress"`
+}
+
+type NetworkResponse struct {
+	GuestMAC    string   `json:"guestMAC"`
+	GuestIPv4   string   `json:"guestIPv4"`
+	SubnetMask  string   `json:"subnetMask"`
+	GatewayIPv4 string   `json:"gatewayIPv4"`
+	DNS         []string `json:"dns"`
+}
+
+func (o *Operator) Run(ctx context.Context) error {
+	cert, err := o.EnsureTLSSecret(ctx)
+	if err != nil {
+		return err
+	}
+
+	certPEM, err := o.servingCertPEM(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := o.injectAPIServiceCABundle(ctx, certPEM); err != nil {
+		return err
+	}
+
+	o.refreshAggregatedClientCAs(ctx)
+
+	server := &http.Server{
+		Addr:              o.Config.ListenAddr,
+		Handler:           o.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+		TLSConfig: &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{cert},
+			ClientAuth:   tls.RequestClientCert,
+			ClientCAs:    o.aggregatedClientCAs,
+		},
+	}
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- server.ListenAndServeTLS("", "")
+	}()
+
+	ticker := time.NewTicker(o.Config.ReconcileInterval)
+	defer ticker.Stop()
+
+	o.ReconcileRunners(ctx) //nolint:errcheck // Periodic reconciliation below will retry transient startup failures.
+
+	for {
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			server.Shutdown(shutdownCtx) //nolint:errcheck // Process is exiting after context cancellation.
+
+			return nil
+		case err := <-errCh:
+			if errors.Is(err, http.ErrServerClosed) {
+				return nil
+			}
+
+			return err
+		case <-ticker.C:
+			o.refreshAggregatedClientCAs(ctx)
+			o.ReconcileRunners(ctx) //nolint:errcheck // Next tick retries transient reconciliation failures.
+		}
+	}
+}
+
+func (o *Operator) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(aggregatedAPIGroupPath, o.handleAPIGroupDiscovery)
+	mux.HandleFunc(aggregatedAPIVersionPath, o.handleAPIVersionDiscovery)
+	mux.HandleFunc(allocsPath, o.handleAllocs)
+	mux.HandleFunc(deallocsPath, o.handleDeallocs)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+
+	return mux
+}
+
+func (o *Operator) handleAPIGroupDiscovery(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != aggregatedAPIGroupPath {
+		http.NotFound(w, r)
+
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	if !o.isTrustedAggregatedRequest(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"kind":       "APIGroup",
+		"apiVersion": "v1",
+		"name":       apiGroup,
+		"versions": []map[string]string{
+			{"groupVersion": apiGroupVersion, "version": apiVersion},
+		},
+		"preferredVersion": map[string]string{"groupVersion": apiGroupVersion, "version": apiVersion},
+	})
+}
+
+func (o *Operator) handleAPIVersionDiscovery(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != aggregatedAPIVersionPath {
+		http.NotFound(w, r)
+
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	if !o.isTrustedAggregatedRequest(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"kind":         "APIResourceList",
+		"apiVersion":   "v1",
+		"groupVersion": apiGroupVersion,
+		"resources": []map[string]any{
+			{"name": "allocs", "singularName": "alloc", "namespaced": false, "kind": "Alloc", "verbs": []string{"create"}},
+			{"name": "deallocs", "singularName": "dealloc", "namespaced": false, "kind": "Dealloc", "verbs": []string{"create"}},
+		},
+	})
+}
+
+func (o *Operator) handleAllocs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	if !o.authorizeAggregatedRequest(w, r, "allocs") {
+		return
+	}
+
+	var req AllocRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON request", http.StatusBadRequest)
+
+		return
+	}
+
+	idempotencyKey := requestIdempotencyKey(r, req.IdempotencyKey)
+	if idempotencyKey == "" {
+		http.Error(w, "Idempotency-Key header or idempotencyKey body field is required", http.StatusBadRequest)
+
+		return
+	}
+
+	resourceType, err := normalizeResourceType(req.ResourceType)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	req.ResourceType = resourceType
+
+	req.WireGuardPublicKey = strings.TrimSpace(req.WireGuardPublicKey)
+	if resourceType == ResourceTypeRunner {
+		if _, err := wgtypes.ParseKey(req.WireGuardPublicKey); err != nil {
+			http.Error(w, "wireGuardPublicKey must be a valid WireGuard public key", http.StatusBadRequest)
+
+			return
+		}
+	}
+
+	arch, err := normalizeArchitecture(req.Architecture)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	req.Architecture = arch
+
+	resp, status, err := o.Alloc(r.Context(), idempotencyKey, req)
+	if err != nil {
+		http.Error(w, err.Error(), status)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (o *Operator) handleDeallocs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	if !o.authorizeAggregatedRequest(w, r, "deallocs") {
+		return
+	}
+
+	idempotencyKey := requestIdempotencyKey(r, "")
+	if idempotencyKey == "" {
+		var req DeallocRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid JSON request", http.StatusBadRequest)
+
+			return
+		}
+
+		idempotencyKey = requestIdempotencyKey(r, req.IdempotencyKey)
+	}
+
+	if idempotencyKey == "" {
+		http.Error(w, "Idempotency-Key header or idempotencyKey body field is required", http.StatusBadRequest)
+
+		return
+	}
+
+	status, err := o.Dealloc(r.Context(), idempotencyKey)
+	if err != nil {
+		http.Error(w, err.Error(), status)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func requestIdempotencyKey(r *http.Request, bodyKey string) string {
+	if headerKey := strings.TrimSpace(r.Header.Get(idempotencyKeyHeader)); headerKey != "" {
+		return headerKey
+	}
+
+	return strings.TrimSpace(bodyKey)
+}
+
+func (o *Operator) Alloc(ctx context.Context, idempotencyKey string, req AllocRequest) (AllocResponse, int, error) {
+	resourceType, err := normalizeResourceType(req.ResourceType)
+	if err != nil {
+		return AllocResponse{}, http.StatusBadRequest, err
+	}
+
+	req.ResourceType = resourceType
+
+	arch, err := normalizeArchitecture(req.Architecture)
+	if err != nil {
+		return AllocResponse{}, http.StatusBadRequest, err
+	}
+
+	req.Architecture = arch
+
+	kubernetesVersion := ""
+	if resourceType == ResourceTypeControlPlane {
+		kubernetesVersion, err = o.normalizeKubernetesVersion(req.KubernetesVersion)
+		if err != nil {
+			return AllocResponse{}, http.StatusBadRequest, err
+		}
+
+		req.KubernetesVersion = kubernetesVersion
+	}
+
+	if resourceType == ResourceTypeRunner && strings.TrimSpace(req.WireGuardPublicKey) == "" {
+		return AllocResponse{}, http.StatusBadRequest, fmt.Errorf("wireGuardPublicKey is required for runner allocations")
+	}
+
+	keyHash := hashString(idempotencyKey)
+	reqHash := hashString(strings.Join([]string{req.ResourceType, req.KubernetesVersion, req.WireGuardPublicKey, req.Architecture}, "\n"))
+
+	managedPods, err := o.listManagedPods(ctx)
+	if err != nil {
+		return AllocResponse{}, http.StatusInternalServerError, err
+	}
+
+	for i := range managedPods {
+		pod := &managedPods[i]
+		if pod.Annotations[AnnotationIdempotencyKeyHash] != keyHash {
+			continue
+		}
+
+		if pod.Annotations[AnnotationRequestHash] != reqHash {
+			return AllocResponse{}, http.StatusConflict, fmt.Errorf("idempotency key was already used with a different request")
+		}
+
+		resp, err := o.responseForPod(ctx, pod)
+		if err != nil {
+			return AllocResponse{}, http.StatusServiceUnavailable, err
+		}
+
+		return resp, http.StatusOK, nil
+	}
+
+	if resourceType == ResourceTypeControlPlane {
+		return o.allocControlPlane(ctx, keyHash, reqHash, req)
+	}
+
+	return o.allocRunner(ctx, keyHash, reqHash, req)
+}
+
+func (o *Operator) allocRunner(ctx context.Context, keyHash, reqHash string, req AllocRequest) (AllocResponse, int, error) {
+	pods, err := o.listRunnerPods(ctx)
+	if err != nil {
+		return AllocResponse{}, http.StatusInternalServerError, err
+	}
+
+	var unavailable []string
+
+	matchingArchitecture := false
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Annotations[AnnotationIdempotencyKeyHash] != "" {
+			continue
+		}
+
+		if podArchitecture(pod) != req.Architecture {
+			continue
+		}
+
+		matchingArchitecture = true
+
+		if reason := runnerPodUnavailableReason(pod); reason != "" {
+			unavailable = append(unavailable, reason)
+
+			continue
+		}
+
+		serverPublicKey, err := serverWireGuardPublicKeyForPod(pod)
+		if err != nil {
+			unavailable = append(unavailable, err.Error())
+
+			continue
+		}
+
+		endpointPort, externalTrafficPolicy, err := endpointForPod(pod)
+		if err != nil {
+			unavailable = append(unavailable, err.Error())
+
+			continue
+		}
+
+		gatewayIP, nodePublicIP, err := o.gatewayForPod(ctx, pod)
+		if err != nil {
+			unavailable = append(unavailable, err.Error())
+
+			continue
+		}
+
+		allocatedPod, claimed, err := o.patchClaim(ctx, pod, keyHash, reqHash, req.WireGuardPublicKey)
+		if err != nil {
+			if errors.Is(err, errRunnerAlreadyAllocated) {
+				continue
+			}
+
+			if errors.Is(err, errIdempotencyRequestConflict) {
+				return AllocResponse{}, http.StatusConflict, err
+			}
+
+			return AllocResponse{}, http.StatusInternalServerError, err
+		}
+
+		if !claimed {
+			resp, err := o.responseForPod(ctx, allocatedPod)
+			if err != nil {
+				return AllocResponse{}, http.StatusServiceUnavailable, err
+			}
+
+			return resp, http.StatusOK, nil
+		}
+
+		resp, err := o.buildResponse(allocatedPod, gatewayIP, nodePublicIP, endpointPort, externalTrafficPolicy, serverPublicKey)
+		if err != nil {
+			return AllocResponse{}, http.StatusInternalServerError, err
+		}
+
+		return resp, http.StatusOK, nil
+	}
+
+	if len(unavailable) > 0 {
+		return AllocResponse{}, http.StatusServiceUnavailable, fmt.Errorf("no idle playpen runner pods are available with hostPort endpoints on ExternalIP nodes: %s", strings.Join(unavailable, "; "))
+	}
+
+	if !matchingArchitecture {
+		return AllocResponse{}, http.StatusServiceUnavailable, fmt.Errorf("no idle %s playpen runner pods are available", req.Architecture)
+	}
+
+	return AllocResponse{}, http.StatusServiceUnavailable, fmt.Errorf("no idle playpen runner pods are available")
+}
+
+func (o *Operator) allocControlPlane(ctx context.Context, keyHash, reqHash string, req AllocRequest) (AllocResponse, int, error) {
+	pods, err := o.listControlPlanePods(ctx)
+	if err != nil {
+		return AllocResponse{}, http.StatusInternalServerError, err
+	}
+
+	var unavailable []string
+
+	matchingVersion := false
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Annotations[AnnotationIdempotencyKeyHash] != "" {
+			continue
+		}
+
+		if podKubernetesVersion(pod) != req.KubernetesVersion {
+			continue
+		}
+
+		matchingVersion = true
+
+		if reason := runnerPodUnavailableReason(pod); reason != "" {
+			unavailable = append(unavailable, reason)
+
+			continue
+		}
+
+		endpointPort, externalTrafficPolicy, err := controlPlaneEndpointForPod(pod)
+		if err != nil {
+			unavailable = append(unavailable, err.Error())
+
+			continue
+		}
+
+		gatewayIP, nodePublicIP, err := o.gatewayForPod(ctx, pod)
+		if err != nil {
+			unavailable = append(unavailable, err.Error())
+
+			continue
+		}
+
+		if strings.TrimSpace(pod.Annotations[AnnotationControlPlaneKubeconfig]) == "" {
+			unavailable = append(unavailable, fmt.Sprintf("control-plane pod %s has no kubeconfig annotation", pod.Name))
+
+			continue
+		}
+
+		allocatedPod, claimed, err := o.patchClaim(ctx, pod, keyHash, reqHash, "")
+		if err != nil {
+			if errors.Is(err, errRunnerAlreadyAllocated) {
+				continue
+			}
+
+			if errors.Is(err, errIdempotencyRequestConflict) {
+				return AllocResponse{}, http.StatusConflict, err
+			}
+
+			return AllocResponse{}, http.StatusInternalServerError, err
+		}
+
+		if !claimed {
+			resp, err := o.responseForPod(ctx, allocatedPod)
+			if err != nil {
+				return AllocResponse{}, http.StatusServiceUnavailable, err
+			}
+
+			return resp, http.StatusOK, nil
+		}
+
+		resp, err := o.buildControlPlaneResponse(allocatedPod, gatewayIP, nodePublicIP, endpointPort, externalTrafficPolicy)
+		if err != nil {
+			return AllocResponse{}, http.StatusInternalServerError, err
+		}
+
+		return resp, http.StatusOK, nil
+	}
+
+	if len(unavailable) > 0 {
+		return AllocResponse{}, http.StatusServiceUnavailable, fmt.Errorf("no idle playpen control-plane pods are available with hostPort endpoints on ExternalIP nodes: %s", strings.Join(unavailable, "; "))
+	}
+
+	if !matchingVersion {
+		return AllocResponse{}, http.StatusServiceUnavailable, fmt.Errorf("no idle %s playpen control-plane pods are available", req.KubernetesVersion)
+	}
+
+	return AllocResponse{}, http.StatusServiceUnavailable, fmt.Errorf("no idle playpen control-plane pods are available")
+}
+
+func (o *Operator) Dealloc(ctx context.Context, idempotencyKey string) (int, error) {
+	keyHash := hashString(idempotencyKey)
+
+	pods, err := o.listManagedPods(ctx)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Annotations[AnnotationIdempotencyKeyHash] != keyHash {
+			continue
+		}
+
+		if err := o.deleteRunnerPod(ctx, pod); err != nil {
+			return http.StatusInternalServerError, err
+		}
+
+		return http.StatusNoContent, nil
+	}
+
+	return http.StatusNoContent, nil
+}
+
+func (o *Operator) ReconcileRunners(ctx context.Context) error {
+	pods, err := o.listManagedPods(ctx)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	remaining := make([]corev1.Pod, 0, len(pods))
+
+	for i := range pods {
+		pod := &pods[i]
+		if o.claimExpired(pod, now) {
+			if err := o.deleteRunnerPod(ctx, pod); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		remaining = append(remaining, *pod)
+	}
+
+	if err := o.reconcileRunnerPool(ctx, remaining); err != nil {
+		return err
+	}
+
+	return o.reconcileControlPlanePool(ctx, remaining)
+}
+
+type runnerPoolTarget struct {
+	architecture string
+	count        int
+}
+
+func (o *Operator) reconcileRunnerPool(ctx context.Context, pods []corev1.Pod) error {
+	targets := []runnerPoolTarget{
+		{architecture: ArchitectureAMD64, count: o.Config.RunnerAMD64Count},
+		{architecture: ArchitectureARM64, count: o.Config.RunnerARM64Count},
+	}
+
+	if o.Config.RunnerWireGuardHostPortStart <= 0 || o.Config.RunnerWireGuardHostPortEnd < o.Config.RunnerWireGuardHostPortStart {
+		return fmt.Errorf("runner WireGuard hostPort range is invalid")
+	}
+
+	usedHostPorts := map[int32]struct{}{}
+	idleCounts := map[string]int{}
+
+	for i := range pods {
+		pod := &pods[i]
+		if podResourceType(pod) != ResourceTypeRunner {
+			continue
+		}
+
+		hostPort := podWireGuardHostPort(pod)
+		if hostPort != 0 {
+			usedHostPorts[hostPort] = struct{}{}
+		}
+
+		if pod.DeletionTimestamp.IsZero() && pod.Annotations[AnnotationIdempotencyKeyHash] == "" && hostPort != 0 {
+			idleCounts[podArchitecture(pod)]++
+		}
+	}
+
+	for _, target := range targets {
+		if target.count < 0 {
+			return fmt.Errorf("desired %s runner count must be non-negative", target.architecture)
+		}
+
+		for idleCounts[target.architecture] < target.count {
+			hostPort, ok := o.nextRunnerHostPort(usedHostPorts)
+			if !ok {
+				return fmt.Errorf("no free WireGuard hostPorts are available in range %d-%d", o.Config.RunnerWireGuardHostPortStart, o.Config.RunnerWireGuardHostPortEnd)
+			}
+
+			usedHostPorts[hostPort] = struct{}{}
+
+			pod := o.runnerPod(target.architecture, hostPort)
+			if err := o.Client.Create(ctx, pod); apierrors.IsAlreadyExists(err) {
+				continue
+			} else if err != nil {
+				return err
+			}
+
+			idleCounts[target.architecture]++
+		}
+	}
+
+	return nil
+}
+
+type controlPlanePoolTarget struct {
+	kubernetesVersion string
+	count             int
+}
+
+func (o *Operator) reconcileControlPlanePool(ctx context.Context, pods []corev1.Pod) error {
+	targets := make([]controlPlanePoolTarget, 0, len(o.Config.ControlPlaneVersions))
+	for _, version := range o.Config.ControlPlaneVersions {
+		normalized, err := normalizeKubernetesVersionValue(version)
+		if err != nil {
+			return err
+		}
+
+		targets = append(targets, controlPlanePoolTarget{kubernetesVersion: normalized, count: o.Config.ControlPlaneCount})
+	}
+
+	if o.Config.ControlPlaneAPIServerHostPortStart <= 0 || o.Config.ControlPlaneAPIServerHostPortEnd < o.Config.ControlPlaneAPIServerHostPortStart {
+		return fmt.Errorf("control-plane API server hostPort range is invalid")
+	}
+
+	usedHostPorts := map[int32]struct{}{}
+	idleCounts := map[string]int{}
+
+	for i := range pods {
+		pod := &pods[i]
+		if podResourceType(pod) != ResourceTypeControlPlane {
+			continue
+		}
+
+		hostPort := podControlPlaneHostPort(pod)
+		if hostPort != 0 {
+			usedHostPorts[hostPort] = struct{}{}
+		}
+
+		if pod.DeletionTimestamp.IsZero() && pod.Annotations[AnnotationIdempotencyKeyHash] == "" && hostPort != 0 {
+			idleCounts[podKubernetesVersion(pod)]++
+		}
+	}
+
+	for _, target := range targets {
+		if target.count < 0 {
+			return fmt.Errorf("desired %s control-plane count must be non-negative", target.kubernetesVersion)
+		}
+
+		for idleCounts[target.kubernetesVersion] < target.count {
+			hostPort, ok := o.nextControlPlaneHostPort(usedHostPorts)
+			if !ok {
+				return fmt.Errorf("no free control-plane API server hostPorts are available in range %d-%d", o.Config.ControlPlaneAPIServerHostPortStart, o.Config.ControlPlaneAPIServerHostPortEnd)
+			}
+
+			usedHostPorts[hostPort] = struct{}{}
+
+			pod := o.controlPlanePod(target.kubernetesVersion, hostPort)
+			if err := o.Client.Create(ctx, pod); apierrors.IsAlreadyExists(err) {
+				continue
+			} else if err != nil {
+				return err
+			}
+
+			idleCounts[target.kubernetesVersion]++
+		}
+	}
+
+	return nil
+}
+
+func (o *Operator) nextRunnerHostPort(used map[int32]struct{}) (int32, bool) {
+	for port := o.Config.RunnerWireGuardHostPortStart; port <= o.Config.RunnerWireGuardHostPortEnd; port++ {
+		if _, ok := used[port]; !ok {
+			return port, true
+		}
+	}
+
+	return 0, false
+}
+
+func (o *Operator) nextControlPlaneHostPort(used map[int32]struct{}) (int32, bool) {
+	for port := o.Config.ControlPlaneAPIServerHostPortStart; port <= o.Config.ControlPlaneAPIServerHostPortEnd; port++ {
+		if _, ok := used[port]; !ok {
+			return port, true
+		}
+	}
+
+	return 0, false
+}
+
+func (o *Operator) runnerPod(architecture string, hostPort int32) *corev1.Pod {
+	privileged := true
+	listenPort := int32(o.Config.Runner.WireGuard.ListenPort) //nolint:gosec // User-configured Kubernetes port.
+	hostPathCharDevice := corev1.HostPathCharDev
+
+	imagePullPolicy := corev1.PullPolicy(strings.TrimSpace(o.Config.RunnerImagePullPolicy))
+	if imagePullPolicy == "" {
+		imagePullPolicy = corev1.PullAlways
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: "data", MountPath: runnerDataMountPath},
+		{Name: "wireguard", MountPath: runnerWGMountPath},
+		{Name: "tun", MountPath: runnerTunPath},
+	}
+
+	volumes := []corev1.Volume{
+		{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "wireguard", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "tun", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: runnerTunPath, Type: &hostPathCharDevice}}},
+	}
+	if o.Config.RunnerRequireKVM {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: "kvm", MountPath: runnerKVMPath})
+		volumes = append(volumes, corev1.Volume{Name: "kvm", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: runnerKVMPath, Type: &hostPathCharDevice}}})
+	}
+
+	var tolerations []corev1.Toleration
+	if o.Config.RunnerControlPlaneToleration {
+		tolerations = []corev1.Toleration{
+			{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+		}
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runnerPodName(architecture, hostPort),
+			Namespace: o.Config.RunnerNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      runnerAppName,
+				"app.kubernetes.io/component": runnerComponent,
+				LabelResourceType:             ResourceTypeRunner,
+				LabelArchitecture:             architecture,
+				runnerHostPortLabel:           strconv.FormatInt(int64(hostPort), 10),
+			},
+			Annotations: map[string]string{
+				runnerKubeFQDNAnnot: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: o.Config.RunnerServiceAccountName,
+			RestartPolicy:      corev1.RestartPolicyAlways,
+			Tolerations:        tolerations,
+			NodeSelector: map[string]string{
+				"kubernetes.io/arch": architecture,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            runnerContainerName,
+					Image:           o.Config.RunnerImage,
+					ImagePullPolicy: imagePullPolicy,
+					Command:         []string{"/unbounded/bin/playpen-runner"},
+					Args: []string{
+						"--architecture=" + architecture,
+						"--wireguard-private-key-file=" + runnerWGMountPath + "/privatekey",
+						"--wireguard-listen-port=" + strconv.Itoa(o.Config.Runner.WireGuard.ListenPort),
+					},
+					Env: append([]corev1.EnvVar{
+						{
+							Name: "POD_NAME",
+							ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.name",
+							}},
+						},
+						{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.namespace",
+							}},
+						},
+					}, kubernetesServiceEnv()...),
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          runnerHTTPSPort,
+							Protocol:      corev1.ProtocolTCP,
+							ContainerPort: runnerHTTPSContainer,
+						},
+						{
+							Name:          runnerWireGuardPort,
+							Protocol:      corev1.ProtocolUDP,
+							ContainerPort: listenPort,
+							HostPort:      hostPort,
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/healthz",
+							Port:   intstr.FromString(runnerHTTPSPort),
+							Scheme: corev1.URISchemeHTTPS,
+						}},
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       10,
+					},
+					SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
+					VolumeMounts:    volumeMounts,
+				},
+			},
+			Volumes: volumes,
+		},
+	}
+}
+
+func kubernetesServiceEnv() []corev1.EnvVar {
+	var env []corev1.EnvVar
+
+	for _, name := range []string{"KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT", "KUBERNETES_SERVICE_PORT_HTTPS"} {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			env = append(env, corev1.EnvVar{Name: name, Value: value})
+		}
+	}
+
+	return env
+}
+
+func (o *Operator) controlPlanePod(kubernetesVersion string, hostPort int32) *corev1.Pod {
+	privileged := true
+	apiPort := int32(6443)
+
+	imagePullPolicy := corev1.PullPolicy(strings.TrimSpace(o.Config.RunnerImagePullPolicy))
+	if imagePullPolicy == "" {
+		imagePullPolicy = corev1.PullAlways
+	}
+
+	image := controlPlaneImage(o.Config.ControlPlaneImage, kubernetesVersion)
+	guestServer := fmt.Sprintf("https://%s:%d", o.Config.Runner.Guest.Gateway, apiPort)
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controlPlanePodName(kubernetesVersion, hostPort),
+			Namespace: o.Config.RunnerNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      controlPlaneAppName,
+				"app.kubernetes.io/component": controlPlaneComponent,
+				LabelResourceType:             ResourceTypeControlPlane,
+				LabelKubernetesVersion:        sanitizeLabelValue(kubernetesVersion),
+				runnerHostPortLabel:           strconv.FormatInt(int64(hostPort), 10),
+			},
+			Annotations: map[string]string{
+				AnnotationControlPlaneGuestServer: guestServer,
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: o.Config.ControlPlaneServiceAccountName,
+			RestartPolicy:      corev1.RestartPolicyAlways,
+			Containers: []corev1.Container{
+				{
+					Name:            controlPlaneContainerName,
+					Image:           image,
+					ImagePullPolicy: imagePullPolicy,
+					Command:         []string{"/bin/k3s"},
+					Args: []string{
+						"server",
+						"--disable-agent",
+						"--disable=traefik,servicelb,metrics-server,local-storage",
+						"--write-kubeconfig=" + controlPlaneKubeconfig,
+						"--write-kubeconfig-mode=0644",
+						"--tls-san=" + o.Config.Runner.Guest.Gateway,
+						"--advertise-address=127.0.0.1",
+						"--bind-address=0.0.0.0",
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          controlPlaneAPIPort,
+							Protocol:      corev1.ProtocolTCP,
+							ContainerPort: apiPort,
+							HostPort:      hostPort,
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+					LivenessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{
+						Path:   "/readyz",
+						Port:   intstr.FromString(controlPlaneAPIPort),
+						Scheme: corev1.URISchemeHTTPS,
+					}}, InitialDelaySeconds: 30, PeriodSeconds: 10},
+					ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{
+						Path:   "/readyz",
+						Port:   intstr.FromString(controlPlaneAPIPort),
+						Scheme: corev1.URISchemeHTTPS,
+					}}, InitialDelaySeconds: 5, PeriodSeconds: 5},
+					SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "data", MountPath: controlPlaneDataMountPath},
+						{Name: "kubeconfig", MountPath: controlPlaneKubeMountPath},
+					},
+				},
+				{
+					Name:            controlPlaneHelperName,
+					Image:           o.Config.RunnerImage,
+					ImagePullPolicy: imagePullPolicy,
+					Command:         []string{"/unbounded/bin/playpen-runner"},
+					Args: []string{
+						"control-plane",
+						"--kubeconfig=" + controlPlaneKubeconfig,
+						"--guest-server=" + guestServer,
+						"--kubernetes-version=" + kubernetesVersion,
+					},
+					Env: append([]corev1.EnvVar{
+						{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
+						{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+					}, kubernetesServiceEnv()...),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+						Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+					},
+					VolumeMounts: []corev1.VolumeMount{{Name: "kubeconfig", MountPath: controlPlaneKubeMountPath}},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "kubeconfig", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}
+}
+
+func runnerPodName(architecture string, hostPort int32) string {
+	return fmt.Sprintf("playpen-runner-%s-%d", architecture, hostPort)
+}
+
+func controlPlanePodName(kubernetesVersion string, hostPort int32) string {
+	return fmt.Sprintf("playpen-control-plane-%s-%d", strings.TrimPrefix(kubernetesVersion, "v"), hostPort)
+}
+
+func (o *Operator) EnsureTLSSecret(ctx context.Context) (tls.Certificate, error) {
+	secret := &corev1.Secret{}
+
+	key := types.NamespacedName{Namespace: o.Config.Namespace, Name: o.Config.TLSSecretName}
+	if err := o.Client.Get(ctx, key, secret); err == nil {
+		cert, err := tls.X509KeyPair(secret.Data[corev1.TLSCertKey], secret.Data[corev1.TLSPrivateKeyKey])
+		if err != nil {
+			return tls.Certificate{}, err
+		}
+
+		return cert, nil
+	} else if !apierrors.IsNotFound(err) {
+		return tls.Certificate{}, err
+	}
+
+	serviceName := strings.TrimSpace(o.Config.ServiceName)
+	if serviceName == "" {
+		serviceName = "playpen-operator"
+	}
+
+	certPEM, keyPEM, err := selfSignedCert(serviceName, []string{
+		serviceName,
+		serviceName + "." + o.Config.Namespace,
+		serviceName + "." + o.Config.Namespace + ".svc",
+		serviceName + "." + o.Config.Namespace + ".svc.cluster.local",
+		"localhost",
+	})
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	secret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: o.Config.TLSSecretName, Namespace: o.Config.Namespace},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+	if err := o.Client.Create(ctx, secret); err != nil && !apierrors.IsAlreadyExists(err) {
+		return tls.Certificate{}, err
+	}
+
+	return tls.X509KeyPair(certPEM, keyPEM)
+}
+
+func (o *Operator) servingCertPEM(ctx context.Context) ([]byte, error) {
+	secret := &corev1.Secret{}
+
+	key := types.NamespacedName{Namespace: o.Config.Namespace, Name: o.Config.TLSSecretName}
+	if err := o.Client.Get(ctx, key, secret); err != nil {
+		return nil, err
+	}
+
+	certPEM := secret.Data[corev1.TLSCertKey]
+	if len(certPEM) == 0 {
+		return nil, fmt.Errorf("secret %s/%s is missing %s", o.Config.Namespace, o.Config.TLSSecretName, corev1.TLSCertKey)
+	}
+
+	return certPEM, nil
+}
+
+func (o *Operator) injectAPIServiceCABundle(ctx context.Context, caBundle []byte) error {
+	if o.APIRegClient == nil || len(caBundle) == 0 {
+		return nil
+	}
+
+	apiService, err := o.APIRegClient.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.Warningf("APIService %s not found; skipping caBundle injection", apiServiceName)
+
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("get APIService %s: %w", apiServiceName, err)
+	}
+
+	if bytes.Equal(apiService.Spec.CABundle, caBundle) {
+		return nil
+	}
+
+	apiService.Spec.CABundle = caBundle
+	if _, err := o.APIRegClient.ApiregistrationV1().APIServices().Update(ctx, apiService, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update APIService %s caBundle: %w", apiServiceName, err)
+	}
+
+	return nil
+}
+
+func (o *Operator) refreshAggregatedClientCAs(ctx context.Context) {
+	if o.KubeClient == nil {
+		o.aggregatedMu.Lock()
+		defer o.aggregatedMu.Unlock()
+
+		o.aggregatedClientCAs = nil
+		o.aggregatedClientAllowedCNs = nil
+
+		return
+	}
+
+	cm, err := o.KubeClient.CoreV1().ConfigMaps(extensionAuthNamespace).Get(ctx, extensionAuthConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("Failed to read %s/%s: %v", extensionAuthNamespace, extensionAuthConfigMapName, err)
+		o.aggregatedMu.Lock()
+		defer o.aggregatedMu.Unlock()
+
+		o.aggregatedClientCAs = nil
+		o.aggregatedClientAllowedCNs = nil
+
+		return
+	}
+
+	pool := x509.NewCertPool()
+
+	caPEM := []byte(cm.Data[extensionAuthClientCAKey])
+	if len(caPEM) == 0 || !pool.AppendCertsFromPEM(caPEM) {
+		klog.Warningf("ConfigMap %s/%s does not contain valid %q PEM data", extensionAuthNamespace, extensionAuthConfigMapName, extensionAuthClientCAKey)
+		o.aggregatedMu.Lock()
+		defer o.aggregatedMu.Unlock()
+
+		o.aggregatedClientCAs = nil
+		o.aggregatedClientAllowedCNs = nil
+
+		return
+	}
+
+	allowedNames, err := parseRequestHeaderAllowedNames(cm.Data[extensionAuthAllowedNamesKey])
+	if err != nil {
+		klog.Warningf("Failed to parse %q from %s/%s: %v", extensionAuthAllowedNamesKey, extensionAuthNamespace, extensionAuthConfigMapName, err)
+		o.aggregatedMu.Lock()
+		defer o.aggregatedMu.Unlock()
+
+		o.aggregatedClientCAs = nil
+		o.aggregatedClientAllowedCNs = nil
+
+		return
+	}
+
+	o.aggregatedMu.Lock()
+	defer o.aggregatedMu.Unlock()
+
+	o.aggregatedClientCAs = pool
+	o.aggregatedClientAllowedCNs = allowedNames
+}
+
+func parseRequestHeaderAllowedNames(raw string) (map[string]struct{}, error) {
+	if raw == "" {
+		return nil, nil
+	}
+
+	var names []string
+	if err := json.Unmarshal([]byte(raw), &names); err != nil {
+		return nil, err
+	}
+
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	allowed := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+
+		allowed[name] = struct{}{}
+	}
+
+	if len(allowed) == 0 {
+		return nil, nil
+	}
+
+	return allowed, nil
+}
+
+func (o *Operator) authorizeAggregatedRequest(w http.ResponseWriter, r *http.Request, resource string) bool {
+	if !o.isTrustedAggregatedRequest(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+
+		return false
+	}
+
+	user := strings.TrimSpace(r.Header.Get(remoteUserHeader))
+	if user == "" {
+		http.Error(w, "missing remote user", http.StatusForbidden)
+
+		return false
+	}
+
+	if o.KubeClient == nil {
+		http.Error(w, "authorization client is not configured", http.StatusInternalServerError)
+
+		return false
+	}
+
+	sar := &authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User:   user,
+			Groups: remoteGroups(r),
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:     "create",
+				Group:    apiGroup,
+				Resource: resource,
+			},
+		},
+	}
+
+	result, err := o.KubeClient.AuthorizationV1().SubjectAccessReviews().Create(r.Context(), sar, metav1.CreateOptions{})
+	if err != nil {
+		http.Error(w, "authorization check failed", http.StatusInternalServerError)
+
+		return false
+	}
+
+	if !result.Status.Allowed || result.Status.Denied {
+		http.Error(w, "forbidden", http.StatusForbidden)
+
+		return false
+	}
+
+	return true
+}
+
+func remoteGroups(r *http.Request) []string {
+	var groups []string
+
+	for _, value := range r.Header.Values(remoteGroupHeader) {
+		for _, group := range strings.Split(value, ",") {
+			group = strings.TrimSpace(group)
+			if group != "" {
+				groups = append(groups, group)
+			}
+		}
+	}
+
+	return groups
+}
+
+func (o *Operator) isTrustedAggregatedRequest(r *http.Request) bool {
+	o.aggregatedMu.RLock()
+	clientCAs := o.aggregatedClientCAs
+	allowedCNs := o.aggregatedClientAllowedCNs
+	o.aggregatedMu.RUnlock()
+
+	if r == nil || r.TLS == nil || len(r.TLS.PeerCertificates) == 0 || clientCAs == nil {
+		return false
+	}
+
+	leaf := r.TLS.PeerCertificates[0]
+
+	intermediates := x509.NewCertPool()
+	for _, cert := range r.TLS.PeerCertificates[1:] {
+		intermediates.AddCert(cert)
+	}
+
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         clientCAs,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		return false
+	}
+
+	if len(allowedCNs) == 0 {
+		return true
+	}
+
+	_, ok := allowedCNs[leaf.Subject.CommonName]
+
+	return ok
+}
+
+func (o *Operator) listRunnerPods(ctx context.Context) (*corev1.PodList, error) {
+	selector, err := labels.Parse(o.Config.RunnerLabelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	list := &corev1.PodList{}
+	if err := o.Client.List(ctx, list, client.InNamespace(o.Config.RunnerNamespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return nil, err
+	}
+
+	return list, nil
+}
+
+func (o *Operator) listManagedPods(ctx context.Context) ([]corev1.Pod, error) {
+	list := &corev1.PodList{}
+	if err := o.Client.List(ctx, list, client.InNamespace(o.Config.RunnerNamespace)); err != nil {
+		return nil, err
+	}
+
+	pods := make([]corev1.Pod, 0, len(list.Items))
+	for _, pod := range list.Items {
+		if isManagedPlaypenPod(&pod) {
+			pods = append(pods, pod)
+		}
+	}
+
+	return pods, nil
+}
+
+func (o *Operator) listControlPlanePods(ctx context.Context) (*corev1.PodList, error) {
+	pods, err := o.listManagedPods(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	list := &corev1.PodList{}
+
+	for _, pod := range pods {
+		if podResourceType(&pod) == ResourceTypeControlPlane {
+			list.Items = append(list.Items, pod)
+		}
+	}
+
+	return list, nil
+}
+
+func isManagedPlaypenPod(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+
+	if _, ok := pod.Labels[LabelResourceType]; ok {
+		if _, err := normalizeResourceType(pod.Labels[LabelResourceType]); err == nil {
+			return true
+		}
+	}
+
+	switch pod.Labels["app.kubernetes.io/name"] {
+	case runnerAppName, controlPlaneAppName:
+		return true
+	default:
+		return false
+	}
+}
+
+func runnerPodUnavailableReason(pod *corev1.Pod) string {
+	if !pod.DeletionTimestamp.IsZero() {
+		return fmt.Sprintf("runner pod %s is terminating", pod.Name)
+	}
+
+	if pod.Status.Phase != corev1.PodRunning {
+		return fmt.Sprintf("runner pod %s is %s", pod.Name, pod.Status.Phase)
+	}
+
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return fmt.Sprintf("runner pod %s has no container status", pod.Name)
+	}
+
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Running == nil {
+			return fmt.Sprintf("runner pod %s container %s is not running", pod.Name, status.Name)
+		}
+
+		if !status.Ready {
+			return fmt.Sprintf("runner pod %s container %s is not ready", pod.Name, status.Name)
+		}
+	}
+
+	return ""
+}
+
+var (
+	errRunnerAlreadyAllocated     = errors.New("runner pod was already allocated")
+	errIdempotencyRequestConflict = errors.New("idempotency key was already used with a different request")
+)
+
+func (o *Operator) patchClaim(ctx context.Context, pod *corev1.Pod, keyHash, reqHash, clientPublicKey string) (*corev1.Pod, bool, error) {
+	var updated *corev1.Pod
+
+	claimed := false
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &corev1.Pod{}
+		if err := o.Client.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, current); err != nil {
+			return err
+		}
+
+		if current.Annotations[AnnotationIdempotencyKeyHash] == keyHash {
+			if current.Annotations[AnnotationRequestHash] != reqHash {
+				return errIdempotencyRequestConflict
+			}
+
+			updated = current
+			claimed = false
+
+			return nil
+		}
+
+		if current.Annotations[AnnotationIdempotencyKeyHash] != "" {
+			return errRunnerAlreadyAllocated
+		}
+
+		if current.Annotations == nil {
+			current.Annotations = map[string]string{}
+		}
+
+		if current.Labels == nil {
+			current.Labels = map[string]string{}
+		}
+
+		allocationID := allocationIDForPod(pod)
+		current.Annotations[AnnotationIdempotencyKeyHash] = keyHash
+		current.Annotations[AnnotationRequestHash] = reqHash
+		current.Annotations[AnnotationClientWireGuardPublicKey] = clientPublicKey
+		current.Annotations[AnnotationClaimedAt] = time.Now().UTC().Format(time.RFC3339)
+		current.Labels[LabelAllocated] = allocationID
+
+		if err := o.Client.Update(ctx, current); err != nil {
+			return err
+		}
+
+		updated = current
+		claimed = true
+
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	return updated, claimed, nil
+}
+
+func (o *Operator) responseForPod(ctx context.Context, pod *corev1.Pod) (AllocResponse, error) {
+	if podResourceType(pod) == ResourceTypeControlPlane {
+		gatewayIP, nodePublicIP, err := o.gatewayForPod(ctx, pod)
+		if err != nil {
+			return AllocResponse{}, err
+		}
+
+		endpointPort, externalTrafficPolicy, err := controlPlaneEndpointForPod(pod)
+		if err != nil {
+			return AllocResponse{}, err
+		}
+
+		return o.buildControlPlaneResponse(pod, gatewayIP, nodePublicIP, endpointPort, externalTrafficPolicy)
+	}
+
+	serverPublicKey, err := serverWireGuardPublicKeyForPod(pod)
+	if err != nil {
+		return AllocResponse{}, err
+	}
+
+	gatewayIP, nodePublicIP, err := o.gatewayForPod(ctx, pod)
+	if err != nil {
+		return AllocResponse{}, err
+	}
+
+	endpointPort, externalTrafficPolicy, err := endpointForPod(pod)
+	if err != nil {
+		return AllocResponse{}, err
+	}
+
+	return o.buildResponse(pod, gatewayIP, nodePublicIP, endpointPort, externalTrafficPolicy, serverPublicKey)
+}
+
+func endpointForPod(pod *corev1.Pod) (int32, string, error) {
+	if hostPort := podWireGuardHostPort(pod); hostPort != 0 {
+		return hostPort, "HostPort", nil
+	}
+
+	return 0, "", fmt.Errorf("runner pod %s/%s has no WireGuard hostPort", pod.Namespace, pod.Name)
+}
+
+func controlPlaneEndpointForPod(pod *corev1.Pod) (int32, string, error) {
+	if hostPort := podControlPlaneHostPort(pod); hostPort != 0 {
+		return hostPort, "HostPort", nil
+	}
+
+	return 0, "", fmt.Errorf("control-plane pod %s/%s has no API server hostPort", pod.Namespace, pod.Name)
+}
+
+func (o *Operator) buildResponse(pod *corev1.Pod, gatewayIP, nodePublicIP string, endpointPort int32, externalTrafficPolicy, serverPublicKey string) (AllocResponse, error) {
+	runnerCfg := o.Config.Runner
+
+	serverWG, err := runnerAddressIP(runnerCfg.WireGuard.ServerAddress)
+	if err != nil {
+		return AllocResponse{}, err
+	}
+
+	clientWG, err := runnerAddressIP(runnerCfg.WireGuard.ClientAddress)
+	if err != nil {
+		return AllocResponse{}, err
+	}
+
+	redfishURL := runnerCfg.PublicRedfishURL
+	if redfishURL == "" {
+		redfishURL = defaultRunnerPublicRedfishURL(runnerCfg)
+	}
+
+	return AllocResponse{
+		ResourceType: ResourceTypeRunner,
+		Pod: PodResponse{
+			Namespace:    pod.Namespace,
+			Name:         pod.Name,
+			NodeName:     pod.Spec.NodeName,
+			NodePublicIP: nodePublicIP,
+			ResourceType: ResourceTypeRunner,
+			Architecture: podArchitecture(pod),
+		},
+		Endpoint: EndpointResponse{
+			Host:                  gatewayIP,
+			WireGuardUDPPort:      endpointPort,
+			ExternalTrafficPolicy: externalTrafficPolicy,
+		},
+		WireGuard: WireGuardResponse{
+			Interface:       runnerCfg.WireGuard.Interface,
+			ServerPublicKey: serverPublicKey,
+			ServerAddress:   runnerCfg.WireGuard.ServerAddress,
+			ClientAddress:   runnerCfg.WireGuard.ClientAddress,
+			ListenPort:      runnerCfg.WireGuard.ListenPort,
+		},
+		VXLAN: VXLANResponse{
+			Interface:     runnerCfg.VXLAN.Interface,
+			VNI:           runnerCfg.VXLAN.VNI,
+			UDPPort:       runnerCfg.VXLAN.Port,
+			ServerAddress: serverWG,
+			ClientAddress: clientWG,
+		},
+		Network: NetworkResponse{
+			GuestMAC:    runnerCfg.Guest.MAC,
+			GuestIPv4:   runnerCfg.Guest.IPv4,
+			SubnetMask:  runnerCfg.Guest.SubnetMask,
+			GatewayIPv4: runnerCfg.Guest.Gateway,
+			DNS:         runnerCfg.Guest.DNS,
+		},
+		Redfish: map[string]string{
+			"url":                    redfishURL,
+			"username":               runnerCfg.Redfish.Username,
+			"password":               runnerCfg.Redfish.Password,
+			"certPEM":                pod.Annotations[AnnotationRedfishCertPEM],
+			"deviceID":               runnerCfg.Redfish.DeviceID,
+			"systemURL":              redfishURL + "/redfish/v1/Systems/" + runnerCfg.Redfish.DeviceID,
+			"serialConsoleStreamURI": "/redfish/v1/Systems/" + runnerCfg.Redfish.DeviceID + "/Oem/Unbounded/SerialConsole/Stream",
+		},
+	}, nil
+}
+
+func (o *Operator) buildControlPlaneResponse(pod *corev1.Pod, gatewayIP, nodePublicIP string, endpointPort int32, externalTrafficPolicy string) (AllocResponse, error) {
+	version := podKubernetesVersion(pod)
+
+	rawKubeconfig := strings.TrimSpace(pod.Annotations[AnnotationControlPlaneKubeconfig])
+	if rawKubeconfig == "" {
+		return AllocResponse{}, fmt.Errorf("control-plane pod %s/%s has no kubeconfig annotation", pod.Namespace, pod.Name)
+	}
+
+	hostServer := fmt.Sprintf("https://%s:%d", gatewayIP, endpointPort)
+
+	guestServer := strings.TrimSpace(pod.Annotations[AnnotationControlPlaneGuestServer])
+	if guestServer == "" {
+		guestServer = fmt.Sprintf("https://%s:6443", o.Config.Runner.Guest.Gateway)
+	}
+
+	hostKubeconfig, err := rewriteKubeconfigServer(rawKubeconfig, hostServer, o.Config.Runner.Guest.Gateway)
+	if err != nil {
+		return AllocResponse{}, err
+	}
+
+	return AllocResponse{
+		ResourceType: ResourceTypeControlPlane,
+		Pod: PodResponse{
+			Namespace:         pod.Namespace,
+			Name:              pod.Name,
+			NodeName:          pod.Spec.NodeName,
+			NodePublicIP:      nodePublicIP,
+			ResourceType:      ResourceTypeControlPlane,
+			Architecture:      podArchitecture(pod),
+			KubernetesVersion: version,
+		},
+		Endpoint: EndpointResponse{
+			Host:                  gatewayIP,
+			APIServerTCPPort:      endpointPort,
+			ExternalTrafficPolicy: externalTrafficPolicy,
+		},
+		ControlPlane: ControlPlaneResponse{
+			KubernetesVersion: version,
+			Kubeconfig:        hostKubeconfig,
+			APIServerURL:      hostServer,
+			GuestAPIServerURL: guestServer,
+		},
+	}, nil
+}
+
+func rewriteKubeconfigServer(raw, server, tlsServerName string) (string, error) {
+	cfg, err := clientcmd.Load([]byte(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse control-plane kubeconfig: %w", err)
+	}
+
+	for _, cluster := range cfg.Clusters {
+		cluster.Server = server
+		cluster.TLSServerName = tlsServerName
+	}
+
+	data, err := clientcmd.Write(*cfg)
+	if err != nil {
+		return "", fmt.Errorf("write control-plane kubeconfig: %w", err)
+	}
+
+	return string(data), nil
+}
+
+func normalizeArchitecture(value string) (string, error) {
+	switch arch := strings.ToLower(strings.TrimSpace(value)); arch {
+	case "", ArchitectureAMD64:
+		return ArchitectureAMD64, nil
+	case ArchitectureARM64:
+		return ArchitectureARM64, nil
+	default:
+		return "", fmt.Errorf("architecture must be %q or %q", ArchitectureAMD64, ArchitectureARM64)
+	}
+}
+
+func normalizeResourceType(value string) (string, error) {
+	switch resourceType := strings.ToLower(strings.TrimSpace(value)); resourceType {
+	case "", strings.ToLower(ResourceTypeRunner):
+		return ResourceTypeRunner, nil
+	case strings.ToLower(ResourceTypeControlPlane), "control-plane", "controlplane":
+		return ResourceTypeControlPlane, nil
+	default:
+		return "", fmt.Errorf("resourceType must be %q or %q", ResourceTypeRunner, ResourceTypeControlPlane)
+	}
+}
+
+func (o *Operator) normalizeKubernetesVersion(value string) (string, error) {
+	requested := strings.TrimSpace(value)
+	if requested == "" {
+		return latestConfiguredKubernetesVersion(o.Config.ControlPlaneVersions)
+	}
+
+	normalized, err := normalizeKubernetesVersionValue(requested)
+	if err != nil {
+		return "", err
+	}
+
+	for _, configured := range o.Config.ControlPlaneVersions {
+		configuredVersion, err := normalizeKubernetesVersionValue(configured)
+		if err != nil {
+			return "", err
+		}
+
+		if normalized == configuredVersion {
+			return normalized, nil
+		}
+	}
+
+	return "", fmt.Errorf("kubernetes version %q is not configured for control-plane allocation", normalized)
+}
+
+type kubernetesVersionParts struct {
+	major int
+	minor int
+	patch int
+}
+
+func latestConfiguredKubernetesVersion(versions []string) (string, error) {
+	if len(versions) == 0 {
+		return "", fmt.Errorf("no control-plane Kubernetes versions are configured")
+	}
+
+	latest := ""
+	var latestParts kubernetesVersionParts
+
+	for _, version := range versions {
+		normalized, err := normalizeKubernetesVersionValue(version)
+		if err != nil {
+			return "", err
+		}
+
+		parts, err := parseKubernetesVersionParts(normalized)
+		if err != nil {
+			return "", err
+		}
+
+		if latest == "" || compareKubernetesVersionParts(parts, latestParts) > 0 {
+			latest = normalized
+			latestParts = parts
+		}
+	}
+
+	return latest, nil
+}
+
+func parseKubernetesVersionParts(version string) (kubernetesVersionParts, error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(version), "v")
+	trimmed = strings.SplitN(trimmed, "-", 2)[0]
+	trimmed = strings.SplitN(trimmed, "+", 2)[0]
+	fields := strings.Split(trimmed, ".")
+	if len(fields) != 3 {
+		return kubernetesVersionParts{}, fmt.Errorf("kubernetes version %q must be major.minor.patch", version)
+	}
+
+	major, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return kubernetesVersionParts{}, fmt.Errorf("parse kubernetes version %q major: %w", version, err)
+	}
+
+	minor, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return kubernetesVersionParts{}, fmt.Errorf("parse kubernetes version %q minor: %w", version, err)
+	}
+
+	patch, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return kubernetesVersionParts{}, fmt.Errorf("parse kubernetes version %q patch: %w", version, err)
+	}
+
+	return kubernetesVersionParts{major: major, minor: minor, patch: patch}, nil
+}
+
+func compareKubernetesVersionParts(a, b kubernetesVersionParts) int {
+	if a.major != b.major {
+		return a.major - b.major
+	}
+	if a.minor != b.minor {
+		return a.minor - b.minor
+	}
+
+	return a.patch - b.patch
+}
+
+func normalizeKubernetesVersionValue(value string) (string, error) {
+	version := strings.TrimSpace(value)
+	if version == "" {
+		return "", fmt.Errorf("kubernetes version is required")
+	}
+
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	return version, nil
+}
+
+func controlPlaneImage(template, kubernetesVersion string) string {
+	template = strings.TrimSpace(template)
+	if template == "" {
+		template = "rancher/k3s:{version}-k3s1"
+	}
+
+	return strings.ReplaceAll(template, "{version}", kubernetesVersion)
+}
+
+func podArchitecture(pod *corev1.Pod) string {
+	arch, err := normalizeArchitecture(pod.Labels[LabelArchitecture])
+	if err != nil {
+		return pod.Labels[LabelArchitecture]
+	}
+
+	return arch
+}
+
+func podResourceType(pod *corev1.Pod) string {
+	resourceType, err := normalizeResourceType(pod.Labels[LabelResourceType])
+	if err == nil && resourceType != ResourceTypeRunner {
+		return resourceType
+	}
+
+	if pod.Labels["app.kubernetes.io/name"] == controlPlaneAppName {
+		return ResourceTypeControlPlane
+	}
+
+	return ResourceTypeRunner
+}
+
+func podKubernetesVersion(pod *corev1.Pod) string {
+	version, err := normalizeKubernetesVersionValue(pod.Labels[LabelKubernetesVersion])
+	if err != nil {
+		return pod.Labels[LabelKubernetesVersion]
+	}
+
+	return version
+}
+
+func serverWireGuardPublicKeyForPod(pod *corev1.Pod) (string, error) {
+	serverPublicKey := strings.TrimSpace(pod.Annotations[AnnotationServerWireGuardPublicKey])
+	if _, err := wgtypes.ParseKey(serverPublicKey); err != nil {
+		return "", fmt.Errorf("runner pod %q has no valid server WireGuard public key", pod.Name)
+	}
+
+	return serverPublicKey, nil
+}
+
+func podWireGuardHostPort(pod *corev1.Pod) int32 {
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Protocol == corev1.ProtocolUDP && port.HostPort != 0 && port.Name == "wireguard" {
+				return port.HostPort
+			}
+		}
+	}
+
+	return 0
+}
+
+func podControlPlaneHostPort(pod *corev1.Pod) int32 {
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Protocol == corev1.ProtocolTCP && port.HostPort != 0 && port.Name == controlPlaneAPIPort {
+				return port.HostPort
+			}
+		}
+	}
+
+	return 0
+}
+
+func (o *Operator) gatewayForPod(ctx context.Context, pod *corev1.Pod) (string, string, error) {
+	if pod.Spec.NodeName == "" {
+		return "", "", fmt.Errorf("runner pod is not scheduled")
+	}
+
+	node := &corev1.Node{}
+	if err := o.Client.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, node); err != nil {
+		return "", "", err
+	}
+
+	nodePublicIP := nodeExternalIP(node)
+	if nodePublicIP == "" {
+		return "", "", fmt.Errorf("runner pod %s/%s is on node %s with no ExternalIP", pod.Namespace, pod.Name, pod.Spec.NodeName)
+	}
+
+	return nodePublicIP, nodePublicIP, nil
+}
+
+func nodeExternalIP(node *corev1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeExternalIP && addr.Address != "" {
+			return addr.Address
+		}
+	}
+
+	return ""
+}
+
+func (o *Operator) deleteRunnerPod(ctx context.Context, pod *corev1.Pod) error {
+	if err := o.Client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (o *Operator) claimExpired(pod *corev1.Pod, now time.Time) bool {
+	if o.Config.PlaypenTTL <= 0 || pod.Annotations[AnnotationIdempotencyKeyHash] == "" {
+		return false
+	}
+
+	claimedAt, err := time.Parse(time.RFC3339, pod.Annotations[AnnotationClaimedAt])
+	if err != nil {
+		return true
+	}
+
+	return !claimedAt.Add(o.Config.PlaypenTTL).After(now)
+}
+
+func selfSignedCert(commonName string, hosts []string) ([]byte, []byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	notBefore := time.Now().Add(-time.Minute)
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(notBefore.UnixNano()),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	for _, host := range hosts {
+		if ip := net.ParseIP(host); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		} else if host != "" {
+			tmpl.DNSNames = append(tmpl.DNSNames, host)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	return certPEM, keyPEM, nil
+}
+
+func allocationIDForPod(pod *corev1.Pod) string {
+	return hashString(pod.Namespace + "/" + pod.Name)[:16]
+}
+
+func hashString(value string) string {
+	sum := sha256.Sum256([]byte(value))
+
+	return hex.EncodeToString(sum[:])
+}
+
+func sanitizeLabelValue(value string) string {
+	return strings.Trim(strings.NewReplacer("+", "-", "_", "-").Replace(value), "-.")
+}
+
+func runnerAddressIP(value string) (string, error) {
+	if i := strings.Index(value, "/"); i >= 0 {
+		value = value[:i]
+	}
+
+	if net.ParseIP(value) == nil {
+		return "", fmt.Errorf("invalid IP address %q", value)
+	}
+
+	return value, nil
+}
+
+func defaultRunnerPublicRedfishURL(cfg runner.Config) string {
+	host, err := runnerAddressIP(cfg.WireGuard.ServerAddress)
+	if err != nil {
+		return "https://" + cfg.ListenAddr
+	}
+
+	_, port, err := net.SplitHostPort(cfg.ListenAddr)
+	if err != nil || port == "" {
+		port = "8443"
+	}
+
+	return "https://" + net.JoinHostPort(host, port)
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(value) //nolint:errcheck // Response body write errors cannot be reported to the client.
+}

--- a/internal/playpen/operator/operator_test.go
+++ b/internal/playpen/operator/operator_test.go
@@ -1,0 +1,1379 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+func TestAllocAllocatesRunnerWithHostPortEndpoint(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+	req := AllocRequest{WireGuardPublicKey: testPublicKey(t)}
+
+	resp, status, err := op.Alloc(t.Context(), "alloc-key", req)
+	if err != nil {
+		t.Fatalf("alloc: %v", err)
+	}
+
+	if status != 200 {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	if resp.Endpoint.Host != "20.30.40.50" {
+		t.Fatalf("endpoint host = %q, want node external ip", resp.Endpoint.Host)
+	}
+
+	if resp.Pod.NodePublicIP != "20.30.40.50" {
+		t.Fatalf("pod node public ip = %q, want node external ip", resp.Pod.NodePublicIP)
+	}
+
+	if resp.Pod.Architecture != ArchitectureAMD64 {
+		t.Fatalf("pod architecture = %q, want %q", resp.Pod.Architecture, ArchitectureAMD64)
+	}
+
+	if resp.Endpoint.WireGuardUDPPort == 0 {
+		t.Fatal("endpoint WireGuard UDP port is empty")
+	}
+
+	if resp.Endpoint.ExternalTrafficPolicy != "HostPort" {
+		t.Fatalf("externalTrafficPolicy = %q, want HostPort", resp.Endpoint.ExternalTrafficPolicy)
+	}
+
+	if resp.WireGuard.ServerPublicKey == "" {
+		t.Fatal("server WireGuard public key is empty")
+	}
+
+	if resp.WireGuard.ServerPublicKey != podServerPublicKey("runner-1") {
+		t.Fatalf("server WireGuard public key = %q, want pod annotation", resp.WireGuard.ServerPublicKey)
+	}
+
+	if got, want := resp.Redfish["url"], "https://10.88.0.1:8443"; got != want {
+		t.Fatalf("redfish url = %q, want %q", got, want)
+	}
+
+	if resp.Redfish["systemURL"] != resp.Redfish["url"]+"/redfish/v1/Systems/"+resp.Redfish["deviceID"] {
+		t.Fatalf("redfish system URL = %q", resp.Redfish["systemURL"])
+	}
+
+	if resp.Redfish["serialConsoleStreamURI"] != "/redfish/v1/Systems/"+resp.Redfish["deviceID"]+"/Oem/Unbounded/SerialConsole/Stream" {
+		t.Fatalf("redfish serial console stream URI = %q", resp.Redfish["serialConsoleStreamURI"])
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "runner-1"}, pod); err != nil {
+		t.Fatal(err)
+	}
+
+	if pod.Annotations[AnnotationClientWireGuardPublicKey] != req.WireGuardPublicKey {
+		t.Fatalf("pod allocation annotation = %q, want %q", pod.Annotations[AnnotationClientWireGuardPublicKey], req.WireGuardPublicKey)
+	}
+
+	if pod.Labels[LabelAllocated] == "" {
+		t.Fatal("pod allocation label is empty")
+	}
+}
+
+func TestAllocPrefersRunnerHostPortOnNodeExternalIP(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPodWithHostPort("runner-1", "node-1", 51821),
+	)
+
+	resp, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil {
+		t.Fatalf("alloc: %v", err)
+	}
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", status, http.StatusOK)
+	}
+
+	if resp.Endpoint.Host != "20.30.40.50" {
+		t.Fatalf("endpoint host = %q, want runner node external IP", resp.Endpoint.Host)
+	}
+
+	if got, want := resp.Endpoint.WireGuardUDPPort, int32(51821); got != want {
+		t.Fatalf("endpoint port = %d, want host port %d", got, want)
+	}
+
+	if resp.Endpoint.ExternalTrafficPolicy != "HostPort" {
+		t.Fatalf("externalTrafficPolicy = %q, want HostPort", resp.Endpoint.ExternalTrafficPolicy)
+	}
+}
+
+func TestAllocUsesDistinctHostPortsForMultiplePodsOnSameNode(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPodWithHostPort("runner-1", "node-1", 51821),
+		testPodWithHostPort("runner-2", "node-1", 51822),
+	)
+
+	first, status, err := op.Alloc(t.Context(), "alloc-key-1", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("first alloc status=%d err=%v", status, err)
+	}
+
+	second, status, err := op.Alloc(t.Context(), "alloc-key-2", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("second alloc status=%d err=%v", status, err)
+	}
+
+	if first.Pod.Name == second.Pod.Name {
+		t.Fatalf("second alloc reused pod %q", second.Pod.Name)
+	}
+
+	if first.Endpoint.Host != "20.30.40.50" || second.Endpoint.Host != "20.30.40.50" {
+		t.Fatalf("endpoints used unexpected hosts: first=%q second=%q", first.Endpoint.Host, second.Endpoint.Host)
+	}
+
+	if first.Endpoint.WireGuardUDPPort == second.Endpoint.WireGuardUDPPort {
+		t.Fatalf("allocs reused host port %d", first.Endpoint.WireGuardUDPPort)
+	}
+}
+
+func TestAllocIsIdempotentAndConflictsOnDifferentRequest(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+	req := AllocRequest{WireGuardPublicKey: testPublicKey(t)}
+
+	first, status, err := op.Alloc(t.Context(), "alloc-key", req)
+	if err != nil || status != 200 {
+		t.Fatalf("first alloc status=%d err=%v", status, err)
+	}
+
+	second, status, err := op.Alloc(t.Context(), "alloc-key", req)
+	if err != nil || status != 200 {
+		t.Fatalf("second alloc status=%d err=%v", status, err)
+	}
+
+	if second.Pod.Name != first.Pod.Name {
+		t.Fatalf("second pod = %q, want %q", second.Pod.Name, first.Pod.Name)
+	}
+
+	_, status, err = op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err == nil {
+		t.Fatal("different alloc request with same idempotency key succeeded")
+	}
+
+	if status != 409 {
+		t.Fatalf("conflict status = %d, want 409", status)
+	}
+}
+
+func TestAllocDefaultsToAMD64AndSkipsARM64Runner(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPodWithArchitecture("arm64-runner", "node-1", ArchitectureARM64),
+		testPodWithArchitecture("amd64-runner", "node-1", ArchitectureAMD64),
+	)
+
+	resp, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("alloc status=%d err=%v", status, err)
+	}
+
+	if resp.Pod.Name != "amd64-runner" {
+		t.Fatalf("pod name = %q, want amd64-runner", resp.Pod.Name)
+	}
+
+	if resp.Pod.Architecture != ArchitectureAMD64 {
+		t.Fatalf("pod architecture = %q, want %q", resp.Pod.Architecture, ArchitectureAMD64)
+	}
+}
+
+func TestAllocCanRequestARM64Runner(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPodWithArchitecture("amd64-runner", "node-1", ArchitectureAMD64),
+		testPodWithArchitecture("arm64-runner", "node-1", ArchitectureARM64),
+	)
+
+	resp, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t), Architecture: ArchitectureARM64})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("alloc status=%d err=%v", status, err)
+	}
+
+	if resp.Pod.Name != "arm64-runner" {
+		t.Fatalf("pod name = %q, want arm64-runner", resp.Pod.Name)
+	}
+
+	if resp.Pod.Architecture != ArchitectureARM64 {
+		t.Fatalf("pod architecture = %q, want %q", resp.Pod.Architecture, ArchitectureARM64)
+	}
+}
+
+func TestAllocRejectsInvalidArchitecture(t *testing.T) {
+	op := testOperator(t)
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t), Architecture: "s390x"})
+	if err == nil {
+		t.Fatal("alloc succeeded with invalid architecture")
+	}
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+}
+
+func TestAllocReportsNoMatchingArchitecture(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPodWithArchitecture("amd64-runner", "node-1", ArchitectureAMD64),
+	)
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t), Architecture: ArchitectureARM64})
+	if err == nil {
+		t.Fatal("alloc succeeded without arm64 runner")
+	}
+
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", status, http.StatusServiceUnavailable)
+	}
+}
+
+func TestAllocIdempotencyIncludesArchitecture(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPodWithArchitecture("amd64-runner", "node-1", ArchitectureAMD64),
+		testPodWithArchitecture("arm64-runner", "node-1", ArchitectureARM64),
+	)
+	publicKey := testPublicKey(t)
+
+	if _, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: publicKey, Architecture: ArchitectureAMD64}); err != nil || status != http.StatusOK {
+		t.Fatalf("first alloc status=%d err=%v", status, err)
+	}
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: publicKey, Architecture: ArchitectureARM64})
+	if err == nil {
+		t.Fatal("same idempotency key succeeded with different architecture")
+	}
+
+	if status != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", status, http.StatusConflict)
+	}
+}
+
+func TestAllocRejectsInvalidResourceType(t *testing.T) {
+	op := testOperator(t)
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{ResourceType: "database"})
+	if err == nil {
+		t.Fatal("alloc succeeded with invalid resource type")
+	}
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+}
+
+func TestAllocAllocatesControlPlaneWithHostReachableKubeconfig(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testControlPlanePod("control-plane-1", "node-1", "v1.33.1", 16443),
+	)
+	op.Config.ControlPlaneVersions = []string{"v1.33.1"}
+
+	resp, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{ResourceType: ResourceTypeControlPlane, KubernetesVersion: "1.33.1"})
+	if err != nil {
+		t.Fatalf("alloc: %v", err)
+	}
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", status, http.StatusOK)
+	}
+
+	if resp.ResourceType != ResourceTypeControlPlane || resp.Pod.ResourceType != ResourceTypeControlPlane {
+		t.Fatalf("resource type response = %#v", resp)
+	}
+
+	if resp.ControlPlane.KubernetesVersion != "v1.33.1" {
+		t.Fatalf("version = %q, want v1.33.1", resp.ControlPlane.KubernetesVersion)
+	}
+
+	if resp.ControlPlane.APIServerURL != "https://20.30.40.50:16443" {
+		t.Fatalf("host API URL = %q", resp.ControlPlane.APIServerURL)
+	}
+
+	if resp.ControlPlane.GuestAPIServerURL != "https://192.168.200.1:6443" {
+		t.Fatalf("guest API URL = %q", resp.ControlPlane.GuestAPIServerURL)
+	}
+
+	cfg, err := clientcmd.Load([]byte(resp.ControlPlane.Kubeconfig))
+	if err != nil {
+		t.Fatalf("parse kubeconfig: %v", err)
+	}
+
+	for _, cluster := range cfg.Clusters {
+		if cluster.Server != "https://20.30.40.50:16443" {
+			t.Fatalf("cluster server = %q", cluster.Server)
+		}
+
+		if cluster.TLSServerName != "192.168.200.1" {
+			t.Fatalf("tls server name = %q", cluster.TLSServerName)
+		}
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "control-plane-1"}, pod); err != nil {
+		t.Fatal(err)
+	}
+
+	if pod.Annotations[AnnotationClientWireGuardPublicKey] != "" {
+		t.Fatalf("client public key = %q, want empty", pod.Annotations[AnnotationClientWireGuardPublicKey])
+	}
+
+	if pod.Labels[LabelAllocated] == "" {
+		t.Fatal("pod allocation label is empty")
+	}
+}
+
+func TestAllocDefaultsControlPlaneVersion(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testControlPlanePod("control-plane-1", "node-1", "v1.33.0", 16443),
+		testControlPlanePod("control-plane-2", "node-1", "v1.34.0", 16444),
+	)
+	op.Config.ControlPlaneVersions = []string{"v1.33.0", "v1.34.0"}
+
+	resp, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{ResourceType: ResourceTypeControlPlane})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("alloc status=%d err=%v", status, err)
+	}
+
+	if resp.ControlPlane.KubernetesVersion != "v1.34.0" {
+		t.Fatalf("version = %q, want default v1.34.0", resp.ControlPlane.KubernetesVersion)
+	}
+}
+
+func TestAllocDefaultsControlPlaneVersionToLatestUnorderedVersion(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testControlPlanePod("control-plane-1", "node-1", "v1.34.1", 16443),
+	)
+	op.Config.ControlPlaneVersions = []string{"v1.34.1", "v1.33.9"}
+
+	resp, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{ResourceType: ResourceTypeControlPlane})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("alloc status=%d err=%v", status, err)
+	}
+
+	if resp.ControlPlane.KubernetesVersion != "v1.34.1" {
+		t.Fatalf("version = %q, want default v1.34.1", resp.ControlPlane.KubernetesVersion)
+	}
+}
+
+func TestAllocRejectsUnconfiguredControlPlaneVersion(t *testing.T) {
+	op := testOperator(t)
+	op.Config.ControlPlaneVersions = []string{"v1.33.0"}
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{ResourceType: ResourceTypeControlPlane, KubernetesVersion: "v1.34.0"})
+	if err == nil {
+		t.Fatal("alloc succeeded with unconfigured version")
+	}
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+}
+
+func TestAllocIdempotencyIncludesResourceType(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+		testControlPlanePod("control-plane-1", "node-1", "v1.33.0", 16443),
+	)
+
+	if _, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t)}); err != nil || status != http.StatusOK {
+		t.Fatalf("runner alloc status=%d err=%v", status, err)
+	}
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{ResourceType: ResourceTypeControlPlane})
+	if err == nil {
+		t.Fatal("same idempotency key succeeded with different resource type")
+	}
+
+	if status != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", status, http.StatusConflict)
+	}
+}
+
+func TestAllocRequiresRunnerNodeExternalIP(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("private-node", ""),
+		testNode("gateway-node", "20.30.40.50"),
+		testPod("runner-1", "private-node", nil),
+	)
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err == nil {
+		t.Fatal("alloc succeeded when runner node had no ExternalIP")
+	}
+
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", status, http.StatusServiceUnavailable)
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "runner-1"}, pod); err != nil {
+		t.Fatal(err)
+	}
+
+	if pod.Annotations[AnnotationIdempotencyKeyHash] != "" {
+		t.Fatal("pod was allocated despite missing runner node ExternalIP")
+	}
+}
+
+func TestAllocRequiresAnyNodeExternalIP(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", ""),
+		testPod("runner-1", "node-1", nil),
+	)
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err == nil {
+		t.Fatal("alloc succeeded without any node ExternalIP")
+	}
+
+	if status != 503 {
+		t.Fatalf("status = %d, want 503", status)
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "runner-1"}, pod); err != nil {
+		t.Fatal(err)
+	}
+
+	if pod.Annotations[AnnotationIdempotencyKeyHash] != "" {
+		t.Fatal("pod was allocated despite missing gateway ExternalIP")
+	}
+}
+
+func TestAllocSkipsRunnerWithoutServerWireGuardPublicKey(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPodWithAnnotations("runner-1", "node-1", map[string]string{}),
+	)
+
+	_, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err == nil {
+		t.Fatal("alloc succeeded without server WireGuard public key")
+	}
+
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", status, http.StatusServiceUnavailable)
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "runner-1"}, pod); err != nil {
+		t.Fatal(err)
+	}
+
+	if pod.Annotations[AnnotationIdempotencyKeyHash] != "" {
+		t.Fatal("pod was allocated despite missing server WireGuard public key")
+	}
+}
+
+func TestAllocSkipsUnavailableRunnerPods(t *testing.T) {
+	terminating := testPod("terminating-runner", "node-1", nil)
+	now := metav1.Now()
+	terminating.DeletionTimestamp = &now
+	terminating.Finalizers = []string{"test.finalizer"}
+
+	pending := testPod("pending-runner", "node-1", nil)
+	pending.Status.Phase = corev1.PodPending
+
+	unready := testPod("unready-runner", "node-1", nil)
+	unready.Status.ContainerStatuses[0].Ready = false
+
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		terminating,
+		pending,
+		unready,
+		testPod("ready-runner", "node-1", nil),
+	)
+
+	resp, status, err := op.Alloc(t.Context(), "alloc-key", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("alloc status=%d err=%v", status, err)
+	}
+
+	if resp.Pod.Name != "ready-runner" {
+		t.Fatalf("claimed pod = %q, want ready-runner", resp.Pod.Name)
+	}
+}
+
+func TestAllocUsesPodScopedServerWireGuardPublicKey(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+		testPod("runner-2", "node-1", nil),
+	)
+
+	first, status, err := op.Alloc(t.Context(), "alloc-key-1", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("first alloc status=%d err=%v", status, err)
+	}
+
+	second, status, err := op.Alloc(t.Context(), "alloc-key-2", AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil || status != http.StatusOK {
+		t.Fatalf("second alloc status=%d err=%v", status, err)
+	}
+
+	if first.Pod.Name == second.Pod.Name {
+		t.Fatalf("second alloc reused pod %q", second.Pod.Name)
+	}
+
+	if first.WireGuard.ServerPublicKey == second.WireGuard.ServerPublicKey {
+		t.Fatal("allocs returned the same server WireGuard public key")
+	}
+}
+
+func TestDeallocDeletesClaimedRunner(t *testing.T) {
+	op := testOperator(
+		t,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+	req := AllocRequest{WireGuardPublicKey: testPublicKey(t)}
+
+	if _, status, err := op.Alloc(t.Context(), "alloc-key", req); err != nil || status != 200 {
+		t.Fatalf("alloc status=%d err=%v", status, err)
+	}
+
+	status, err := op.Dealloc(t.Context(), "alloc-key")
+	if err != nil {
+		t.Fatalf("dealloc: %v", err)
+	}
+
+	if status != 204 {
+		t.Fatalf("dealloc status = %d, want 204", status)
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "runner-1"}, pod); err == nil {
+		t.Fatal("allocated pod still exists after dealloc")
+	}
+}
+
+func TestDeallocIsIdempotentWhenClaimIsMissing(t *testing.T) {
+	op := testOperator(t)
+
+	status, err := op.Dealloc(t.Context(), "alloc-key")
+	if err != nil {
+		t.Fatalf("dealloc: %v", err)
+	}
+
+	if status != 204 {
+		t.Fatalf("dealloc status = %d, want 204", status)
+	}
+}
+
+func TestAggregatedDiscoveryRequiresTrustedFrontProxy(t *testing.T) {
+	op := testAggregatedOperator(t, true)
+
+	groupReq := trustedAggregatedRequest(t, op, http.MethodGet, aggregatedAPIGroupPath, nil)
+	groupRecorder := httptest.NewRecorder()
+	op.Handler().ServeHTTP(groupRecorder, groupReq)
+
+	if groupRecorder.Code != http.StatusOK {
+		t.Fatalf("group discovery status = %d, want %d", groupRecorder.Code, http.StatusOK)
+	}
+
+	if !bytes.Contains(groupRecorder.Body.Bytes(), []byte(apiGroupVersion)) {
+		t.Fatalf("group discovery body = %s", groupRecorder.Body.String())
+	}
+
+	versionReq := trustedAggregatedRequest(t, op, http.MethodGet, aggregatedAPIVersionPath, nil)
+	versionRecorder := httptest.NewRecorder()
+	op.Handler().ServeHTTP(versionRecorder, versionReq)
+
+	if versionRecorder.Code != http.StatusOK {
+		t.Fatalf("version discovery status = %d, want %d", versionRecorder.Code, http.StatusOK)
+	}
+
+	if !bytes.Contains(versionRecorder.Body.Bytes(), []byte(`"allocs"`)) || !bytes.Contains(versionRecorder.Body.Bytes(), []byte(`"deallocs"`)) {
+		t.Fatalf("version discovery body = %s", versionRecorder.Body.String())
+	}
+
+	untrustedReq := httptest.NewRequest(http.MethodGet, aggregatedAPIVersionPath, nil)
+	untrustedRecorder := httptest.NewRecorder()
+	op.Handler().ServeHTTP(untrustedRecorder, untrustedReq)
+
+	if untrustedRecorder.Code != http.StatusForbidden {
+		t.Fatalf("untrusted discovery status = %d, want %d", untrustedRecorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestAllocEndpointAuthorizesSharedAllocAction(t *testing.T) {
+	op := testAggregatedOperator(
+		t, true,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+
+	reqBody, err := json.Marshal(AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := trustedAggregatedRequest(t, op, http.MethodPost, allocsPath, bytes.NewReader(reqBody))
+	req.Header.Set(idempotencyKeyHeader, "alloc-key")
+	req.Header.Set(remoteUserHeader, "alice")
+	req.Header.Add(remoteGroupHeader, "team-a")
+	req.Header.Add(remoteGroupHeader, "team-b,team-c")
+
+	recorder := httptest.NewRecorder()
+	op.Handler().ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("alloc endpoint status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+}
+
+func TestAllocEndpointAcceptsBodyIdempotencyKey(t *testing.T) {
+	op := testAggregatedOperator(
+		t, true,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+
+	reqBody, err := json.Marshal(AllocRequest{IdempotencyKey: "alloc-key", WireGuardPublicKey: testPublicKey(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := trustedAggregatedRequest(t, op, http.MethodPost, allocsPath, bytes.NewReader(reqBody))
+	req.Header.Set(remoteUserHeader, "alice")
+
+	recorder := httptest.NewRecorder()
+	op.Handler().ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("alloc endpoint status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+}
+
+func TestAllocEndpointRejectsMissingRemoteUser(t *testing.T) {
+	op := testAggregatedOperator(
+		t, true,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+
+	reqBody, err := json.Marshal(AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := trustedAggregatedRequest(t, op, http.MethodPost, allocsPath, bytes.NewReader(reqBody))
+	req.Header.Set(idempotencyKeyHeader, "alloc-key")
+
+	recorder := httptest.NewRecorder()
+	op.Handler().ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("alloc endpoint status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestAllocEndpointRejectsDeniedSubjectAccessReview(t *testing.T) {
+	op := testAggregatedOperator(
+		t, false,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+
+	reqBody, err := json.Marshal(AllocRequest{WireGuardPublicKey: testPublicKey(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := trustedAggregatedRequest(t, op, http.MethodPost, allocsPath, bytes.NewReader(reqBody))
+	req.Header.Set(idempotencyKeyHeader, "alloc-key")
+	req.Header.Set(remoteUserHeader, "alice")
+
+	recorder := httptest.NewRecorder()
+	op.Handler().ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("alloc endpoint status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestDeallocEndpointDeletesAllocatedRunner(t *testing.T) {
+	op := testAggregatedOperator(
+		t, true,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+
+	req := AllocRequest{WireGuardPublicKey: testPublicKey(t)}
+	if _, status, err := op.Alloc(t.Context(), "alloc-key", req); err != nil || status != 200 {
+		t.Fatalf("alloc status=%d err=%v", status, err)
+	}
+
+	httpReq := trustedAggregatedRequest(t, op, http.MethodPost, deallocsPath, nil)
+	httpReq.Header.Set(idempotencyKeyHeader, "alloc-key")
+	httpReq.Header.Set(remoteUserHeader, "alice")
+
+	recorder := httptest.NewRecorder()
+
+	op.Handler().ServeHTTP(recorder, httpReq)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("dealloc endpoint status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "runner-1"}, pod); err == nil {
+		t.Fatal("claimed pod still exists after dealloc endpoint call")
+	}
+}
+
+func TestDeallocEndpointAcceptsBodyIdempotencyKey(t *testing.T) {
+	op := testAggregatedOperator(
+		t, true,
+		testNode("node-1", "20.30.40.50"),
+		testPod("runner-1", "node-1", nil),
+	)
+
+	req := AllocRequest{WireGuardPublicKey: testPublicKey(t)}
+	if _, status, err := op.Alloc(t.Context(), "alloc-key", req); err != nil || status != 200 {
+		t.Fatalf("alloc status=%d err=%v", status, err)
+	}
+
+	reqBody, err := json.Marshal(DeallocRequest{IdempotencyKey: "alloc-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpReq := trustedAggregatedRequest(t, op, http.MethodPost, deallocsPath, bytes.NewReader(reqBody))
+	httpReq.Header.Set(remoteUserHeader, "alice")
+
+	recorder := httptest.NewRecorder()
+	op.Handler().ServeHTTP(recorder, httpReq)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("dealloc endpoint status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestReconcileDeletesExpiredClaimedRunner(t *testing.T) {
+	oldClaim := map[string]string{
+		AnnotationIdempotencyKeyHash: hashString("old-claim"),
+		AnnotationRequestHash:        hashString("old-request"),
+		AnnotationClaimedAt:          time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+	}
+	freshClaim := map[string]string{
+		AnnotationIdempotencyKeyHash: hashString("fresh-claim"),
+		AnnotationRequestHash:        hashString("fresh-request"),
+		AnnotationClaimedAt:          time.Now().UTC().Format(time.RFC3339),
+	}
+	op := testOperator(
+		t,
+		testPod("old-runner", "node-1", oldClaim),
+		testPod("fresh-runner", "node-1", freshClaim),
+	)
+	op.Config.PlaypenTTL = time.Hour
+
+	if err := op.ReconcileRunners(t.Context()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "old-runner"}, pod); err == nil {
+		t.Fatal("expired pod still exists after reconcile")
+	}
+
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "fresh-runner"}, pod); err != nil {
+		t.Fatalf("fresh pod was deleted: %v", err)
+	}
+}
+
+func TestReconcileDeletesClaimWithInvalidClaimedAt(t *testing.T) {
+	claim := map[string]string{
+		AnnotationIdempotencyKeyHash: hashString("claim"),
+		AnnotationRequestHash:        hashString("request"),
+		AnnotationClaimedAt:          "not-a-time",
+	}
+	op := testOperator(t, testPod("runner-1", "node-1", claim))
+	op.Config.PlaypenTTL = time.Hour
+
+	if err := op.ReconcileRunners(t.Context()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	pod := &corev1.Pod{}
+	if err := op.Client.Get(t.Context(), client.ObjectKey{Namespace: "playpen", Name: "runner-1"}, pod); err == nil {
+		t.Fatal("pod with invalid claimed-at still exists after reconcile")
+	}
+}
+
+func TestReconcileCreatesIdleRunnerPodsWithUniqueHostPorts(t *testing.T) {
+	op := testOperator(t)
+	op.Config.RunnerAMD64Count = 2
+	op.Config.RunnerARM64Count = 1
+	op.Config.RunnerWireGuardHostPortStart = 52000
+	op.Config.RunnerWireGuardHostPortEnd = 52002
+
+	if err := op.ReconcileRunners(t.Context()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	pods := &corev1.PodList{}
+	if err := op.Client.List(t.Context(), pods, client.InNamespace("playpen"), client.MatchingLabels{"app.kubernetes.io/name": "playpen-runner"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pods.Items) != 3 {
+		t.Fatalf("pods = %d, want 3", len(pods.Items))
+	}
+
+	hostPorts := map[int32]struct{}{}
+	counts := map[string]int{}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		hostPort := podWireGuardHostPort(pod)
+		if hostPort < 52000 || hostPort > 52002 {
+			t.Fatalf("pod %s hostPort = %d, want in range", pod.Name, hostPort)
+		}
+
+		if _, ok := hostPorts[hostPort]; ok {
+			t.Fatalf("duplicate hostPort %d", hostPort)
+		}
+
+		hostPorts[hostPort] = struct{}{}
+		counts[podArchitecture(pod)]++
+
+		if pod.Spec.ServiceAccountName != "playpen-runner" {
+			t.Fatalf("pod %s serviceAccount = %q", pod.Name, pod.Spec.ServiceAccountName)
+		}
+
+		if pod.Spec.NodeSelector["kubernetes.io/arch"] != podArchitecture(pod) {
+			t.Fatalf("pod %s node selector = %#v", pod.Name, pod.Spec.NodeSelector)
+		}
+	}
+
+	if counts[ArchitectureAMD64] != 2 || counts[ArchitectureARM64] != 1 {
+		t.Fatalf("counts = %#v, want amd64=2 arm64=1", counts)
+	}
+}
+
+func TestReconcileSkipsUsedRunnerHostPorts(t *testing.T) {
+	existing := testPodWithHostPort("existing-runner", "node-1", 52000)
+	op := testOperator(t, existing)
+	op.Config.RunnerAMD64Count = 2
+	op.Config.RunnerARM64Count = 0
+	op.Config.RunnerWireGuardHostPortStart = 52000
+	op.Config.RunnerWireGuardHostPortEnd = 52001
+
+	if err := op.ReconcileRunners(t.Context()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	pods := &corev1.PodList{}
+	if err := op.Client.List(t.Context(), pods, client.InNamespace("playpen"), client.MatchingLabels{"app.kubernetes.io/name": "playpen-runner"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pods.Items) != 2 {
+		t.Fatalf("pods = %d, want 2", len(pods.Items))
+	}
+
+	seen := map[int32]struct{}{}
+	for i := range pods.Items {
+		seen[podWireGuardHostPort(&pods.Items[i])] = struct{}{}
+	}
+
+	if _, ok := seen[52000]; !ok {
+		t.Fatal("existing hostPort 52000 was not preserved")
+	}
+
+	if _, ok := seen[52001]; !ok {
+		t.Fatal("new runner did not use next free hostPort 52001")
+	}
+}
+
+func TestReconcileReportsNoFreeRunnerHostPorts(t *testing.T) {
+	op := testOperator(t, testPodWithHostPort("existing-runner", "node-1", 52000))
+	op.Config.RunnerAMD64Count = 2
+	op.Config.RunnerARM64Count = 0
+	op.Config.RunnerWireGuardHostPortStart = 52000
+	op.Config.RunnerWireGuardHostPortEnd = 52000
+
+	if err := op.ReconcileRunners(t.Context()); err == nil {
+		t.Fatal("reconcile succeeded without a free hostPort")
+	}
+}
+
+func TestReconcileCreatesIdleControlPlanePodsPerVersion(t *testing.T) {
+	op := testOperator(t)
+	op.Config.RunnerAMD64Count = 0
+	op.Config.RunnerARM64Count = 0
+	op.Config.ControlPlaneCount = 1
+	op.Config.ControlPlaneVersions = []string{"v1.33.0", "1.34.0"}
+	op.Config.ControlPlaneAPIServerHostPortStart = 16443
+	op.Config.ControlPlaneAPIServerHostPortEnd = 16444
+
+	if err := op.ReconcileRunners(t.Context()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	pods := &corev1.PodList{}
+	if err := op.Client.List(t.Context(), pods, client.InNamespace("playpen"), client.MatchingLabels{"app.kubernetes.io/name": controlPlaneAppName}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pods.Items) != 2 {
+		t.Fatalf("pods = %d, want 2", len(pods.Items))
+	}
+
+	versions := map[string]int{}
+	hostPorts := map[int32]struct{}{}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		versions[podKubernetesVersion(pod)]++
+
+		hostPort := podControlPlaneHostPort(pod)
+		if hostPort < 16443 || hostPort > 16444 {
+			t.Fatalf("pod %s hostPort = %d", pod.Name, hostPort)
+		}
+
+		if _, ok := hostPorts[hostPort]; ok {
+			t.Fatalf("duplicate hostPort %d", hostPort)
+		}
+
+		hostPorts[hostPort] = struct{}{}
+
+		if pod.Spec.ServiceAccountName != "playpen-control-plane" {
+			t.Fatalf("pod %s serviceAccount = %q", pod.Name, pod.Spec.ServiceAccountName)
+		}
+
+		controlPlaneContainer := pod.Spec.Containers[0]
+		if !containsString(controlPlaneContainer.Args, "--write-kubeconfig="+controlPlaneKubeconfig) {
+			t.Fatalf("pod %s k3s args = %#v, want explicit shared kubeconfig path", pod.Name, controlPlaneContainer.Args)
+		}
+
+		helperContainer := pod.Spec.Containers[1]
+		if len(helperContainer.Command) != 1 || helperContainer.Command[0] != "/unbounded/bin/playpen-runner" {
+			t.Fatalf("pod %s helper command = %#v, want playpen-runner", pod.Name, helperContainer.Command)
+		}
+
+		if len(helperContainer.Args) == 0 || helperContainer.Args[0] != "control-plane" {
+			t.Fatalf("pod %s helper args = %#v, want control-plane subcommand", pod.Name, helperContainer.Args)
+		}
+	}
+
+	if versions["v1.33.0"] != 1 || versions["v1.34.0"] != 1 {
+		t.Fatalf("versions = %#v", versions)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestManagedPodsInheritKubernetesServiceEnvOverrides(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "172.18.0.3")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "6443")
+	t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "6443")
+
+	op := testOperator(t)
+
+	runnerPod := op.runnerPod(ArchitectureAMD64, 51820)
+	assertEnvVar(t, runnerPod.Spec.Containers[0].Env, "KUBERNETES_SERVICE_HOST", "172.18.0.3")
+	assertEnvVar(t, runnerPod.Spec.Containers[0].Env, "KUBERNETES_SERVICE_PORT", "6443")
+	assertEnvVar(t, runnerPod.Spec.Containers[0].Env, "KUBERNETES_SERVICE_PORT_HTTPS", "6443")
+
+	cpPod := op.controlPlanePod("v1.33.0", 16443)
+	assertEnvVar(t, cpPod.Spec.Containers[1].Env, "KUBERNETES_SERVICE_HOST", "172.18.0.3")
+	assertEnvVar(t, cpPod.Spec.Containers[1].Env, "KUBERNETES_SERVICE_PORT", "6443")
+	assertEnvVar(t, cpPod.Spec.Containers[1].Env, "KUBERNETES_SERVICE_PORT_HTTPS", "6443")
+}
+
+func assertEnvVar(t *testing.T, env []corev1.EnvVar, name, want string) {
+	t.Helper()
+
+	for _, entry := range env {
+		if entry.Name == name {
+			if entry.Value != want {
+				t.Fatalf("env %s = %q, want %q", name, entry.Value, want)
+			}
+
+			return
+		}
+	}
+
+	t.Fatalf("env %s missing in %#v", name, env)
+}
+
+func testOperator(t *testing.T, objects ...client.Object) *Operator {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	op := &Operator{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build(),
+		Config: DefaultConfig(),
+		Scheme: scheme,
+	}
+
+	return op
+}
+
+var testAggregatedClientCerts = map[*Operator]*x509.Certificate{}
+
+func testAggregatedOperator(t *testing.T, sarAllowed bool, objects ...client.Object) *Operator {
+	t.Helper()
+
+	op := testOperator(t, objects...)
+	leaf, pool := testFrontProxyCert(t, "front-proxy-client")
+	op.aggregatedClientCAs = pool
+	op.aggregatedClientAllowedCNs = map[string]struct{}{leaf.Subject.CommonName: {}}
+	testAggregatedClientCerts[op] = leaf
+	op.KubeClient = kubefake.NewClientset()
+	op.KubeClient.(*kubefake.Clientset).PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(k8stesting.CreateAction)
+
+		sar := createAction.GetObject().(*authzv1.SubjectAccessReview)
+		if sar.Spec.User != "alice" {
+			t.Fatalf("SAR user = %q, want alice", sar.Spec.User)
+		}
+
+		if sar.Spec.ResourceAttributes == nil {
+			t.Fatal("SAR missing resource attributes")
+		}
+
+		attrs := sar.Spec.ResourceAttributes
+		if attrs.Verb != "create" || attrs.Group != apiGroup || (attrs.Resource != "allocs" && attrs.Resource != "deallocs") {
+			t.Fatalf("SAR attrs = %#v, want create %s allocs or deallocs", attrs, apiGroup)
+		}
+
+		return true, &authzv1.SubjectAccessReview{Status: authzv1.SubjectAccessReviewStatus{Allowed: sarAllowed}}, nil
+	})
+
+	return op
+}
+
+func trustedAggregatedRequest(t *testing.T, op *Operator, method, path string, body *bytes.Reader) *http.Request {
+	t.Helper()
+
+	if body == nil {
+		body = bytes.NewReader(nil)
+	}
+
+	req := httptest.NewRequest(method, path, body)
+
+	_, ok := op.aggregatedClientAllowedCNs["front-proxy-client"]
+	if !ok {
+		t.Fatal("test operator is missing front-proxy-client allowed CN")
+	}
+
+	cert := testAggregatedClientCerts[op]
+	if cert == nil {
+		t.Fatal("test operator is missing client certificate")
+	}
+
+	req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}
+
+	return req
+}
+
+func testFrontProxyCert(t *testing.T, commonName string) (*x509.Certificate, *x509.CertPool) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(now.UnixNano()),
+		Subject:               pkix.Name{CommonName: "test-front-proxy-ca"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(now.UnixNano() + 1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientCert, err := x509.ParseCertificate(clientDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+
+	return clientCert, pool
+}
+
+func testPod(name, nodeName string, annotations map[string]string) *corev1.Pod {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[AnnotationServerWireGuardPublicKey] = podServerPublicKey(name)
+
+	pod := testPodWithAnnotations(name, nodeName, annotations)
+	setPodWireGuardHostPort(pod, testHostPort(name))
+
+	return pod
+}
+
+func testPodWithArchitecture(name, nodeName, architecture string) *corev1.Pod {
+	pod := testPod(name, nodeName, nil)
+	pod.Labels[LabelArchitecture] = architecture
+
+	return pod
+}
+
+func testPodWithHostPort(name, nodeName string, hostPort int32) *corev1.Pod {
+	pod := testPod(name, nodeName, nil)
+	setPodWireGuardHostPort(pod, hostPort)
+
+	return pod
+}
+
+func testControlPlanePod(name, nodeName, kubernetesVersion string, hostPort int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "playpen",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      controlPlaneAppName,
+				"app.kubernetes.io/component": controlPlaneComponent,
+				LabelResourceType:             ResourceTypeControlPlane,
+				LabelKubernetesVersion:        kubernetesVersion,
+			},
+			Annotations: map[string]string{
+				AnnotationControlPlaneKubeconfig:  testKubeconfig("https://127.0.0.1:6443"),
+				AnnotationControlPlaneGuestServer: "https://192.168.200.1:6443",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name: controlPlaneContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: controlPlaneAPIPort, Protocol: corev1.ProtocolTCP, ContainerPort: 6443, HostPort: hostPort},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  controlPlaneContainerName,
+					Ready: true,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()}},
+				},
+				{
+					Name:  controlPlaneHelperName,
+					Ready: true,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()}},
+				},
+			},
+		},
+	}
+}
+
+func testKubeconfig(server string) string {
+	return `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: ` + server + `
+    insecure-skip-tls-verify: true
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user:
+    token: test-token
+`
+}
+
+func setPodWireGuardHostPort(pod *corev1.Pod, hostPort int32) {
+	pod.Spec.Containers = []corev1.Container{
+		{
+			Name: "runner",
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          "wireguard",
+					Protocol:      corev1.ProtocolUDP,
+					ContainerPort: 51820,
+					HostPort:      hostPort,
+				},
+			},
+		},
+	}
+}
+
+func testHostPort(name string) int32 {
+	var sum int32
+	for _, r := range name {
+		sum += r
+	}
+
+	return 51000 + sum%1000
+}
+
+func testPodWithAnnotations(name, nodeName string, annotations map[string]string) *corev1.Pod {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "playpen",
+			Labels:      map[string]string{"app.kubernetes.io/name": "playpen-runner"},
+			Annotations: annotations,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{Name: "runner"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "runner",
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()},
+					},
+				},
+			},
+		},
+	}
+}
+
+func podServerPublicKey(name string) string {
+	key := wgtypes.Key{}
+	for i := range key {
+		key[i] = byte(name[i%len(name)]) + byte(i)
+	}
+
+	return key.String()
+}
+
+func testNode(name, externalIP string) *corev1.Node {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if externalIP != "" {
+		node.Status.Addresses = append(node.Status.Addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: externalIP})
+	}
+
+	return node
+}
+
+func testPublicKey(t *testing.T) string {
+	t.Helper()
+
+	key, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return key.PublicKey().String()
+}

--- a/internal/playpen/runner/config.go
+++ b/internal/playpen/runner/config.go
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package runner
+
+import (
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/unbounded/internal/playpen/meta"
+)
+
+const (
+	ArchitectureAMD64 = meta.ArchitectureAMD64
+	ArchitectureARM64 = meta.ArchitectureARM64
+
+	defaultAMD64QEMUBinary       = "qemu-system-x86_64"
+	defaultAMD64QEMUMachine      = "q35,accel=kvm"
+	defaultAMD64QEMUCPU          = "host"
+	defaultAMD64QEMUNICDevice    = "virtio-net-pci"
+	defaultAMD64QEMUSerialDevice = "virtio-serial-pci"
+	defaultAMD64QEMUTPMDevice    = "tpm-tis"
+	defaultAMD64OVMFCodeFile     = "/usr/share/OVMF/OVMF_CODE_4M.fd"
+	defaultAMD64OVMFVarsTemplate = "/usr/share/OVMF/OVMF_VARS_4M.fd"
+
+	defaultARM64QEMUBinary       = "qemu-system-aarch64"
+	defaultARM64QEMUMachine      = "virt,accel=kvm"
+	defaultARM64QEMUCPU          = "host"
+	defaultARM64QEMUNICDevice    = "virtio-net-pci"
+	defaultARM64QEMUSerialDevice = "virtio-serial-pci"
+	defaultARM64QEMUTPMDevice    = "tpm-tis-device"
+	defaultARM64OVMFCodeFile     = "/usr/share/AAVMF/AAVMF_CODE.fd"
+	defaultARM64OVMFVarsTemplate = "/usr/share/AAVMF/AAVMF_VARS.fd"
+)
+
+// Config contains all settings for one standalone playpen runner pod.
+type Config struct {
+	ListenAddr       string
+	PublicRedfishURL string
+	DataDir          string
+	PodName          string
+	PodNamespace     string
+	Architecture     string
+	KubernetesClient client.Client
+	ConfigureNetwork bool
+	WireGuard        WireGuardConfig
+	VXLAN            VXLANConfig
+	BridgeName       string
+	TapName          string
+	Guest            GuestConfig
+	Redfish          RedfishConfig
+	QEMU             QEMUConfig
+}
+
+type WireGuardConfig struct {
+	PrivateKeyFile  string
+	ClientPublicKey string
+	Interface       string
+	ServerAddress   string
+	ClientAddress   string
+	ListenPort      int
+}
+
+type VXLANConfig struct {
+	Interface string
+	VNI       int
+	Port      int
+}
+
+type GuestConfig struct {
+	MAC        string
+	IPv4       string
+	SubnetMask string
+	Gateway    string
+	DNS        []string
+}
+
+type RedfishConfig struct {
+	Username string
+	Password string
+	DeviceID string
+}
+
+type QEMUConfig struct {
+	Binary           string
+	ImgBinary        string
+	SWTPMBinary      string
+	EnableTPM        bool
+	Machine          string
+	CPU              string
+	NICDevice        string
+	SerialDevice     string
+	TPMDevice        string
+	OVMFCodeFile     string
+	OVMFVarsTemplate string
+	DiskSize         string
+	MemoryMiB        int
+	CPUs             int
+}
+
+func DefaultConfig() Config {
+	return Config{
+		ListenAddr:       ":8443",
+		DataDir:          "/var/lib/playpen-runner",
+		Architecture:     ArchitectureAMD64,
+		ConfigureNetwork: true,
+		WireGuard: WireGuardConfig{
+			PrivateKeyFile: "/etc/playpen/wireguard/privatekey",
+			Interface:      "wg0",
+			ServerAddress:  "10.88.0.1/24",
+			ClientAddress:  "10.88.0.2/32",
+			ListenPort:     51820,
+		},
+		VXLAN: VXLANConfig{
+			Interface: "vxlan0",
+			VNI:       12001,
+			Port:      4789,
+		},
+		BridgeName: "br0",
+		TapName:    "tap0",
+		Guest: GuestConfig{
+			MAC:        "52:54:00:aa:bb:01",
+			IPv4:       "192.168.200.10",
+			SubnetMask: "255.255.255.0",
+			Gateway:    "192.168.200.1",
+			DNS:        []string{"8.8.8.8"},
+		},
+		Redfish: RedfishConfig{
+			DeviceID: "1",
+		},
+		QEMU: QEMUConfig{
+			Binary:           defaultAMD64QEMUBinary,
+			ImgBinary:        "qemu-img",
+			SWTPMBinary:      "swtpm",
+			EnableTPM:        true,
+			Machine:          defaultAMD64QEMUMachine,
+			CPU:              defaultAMD64QEMUCPU,
+			NICDevice:        defaultAMD64QEMUNICDevice,
+			SerialDevice:     defaultAMD64QEMUSerialDevice,
+			TPMDevice:        defaultAMD64QEMUTPMDevice,
+			OVMFCodeFile:     defaultAMD64OVMFCodeFile,
+			OVMFVarsTemplate: defaultAMD64OVMFVarsTemplate,
+			DiskSize:         "20G",
+			MemoryMiB:        4096,
+			CPUs:             2,
+		},
+	}
+}
+
+func (c *Config) ApplyArchitectureDefaults() error {
+	arch, err := normalizeArchitecture(c.Architecture)
+	if err != nil {
+		return err
+	}
+
+	c.Architecture = arch
+
+	switch arch {
+	case ArchitectureAMD64:
+		applyDefault(&c.QEMU.Binary, defaultAMD64QEMUBinary)
+		applyDefault(&c.QEMU.Machine, defaultAMD64QEMUMachine)
+		applyDefault(&c.QEMU.CPU, defaultAMD64QEMUCPU)
+		applyDefault(&c.QEMU.NICDevice, defaultAMD64QEMUNICDevice)
+		applyDefault(&c.QEMU.SerialDevice, defaultAMD64QEMUSerialDevice)
+		applyDefault(&c.QEMU.TPMDevice, defaultAMD64QEMUTPMDevice)
+		applyDefault(&c.QEMU.OVMFCodeFile, defaultAMD64OVMFCodeFile)
+		applyDefault(&c.QEMU.OVMFVarsTemplate, defaultAMD64OVMFVarsTemplate)
+	case ArchitectureARM64:
+		applyArchitectureDefault(&c.QEMU.Binary, defaultARM64QEMUBinary, defaultAMD64QEMUBinary)
+		applyArchitectureDefault(&c.QEMU.Machine, defaultARM64QEMUMachine, defaultAMD64QEMUMachine)
+		applyArchitectureDefault(&c.QEMU.CPU, defaultARM64QEMUCPU, defaultAMD64QEMUCPU)
+		applyArchitectureDefault(&c.QEMU.NICDevice, defaultARM64QEMUNICDevice, defaultAMD64QEMUNICDevice)
+		applyArchitectureDefault(&c.QEMU.SerialDevice, defaultARM64QEMUSerialDevice, defaultAMD64QEMUSerialDevice)
+		applyArchitectureDefault(&c.QEMU.TPMDevice, defaultARM64QEMUTPMDevice, defaultAMD64QEMUTPMDevice)
+		applyArchitectureDefault(&c.QEMU.OVMFCodeFile, defaultARM64OVMFCodeFile, defaultAMD64OVMFCodeFile)
+		applyArchitectureDefault(&c.QEMU.OVMFVarsTemplate, defaultARM64OVMFVarsTemplate, defaultAMD64OVMFVarsTemplate)
+	}
+
+	return nil
+}
+
+func normalizeArchitecture(value string) (string, error) {
+	switch arch := strings.ToLower(strings.TrimSpace(value)); arch {
+	case "", ArchitectureAMD64:
+		return ArchitectureAMD64, nil
+	case ArchitectureARM64:
+		return ArchitectureARM64, nil
+	default:
+		return "", fmt.Errorf("architecture must be %q or %q", ArchitectureAMD64, ArchitectureARM64)
+	}
+}
+
+func applyDefault(value *string, defaultValue string) {
+	if strings.TrimSpace(*value) == "" {
+		*value = defaultValue
+	}
+}
+
+func applyArchitectureDefault(value *string, archDefault string, replaceValues ...string) {
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		*value = archDefault
+
+		return
+	}
+
+	for _, replaceValue := range replaceValues {
+		if trimmed == replaceValue {
+			*value = archDefault
+
+			return
+		}
+	}
+}

--- a/internal/playpen/runner/exec.go
+++ b/internal/playpen/runner/exec.go
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+)
+
+type Commander interface {
+	Run(ctx context.Context, name string, args ...string) error
+	Start(ctx context.Context, name string, args []string, stdoutPath, stderrPath string) (Process, error)
+}
+
+type Process interface {
+	PID() int
+	Exited() bool
+	Signal(sig os.Signal) error
+	Kill() error
+	Wait() error
+}
+
+type OSCommander struct{}
+
+func (OSCommander) Run(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func (OSCommander) Start(ctx context.Context, name string, args []string, stdoutPath, stderrPath string) (Process, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	stdout, err := os.OpenFile(stdoutPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, err
+	}
+
+	stderr, err := os.OpenFile(stderrPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, errors.Join(err, stdout.Close())
+	}
+
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, errors.Join(err, stdout.Close(), stderr.Close())
+	}
+
+	p := &osProcess{cmd: cmd, done: make(chan struct{})}
+
+	go func() {
+		waitErr := cmd.Wait()
+		stdoutErr := stdout.Close()
+		stderrErr := stderr.Close()
+
+		if waitErr != nil {
+			p.err = waitErr
+		} else {
+			p.err = errors.Join(stdoutErr, stderrErr)
+		}
+
+		close(p.done)
+	}()
+
+	return p, nil
+}
+
+type osProcess struct {
+	cmd  *exec.Cmd
+	done chan struct{}
+	err  error
+}
+
+func (p *osProcess) PID() int {
+	if p.cmd.Process == nil {
+		return 0
+	}
+
+	return p.cmd.Process.Pid
+}
+
+func (p *osProcess) Exited() bool {
+	select {
+	case <-p.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *osProcess) Signal(sig os.Signal) error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+
+	return p.cmd.Process.Signal(sig)
+}
+
+func (p *osProcess) Kill() error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+
+	return p.cmd.Process.Kill()
+}
+
+func (p *osProcess) Wait() error {
+	<-p.done
+
+	return p.err
+}

--- a/internal/playpen/runner/network.go
+++ b/internal/playpen/runner/network.go
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+type NetworkManager struct {
+	cmd Commander
+	cfg Config
+}
+
+func NewNetworkManager(cmd Commander, cfg Config) *NetworkManager {
+	return &NetworkManager{cmd: cmd, cfg: cfg}
+}
+
+func (m *NetworkManager) Setup(ctx context.Context) error {
+	if !m.cfg.ConfigureNetwork {
+		return nil
+	}
+
+	serverAddr, err := addressIP(m.cfg.WireGuard.ServerAddress)
+	if err != nil {
+		return fmt.Errorf("parse wireguard server address: %w", err)
+	}
+
+	clientAddr, err := addressIP(m.cfg.WireGuard.ClientAddress)
+	if err != nil {
+		return fmt.Errorf("parse wireguard client address: %w", err)
+	}
+
+	m.Teardown(ctx) //nolint:errcheck // Setup is idempotent and recreates network resources below.
+
+	commands := [][]string{
+		{"ip", "link", "add", m.cfg.WireGuard.Interface, "type", "wireguard"},
+		{
+			"wg", "set", m.cfg.WireGuard.Interface,
+			"private-key", m.cfg.WireGuard.PrivateKeyFile,
+			"listen-port", fmt.Sprint(m.cfg.WireGuard.ListenPort),
+		},
+		{"ip", "addr", "add", m.cfg.WireGuard.ServerAddress, "dev", m.cfg.WireGuard.Interface},
+		{"ip", "link", "set", m.cfg.WireGuard.Interface, "up"},
+		{"ip", "link", "add", m.cfg.BridgeName, "type", "bridge"},
+		{"ip", "link", "set", m.cfg.BridgeName, "up"},
+		{
+			"ip", "link", "add", m.cfg.VXLAN.Interface,
+			"type", "vxlan",
+			"id", fmt.Sprint(m.cfg.VXLAN.VNI),
+			"dev", m.cfg.WireGuard.Interface,
+			"local", serverAddr.String(),
+			"remote", clientAddr.String(),
+			"dstport", fmt.Sprint(m.cfg.VXLAN.Port),
+			"nolearning",
+		},
+		{"bridge", "fdb", "append", "00:00:00:00:00:00", "dev", m.cfg.VXLAN.Interface, "dst", clientAddr.String()},
+		{"ip", "link", "set", m.cfg.VXLAN.Interface, "master", m.cfg.BridgeName},
+		{"ip", "link", "set", m.cfg.VXLAN.Interface, "up"},
+		{"ip", "tuntap", "add", "dev", m.cfg.TapName, "mode", "tap"},
+		{"ip", "link", "set", m.cfg.TapName, "master", m.cfg.BridgeName},
+		{"ip", "link", "set", m.cfg.TapName, "up"},
+	}
+
+	for _, c := range commands {
+		if err := m.cmd.Run(ctx, c[0], c[1:]...); err != nil {
+			return fmt.Errorf("run %q: %w", joinCommand(c), err)
+		}
+	}
+
+	if m.cfg.WireGuard.ClientPublicKey != "" {
+		if err := m.ConfigurePeer(ctx, m.cfg.WireGuard.ClientPublicKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *NetworkManager) ConfigurePeer(ctx context.Context, clientPublicKey string) error {
+	if !m.cfg.ConfigureNetwork {
+		return nil
+	}
+
+	clientPublicKey = strings.TrimSpace(clientPublicKey)
+	if clientPublicKey == "" {
+		return fmt.Errorf("wireguard client public key is required")
+	}
+
+	c := []string{
+		"wg", "set", m.cfg.WireGuard.Interface,
+		"peer", clientPublicKey,
+		"allowed-ips", m.cfg.WireGuard.ClientAddress,
+	}
+	if err := m.cmd.Run(ctx, c[0], c[1:]...); err != nil {
+		return fmt.Errorf("run %q: %w", joinCommand(c), err)
+	}
+
+	return nil
+}
+
+func (m *NetworkManager) Teardown(ctx context.Context) error {
+	if !m.cfg.ConfigureNetwork {
+		return nil
+	}
+
+	for _, c := range [][]string{
+		{"ip", "link", "delete", m.cfg.TapName},
+		{"ip", "link", "delete", m.cfg.VXLAN.Interface},
+		{"ip", "link", "delete", m.cfg.BridgeName},
+		{"ip", "link", "delete", m.cfg.WireGuard.Interface},
+	} {
+		m.cmd.Run(ctx, c[0], c[1:]...) //nolint:errcheck // Teardown is best-effort for idempotency.
+	}
+
+	return nil
+}
+
+func addressIP(value string) (netip.Addr, error) {
+	if prefix, err := netip.ParsePrefix(value); err == nil {
+		return prefix.Addr(), nil
+	}
+
+	return netip.ParseAddr(value)
+}
+
+func joinCommand(parts []string) string {
+	result := ""
+
+	for i, part := range parts {
+		if i > 0 {
+			result += " "
+		}
+
+		result += part
+	}
+
+	return result
+}
+
+func ensureWireGuardPrivateKey(path string) (string, error) {
+	if existing, err := os.ReadFile(path); err == nil {
+		key, err := wgtypes.ParseKey(strings.TrimSpace(string(existing)))
+		if err != nil {
+			return "", fmt.Errorf("parse wireguard private key: %w", err)
+		}
+
+		return key.PublicKey().String(), nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	key, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(path, []byte(key.String()+"\n"), 0o600); err != nil {
+		return "", err
+	}
+
+	return key.PublicKey().String(), nil
+}

--- a/internal/playpen/runner/qemu.go
+++ b/internal/playpen/runner/qemu.go
@@ -1,0 +1,328 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type PowerState string
+
+const (
+	PowerOn  PowerState = "On"
+	PowerOff PowerState = "Off"
+)
+
+type ResetType string
+
+const (
+	ResetForceOff ResetType = "ForceOff"
+	ResetOn       ResetType = "On"
+)
+
+type BootTarget string
+
+const (
+	BootTargetPxe BootTarget = "Pxe"
+	BootTargetHdd BootTarget = "Hdd"
+)
+
+type BootEnabled string
+
+const (
+	BootContinuous BootEnabled = "Continuous"
+	BootDisabled   BootEnabled = "Disabled"
+)
+
+type VMManager struct {
+	cmd Commander
+	cfg Config
+	mu  sync.Mutex
+
+	qemuProc  Process
+	swtpmProc Process
+	boot      BootConfig
+}
+
+type BootConfig struct {
+	Target  BootTarget
+	Enabled BootEnabled
+}
+
+func NewVMManager(cmd Commander, cfg Config) *VMManager {
+	return &VMManager{
+		cmd: cmd,
+		cfg: cfg,
+		boot: BootConfig{
+			Target:  BootTargetPxe,
+			Enabled: BootContinuous,
+		},
+	}
+}
+
+func (m *VMManager) PowerState() PowerState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.qemuProc == nil || m.qemuProc.Exited() {
+		return PowerOff
+	}
+
+	return PowerOn
+}
+
+func (m *VMManager) BootConfig() BootConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.boot
+}
+
+func (m *VMManager) SetBootConfig(config BootConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if config.Target != "" {
+		m.boot.Target = config.Target
+	}
+
+	if config.Enabled != "" {
+		m.boot.Enabled = config.Enabled
+	}
+}
+
+func (m *VMManager) Reset(ctx context.Context, reset ResetType) error {
+	switch reset {
+	case ResetOn:
+		return m.Start(ctx)
+	case ResetForceOff:
+		return m.Stop()
+	default:
+		return fmt.Errorf("unsupported reset type %q", reset)
+	}
+}
+
+func (m *VMManager) Start(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.qemuProc != nil && !m.qemuProc.Exited() {
+		return nil
+	}
+
+	if err := os.MkdirAll(m.cfg.DataDir, 0o755); err != nil {
+		return err
+	}
+
+	if err := m.ensureDisk(ctx); err != nil {
+		return err
+	}
+
+	if err := m.ensureOVMFVars(); err != nil {
+		return err
+	}
+
+	if m.cfg.QEMU.EnableTPM {
+		swtpmProc, err := m.startSWTPM(context.WithoutCancel(ctx))
+		if err != nil {
+			return err
+		}
+
+		m.swtpmProc = swtpmProc
+	}
+
+	args := m.qemuArgs()
+
+	proc, err := m.cmd.Start(context.WithoutCancel(ctx), m.cfg.QEMU.Binary, args, filepath.Join(m.cfg.DataDir, "qemu.log"), filepath.Join(m.cfg.DataDir, "qemu.err"))
+	if err != nil {
+		err = errors.Join(err, m.stopProcess(m.swtpmProc))
+		m.swtpmProc = nil
+
+		return err
+	}
+
+	m.qemuProc = proc
+
+	return nil
+}
+
+func (m *VMManager) Stop() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var errs []error
+	if err := m.stopProcess(m.qemuProc); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := m.stopProcess(m.swtpmProc); err != nil {
+		errs = append(errs, err)
+	}
+
+	m.qemuProc = nil
+	m.swtpmProc = nil
+
+	return errors.Join(errs...)
+}
+
+func (m *VMManager) ensureDisk(ctx context.Context) error {
+	disk := filepath.Join(m.cfg.DataDir, "disk.qcow2")
+	if _, err := os.Stat(disk); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return m.cmd.Run(ctx, m.cfg.QEMU.ImgBinary, "create", "-f", "qcow2", disk, m.cfg.QEMU.DiskSize)
+}
+
+func (m *VMManager) ensureOVMFVars() error {
+	vars := filepath.Join(m.cfg.DataDir, "OVMF_VARS.fd")
+	if _, err := os.Stat(vars); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	data, err := os.ReadFile(m.cfg.QEMU.OVMFVarsTemplate)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(vars, data, 0o600)
+}
+
+func (m *VMManager) startSWTPM(ctx context.Context) (Process, error) {
+	tpmDir := filepath.Join(os.TempDir(), "playpen-runner-tpm")
+	if err := os.MkdirAll(tpmDir, 0o700); err != nil {
+		return nil, err
+	}
+
+	socketPath := m.swtpmSocketPath()
+	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	args := []string{
+		"socket",
+		"--tpm2",
+		"--runas", "0",
+		"--tpmstate", "dir=" + tpmDir,
+		"--ctrl", "type=unixio,path=" + socketPath,
+		"--log", "level=20",
+	}
+
+	proc, err := m.cmd.Start(ctx, m.cfg.QEMU.SWTPMBinary, args, filepath.Join(m.cfg.DataDir, "swtpm.log"), filepath.Join(m.cfg.DataDir, "swtpm.err"))
+	if err != nil {
+		return nil, err
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := waitForUnixSocket(waitCtx, socketPath); err != nil {
+		return nil, errors.Join(err, m.stopProcess(proc))
+	}
+
+	return proc, nil
+}
+
+func (m *VMManager) swtpmSocketPath() string {
+	return filepath.Join(os.TempDir(), "playpen-runner-swtpm.sock")
+}
+
+func waitForUnixSocket(ctx context.Context, path string) error {
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if info.Mode()&os.ModeSocket == 0 {
+				return fmt.Errorf("%s exists but is not a Unix socket", path)
+			}
+
+			return nil
+		}
+
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for Unix socket %s: %w", path, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *VMManager) qemuArgs() []string {
+	bootOrder := "n"
+	if m.boot.Enabled == BootDisabled || m.boot.Target == BootTargetHdd {
+		bootOrder = "c"
+	}
+
+	args := []string{
+		"-enable-kvm",
+		"-machine", m.cfg.QEMU.Machine,
+		"-cpu", m.cfg.QEMU.CPU,
+		"-m", strconv.Itoa(m.cfg.QEMU.MemoryMiB),
+		"-smp", strconv.Itoa(m.cfg.QEMU.CPUs),
+		"-drive", "if=pflash,format=raw,readonly=on,file=" + m.cfg.QEMU.OVMFCodeFile,
+		"-drive", "if=pflash,format=raw,file=" + filepath.Join(m.cfg.DataDir, "OVMF_VARS.fd"),
+		"-drive", "file=" + filepath.Join(m.cfg.DataDir, "disk.qcow2") + ",format=qcow2,if=virtio",
+		"-netdev", "tap,id=net0,ifname=" + m.cfg.TapName + ",script=no,downscript=no",
+		"-device", m.cfg.QEMU.NICDevice + ",netdev=net0,mac=" + m.cfg.Guest.MAC,
+		"-boot", "order=" + bootOrder,
+		"-serial", "file:" + filepath.Join(m.cfg.DataDir, "serial.log"),
+		"-chardev", "socket,path=" + filepath.Join(m.cfg.DataDir, "qga.sock") + ",server=on,wait=off,id=qga0",
+		"-device", m.cfg.QEMU.SerialDevice,
+		"-device", "virtserialport,chardev=qga0,name=org.qemu.guest_agent.0",
+		"-display", "none",
+	}
+
+	if m.cfg.QEMU.EnableTPM {
+		args = append(args,
+			"-chardev", "socket,id=chrtpm,path="+m.swtpmSocketPath(),
+			"-tpmdev", "emulator,id=tpm0,chardev=chrtpm",
+			"-device", m.cfg.QEMU.TPMDevice+",tpmdev=tpm0",
+		)
+	}
+
+	return args
+}
+
+func (m *VMManager) stopProcess(proc Process) error {
+	if proc == nil || proc.Exited() {
+		return nil
+	}
+
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return err
+	}
+
+	done := make(chan error, 1)
+
+	go func() { done <- proc.Wait() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(10 * time.Second):
+		if err := proc.Kill(); err != nil {
+			return err
+		}
+
+		return <-done
+	}
+}

--- a/internal/playpen/runner/redfish.go
+++ b/internal/playpen/runner/redfish.go
@@ -1,0 +1,331 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package runner
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+type RedfishHandler struct {
+	vm       *VMManager
+	cfg      RedfishConfig
+	dataDir  string
+	sessions map[string]struct{}
+	mu       sync.Mutex
+}
+
+func NewRedfishHandler(vm *VMManager, cfg RedfishConfig, dataDir string) *RedfishHandler {
+	return &RedfishHandler{
+		vm:       vm,
+		cfg:      cfg,
+		dataDir:  dataDir,
+		sessions: map[string]struct{}{},
+	}
+}
+
+func (h *RedfishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimRight(r.URL.Path, "/")
+	if path == "" {
+		path = "/"
+	}
+
+	if r.Method == http.MethodGet && (path == "/redfish/v1" || path == "/redfish/v1/") {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"@odata.id": "/redfish/v1/",
+			"Systems":   map[string]string{"@odata.id": "/redfish/v1/Systems"},
+		})
+
+		return
+	}
+
+	if r.Method == http.MethodPost && path == "/redfish/v1/SessionService/Sessions" {
+		h.createSession(w, r)
+
+		return
+	}
+
+	if r.Method == http.MethodDelete && strings.HasPrefix(path, "/redfish/v1/SessionService/Sessions/") {
+		h.deleteSession(w, r)
+
+		return
+	}
+
+	if !h.authenticated(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodGet && path == "/redfish/v1/Systems":
+		writeJSON(w, http.StatusOK, map[string]any{
+			"Members": []map[string]string{{"@odata.id": "/redfish/v1/Systems/" + h.cfg.DeviceID}},
+		})
+	case r.Method == http.MethodGet && path == "/redfish/v1/Systems/"+h.cfg.DeviceID:
+		h.getSystem(w)
+	case r.Method == http.MethodGet && path == h.serialConsoleStreamPath():
+		h.streamSerialConsole(w, r)
+	case r.Method == http.MethodPatch && path == "/redfish/v1/Systems/"+h.cfg.DeviceID:
+		h.patchSystem(w, r)
+	case r.Method == http.MethodPost && path == "/redfish/v1/Systems/"+h.cfg.DeviceID+"/Actions/ComputerSystem.Reset":
+		h.reset(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *RedfishHandler) createSession(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		UserName string `json:"UserName"`
+		Password string `json:"Password"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+
+		return
+	}
+
+	if !h.credentialsMatch(body.UserName, body.Password) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+		return
+	}
+
+	token, err := randomToken()
+	if err != nil {
+		http.Error(w, "create token", http.StatusInternalServerError)
+
+		return
+	}
+
+	h.mu.Lock()
+	h.sessions[token] = struct{}{}
+	h.mu.Unlock()
+
+	w.Header().Set("X-Auth-Token", token)
+	w.Header().Set("Location", "/redfish/v1/SessionService/Sessions/"+token)
+	writeJSON(w, http.StatusCreated, map[string]string{"Id": token})
+}
+
+func (h *RedfishHandler) deleteSession(w http.ResponseWriter, r *http.Request) {
+	token := strings.TrimPrefix(strings.TrimRight(r.URL.Path, "/"), "/redfish/v1/SessionService/Sessions/")
+
+	h.mu.Lock()
+	delete(h.sessions, token)
+	h.mu.Unlock()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *RedfishHandler) authenticated(r *http.Request) bool {
+	if token := r.Header.Get("X-Auth-Token"); token != "" {
+		h.mu.Lock()
+		_, ok := h.sessions[token]
+		h.mu.Unlock()
+
+		if ok {
+			return true
+		}
+	}
+
+	user, pass, ok := r.BasicAuth()
+
+	return ok && h.credentialsMatch(user, pass)
+}
+
+func (h *RedfishHandler) credentialsMatch(user, pass string) bool {
+	return subtle.ConstantTimeCompare([]byte(user), []byte(h.cfg.Username)) == 1 &&
+		subtle.ConstantTimeCompare([]byte(pass), []byte(h.cfg.Password)) == 1
+}
+
+func (h *RedfishHandler) getSystem(w http.ResponseWriter) {
+	boot := h.vm.BootConfig()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"@odata.id":   "/redfish/v1/Systems/" + h.cfg.DeviceID,
+		"@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+		"Id":          h.cfg.DeviceID,
+		"Name":        "Playpen VM",
+		"PowerState":  h.vm.PowerState(),
+		"Boot": map[string]string{
+			"BootSourceOverrideTarget":  string(boot.Target),
+			"BootSourceOverrideEnabled": string(boot.Enabled),
+		},
+		"SerialConsole": map[string]any{
+			"ServiceEnabled":        true,
+			"MaxConcurrentSessions": 1,
+			"ConnectTypesSupported": []string{"OEM"},
+			"Oem": map[string]any{
+				"Unbounded": map[string]any{
+					"ReadOnly":  true,
+					"Protocol":  "WebSocket",
+					"StreamURI": h.serialConsoleStreamPath(),
+				},
+			},
+		},
+	})
+}
+
+func (h *RedfishHandler) streamSerialConsole(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{OriginPatterns: []string{"*"}})
+	if err != nil {
+		return
+	}
+	defer conn.CloseNow() //nolint:errcheck // Connection cleanup only.
+
+	if err := h.followSerialLog(r.Context(), conn); err != nil && !errors.Is(err, context.Canceled) {
+		conn.Close(websocket.StatusInternalError, err.Error()) //nolint:errcheck // Connection is already closing on stream failure.
+	}
+}
+
+func (h *RedfishHandler) followSerialLog(ctx context.Context, conn *websocket.Conn) error {
+	path := filepath.Join(h.dataDir, "serial.log")
+	buf := make([]byte, 32*1024)
+
+	for {
+		file, err := os.Open(path)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+
+			if err := sleepContext(ctx, 200*time.Millisecond); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		if err := streamOpenSerialLog(ctx, conn, file, path, buf); err != nil {
+			return errors.Join(err, file.Close())
+		}
+
+		if err := file.Close(); err != nil {
+			return err
+		}
+	}
+}
+
+func streamOpenSerialLog(ctx context.Context, conn *websocket.Conn, file *os.File, path string, buf []byte) error {
+	for {
+		n, err := file.Read(buf)
+		if n > 0 {
+			if writeErr := conn.Write(ctx, websocket.MessageBinary, buf[:n]); writeErr != nil {
+				return writeErr
+			}
+		}
+
+		switch {
+		case err == nil:
+			continue
+		case errors.Is(err, io.EOF):
+			offset, seekErr := file.Seek(0, io.SeekCurrent)
+			if seekErr != nil {
+				return seekErr
+			}
+
+			info, statErr := os.Stat(path)
+			if statErr == nil && info.Size() < offset {
+				if _, seekErr := file.Seek(0, io.SeekStart); seekErr != nil {
+					return seekErr
+				}
+			}
+
+			if sleepErr := sleepContext(ctx, 200*time.Millisecond); sleepErr != nil {
+				return sleepErr
+			}
+		default:
+			return err
+		}
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (h *RedfishHandler) serialConsoleStreamPath() string {
+	return "/redfish/v1/Systems/" + h.cfg.DeviceID + "/Oem/Unbounded/SerialConsole/Stream"
+}
+
+func (h *RedfishHandler) patchSystem(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Boot struct {
+			BootSourceOverrideTarget  BootTarget  `json:"BootSourceOverrideTarget"`
+			BootSourceOverrideEnabled BootEnabled `json:"BootSourceOverrideEnabled"`
+		} `json:"Boot"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+
+		return
+	}
+
+	h.vm.SetBootConfig(BootConfig{
+		Target:  body.Boot.BootSourceOverrideTarget,
+		Enabled: body.Boot.BootSourceOverrideEnabled,
+	})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *RedfishHandler) reset(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ResetType ResetType `json:"ResetType"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := h.vm.Reset(r.Context(), body.ResetType); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func randomToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(b[:]), nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		fmt.Fprintln(w, err.Error()) //nolint:errcheck // Best effort after response write.
+	}
+}

--- a/internal/playpen/runner/runner_test.go
+++ b/internal/playpen/runner/runner_test.go
@@ -1,0 +1,625 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package runner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metalredfish "github.com/Azure/unbounded/internal/metalman/redfish"
+	"github.com/Azure/unbounded/internal/playpen/meta"
+)
+
+type recordedCommand struct {
+	Name string
+	Args []string
+}
+
+type fakeCommander struct {
+	mu        sync.Mutex
+	runs      []recordedCommand
+	starts    []recordedCommand
+	startErr  error
+	startHook func(recordedCommand) error
+}
+
+func (f *fakeCommander) Run(_ context.Context, name string, args ...string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.runs = append(f.runs, recordedCommand{Name: name, Args: append([]string(nil), args...)})
+
+	return nil
+}
+
+func (f *fakeCommander) Start(_ context.Context, name string, args []string, _, _ string) (Process, error) {
+	cmd := recordedCommand{Name: name, Args: append([]string(nil), args...)}
+
+	f.mu.Lock()
+	f.starts = append(f.starts, cmd)
+	startErr := f.startErr
+	startHook := f.startHook
+	f.mu.Unlock()
+
+	if startErr != nil {
+		return nil, startErr
+	}
+
+	if startHook != nil {
+		if err := startHook(cmd); err != nil {
+			return nil, err
+		}
+	}
+
+	return &fakeProcess{pid: len(f.starts)}, nil
+}
+
+func (f *fakeCommander) runStrings() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	commands := make([]string, 0, len(f.runs))
+	for _, cmd := range f.runs {
+		commands = append(commands, cmd.Name+" "+strings.Join(cmd.Args, " "))
+	}
+
+	return commands
+}
+
+func (f *fakeCommander) startStrings() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	commands := make([]string, 0, len(f.starts))
+	for _, cmd := range f.starts {
+		commands = append(commands, cmd.Name+" "+strings.Join(cmd.Args, " "))
+	}
+
+	return commands
+}
+
+type fakeProcess struct {
+	pid    int
+	exited bool
+}
+
+func (p *fakeProcess) PID() int { return p.pid }
+
+func (p *fakeProcess) Exited() bool { return p.exited }
+
+func (p *fakeProcess) Signal(os.Signal) error {
+	p.exited = true
+
+	return nil
+}
+
+func (p *fakeProcess) Kill() error {
+	p.exited = true
+
+	return nil
+}
+
+func (p *fakeProcess) Wait() error { return nil }
+
+func TestNetworkSetupCommands(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WireGuard.ClientPublicKey = "client-public-key"
+	fake := &fakeCommander{}
+
+	manager := NewNetworkManager(fake, cfg)
+	if err := manager.Setup(t.Context()); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	commands := strings.Join(fake.runStrings(), "\n")
+	for _, want := range []string{
+		"ip link add wg0 type wireguard",
+		"wg set wg0 private-key /etc/playpen/wireguard/privatekey listen-port 51820",
+		"wg set wg0 peer client-public-key allowed-ips 10.88.0.2/32",
+		"ip link add br0 type bridge",
+		"ip link add vxlan0 type vxlan id 12001 dev wg0 local 10.88.0.1 remote 10.88.0.2 dstport 4789 nolearning",
+		"bridge fdb append 00:00:00:00:00:00 dev vxlan0 dst 10.88.0.2",
+		"ip tuntap add dev tap0 mode tap",
+	} {
+		if !strings.Contains(commands, want) {
+			t.Fatalf("commands missing %q:\n%s", want, commands)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"192.168.200.1",
+		"MASQUERADE",
+		"net.ipv4.ip_forward",
+		"iptables",
+	} {
+		if strings.Contains(commands, forbidden) {
+			t.Fatalf("runner network setup contains %q, want VM egress isolated to VXLAN:\n%s", forbidden, commands)
+		}
+	}
+}
+
+func TestNetworkSetupWithoutInitialPeer(t *testing.T) {
+	cfg := DefaultConfig()
+	fake := &fakeCommander{}
+
+	manager := NewNetworkManager(fake, cfg)
+	if err := manager.Setup(t.Context()); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	commands := strings.Join(fake.runStrings(), "\n")
+	if strings.Contains(commands, " peer ") {
+		t.Fatalf("setup configured peer before claim:\n%s", commands)
+	}
+
+	if err := manager.ConfigurePeer(t.Context(), "client-public-key"); err != nil {
+		t.Fatalf("configure peer: %v", err)
+	}
+
+	commands = strings.Join(fake.runStrings(), "\n")
+	if !strings.Contains(commands, "wg set wg0 peer client-public-key allowed-ips 10.88.0.2/32") {
+		t.Fatalf("commands missing delayed peer:\n%s", commands)
+	}
+}
+
+func TestWaitForClientPublicKeyAnnotationConfiguresPeer(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ConfigureNetwork = true
+	cfg.PodName = "runner-1"
+	cfg.PodNamespace = "playpen"
+	cfg.KubernetesClient = testKubernetesClient(t, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: cfg.PodName, Namespace: cfg.PodNamespace},
+	})
+	fake := &fakeCommander{}
+	manager := NewNetworkManager(fake, cfg)
+	state := NewRuntimeState("server-public-key", false)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go waitForClientPublicKeyAnnotation(ctx, cfg, manager, state)
+
+	if state.Ready() {
+		t.Fatal("state is ready before claim")
+	}
+
+	pod := &corev1.Pod{}
+	if err := cfg.KubernetesClient.Get(t.Context(), client.ObjectKey{Namespace: cfg.PodNamespace, Name: cfg.PodName}, pod); err != nil {
+		t.Fatal(err)
+	}
+
+	base := pod.DeepCopy()
+
+	pod.Annotations = map[string]string{meta.AnnotationClientWireGuardPublicKey: "client-public-key"}
+	if err := cfg.KubernetesClient.Patch(t.Context(), pod, client.MergeFrom(base)); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !state.Ready() && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if !state.Ready() {
+		t.Fatal("state did not become ready")
+	}
+
+	commands := strings.Join(fake.runStrings(), "\n")
+	if !strings.Contains(commands, "wg set wg0 peer client-public-key allowed-ips 10.88.0.2/32") {
+		t.Fatalf("commands missing delayed peer:\n%s", commands)
+	}
+}
+
+func TestInfoResponseUsesWireGuardAddressForDefaultRedfishURL(t *testing.T) {
+	cfg := DefaultConfig()
+	info := infoResponse(cfg, "server-public-key")
+	redfish := info["redfish"].(map[string]string)
+
+	if got, want := redfish["url"], "https://10.88.0.1:8443"; got != want {
+		t.Fatalf("redfish url = %q, want %q", got, want)
+	}
+}
+
+func TestVMManagerQEMUCommands(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.QEMU.EnableTPM = true
+
+	var swtpmSocket net.Listener
+
+	fake := &fakeCommander{
+		startHook: func(cmd recordedCommand) error {
+			if cmd.Name != cfg.QEMU.SWTPMBinary {
+				return nil
+			}
+
+			listener, err := net.Listen("unix", filepath.Join(os.TempDir(), "playpen-runner-swtpm.sock"))
+			if err != nil {
+				return err
+			}
+
+			swtpmSocket = listener
+
+			return nil
+		},
+	}
+
+	t.Cleanup(func() {
+		if swtpmSocket != nil {
+			_ = swtpmSocket.Close()
+		}
+
+		_ = os.Remove(filepath.Join(os.TempDir(), "playpen-runner-swtpm.sock"))
+	})
+
+	vm := NewVMManager(fake, cfg)
+
+	if err := vm.Reset(t.Context(), ResetOn); err != nil {
+		t.Fatalf("reset on: %v", err)
+	}
+
+	if state := vm.PowerState(); state != PowerOn {
+		t.Fatalf("power state = %s, want %s", state, PowerOn)
+	}
+
+	starts := strings.Join(fake.startStrings(), "\n")
+	for _, want := range []string{
+		"swtpm socket --tpm2 --runas 0",
+		"qemu-system-x86_64 -enable-kvm",
+		"-machine q35,accel=kvm",
+		"-netdev tap,id=net0,ifname=tap0,script=no,downscript=no",
+		"-device virtio-net-pci,netdev=net0,mac=52:54:00:aa:bb:01",
+		"-boot order=n",
+		"-device tpm-tis,tpmdev=tpm0",
+	} {
+		if !strings.Contains(starts, want) {
+			t.Fatalf("start commands missing %q:\n%s", want, starts)
+		}
+	}
+
+	if strings.Contains(starts, "-no-reboot") {
+		t.Fatalf("qemu command disables guest reboot:\n%s", starts)
+	}
+
+	if err := vm.Reset(t.Context(), ResetForceOff); err != nil {
+		t.Fatalf("reset force off: %v", err)
+	}
+
+	if state := vm.PowerState(); state != PowerOff {
+		t.Fatalf("power state = %s, want %s", state, PowerOff)
+	}
+}
+
+func TestVMManagerQEMUCommandsForARM64(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Architecture = ArchitectureARM64
+
+	cfg.QEMU.EnableTPM = true
+	if err := cfg.ApplyArchitectureDefaults(); err != nil {
+		t.Fatalf("apply architecture defaults: %v", err)
+	}
+
+	if err := os.WriteFile(cfg.QEMU.OVMFVarsTemplate, []byte("vars"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var swtpmSocket net.Listener
+
+	fake := &fakeCommander{
+		startHook: func(cmd recordedCommand) error {
+			if cmd.Name != cfg.QEMU.SWTPMBinary {
+				return nil
+			}
+
+			listener, err := net.Listen("unix", filepath.Join(os.TempDir(), "playpen-runner-swtpm.sock"))
+			if err != nil {
+				return err
+			}
+
+			swtpmSocket = listener
+
+			return nil
+		},
+	}
+
+	t.Cleanup(func() {
+		if swtpmSocket != nil {
+			_ = swtpmSocket.Close()
+		}
+
+		_ = os.Remove(filepath.Join(os.TempDir(), "playpen-runner-swtpm.sock"))
+	})
+
+	vm := NewVMManager(fake, cfg)
+
+	if err := vm.Reset(t.Context(), ResetOn); err != nil {
+		t.Fatalf("reset on: %v", err)
+	}
+
+	starts := strings.Join(fake.startStrings(), "\n")
+	for _, want := range []string{
+		"qemu-system-aarch64 -enable-kvm",
+		"-machine virt,accel=kvm",
+		"-cpu host",
+		"-drive if=pflash,format=raw,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.fd",
+		"-device virtio-net-pci,netdev=net0,mac=52:54:00:aa:bb:01",
+		"-device tpm-tis-device,tpmdev=tpm0",
+	} {
+		if !strings.Contains(starts, want) {
+			t.Fatalf("start commands missing %q:\n%s", want, starts)
+		}
+	}
+}
+
+func TestRedfishWithMetalmanClient(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.QEMU.EnableTPM = false
+	fake := &fakeCommander{}
+	vm := NewVMManager(fake, cfg)
+	handler := NewRedfishHandler(vm, cfg.Redfish, cfg.DataDir)
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := metalredfish.Dial(t.Context(), server.URL, tlsServerFingerprint(server), cfg.Redfish.Username, cfg.Redfish.Password, cfg.Redfish.DeviceID)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	t.Cleanup(client.Close)
+
+	state, err := client.PowerState(t.Context())
+	if err != nil {
+		t.Fatalf("power state: %v", err)
+	}
+
+	if state != metalredfish.PowerOff {
+		t.Fatalf("power state = %s, want %s", state, metalredfish.PowerOff)
+	}
+
+	if err := client.SetBootOverride(t.Context(), metalredfish.BootTargetPxe, metalredfish.BootContinuous); err != nil {
+		t.Fatalf("set boot override: %v", err)
+	}
+
+	if err := client.Reset(t.Context(), metalredfish.ResetOn); err != nil {
+		t.Fatalf("reset on: %v", err)
+	}
+
+	state, err = client.PowerState(t.Context())
+	if err != nil {
+		t.Fatalf("power state after on: %v", err)
+	}
+
+	if state != metalredfish.PowerOn {
+		t.Fatalf("power state = %s, want %s", state, metalredfish.PowerOn)
+	}
+
+	if err := client.DisableBootOverride(t.Context()); err != nil {
+		t.Fatalf("disable boot override: %v", err)
+	}
+
+	boot, err := client.GetBootConfig(t.Context())
+	if err != nil {
+		t.Fatalf("get boot config: %v", err)
+	}
+
+	if boot.Enabled != metalredfish.BootDisabled {
+		t.Fatalf("boot enabled = %s, want %s", boot.Enabled, metalredfish.BootDisabled)
+	}
+
+	if err := client.Reset(t.Context(), metalredfish.ResetForceOff); err != nil {
+		t.Fatalf("reset force off: %v", err)
+	}
+}
+
+func TestRedfishSystemAdvertisesSerialConsole(t *testing.T) {
+	cfg := testConfig(t)
+	vm := NewVMManager(&fakeCommander{}, cfg)
+	server := httptest.NewServer(NewRedfishHandler(vm, cfg.Redfish, cfg.DataDir))
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL+"/redfish/v1/Systems/"+cfg.Redfish.DeviceID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.SetBasicAuth(cfg.Redfish.Username, cfg.Redfish.Password)
+
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body struct {
+		ODataType     string `json:"@odata.type"`
+		ID            string `json:"Id"`
+		Name          string `json:"Name"`
+		SerialConsole struct {
+			ServiceEnabled        bool     `json:"ServiceEnabled"`
+			MaxConcurrentSessions int      `json:"MaxConcurrentSessions"`
+			ConnectTypesSupported []string `json:"ConnectTypesSupported"`
+			Oem                   struct {
+				Unbounded struct {
+					ReadOnly  bool   `json:"ReadOnly"`
+					Protocol  string `json:"Protocol"`
+					StreamURI string `json:"StreamURI"`
+				} `json:"Unbounded"`
+			} `json:"Oem"`
+		} `json:"SerialConsole"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+
+	if body.ODataType != "#ComputerSystem.v1_20_0.ComputerSystem" {
+		t.Fatalf("@odata.type = %q", body.ODataType)
+	}
+
+	if body.ID != cfg.Redfish.DeviceID || body.Name == "" {
+		t.Fatalf("unexpected system identity: id=%q name=%q", body.ID, body.Name)
+	}
+
+	if !body.SerialConsole.ServiceEnabled {
+		t.Fatal("serial console service is not enabled")
+	}
+
+	if body.SerialConsole.MaxConcurrentSessions != 1 {
+		t.Fatalf("max sessions = %d, want 1", body.SerialConsole.MaxConcurrentSessions)
+	}
+
+	if len(body.SerialConsole.ConnectTypesSupported) != 1 || body.SerialConsole.ConnectTypesSupported[0] != "OEM" {
+		t.Fatalf("connect types = %#v, want OEM", body.SerialConsole.ConnectTypesSupported)
+	}
+
+	if !body.SerialConsole.Oem.Unbounded.ReadOnly {
+		t.Fatal("serial console stream is not marked read-only")
+	}
+
+	if body.SerialConsole.Oem.Unbounded.Protocol != "WebSocket" {
+		t.Fatalf("protocol = %q, want WebSocket", body.SerialConsole.Oem.Unbounded.Protocol)
+	}
+
+	wantURI := "/redfish/v1/Systems/" + cfg.Redfish.DeviceID + "/Oem/Unbounded/SerialConsole/Stream"
+	if body.SerialConsole.Oem.Unbounded.StreamURI != wantURI {
+		t.Fatalf("stream URI = %q, want %q", body.SerialConsole.Oem.Unbounded.StreamURI, wantURI)
+	}
+}
+
+func TestRedfishSerialConsoleStreamRequiresAuth(t *testing.T) {
+	cfg := testConfig(t)
+	vm := NewVMManager(&fakeCommander{}, cfg)
+	server := httptest.NewServer(NewRedfishHandler(vm, cfg.Redfish, cfg.DataDir))
+	t.Cleanup(server.Close)
+
+	resp, err := server.Client().Get(server.URL + "/redfish/v1/Systems/" + cfg.Redfish.DeviceID + "/Oem/Unbounded/SerialConsole/Stream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestRedfishSerialConsoleStreamFollowsSerialLog(t *testing.T) {
+	cfg := testConfig(t)
+	vm := NewVMManager(&fakeCommander{}, cfg)
+	server := httptest.NewServer(NewRedfishHandler(vm, cfg.Redfish, cfg.DataDir))
+	t.Cleanup(server.Close)
+
+	if err := os.WriteFile(filepath.Join(cfg.DataDir, "serial.log"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/redfish/v1/Systems/" + cfg.Redfish.DeviceID + "/Oem/Unbounded/SerialConsole/Stream"
+
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: redfishBasicAuthHeader(cfg)})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.CloseNow() //nolint:errcheck // Test cleanup.
+
+	file, err := os.OpenFile(filepath.Join(cfg.DataDir, "serial.log"), os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := file.WriteString("booting\n"); err != nil {
+		_ = file.Close()
+
+		t.Fatal(err)
+	}
+
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	messageType, data, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if messageType != websocket.MessageBinary {
+		t.Fatalf("message type = %v, want binary", messageType)
+	}
+
+	if string(data) != "booting\n" {
+		t.Fatalf("stream data = %q, want serial log bytes", string(data))
+	}
+}
+
+func testConfig(t *testing.T) Config {
+	t.Helper()
+
+	cfg := DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.ConfigureNetwork = false
+	cfg.Redfish.Username = "admin"
+	cfg.Redfish.Password = "secret"
+
+	cfg.QEMU.OVMFVarsTemplate = filepath.Join(cfg.DataDir, "OVMF_VARS_TEMPLATE.fd")
+	if err := os.WriteFile(cfg.QEMU.OVMFVarsTemplate, []byte("vars"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return cfg
+}
+
+func tlsServerFingerprint(server *httptest.Server) string {
+	cert := server.Certificate()
+	sum := sha256.Sum256(cert.Raw)
+
+	parts := make([]string, len(sum))
+	for i, b := range sum {
+		parts[i] = fmt.Sprintf("%02x", b)
+	}
+
+	return strings.Join(parts, ":")
+}
+
+func redfishBasicAuthHeader(cfg Config) http.Header {
+	header := http.Header{}
+	token := base64.StdEncoding.EncodeToString([]byte(cfg.Redfish.Username + ":" + cfg.Redfish.Password))
+	header.Set("Authorization", "Basic "+token)
+
+	return header
+}
+
+func testKubernetesClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}

--- a/internal/playpen/runner/server.go
+++ b/internal/playpen/runner/server.go
@@ -1,0 +1,428 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package runner
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"net/netip"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/unbounded/internal/playpen/meta"
+)
+
+type RuntimeState struct {
+	mu                       sync.RWMutex
+	ready                    bool
+	serverWireGuardPublicKey string
+}
+
+func NewRuntimeState(serverWireGuardPublicKey string, ready bool) *RuntimeState {
+	return &RuntimeState{serverWireGuardPublicKey: serverWireGuardPublicKey, ready: ready}
+}
+
+func (s *RuntimeState) Ready() bool {
+	if s == nil {
+		return true
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.ready
+}
+
+func (s *RuntimeState) SetReady() {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ready = true
+}
+
+func (s *RuntimeState) ServerWireGuardPublicKey() string {
+	if s == nil {
+		return ""
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.serverWireGuardPublicKey
+}
+
+func Run(ctx context.Context, cfg Config) error {
+	if err := cfg.ApplyArchitectureDefaults(); err != nil {
+		return err
+	}
+
+	if cfg.Redfish.DeviceID == "" {
+		cfg.Redfish.DeviceID = "1"
+	}
+
+	cmd := OSCommander{}
+	serverPublicKey := ""
+
+	if cfg.ConfigureNetwork {
+		var err error
+
+		serverPublicKey, err = ensureWireGuardPrivateKey(cfg.WireGuard.PrivateKeyFile)
+		if err != nil {
+			return err
+		}
+
+		if err := ensureTLSCert(cfg); err != nil {
+			return err
+		}
+
+		certPEM, err := readTLSCertPEM(cfg)
+		if err != nil {
+			return err
+		}
+
+		go publishRunnerMetadataUntilReady(ctx, cfg, serverPublicKey, certPEM)
+	}
+
+	state := NewRuntimeState(serverPublicKey, !cfg.ConfigureNetwork || cfg.WireGuard.ClientPublicKey != "")
+
+	network := NewNetworkManager(cmd, cfg)
+	if err := network.Setup(ctx); err != nil {
+		return err
+	}
+	defer network.Teardown(context.Background()) //nolint:errcheck // Pod teardown also removes the network namespace.
+
+	vm := NewVMManager(cmd, cfg)
+	defer vm.Stop() //nolint:errcheck // Best effort on process exit.
+
+	server, err := NewServer(cfg, vm, state)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- server.ListenAndServeTLS(filepath.Join(cfg.DataDir, "tls.crt"), filepath.Join(cfg.DataDir, "tls.key"))
+	}()
+
+	if cfg.ConfigureNetwork && cfg.WireGuard.ClientPublicKey == "" {
+		go waitForClientPublicKeyAnnotation(ctx, cfg, network, state)
+	}
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		server.Shutdown(shutdownCtx) //nolint:errcheck // Process is exiting after context cancellation.
+
+		return nil
+	case err := <-errCh:
+		if err == http.ErrServerClosed {
+			return nil
+		}
+
+		return err
+	}
+}
+
+func NewServer(cfg Config, vm *VMManager, state *RuntimeState) (*http.Server, error) {
+	if err := ensureTLSCert(cfg); err != nil {
+		return nil, err
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/redfish/v1/", NewRedfishHandler(vm, cfg.Redfish, cfg.DataDir))
+	mux.HandleFunc("/playpen/v1/info", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, infoResponse(cfg, state.ServerWireGuardPublicKey()))
+	})
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if !state.Ready() {
+			http.Error(w, "runner has not been claimed", http.StatusServiceUnavailable)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	return &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}, nil
+}
+
+func infoResponse(cfg Config, serverPublicKey string) map[string]any {
+	redfishURL := cfg.PublicRedfishURL
+	if redfishURL == "" {
+		redfishURL = defaultPublicRedfishURL(cfg)
+	}
+
+	serverWG, err := addressIP(cfg.WireGuard.ServerAddress)
+	if err != nil {
+		serverWG = netip.Addr{}
+	}
+
+	clientWG, err := addressIP(cfg.WireGuard.ClientAddress)
+	if err != nil {
+		clientWG = netip.Addr{}
+	}
+
+	certPEM, _ := readTLSCertPEM(cfg) //nolint:errcheck // Optional metadata for clients using trusted cluster TLS.
+
+	return map[string]any{
+		"architecture": cfg.Architecture,
+		"wireGuard": map[string]any{
+			"interface":       cfg.WireGuard.Interface,
+			"serverPublicKey": serverPublicKey,
+			"serverAddress":   cfg.WireGuard.ServerAddress,
+			"clientAddress":   cfg.WireGuard.ClientAddress,
+			"listenPort":      cfg.WireGuard.ListenPort,
+		},
+		"vxlan": map[string]any{
+			"interface":     cfg.VXLAN.Interface,
+			"vni":           cfg.VXLAN.VNI,
+			"udpPort":       cfg.VXLAN.Port,
+			"serverAddress": serverWG.String(),
+			"clientAddress": clientWG.String(),
+		},
+		"network": map[string]any{
+			"guestMAC":    cfg.Guest.MAC,
+			"guestIPv4":   cfg.Guest.IPv4,
+			"subnetMask":  cfg.Guest.SubnetMask,
+			"gatewayIPv4": cfg.Guest.Gateway,
+			"dns":         cfg.Guest.DNS,
+		},
+		"redfish": map[string]string{
+			"url":      redfishURL,
+			"username": cfg.Redfish.Username,
+			"password": cfg.Redfish.Password,
+			"certPEM":  certPEM,
+			"deviceID": cfg.Redfish.DeviceID,
+		},
+	}
+}
+
+func publishRunnerMetadata(ctx context.Context, cfg Config, serverPublicKey, redfishCertPEM string) error {
+	if cfg.KubernetesClient == nil || cfg.PodName == "" || cfg.PodNamespace == "" {
+		return fmt.Errorf("pod name, namespace, and Kubernetes client are required to publish runner metadata")
+	}
+
+	pod := &corev1.Pod{}
+
+	key := types.NamespacedName{Namespace: cfg.PodNamespace, Name: cfg.PodName}
+	if err := cfg.KubernetesClient.Get(ctx, key, pod); err != nil {
+		return err
+	}
+
+	base := pod.DeepCopy()
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+
+	pod.Annotations[meta.AnnotationServerWireGuardPublicKey] = serverPublicKey
+	pod.Annotations[meta.AnnotationRedfishCertPEM] = redfishCertPEM
+
+	return cfg.KubernetesClient.Patch(ctx, pod, client.MergeFrom(base))
+}
+
+func publishRunnerMetadataUntilReady(ctx context.Context, cfg Config, serverPublicKey, redfishCertPEM string) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		if err := publishRunnerMetadata(ctx, cfg, serverPublicKey, redfishCertPEM); err == nil {
+			return
+		} else {
+			slog.Warn("publish runner metadata", "error", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForClientPublicKeyAnnotation(ctx context.Context, cfg Config, network *NetworkManager, state *RuntimeState) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		if clientPublicKey, err := clientPublicKeyAnnotation(ctx, cfg); err == nil && clientPublicKey != "" {
+			if err := network.ConfigurePeer(ctx, clientPublicKey); err == nil {
+				state.SetReady()
+
+				return
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func clientPublicKeyAnnotation(ctx context.Context, cfg Config) (string, error) {
+	if cfg.KubernetesClient == nil || cfg.PodName == "" || cfg.PodNamespace == "" {
+		return "", fmt.Errorf("pod name, namespace, and Kubernetes client are required to read client WireGuard public key")
+	}
+
+	pod := &corev1.Pod{}
+
+	key := types.NamespacedName{Namespace: cfg.PodNamespace, Name: cfg.PodName}
+	if err := cfg.KubernetesClient.Get(ctx, key, pod); err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(pod.Annotations[meta.AnnotationClientWireGuardPublicKey]), nil
+}
+
+func ensureTLSCert(cfg Config) error {
+	if err := os.MkdirAll(cfg.DataDir, 0o755); err != nil {
+		return err
+	}
+
+	certPath := filepath.Join(cfg.DataDir, "tls.crt")
+
+	keyPath := filepath.Join(cfg.DataDir, "tls.key")
+	if _, err := os.Stat(certPath); err == nil {
+		if _, err := os.Stat(keyPath); err == nil {
+			return nil
+		}
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	notBefore := time.Now().Add(-time.Minute)
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(notBefore.UnixNano()),
+		Subject: pkix.Name{
+			CommonName: "playpen-runner",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	for _, host := range certHosts(cfg) {
+		if ip := net.ParseIP(host); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		} else if host != "" {
+			tmpl.DNSNames = append(tmpl.DNSNames, host)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		return err
+	}
+
+	certFile, err := os.OpenFile(certPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		return errors.Join(err, certFile.Close())
+	}
+
+	if err := certFile.Close(); err != nil {
+		return err
+	}
+
+	keyFile, err := os.OpenFile(keyPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		return errors.Join(err, keyFile.Close())
+	}
+
+	return keyFile.Close()
+}
+
+func readTLSCertPEM(cfg Config) (string, error) {
+	data, err := os.ReadFile(filepath.Join(cfg.DataDir, "tls.crt"))
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func certHosts(cfg Config) []string {
+	hosts := []string{"localhost", "127.0.0.1"}
+	if host, _, err := net.SplitHostPort(cfg.ListenAddr); err == nil {
+		hosts = append(hosts, strings.Trim(host, "[]"))
+	}
+
+	if addr, err := addressIP(cfg.WireGuard.ServerAddress); err == nil {
+		hosts = append(hosts, addr.String())
+	}
+
+	if cfg.PublicRedfishURL != "" {
+		trimmed := strings.TrimPrefix(strings.TrimPrefix(cfg.PublicRedfishURL, "https://"), "http://")
+		if host, _, err := net.SplitHostPort(trimmed); err == nil {
+			hosts = append(hosts, host)
+		} else if i := strings.Index(trimmed, "/"); i >= 0 {
+			hosts = append(hosts, trimmed[:i])
+		} else {
+			hosts = append(hosts, trimmed)
+		}
+	}
+
+	return hosts
+}
+
+func defaultPublicRedfishURL(cfg Config) string {
+	host, err := addressIP(cfg.WireGuard.ServerAddress)
+	if err != nil {
+		return "https://" + cfg.ListenAddr
+	}
+
+	_, port, err := net.SplitHostPort(cfg.ListenAddr)
+	if err != nil || port == "" {
+		port = "8443"
+	}
+
+	return "https://" + net.JoinHostPort(host.String(), port)
+}


### PR DESCRIPTION
Playpen exposes an aggregated k8s API that can be used by test cases (metalman, etc.) to claim VMs and pre-allocated k8s control planes. The goal is to offload and parallelize the more expensive parts of the metalman test suite so we can improve coverage without making the already slow CI build even worse.