### PR TITLE
metalman: add missing rbac rules

### DIFF
--- a/deploy/machina/06-metalman-rbac.yaml.tmpl
+++ b/deploy/machina/06-metalman-rbac.yaml.tmpl
@@ -126,7 +126,7 @@ rules:
   # Secrets (Redfish passwords)
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get", "list", watch"]
   # ConfigMaps (cloud-init user-data)
   - apiGroups: [""]
     resources: ["configmaps"]


### PR DESCRIPTION
List/watch is required for Redfish cred secrets now. I'll open another PR for the smoke tests to use this role.