### PR TITLE
metalman: uefi http boot support

### DIFF
--- a/api/machina/v1alpha3/machine_types.go
+++ b/api/machina/v1alpha3/machine_types.go
@@ -292,6 +292,14 @@ type PXESpec struct {
 	// +optional
 	NetbootImage string `json:"netbootImage,omitempty"`
 
+	// BootProtocol selects how metalman should trigger network boot for
+	// repaves. PXE uses DHCP/TFTP bootfile options. HTTP uses Redfish UEFI
+	// HTTP boot with a URL derived from the netboot image metadata.
+	// +kubebuilder:validation:Enum=PXE;HTTP
+	// +kubebuilder:default=PXE
+	// +optional
+	BootProtocol string `json:"bootProtocol,omitempty"`
+
 	// DHCPLeases defines static DHCP leases for PXE booting.
 	// +optional
 	DHCPLeases []DHCPLease `json:"dhcpLeases,omitempty"`
@@ -307,12 +315,18 @@ type PXESpec struct {
 }
 
 const (
+	// PXEBootProtocolPXE uses DHCP/TFTP PXE boot.
+	PXEBootProtocolPXE = "PXE"
+	// PXEBootProtocolHTTP uses Redfish UEFI HTTP boot.
+	PXEBootProtocolHTTP = "HTTP"
 	// PXEArchitectureAMD64 is the x86_64 target architecture for PXE boot.
 	PXEArchitectureAMD64 = "amd64"
 	// PXEArchitectureARM64 is the aarch64 target architecture for PXE boot.
 	PXEArchitectureARM64 = "arm64"
 	// DefaultPXEArchitecture is used when spec.pxe.architecture is omitted.
 	DefaultPXEArchitecture = PXEArchitectureAMD64
+	// DefaultPXEBootProtocol is used when spec.pxe.bootProtocol is omitted.
+	DefaultPXEBootProtocol = PXEBootProtocolPXE
 )
 
 // TargetArchitecture returns the effective PXE target architecture.
@@ -322,6 +336,15 @@ func (p *PXESpec) TargetArchitecture() string {
 	}
 
 	return p.Architecture
+}
+
+// TargetBootProtocol returns the effective network boot protocol.
+func (p *PXESpec) TargetBootProtocol() string {
+	if p == nil || p.BootProtocol == "" {
+		return DefaultPXEBootProtocol
+	}
+
+	return p.BootProtocol
 }
 
 // CloudInitSpec defines cloud-init customization for PXE-booted machines.

--- a/cmd/metalman/README.md
+++ b/cmd/metalman/README.md
@@ -163,7 +163,7 @@ Both images are built `FROM scratch` and use `/disk/` as the artifact root,
 following the kubevirt containerDisk convention. Files with a `.tmpl` suffix in
 the netboot image are Go templates rendered per-machine at serve time; other
 files are served verbatim. A `metadata.yaml` file in the netboot image provides
-image-level configuration such as `dhcpBootImageName`.
+image-level configuration such as `dhcpBootImageName` and `httpBootPath`.
 
 Images are built, tagged, and pushed using standard container tooling:
 
@@ -187,6 +187,8 @@ metadata:
 spec:
   pxe:
     image: ghcr.io/azure/host-ubuntu2404:v1
+    # Defaults to PXE. Set to HTTP to use Redfish UEFI HTTP boot.
+    bootProtocol: PXE
     dhcpLeases:
     - mac: "aa:bb:cc:dd:ee:01"
       ipv4: "10.0.0.11"
@@ -238,5 +240,6 @@ kubectl unbounded machine repave node-01
 ```
 
 This increments `spec.operations.repaveCounter` and `spec.operations.rebootCounter`. The
-controller handles the rest - it configures the boot order to PXE, executes a
-ForceOff/On power cycle, and clears the condition once the node is back up.
+controller handles the rest - it configures the boot order for the selected
+`spec.pxe.bootProtocol`, executes a ForceOff/On power cycle, and clears the
+condition once the node is back up.

--- a/deploy/machina/crd/unbounded-cloud.io_machines.yaml
+++ b/deploy/machina/crd/unbounded-cloud.io_machines.yaml
@@ -328,6 +328,16 @@ spec:
                     - amd64
                     - arm64
                     type: string
+                  bootProtocol:
+                    default: PXE
+                    description: |-
+                      BootProtocol selects how metalman should trigger network boot for
+                      repaves. PXE uses DHCP/TFTP bootfile options. HTTP uses Redfish UEFI
+                      HTTP boot with a URL derived from the netboot image metadata.
+                    enum:
+                    - PXE
+                    - HTTP
+                    type: string
                   cloudInit:
                     description: |-
                       CloudInit contains optional cloud-init customization for PXE-booted

--- a/docs/content/guides/pxe.md
+++ b/docs/content/guides/pxe.md
@@ -56,12 +56,15 @@ Metalman uses a machine image and a netboot image for each PXE repave.
 - `spec.pxe.netbootImage` is the reusable PXE boot environment. It contains
   bootloaders, kernel, initrd, templates, metadata, and `unbounded-agent`. If
   omitted, Metalman uses the release-matched `--default-netboot-image`.
+- `spec.pxe.bootProtocol` selects the network boot trigger. `PXE` is the
+  default and uses DHCP/TFTP bootfile options. `HTTP` uses Redfish UEFI HTTP
+  boot and requires a Redfish block.
 
 Both images are standard OCI container images built `FROM scratch` with
 artifacts under `/disk/`. Files with a `.tmpl` suffix in the netboot image are
 Go templates rendered per-machine at serve time; other files are served
 verbatim. A `metadata.yaml` file in the netboot image provides image-level
-configuration such as `dhcpBootImageName`.
+configuration such as `dhcpBootImageName` and `httpBootPath`.
 
 Images are built, tagged, and pushed using standard container tooling:
 
@@ -91,6 +94,8 @@ spec:
   pxe:
     image: ghcr.io/azure/host-ubuntu2404:v1
     architecture: amd64
+    # Optional. Defaults to PXE. Set to HTTP for Redfish UEFI HTTP boot.
+    bootProtocol: PXE
     # Optional. Omit to use Metalman's default netboot image.
     netbootImage: ghcr.io/azure/netboot:v1
     dhcpLeases:
@@ -166,8 +171,8 @@ If the referenced ConfigMap does not exist, metalman falls back to the default m
 
 ## Boot Flow
 
-1. **Machine CR created.** The Redfish reconciler sets the boot device to PXE and power-cycles the server (ForceOff → On).
-2. **PXE boot.** DHCP assigns the static IP by MAC. TFTP serves `shimx64.efi`, which chainloads GRUB over HTTP.
+1. **Machine CR created.** The Redfish reconciler sets the boot device and power-cycles the server (ForceOff → On). For `bootProtocol: PXE`, it selects PXE boot. For `bootProtocol: HTTP`, it sets a one-time Redfish UEFI HTTP boot URL from the netboot image metadata.
+2. **Network boot.** DHCP assigns the static IP by MAC. In PXE mode, DHCP also advertises the TFTP bootfile and TFTP serves `shimx64.efi`. In HTTP mode, the firmware downloads the Redfish-supplied URL from metalman's HTTP server.
 3. **GRUB decision.** A rendered `grub.cfg` (from a `.tmpl` file in the netboot image) checks `repaveCounter` against status: if counter is ahead, boot the PXE installer; otherwise chainload the local OS.
 4. **Installer (initrd overlay).** An init script in the initrd:
    - Loads storage and network drivers, configures the static IP from kernel cmdline.

--- a/docs/content/reference/machina-crd.md
+++ b/docs/content/reference/machina-crd.md
@@ -55,6 +55,7 @@ PXE boot configuration consumed by the metalman controller.
 | `pxe.image` | string | Yes | - | OCI machine image reference containing `/disk/disk.img.gz` (e.g. `"ghcr.io/azure/host-ubuntu2404:v1"`). |
 | `pxe.architecture` | string | No | `amd64` | Target CPU architecture for PXE boot artifacts and machine images. Allowed values: `amd64`, `arm64`. |
 | `pxe.netbootImage` | string | No | Metalman default | OCI netboot image reference containing PXE boot artifacts. |
+| `pxe.bootProtocol` | string | No | `PXE` | Network boot trigger protocol for repaves. `PXE` uses DHCP/TFTP bootfile options. `HTTP` uses Redfish UEFI HTTP boot with a URL derived from the netboot image metadata. Allowed values: `PXE`, `HTTP`. |
 | `pxe.dhcpLeases` | []DHCPLease | No | - | Static DHCP leases served during PXE boot. |
 | `pxe.dhcpLeases[].ipv4` | string | Yes | - | Static IPv4 address to assign. |
 | `pxe.dhcpLeases[].mac` | string | Yes | - | NIC MAC address (matched case-insensitively). |
@@ -416,7 +417,7 @@ under `/disk/`. This follows the kubevirt containerDisk convention.
 Files with a `.tmpl` suffix in the netboot image are Go templates rendered
 per-machine at serve time; other files are served verbatim. A `metadata.yaml`
 file in the netboot image provides image-level configuration such as
-`dhcpBootImageName`.
+`dhcpBootImageName` and `httpBootPath`.
 
 ### Image layout
 
@@ -452,10 +453,15 @@ reusable netboot image Containerfile.
 
 ```yaml
 dhcpBootImageName: shimx64.efi
+httpBootPath: shimx64.efi
 ```
 
 The `dhcpBootImageName` field specifies the boot filename included in DHCP
-responses (option 67).
+responses (option 67) for `spec.pxe.bootProtocol: PXE`.
+
+The `httpBootPath` field specifies the file path, relative to metalman's HTTP
+artifact server, used for `spec.pxe.bootProtocol: HTTP`. If `httpBootPath` is
+omitted, metalman falls back to `dhcpBootImageName` for the UEFI HTTP boot URL.
 
 ---
 

--- a/images/netboot/Containerfile
+++ b/images/netboot/Containerfile
@@ -75,13 +75,13 @@ RUN chmod 755 /tmp/initrd-root/init && \
 
 RUN mkdir -p /disk/grub /disk/cloud-init && \
     cp /artifacts/vmlinuz /artifacts/initrd /artifacts/init.cpio /disk/ && \
-    if [ "${TARGETARCH}" = "amd64" ]; then \
-        cp /artifacts/shimx64.efi /artifacts/grubx64.efi /disk/ && \
-        echo "dhcpBootImageName: shimx64.efi" > /disk/metadata.yaml; \
-    elif [ "${TARGETARCH}" = "arm64" ]; then \
-        cp /artifacts/shimaa64.efi /artifacts/grubaa64.efi /disk/ && \
-        echo "dhcpBootImageName: shimaa64.efi" > /disk/metadata.yaml; \
-    fi
+	if [ "${TARGETARCH}" = "amd64" ]; then \
+		cp /artifacts/shimx64.efi /artifacts/grubx64.efi /disk/ && \
+		printf '%s\n' "dhcpBootImageName: shimx64.efi" "httpBootPath: shimx64.efi" > /disk/metadata.yaml; \
+	elif [ "${TARGETARCH}" = "arm64" ]; then \
+		cp /artifacts/shimaa64.efi /artifacts/grubaa64.efi /disk/ && \
+		printf '%s\n' "dhcpBootImageName: shimaa64.efi" "httpBootPath: shimaa64.efi" > /disk/metadata.yaml; \
+	fi
 
 COPY images/netboot/assets/grub.cfg.tmpl /disk/grub/grub.cfg.tmpl
 COPY images/netboot/assets/meta-data.tmpl /disk/cloud-init/meta-data.tmpl

--- a/internal/metalman/commands/serve_pxe.go
+++ b/internal/metalman/commands/serve_pxe.go
@@ -203,7 +203,18 @@ func ServePXECmd() *cobra.Command {
 
 			statusQueue := &metalmachineops.StatusQueue{Client: mgr.GetClient()}
 
-			if err := (&redfish.Reconciler{Client: mgr.GetClient(), Pool: redfishPool}).SetupWithManager(mgr); err != nil {
+			resolver := netboot.FileResolver{
+				Cache:             ociCache,
+				Reader:            mgr.GetClient(),
+				Cluster:           clusterInfoWatcher,
+				ServeURL:          serveURL,
+				DefaultNetbootRef: defaultNetbootImage,
+				KubernetesVersion: kubeVersion,
+				ClusterDNS:        clusterDNS,
+				ProviderLabels:    providerLabels,
+			}
+
+			if err := (&redfish.Reconciler{Client: mgr.GetClient(), Pool: redfishPool, FileResolver: &resolver}).SetupWithManager(mgr); err != nil {
 				return fmt.Errorf("setting up Redfish reconciler: %w", err)
 			}
 
@@ -225,17 +236,6 @@ func ServePXECmd() *cobra.Command {
 
 			if err := (&cloudinit.Reconciler{Client: mgr.GetClient(), StatusRecorder: statusQueue}).SetupWithManager(mgr); err != nil {
 				return fmt.Errorf("setting up CloudInit reconciler: %w", err)
-			}
-
-			resolver := netboot.FileResolver{
-				Cache:             ociCache,
-				Reader:            mgr.GetClient(),
-				Cluster:           clusterInfoWatcher,
-				ServeURL:          serveURL,
-				DefaultNetbootRef: defaultNetbootImage,
-				KubernetesVersion: kubeVersion,
-				ClusterDNS:        clusterDNS,
-				ProviderLabels:    providerLabels,
 			}
 
 			if dhcpInterface != "" && dhcpAutoInterface {

--- a/internal/metalman/dhcp/dhcp.go
+++ b/internal/metalman/dhcp/dhcp.go
@@ -192,7 +192,7 @@ func (s *Server) handler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4) {
 		netbootImage = s.DefaultNetbootRef
 	}
 
-	if netbootImage != "" && s.OCICache != nil {
+	if node.Spec.PXE.TargetBootProtocol() != v1alpha3.PXEBootProtocolHTTP && netbootImage != "" && s.OCICache != nil {
 		architecture := node.Spec.PXE.TargetArchitecture()
 
 		meta, err := s.OCICache.MetadataForRefArchitecture(netbootImage, architecture)

--- a/internal/metalman/dhcp/dhcp_test.go
+++ b/internal/metalman/dhcp/dhcp_test.go
@@ -256,6 +256,81 @@ func TestDHCPHandlerPXEUsesDefaultNetbootImage(t *testing.T) {
 	}
 }
 
+func TestDHCPHandlerHTTPBootSuppressesPXEBootOptions(t *testing.T) {
+	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:f3")
+	serverIP := net.ParseIP("10.0.1.254").To4()
+	netbootImageRef := "ghcr.io/test/netboot:v1"
+
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-http-boot"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				NetbootImage: netbootImageRef,
+				BootProtocol: v1alpha3.PXEBootProtocolHTTP,
+				DHCPLeases: []v1alpha3.DHCPLease{{
+					MAC:        "aa:bb:cc:dd:ee:f3",
+					IPv4:       "10.0.1.13",
+					SubnetMask: "255.255.255.0",
+				}},
+			},
+		},
+	}
+
+	cacheDir := t.TempDir()
+	ociCache := netboot.NewOCICache(cacheDir)
+
+	digest := "sha256:httpboot1234567890"
+	ociCache.SetDigest(netbootImageRef, digest)
+
+	diskDir := filepath.Join(ociCache.DiskDir(digest))
+	if err := os.MkdirAll(diskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(diskDir, "metadata.yaml"), []byte("dhcpBootImageName: shimx64.efi\nhttpBootPath: shimx64.efi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := newFakeReader(t, node)
+	srv := &Server{
+		Interface: "eth0",
+		Reader:    reader,
+		ServerIP:  serverIP,
+		OCICache:  ociCache,
+	}
+
+	discover, err := dhcpv4.NewDiscovery(mac)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn := &fakePacketConn{}
+	peer := &net.UDPAddr{IP: net.ParseIP("10.0.1.13"), Port: 68}
+
+	srv.handler(conn, peer, discover)
+
+	if conn.written == nil {
+		t.Fatal("expected DHCP response, got none")
+	}
+
+	resp, err := dhcpv4.FromBytes(conn.written)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tftpServer := resp.TFTPServerName(); tftpServer != "" {
+		t.Errorf("expected no TFTP server for HTTP boot, got %s", tftpServer)
+	}
+
+	if bootfile := resp.BootFileNameOption(); bootfile != "" {
+		t.Errorf("expected no bootfile for HTTP boot, got %s", bootfile)
+	}
+
+	if !resp.YourIPAddr.Equal(net.ParseIP("10.0.1.13")) {
+		t.Errorf("expected YourIP 10.0.1.13, got %s", resp.YourIPAddr)
+	}
+}
+
 func TestDHCPHandlerUnknownMAC(t *testing.T) {
 	mac, _ := net.ParseMAC("ff:ff:ff:ff:ff:ff")
 	serverIP := net.ParseIP("10.0.1.254").To4()

--- a/internal/metalman/netboot/http.go
+++ b/internal/metalman/netboot/http.go
@@ -40,6 +40,7 @@ type HTTPServer struct {
 }
 
 type StatusRecorder interface {
+	RecordBootLoaderDownloaded(ctx context.Context, machineName, filename string) error
 	RecordBootImageWritten(ctx context.Context, machineName string) error
 	RecordCloudInitDone(ctx context.Context, machineName string) error
 	RecordMachineCondition(ctx context.Context, machineName string, condition metav1.Condition) error
@@ -141,6 +142,7 @@ func (h *HTTPServer) handleFile(w http.ResponseWriter, r *http.Request) {
 	if resolved.DiskPath != "" {
 		log.Info("serving cached file", "node", node.Name)
 		http.ServeFile(w, r, resolved.DiskPath)
+		h.recordHTTPBootLoaderDownloaded(r.Context(), log, node, imageRef, path)
 
 		return
 	}
@@ -148,6 +150,7 @@ func (h *HTTPServer) handleFile(w http.ResponseWriter, r *http.Request) {
 	log.Info("serving file", "node", node.Name, "size", len(resolved.Data))
 	w.Header().Set("Content-Type", resolved.ContentType)
 	w.Write(resolved.Data) //nolint:errcheck // Best-effort HTTP response write.
+	h.recordHTTPBootLoaderDownloaded(r.Context(), log, node, imageRef, path)
 }
 
 func (h *HTTPServer) handleCloudInitLog(w http.ResponseWriter, r *http.Request) {
@@ -346,6 +349,33 @@ func (h *HTTPServer) recordBootImageWritten(ctx context.Context, log *slog.Logge
 	if err := h.StatusRecorder.RecordBootImageWritten(ctx, machineName); err != nil {
 		log.Error("recording boot image written", "node", machineName, "err", err)
 	}
+}
+
+func (h *HTTPServer) recordHTTPBootLoaderDownloaded(ctx context.Context, log *slog.Logger, node *v1alpha3.Machine, imageRef, path string) {
+	if h.StatusRecorder == nil || node == nil || node.Spec.PXE == nil || node.Spec.PXE.TargetBootProtocol() != v1alpha3.PXEBootProtocolHTTP {
+		return
+	}
+
+	if !h.isHTTPBootLoaderDownload(imageRef, node.Spec.PXE.TargetArchitecture(), path) {
+		return
+	}
+
+	if err := h.StatusRecorder.RecordBootLoaderDownloaded(ctx, node.Name, path); err != nil {
+		log.Error("recording boot loader download", "node", node.Name, "err", err)
+	}
+}
+
+func (h *HTTPServer) isHTTPBootLoaderDownload(imageRef, architecture, path string) bool {
+	if h.Cache == nil || imageRef == "" {
+		return false
+	}
+
+	meta, err := h.Cache.MetadataForRefArchitecture(imageRef, architecture)
+	if err != nil {
+		return false
+	}
+
+	return HTTPBootPathFromMetadata(meta) == strings.TrimPrefix(path, "/")
 }
 
 func (h *HTTPServer) recordCloudInitStatus(ctx context.Context, log *slog.Logger, machineName string, ev *cloudInitEvent) {

--- a/internal/metalman/netboot/netboot.go
+++ b/internal/metalman/netboot/netboot.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	pathpkg "path"
 	"strings"
 	"sync"
 	"text/template"
@@ -84,6 +86,80 @@ func (f *FileResolver) NetbootImageRef(node *v1alpha3.Machine) string {
 	}
 
 	return node.Spec.PXE.Image
+}
+
+func (f *FileResolver) HTTPBootPath(node *v1alpha3.Machine) (string, error) {
+	if node == nil || node.Spec.PXE == nil {
+		return "", fmt.Errorf("node has no PXE config")
+	}
+
+	imageRef := f.NetbootImageRef(node)
+	if imageRef == "" {
+		return "", fmt.Errorf("node %s has no netboot image", node.Name)
+	}
+
+	if f.Cache == nil {
+		return "", fmt.Errorf("OCI cache is not configured")
+	}
+
+	meta, err := f.Cache.MetadataForRefArchitecture(imageRef, node.Spec.PXE.TargetArchitecture())
+	if err != nil {
+		return "", err
+	}
+
+	return HTTPBootPathFromMetadata(meta), nil
+}
+
+func (f *FileResolver) HTTPBootURL(node *v1alpha3.Machine) (string, error) {
+	path, err := f.HTTPBootPath(node)
+	if err != nil {
+		return "", err
+	}
+
+	return JoinServeURLPath(f.ServeURL, path)
+}
+
+func HTTPBootPathFromMetadata(meta *ImageMetadata) string {
+	if meta == nil {
+		return ""
+	}
+
+	if meta.HTTPBootPath != "" {
+		return strings.TrimPrefix(meta.HTTPBootPath, "/")
+	}
+
+	return strings.TrimPrefix(meta.DHCPBootImageName, "/")
+}
+
+func JoinServeURLPath(serveURL, path string) (string, error) {
+	if strings.TrimSpace(serveURL) == "" {
+		return "", fmt.Errorf("serve URL is not configured")
+	}
+
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		return "", fmt.Errorf("HTTP boot path is not configured")
+	}
+
+	cleanPath := pathpkg.Clean(path)
+	if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
+		return "", fmt.Errorf("invalid HTTP boot path %q: resolves outside cache directory", path)
+	}
+
+	base, err := url.Parse(serveURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing serve URL: %w", err)
+	}
+
+	if base.Scheme == "" || base.Host == "" {
+		return "", fmt.Errorf("serve URL %q must be absolute", serveURL)
+	}
+
+	base.Path = strings.TrimRight(base.Path, "/") + "/" + cleanPath
+	base.RawQuery = ""
+	base.Fragment = ""
+
+	return base.String(), nil
 }
 
 func (f *FileResolver) LookupNodeByIP(ctx context.Context, ip string) (*v1alpha3.Machine, error) {

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -671,13 +671,6 @@ func (r *recordingStatusRecorder) bootImageWrittenEvents() []string {
 	return append([]string(nil), r.bootImageWritten...)
 }
 
-func (r *recordingStatusRecorder) bootLoaderEvents() []string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	return append([]string(nil), r.bootLoader...)
-}
-
 func (r *recordingStatusRecorder) cloudInitDoneEvents() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -592,10 +592,24 @@ type recordedPXEDisabled struct {
 type recordingStatusRecorder struct {
 	mu               sync.Mutex
 	err              error
+	bootLoader       []string
 	bootImageWritten []string
 	cloudInitDone    []string
 	conditions       []recordedMachineCondition
 	disabled         []recordedPXEDisabled
+}
+
+func (r *recordingStatusRecorder) RecordBootLoaderDownloaded(_ context.Context, machineName, filename string) error {
+	if r.err != nil {
+		return r.err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.bootLoader = append(r.bootLoader, fmt.Sprintf("%s:%s", machineName, filename))
+
+	return nil
 }
 
 func (r *recordingStatusRecorder) RecordBootImageWritten(_ context.Context, machineName string) error {
@@ -655,6 +669,13 @@ func (r *recordingStatusRecorder) bootImageWrittenEvents() []string {
 	defer r.mu.Unlock()
 
 	return append([]string(nil), r.bootImageWritten...)
+}
+
+func (r *recordingStatusRecorder) bootLoaderEvents() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]string(nil), r.bootLoader...)
 }
 
 func (r *recordingStatusRecorder) cloudInitDoneEvents() []string {
@@ -2311,7 +2332,7 @@ func TestOCICache_Metadata(t *testing.T) {
 	cache := NewOCICache(cacheDir)
 
 	digest := "testdigest123"
-	metadataContent := "dhcpBootImageName: shimx64.efi\n"
+	metadataContent := "dhcpBootImageName: shimx64.efi\nhttpBootPath: http/shimx64.efi\n"
 
 	if err := populateOCICache(cacheDir, digest, map[string][]byte{
 		"metadata.yaml": []byte(metadataContent),
@@ -2329,6 +2350,51 @@ func TestOCICache_Metadata(t *testing.T) {
 	if meta.DHCPBootImageName != "shimx64.efi" {
 		t.Errorf("DHCPBootImageName: got %q, want %q", meta.DHCPBootImageName, "shimx64.efi")
 	}
+
+	if meta.HTTPBootPath != "http/shimx64.efi" {
+		t.Errorf("HTTPBootPath: got %q, want %q", meta.HTTPBootPath, "http/shimx64.efi")
+	}
+}
+
+func TestFileResolverHTTPBootURL(t *testing.T) {
+	cache := setupOCICache(t, "ghcr.io/test/image:v1", "httpurl123", map[string][]byte{
+		"metadata.yaml": []byte("dhcpBootImageName: shimx64.efi\nhttpBootPath: /efi/bootx64.efi\n"),
+	})
+
+	resolver := &FileResolver{Cache: cache, ServeURL: "http://10.0.0.10:8880/base/"}
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-http-url"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{Image: "ghcr.io/test/image:v1"},
+		},
+	}
+
+	bootURL, err := resolver.HTTPBootURL(node)
+	require.NoError(t, err)
+	require.Equal(t, "http://10.0.0.10:8880/base/efi/bootx64.efi", bootURL)
+}
+
+func TestFileResolverHTTPBootURLFallsBackToDHCPBootImageName(t *testing.T) {
+	cache := setupOCICache(t, "ghcr.io/test/image:v1", "httpfallback123", map[string][]byte{
+		"metadata.yaml": []byte("dhcpBootImageName: shimx64.efi\n"),
+	})
+
+	resolver := &FileResolver{Cache: cache, ServeURL: "http://10.0.0.10:8880"}
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-http-url"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{Image: "ghcr.io/test/image:v1"},
+		},
+	}
+
+	bootURL, err := resolver.HTTPBootURL(node)
+	require.NoError(t, err)
+	require.Equal(t, "http://10.0.0.10:8880/shimx64.efi", bootURL)
+}
+
+func TestJoinServeURLPathRejectsTraversal(t *testing.T) {
+	_, err := JoinServeURLPath("http://10.0.0.10:8880", "../shimx64.efi")
+	require.Error(t, err)
 }
 
 func TestOCICache_MetadataNoFile(t *testing.T) {

--- a/internal/metalman/netboot/oci_cache.go
+++ b/internal/metalman/netboot/oci_cache.go
@@ -17,6 +17,7 @@ import (
 
 type ImageMetadata struct {
 	DHCPBootImageName string `yaml:"dhcpBootImageName"`
+	HTTPBootPath      string `yaml:"httpBootPath"`
 }
 
 // OCICache manages unpacked OCI images on the local filesystem.

--- a/internal/metalman/netboot/tftp.go
+++ b/internal/metalman/netboot/tftp.go
@@ -93,7 +93,7 @@ func (t *TFTPServer) readHandler(filename string, rf io.ReaderFrom) error {
 			return err
 		}
 
-		t.recordBootLoaderDownloaded(ctx, log, node.Name, node.Spec.PXE.Image, filename)
+		t.recordBootLoaderDownloaded(ctx, log, node.Name, imageRef, filename)
 
 		return nil
 	}
@@ -105,7 +105,7 @@ func (t *TFTPServer) readHandler(filename string, rf io.ReaderFrom) error {
 		return err
 	}
 
-	t.recordBootLoaderDownloaded(ctx, log, node.Name, node.Spec.PXE.Image, filename)
+	t.recordBootLoaderDownloaded(ctx, log, node.Name, imageRef, filename)
 
 	return nil
 }

--- a/internal/metalman/redfish/client.go
+++ b/internal/metalman/redfish/client.go
@@ -165,10 +165,10 @@ func (c *Client) GetBootConfig(ctx context.Context) (BootConfig, error) {
 
 	var system struct {
 		Boot struct {
-			BootSourceOverrideTarget     BootTarget  `json:"BootSourceOverrideTarget"`
-			BootSourceOverrideEnabled    BootEnabled `json:"BootSourceOverrideEnabled"`
-			BootSourceOverrideMode       BootMode    `json:"BootSourceOverrideMode"`
-			UefiTargetBootSourceOverride string      `json:"UefiTargetBootSourceOverride"`
+			BootSourceOverrideTarget  BootTarget  `json:"BootSourceOverrideTarget"`
+			BootSourceOverrideEnabled BootEnabled `json:"BootSourceOverrideEnabled"`
+			BootSourceOverrideMode    BootMode    `json:"BootSourceOverrideMode"`
+			HTTPBootURI               string      `json:"HttpBootUri"`
 		} `json:"Boot"`
 	}
 	if err := json.Unmarshal(data, &system); err != nil {
@@ -179,7 +179,7 @@ func (c *Client) GetBootConfig(ctx context.Context) (BootConfig, error) {
 		Target:         system.Boot.BootSourceOverrideTarget,
 		Enabled:        system.Boot.BootSourceOverrideEnabled,
 		Mode:           system.Boot.BootSourceOverrideMode,
-		UefiHTTPSource: system.Boot.UefiTargetBootSourceOverride,
+		UefiHTTPSource: system.Boot.HTTPBootURI,
 	}, nil
 }
 
@@ -218,10 +218,10 @@ func (c *Client) SetHTTPBootOverride(ctx context.Context, bootURL string) error 
 
 	body := map[string]any{
 		"Boot": map[string]string{
-			"BootSourceOverrideTarget":     string(BootTargetUefiHTTP),
-			"BootSourceOverrideEnabled":    string(BootOnce),
-			"BootSourceOverrideMode":       string(BootModeUEFI),
-			"UefiTargetBootSourceOverride": bootURL,
+			"BootSourceOverrideTarget":  string(BootTargetUefiHTTP),
+			"BootSourceOverrideEnabled": string(BootOnce),
+			"BootSourceOverrideMode":    string(BootModeUEFI),
+			"HttpBootUri":               bootURL,
 		},
 	}
 

--- a/internal/metalman/redfish/client.go
+++ b/internal/metalman/redfish/client.go
@@ -40,8 +40,9 @@ const (
 type BootTarget string
 
 const (
-	BootTargetPxe BootTarget = "Pxe"
-	BootTargetHdd BootTarget = "Hdd"
+	BootTargetPxe      BootTarget = "Pxe"
+	BootTargetHdd      BootTarget = "Hdd"
+	BootTargetUefiHTTP BootTarget = "UefiHttp"
 )
 
 // BootEnabled represents a Redfish boot source override enabled mode.
@@ -49,13 +50,23 @@ type BootEnabled string
 
 const (
 	BootContinuous BootEnabled = "Continuous"
+	BootOnce       BootEnabled = "Once"
 	BootDisabled   BootEnabled = "Disabled"
+)
+
+// BootMode represents a Redfish boot source override mode.
+type BootMode string
+
+const (
+	BootModeUEFI BootMode = "UEFI"
 )
 
 // BootConfig holds the current boot source override configuration.
 type BootConfig struct {
-	Target  BootTarget
-	Enabled BootEnabled
+	Target         BootTarget
+	Enabled        BootEnabled
+	Mode           BootMode
+	UefiHTTPSource string
 }
 
 // Client provides Redfish operations against a single BMC.
@@ -154,8 +165,10 @@ func (c *Client) GetBootConfig(ctx context.Context) (BootConfig, error) {
 
 	var system struct {
 		Boot struct {
-			BootSourceOverrideTarget  BootTarget  `json:"BootSourceOverrideTarget"`
-			BootSourceOverrideEnabled BootEnabled `json:"BootSourceOverrideEnabled"`
+			BootSourceOverrideTarget     BootTarget  `json:"BootSourceOverrideTarget"`
+			BootSourceOverrideEnabled    BootEnabled `json:"BootSourceOverrideEnabled"`
+			BootSourceOverrideMode       BootMode    `json:"BootSourceOverrideMode"`
+			UefiTargetBootSourceOverride string      `json:"UefiTargetBootSourceOverride"`
 		} `json:"Boot"`
 	}
 	if err := json.Unmarshal(data, &system); err != nil {
@@ -163,8 +176,10 @@ func (c *Client) GetBootConfig(ctx context.Context) (BootConfig, error) {
 	}
 
 	return BootConfig{
-		Target:  system.Boot.BootSourceOverrideTarget,
-		Enabled: system.Boot.BootSourceOverrideEnabled,
+		Target:         system.Boot.BootSourceOverrideTarget,
+		Enabled:        system.Boot.BootSourceOverrideEnabled,
+		Mode:           system.Boot.BootSourceOverrideMode,
+		UefiHTTPSource: system.Boot.UefiTargetBootSourceOverride,
 	}, nil
 }
 
@@ -191,6 +206,36 @@ func (c *Client) SetBootOverride(ctx context.Context, target BootTarget, enabled
 
 	if !isSuccessStatus(status) {
 		return fmt.Errorf("unexpected status %d from boot override PATCH", status)
+	}
+
+	return nil
+}
+
+// SetHTTPBootOverride sets a one-time Redfish UEFI HTTP boot override.
+// Returns ErrUnsupported if the BMC does not support the PATCH.
+func (c *Client) SetHTTPBootOverride(ctx context.Context, bootURL string) error {
+	path := fmt.Sprintf("/redfish/v1/Systems/%s", c.deviceID)
+
+	body := map[string]any{
+		"Boot": map[string]string{
+			"BootSourceOverrideTarget":     string(BootTargetUefiHTTP),
+			"BootSourceOverrideEnabled":    string(BootOnce),
+			"BootSourceOverrideMode":       string(BootModeUEFI),
+			"UefiTargetBootSourceOverride": bootURL,
+		},
+	}
+
+	_, status, err := c.session.do(ctx, http.MethodPatch, path, body)
+	if err != nil {
+		return err
+	}
+
+	if isUnsupportedStatus(status) {
+		return fmt.Errorf("UEFI HTTP boot override PATCH returned %d: %w", status, ErrUnsupported)
+	}
+
+	if !isSuccessStatus(status) {
+		return fmt.Errorf("unexpected status %d from UEFI HTTP boot override PATCH", status)
 	}
 
 	return nil

--- a/internal/metalman/redfish/reconciler.go
+++ b/internal/metalman/redfish/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/metalman/netboot"
 )
 
 const (
@@ -40,8 +41,9 @@ const (
 )
 
 type Reconciler struct {
-	Client client.Client
-	Pool   *Pool
+	Client       client.Client
+	Pool         *Pool
+	FileResolver *netboot.FileResolver
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -189,6 +191,21 @@ func (r *Reconciler) reconcileBootOrder(ctx context.Context, log *slog.Logger, m
 	}
 
 	if pendingRepave {
+		if machine.Spec.PXE.TargetBootProtocol() == v1alpha3.PXEBootProtocolHTTP {
+			bootURL, err := r.httpBootURL(machine)
+			if err != nil {
+				return err
+			}
+
+			if config.Target == BootTargetUefiHTTP && config.Enabled == BootOnce && config.Mode == BootModeUEFI && config.UefiHTTPSource == bootURL {
+				return nil // Already set to one-time UEFI HTTP boot.
+			}
+
+			log.Info("setting boot source override to UEFI HTTP", "currentTarget", config.Target, "currentEnabled", config.Enabled, "bootURL", bootURL)
+
+			return c.SetHTTPBootOverride(ctx, bootURL)
+		}
+
 		if config.Target == BootTargetPxe && config.Enabled == BootContinuous {
 			return nil // Already set to PXE boot.
 		}
@@ -206,6 +223,19 @@ func (r *Reconciler) reconcileBootOrder(ctx context.Context, log *slog.Logger, m
 	log.Info("disabling boot source override", "currentTarget", config.Target, "currentEnabled", config.Enabled)
 
 	return c.DisableBootOverride(ctx)
+}
+
+func (r *Reconciler) httpBootURL(machine *v1alpha3.Machine) (string, error) {
+	if r.FileResolver == nil {
+		return "", fmt.Errorf("netboot file resolver is not configured")
+	}
+
+	bootURL, err := r.FileResolver.HTTPBootURL(machine)
+	if err != nil {
+		return "", fmt.Errorf("resolving UEFI HTTP boot URL: %w", err)
+	}
+
+	return bootURL, nil
 }
 
 // reconcilePowerOff drives the machine to the Off state by sending ForceOff

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -4,13 +4,17 @@
 package redfish
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -26,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/metalman/indexing"
+	"github.com/Azure/unbounded/internal/metalman/netboot"
 )
 
 func TestMain(m *testing.M) {
@@ -956,6 +962,333 @@ func TestBootOrderConfigPxeOff(t *testing.T) {
 	}
 }
 
+func TestBootOrderConfigUEFIHTTPOn(t *testing.T) {
+	var (
+		patchCalls atomic.Int64
+		patchBody  map[string]any
+	)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			json.NewEncoder(w).Encode(map[string]any{
+				"PowerState": "On",
+				"Boot": map[string]string{
+					"BootSourceOverrideTarget":  "Hdd",
+					"BootSourceOverrideEnabled": "Disabled",
+				},
+				"Links": map[string]any{
+					"Chassis": []map[string]any{
+						{"@odata.id": "/redfish/v1/Chassis/1"},
+					},
+				},
+			})
+
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			patchCalls.Add(1)
+			json.NewDecoder(r.Body).Decode(&patchBody)
+			w.WriteHeader(http.StatusOK)
+
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	fp := tlsServerFingerprint(srv)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "bmc-pass", Namespace: "default"},
+		Data:       map[string][]byte{"password": []byte("secret")},
+	}
+
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-boot-http", Namespace: "default"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:        "ghcr.io/test/test-image:v1",
+				BootProtocol: v1alpha3.PXEBootProtocolHTTP,
+				DHCPLeases:   []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:c0", IPv4: "10.0.0.40", SubnetMask: "255.255.255.0"}},
+				Redfish: &v1alpha3.RedfishSpec{
+					URL:         srv.URL,
+					Username:    "admin",
+					DeviceID:    "System.Embedded.1",
+					PasswordRef: v1alpha3.SecretKeySelector{Name: "bmc-pass", Namespace: "default", Key: "password"},
+				},
+			},
+			Operations: &v1alpha3.OperationsSpec{RepaveCounter: 1},
+		},
+		Status: v1alpha3.MachineStatus{
+			Redfish: &v1alpha3.RedfishStatus{CertFingerprint: fp},
+		},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(node, secret).
+		WithStatusSubresource(node).
+		Build()
+	reconciler := &Reconciler{
+		Client: fc,
+		Pool:   NewPool(),
+		FileResolver: &netboot.FileResolver{
+			Cache:    setupRedfishOCICache(t, "ghcr.io/test/test-image:v1", "httpredfish123", "httpBootPath: shimx64.efi\n"),
+			ServeURL: "http://10.0.0.10:8880",
+		},
+	}
+	ctx := t.Context()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "node-boot-http", Namespace: "default"}}
+
+	_, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if patchCalls.Load() != 1 {
+		t.Fatalf("expected 1 PATCH call, got %d", patchCalls.Load())
+	}
+
+	boot, ok := patchBody["Boot"].(map[string]any)
+	if !ok {
+		t.Fatal("expected Boot in PATCH body")
+	}
+
+	want := map[string]string{
+		"BootSourceOverrideTarget":     "UefiHttp",
+		"BootSourceOverrideEnabled":    "Once",
+		"BootSourceOverrideMode":       "UEFI",
+		"UefiTargetBootSourceOverride": "http://10.0.0.10:8880/shimx64.efi",
+	}
+	for key, value := range want {
+		if boot[key] != value {
+			t.Fatalf("expected %s=%s, got %v", key, value, boot[key])
+		}
+	}
+}
+
+func TestBootOrderConfigUEFIHTTPNoOp(t *testing.T) {
+	var patchCalls atomic.Int64
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			json.NewEncoder(w).Encode(map[string]any{
+				"PowerState": "On",
+				"Boot": map[string]string{
+					"BootSourceOverrideTarget":     "UefiHttp",
+					"BootSourceOverrideEnabled":    "Once",
+					"BootSourceOverrideMode":       "UEFI",
+					"UefiTargetBootSourceOverride": "http://10.0.0.10:8880/shimx64.efi",
+				},
+				"Links": map[string]any{
+					"Chassis": []map[string]any{
+						{"@odata.id": "/redfish/v1/Chassis/1"},
+					},
+				},
+			})
+
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			patchCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	fp := tlsServerFingerprint(srv)
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bmc-pass", Namespace: "default"}, Data: map[string][]byte{"password": []byte("secret")}}
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-boot-http-noop", Namespace: "default"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:        "ghcr.io/test/test-image:v1",
+				BootProtocol: v1alpha3.PXEBootProtocolHTTP,
+				Redfish: &v1alpha3.RedfishSpec{
+					URL:         srv.URL,
+					Username:    "admin",
+					DeviceID:    "System.Embedded.1",
+					PasswordRef: v1alpha3.SecretKeySelector{Name: "bmc-pass", Namespace: "default", Key: "password"},
+				},
+			},
+			Operations: &v1alpha3.OperationsSpec{RepaveCounter: 1},
+		},
+		Status: v1alpha3.MachineStatus{Redfish: &v1alpha3.RedfishStatus{CertFingerprint: fp}},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node, secret).WithStatusSubresource(node).Build()
+	reconciler := &Reconciler{
+		Client: fc,
+		Pool:   NewPool(),
+		FileResolver: &netboot.FileResolver{
+			Cache:    setupRedfishOCICache(t, "ghcr.io/test/test-image:v1", "httpredfishnoop123", "httpBootPath: shimx64.efi\n"),
+			ServeURL: "http://10.0.0.10:8880",
+		},
+	}
+
+	_, err := reconciler.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "node-boot-http-noop", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if patchCalls.Load() != 0 {
+		t.Fatalf("expected no PATCH call, got %d", patchCalls.Load())
+	}
+}
+
+func TestUEFIHTTPBootEndToEnd(t *testing.T) {
+	var patchBody map[string]any
+
+	bmc := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			json.NewEncoder(w).Encode(map[string]any{
+				"PowerState": "On",
+				"Boot": map[string]string{
+					"BootSourceOverrideTarget":  "Hdd",
+					"BootSourceOverrideEnabled": "Disabled",
+				},
+				"Links": map[string]any{
+					"Chassis": []map[string]any{{"@odata.id": "/redfish/v1/Chassis/1"}},
+				},
+			})
+
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			json.NewDecoder(r.Body).Decode(&patchBody)
+			w.WriteHeader(http.StatusOK)
+
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer bmc.Close()
+
+	port := freeTCPPort(t)
+	serveURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	imageRef := "ghcr.io/test/test-image:v1"
+	cache := setupRedfishOCICacheFiles(t, imageRef, "httpe2e123", map[string][]byte{
+		"metadata.yaml": []byte("dhcpBootImageName: shimx64.efi\nhttpBootPath: shimx64.efi\n"),
+		"shimx64.efi":   []byte("shim efi binary"),
+	})
+
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bmc-pass", Namespace: "default"}, Data: map[string][]byte{"password": []byte("secret")}}
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-http-e2e", Namespace: "default"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:        imageRef,
+				BootProtocol: v1alpha3.PXEBootProtocolHTTP,
+				DHCPLeases:   []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:e2", IPv4: "10.0.0.42", SubnetMask: "255.255.255.0"}},
+				Redfish: &v1alpha3.RedfishSpec{
+					URL:         bmc.URL,
+					Username:    "admin",
+					DeviceID:    "System.Embedded.1",
+					PasswordRef: v1alpha3.SecretKeySelector{Name: "bmc-pass", Namespace: "default", Key: "password"},
+				},
+			},
+			Operations: &v1alpha3.OperationsSpec{RepaveCounter: 1},
+		},
+		Status: v1alpha3.MachineStatus{Redfish: &v1alpha3.RedfishStatus{CertFingerprint: tlsServerFingerprint(bmc)}},
+	}
+
+	scheme := testScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(node, secret).
+		WithStatusSubresource(node).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+
+	resolver := netboot.FileResolver{Cache: cache, Reader: fc, ServeURL: serveURL}
+	statusRecorder := &recordingNetbootStatusRecorder{}
+	httpServer := &netboot.HTTPServer{
+		BindAddr:       "127.0.0.1",
+		Port:           port,
+		FileResolver:   resolver,
+		StatusRecorder: statusRecorder,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- httpServer.Start(ctx) }()
+	waitForHTTPHealth(t, serveURL+"/healthz")
+
+	reconciler := &Reconciler{Client: fc, Pool: NewPool(), FileResolver: &resolver}
+	_, err := reconciler.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "node-http-e2e", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	boot, ok := patchBody["Boot"].(map[string]any)
+	if !ok {
+		t.Fatal("expected Boot in Redfish PATCH body")
+	}
+
+	bootURL, ok := boot["UefiTargetBootSourceOverride"].(string)
+	if !ok || bootURL != serveURL+"/shimx64.efi" {
+		t.Fatalf("expected UEFI HTTP URL %s/shimx64.efi, got %v", serveURL, boot["UefiTargetBootSourceOverride"])
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, bootURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("X-Forwarded-For", "10.0.0.42")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET UEFI HTTP boot URL: %v", err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET UEFI HTTP boot URL status: got %d, want 200", resp.StatusCode)
+	}
+
+	if string(body) != "shim efi binary" {
+		t.Fatalf("GET UEFI HTTP boot URL body: got %q", body)
+	}
+
+	if got := statusRecorder.bootLoaderEvents(); len(got) != 1 || got[0] != "node-http-e2e:shimx64.efi" {
+		t.Fatalf("bootloader events: got %v, want [node-http-e2e:shimx64.efi]", got)
+	}
+
+	cancel()
+	if err := <-serverErr; err != nil {
+		t.Fatalf("HTTP server returned error: %v", err)
+	}
+}
+
 func TestBootOrderConfigNoOp(t *testing.T) {
 	var patchCalls atomic.Int64
 
@@ -1720,6 +2053,95 @@ func TestSessionExpiryRetry(t *testing.T) {
 	if got := sessionCount.Load(); got != 2 {
 		t.Fatalf("expected 2 sessions (initial + reauth), got %d", got)
 	}
+}
+
+func setupRedfishOCICache(t *testing.T, imageRef, digest, metadata string) *netboot.OCICache {
+	t.Helper()
+
+	return setupRedfishOCICacheFiles(t, imageRef, digest, map[string][]byte{"metadata.yaml": []byte(metadata)})
+}
+
+func setupRedfishOCICacheFiles(t *testing.T, imageRef, digest string, files map[string][]byte) *netboot.OCICache {
+	t.Helper()
+
+	cache := netboot.NewOCICache(t.TempDir())
+	cache.SetDigest(imageRef, "sha256:"+digest)
+
+	diskDir := cache.DiskDir("sha256:" + digest)
+	for path, content := range files {
+		fullPath := filepath.Join(diskDir, path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.WriteFile(fullPath, content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return cache
+}
+
+type recordingNetbootStatusRecorder struct {
+	bootLoader []string
+}
+
+func (r *recordingNetbootStatusRecorder) RecordBootLoaderDownloaded(_ context.Context, machineName, filename string) error {
+	r.bootLoader = append(r.bootLoader, fmt.Sprintf("%s:%s", machineName, filename))
+
+	return nil
+}
+
+func (r *recordingNetbootStatusRecorder) RecordBootImageWritten(context.Context, string) error {
+	return nil
+}
+
+func (r *recordingNetbootStatusRecorder) RecordCloudInitDone(context.Context, string) error {
+	return nil
+}
+
+func (r *recordingNetbootStatusRecorder) RecordMachineCondition(context.Context, string, metav1.Condition) error {
+	return nil
+}
+
+func (r *recordingNetbootStatusRecorder) RecordPXEDisabled(context.Context, string, int64, string) error {
+	return nil
+}
+
+func (r *recordingNetbootStatusRecorder) bootLoaderEvents() []string {
+	return append([]string(nil), r.bootLoader...)
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer ln.Close()
+
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func waitForHTTPHealth(t *testing.T, healthURL string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(healthURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("HTTP server did not become healthy at %s", healthURL)
 }
 
 func testScheme(t *testing.T) *runtime.Scheme {

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -1234,10 +1234,13 @@ func TestUEFIHTTPBootEndToEnd(t *testing.T) {
 	defer cancel()
 
 	serverErr := make(chan error, 1)
+
 	go func() { serverErr <- httpServer.Start(ctx) }()
+
 	waitForHTTPHealth(t, serveURL+"/healthz")
 
 	reconciler := &Reconciler{Client: fc, Pool: NewPool(), FileResolver: &resolver}
+
 	_, err := reconciler.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "node-http-e2e", Namespace: "default"}})
 	if err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -1267,6 +1270,7 @@ func TestUEFIHTTPBootEndToEnd(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1284,6 +1288,7 @@ func TestUEFIHTTPBootEndToEnd(t *testing.T) {
 	}
 
 	cancel()
+
 	if err := <-serverErr; err != nil {
 		t.Fatalf("HTTP server returned error: %v", err)
 	}
@@ -2133,6 +2138,7 @@ func waitForHTTPHealth(t *testing.T, healthURL string) {
 		resp, err := http.Get(healthURL)
 		if err == nil {
 			resp.Body.Close()
+
 			if resp.StatusCode == http.StatusOK {
 				return
 			}

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -1061,10 +1061,10 @@ func TestBootOrderConfigUEFIHTTPOn(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"BootSourceOverrideTarget":     "UefiHttp",
-		"BootSourceOverrideEnabled":    "Once",
-		"BootSourceOverrideMode":       "UEFI",
-		"UefiTargetBootSourceOverride": "http://10.0.0.10:8880/shimx64.efi",
+		"BootSourceOverrideTarget":  "UefiHttp",
+		"BootSourceOverrideEnabled": "Once",
+		"BootSourceOverrideMode":    "UEFI",
+		"HttpBootUri":               "http://10.0.0.10:8880/shimx64.efi",
 	}
 	for key, value := range want {
 		if boot[key] != value {
@@ -1086,10 +1086,10 @@ func TestBootOrderConfigUEFIHTTPNoOp(t *testing.T) {
 			json.NewEncoder(w).Encode(map[string]any{
 				"PowerState": "On",
 				"Boot": map[string]string{
-					"BootSourceOverrideTarget":     "UefiHttp",
-					"BootSourceOverrideEnabled":    "Once",
-					"BootSourceOverrideMode":       "UEFI",
-					"UefiTargetBootSourceOverride": "http://10.0.0.10:8880/shimx64.efi",
+					"BootSourceOverrideTarget":  "UefiHttp",
+					"BootSourceOverrideEnabled": "Once",
+					"BootSourceOverrideMode":    "UEFI",
+					"HttpBootUri":               "http://10.0.0.10:8880/shimx64.efi",
 				},
 				"Links": map[string]any{
 					"Chassis": []map[string]any{
@@ -1251,9 +1251,9 @@ func TestUEFIHTTPBootEndToEnd(t *testing.T) {
 		t.Fatal("expected Boot in Redfish PATCH body")
 	}
 
-	bootURL, ok := boot["UefiTargetBootSourceOverride"].(string)
+	bootURL, ok := boot["HttpBootUri"].(string)
 	if !ok || bootURL != serveURL+"/shimx64.efi" {
-		t.Fatalf("expected UEFI HTTP URL %s/shimx64.efi, got %v", serveURL, boot["UefiTargetBootSourceOverride"])
+		t.Fatalf("expected UEFI HTTP URL %s/shimx64.efi, got %v", serveURL, boot["HttpBootUri"])
 	}
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, bootURL, nil)


### PR DESCRIPTION
Adds support for Redfish controlled UEFI HTTP boot in metalman. Currently there is not any e2e coverage because the Sushy emulator doesn't support it.