### PR TITLE
metalman: support HPE UEFI HTTP boot

### DIFF
--- a/internal/metalman/commands/serve_pxe.go
+++ b/internal/metalman/commands/serve_pxe.go
@@ -267,6 +267,7 @@ func ServePXECmd() *cobra.Command {
 				Reader:            mgr.GetClient(),
 				ServerIP:          dhcpServerIP,
 				OCICache:          ociCache,
+				ServeURL:          serveURL,
 				DefaultNetbootRef: defaultNetbootImage,
 			}
 			if err := mgr.Add(dhcpServer); err != nil {

--- a/internal/metalman/dhcp/dhcp.go
+++ b/internal/metalman/dhcp/dhcp.go
@@ -27,6 +27,7 @@ type Server struct {
 	Reader            client.Reader
 	ServerIP          net.IP
 	OCICache          *netboot.OCICache
+	ServeURL          string
 	DefaultNetbootRef string
 }
 
@@ -192,12 +193,21 @@ func (s *Server) handler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4) {
 		netbootImage = s.DefaultNetbootRef
 	}
 
-	if node.Spec.PXE.TargetBootProtocol() != v1alpha3.PXEBootProtocolHTTP && netbootImage != "" && s.OCICache != nil {
+	if netbootImage != "" && s.OCICache != nil {
 		architecture := node.Spec.PXE.TargetArchitecture()
 
 		meta, err := s.OCICache.MetadataForRefArchitecture(netbootImage, architecture)
 		if err != nil {
 			log.Warn("OCI image metadata not available", "image", netbootImage, "architecture", architecture, "err", err)
+		} else if node.Spec.PXE.TargetBootProtocol() == v1alpha3.PXEBootProtocolHTTP {
+			if isHTTPClientRequest(m) {
+				bootURL, err := netboot.JoinServeURLPath(s.ServeURL, netboot.HTTPBootPathFromMetadata(meta))
+				if err != nil {
+					log.Warn("HTTP boot URL not available", "image", netbootImage, "architecture", architecture, "err", err)
+				} else {
+					resp.UpdateOption(dhcpv4.OptBootFileName(bootURL))
+				}
+			}
 		} else if meta.DHCPBootImageName != "" {
 			resp.UpdateOption(dhcpv4.OptTFTPServerName(s.ServerIP.String()))
 			resp.UpdateOption(dhcpv4.OptBootFileName(meta.DHCPBootImageName))
@@ -224,4 +234,8 @@ func (s *Server) handler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4) {
 	if _, err := conn.WriteTo(resp.ToBytes(), dest); err != nil {
 		log.Error("sending DHCP response", "err", err)
 	}
+}
+
+func isHTTPClientRequest(m *dhcpv4.DHCPv4) bool {
+	return strings.HasPrefix(m.ClassIdentifier(), "HTTPClient")
 }

--- a/internal/metalman/dhcp/dhcp.go
+++ b/internal/metalman/dhcp/dhcp.go
@@ -159,7 +159,8 @@ func (s *Server) handler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4) {
 		return
 	}
 
-	resp, err := dhcpv4.NewReplyFromRequest(m,
+	resp, err := dhcpv4.NewReplyFromRequest(
+		m,
 		dhcpv4.WithYourIP(clientIP),
 		dhcpv4.WithServerIP(s.ServerIP),
 		dhcpv4.WithOption(dhcpv4.OptSubnetMask(net.IPMask(net.ParseIP(lease.SubnetMask).To4()))),

--- a/internal/metalman/dhcp/dhcp_test.go
+++ b/internal/metalman/dhcp/dhcp_test.go
@@ -331,6 +331,87 @@ func TestDHCPHandlerHTTPBootSuppressesPXEBootOptions(t *testing.T) {
 	}
 }
 
+func TestDHCPHandlerHTTPBootClientGetsHTTPBootURL(t *testing.T) {
+	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:f4")
+	serverIP := net.ParseIP("10.0.1.254").To4()
+	netbootImageRef := "ghcr.io/test/netboot:v1"
+
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-http-client-boot"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				NetbootImage: netbootImageRef,
+				BootProtocol: v1alpha3.PXEBootProtocolHTTP,
+				DHCPLeases: []v1alpha3.DHCPLease{{
+					MAC:        "aa:bb:cc:dd:ee:f4",
+					IPv4:       "10.0.1.14",
+					SubnetMask: "255.255.255.0",
+				}},
+			},
+		},
+	}
+
+	cacheDir := t.TempDir()
+	ociCache := netboot.NewOCICache(cacheDir)
+
+	digest := "sha256:httpclientboot1234567890"
+	ociCache.SetDigest(netbootImageRef, digest)
+
+	diskDir := filepath.Join(ociCache.DiskDir(digest))
+	if err := os.MkdirAll(diskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(diskDir, "metadata.yaml"), []byte("dhcpBootImageName: pxe-shimx64.efi\nhttpBootPath: http/shimx64.efi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := newFakeReader(t, node)
+	srv := &Server{
+		Interface: "eth0",
+		Reader:    reader,
+		ServerIP:  serverIP,
+		OCICache:  ociCache,
+		ServeURL:  "http://10.0.1.254:8880/base/",
+	}
+
+	discover, err := dhcpv4.NewDiscovery(mac)
+	if err != nil {
+		t.Fatal(err)
+	}
+	discover.UpdateOption(dhcpv4.OptClassIdentifier("HTTPClient:Arch:00016:UNDI:003016"))
+
+	conn := &fakePacketConn{}
+	peer := &net.UDPAddr{IP: net.ParseIP("10.0.1.14"), Port: 68}
+
+	srv.handler(conn, peer, discover)
+
+	if conn.written == nil {
+		t.Fatal("expected DHCP response, got none")
+	}
+
+	resp, err := dhcpv4.FromBytes(conn.written)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tftpServer := resp.TFTPServerName(); tftpServer != "" {
+		t.Errorf("expected no TFTP server for HTTP boot, got %s", tftpServer)
+	}
+
+	if bootfile := resp.BootFileNameOption(); bootfile != "http://10.0.1.254:8880/base/http/shimx64.efi" {
+		t.Errorf("expected HTTP boot URL, got %s", bootfile)
+	}
+
+	if resp.GetOneOption(dhcpv4.OptionTFTPServerName) != nil {
+		t.Error("expected no TFTP server option for HTTP boot")
+	}
+
+	if !resp.YourIPAddr.Equal(net.ParseIP("10.0.1.14")) {
+		t.Errorf("expected YourIP 10.0.1.14, got %s", resp.YourIPAddr)
+	}
+}
+
 func TestDHCPHandlerUnknownMAC(t *testing.T) {
 	mac, _ := net.ParseMAC("ff:ff:ff:ff:ff:ff")
 	serverIP := net.ParseIP("10.0.1.254").To4()

--- a/internal/metalman/dhcp/dhcp_test.go
+++ b/internal/metalman/dhcp/dhcp_test.go
@@ -379,6 +379,7 @@ func TestDHCPHandlerHTTPBootClientGetsHTTPBootURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	discover.UpdateOption(dhcpv4.OptClassIdentifier("HTTPClient:Arch:00016:UNDI:003016"))
 
 	conn := &fakePacketConn{}

--- a/internal/metalman/machineops/controller.go
+++ b/internal/metalman/machineops/controller.go
@@ -51,6 +51,7 @@ type PowerClient interface {
 	DisableBootOverride(ctx context.Context) error
 	SetBootOverride(ctx context.Context, target redfish.BootTarget, enabled redfish.BootEnabled) error
 	SetHTTPBootOverride(ctx context.Context, bootURL string) error
+	SetBIOSHTTPBootURI(ctx context.Context, bootURL string) error
 }
 
 // PowerClientFactory builds a PowerClient for a Machine.
@@ -612,7 +613,7 @@ func (r *Reconciler) requestRepaveBoot(ctx context.Context, machine *v1alpha3.Ma
 			return err
 		}
 
-		if err := pc.SetHTTPBootOverride(ctx, bootURL); err != nil {
+		if err := setHTTPBootOverride(ctx, pc, bootURL); err != nil {
 			return err
 		}
 	} else if err := pc.SetBootOverride(ctx, redfish.BootTargetPxe, redfish.BootContinuous); err != nil {
@@ -629,6 +630,22 @@ func (r *Reconciler) requestRepaveBoot(ctx context.Context, machine *v1alpha3.Ma
 	}
 
 	return pc.Reset(ctx, redfish.ResetForceRestart)
+}
+
+func setHTTPBootOverride(ctx context.Context, pc PowerClient, bootURL string) error {
+	if err := pc.SetHTTPBootOverride(ctx, bootURL); err != nil {
+		if !errors.Is(err, redfish.ErrUnsupported) {
+			return err
+		}
+
+		if err := pc.SetBIOSHTTPBootURI(ctx, bootURL); err != nil {
+			return err
+		}
+
+		return pc.SetBootOverride(ctx, redfish.BootTargetUefiHTTP, redfish.BootOnce)
+	}
+
+	return nil
 }
 
 func (r *Reconciler) waitForRepaveBoot(ctx context.Context, machine *v1alpha3.Machine, target v1alpha3.MachineOperationTargetStatus, now metav1.Time) targetChange {

--- a/internal/metalman/machineops/controller.go
+++ b/internal/metalman/machineops/controller.go
@@ -50,6 +50,7 @@ type PowerClient interface {
 	Reset(ctx context.Context, resetType redfish.ResetType) error
 	DisableBootOverride(ctx context.Context) error
 	SetBootOverride(ctx context.Context, target redfish.BootTarget, enabled redfish.BootEnabled) error
+	GetBootConfig(ctx context.Context) (redfish.BootConfig, error)
 	SetHTTPBootOverride(ctx context.Context, bootURL string) error
 	SetBIOSHTTPBootURI(ctx context.Context, bootURL string) error
 }
@@ -633,19 +634,32 @@ func (r *Reconciler) requestRepaveBoot(ctx context.Context, machine *v1alpha3.Ma
 }
 
 func setHTTPBootOverride(ctx context.Context, pc PowerClient, bootURL string) error {
+	config, err := pc.GetBootConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !config.HasHTTPBootURI {
+		return setBIOSHTTPBootOverride(ctx, pc, bootURL)
+	}
+
 	if err := pc.SetHTTPBootOverride(ctx, bootURL); err != nil {
 		if !errors.Is(err, redfish.ErrUnsupported) {
 			return err
 		}
 
-		if err := pc.SetBIOSHTTPBootURI(ctx, bootURL); err != nil {
-			return err
-		}
-
-		return pc.SetBootOverride(ctx, redfish.BootTargetUefiHTTP, redfish.BootOnce)
+		return setBIOSHTTPBootOverride(ctx, pc, bootURL)
 	}
 
 	return nil
+}
+
+func setBIOSHTTPBootOverride(ctx context.Context, pc PowerClient, bootURL string) error {
+	if err := pc.SetBIOSHTTPBootURI(ctx, bootURL); err != nil {
+		return err
+	}
+
+	return pc.SetBootOverride(ctx, redfish.BootTargetUefiHTTP, redfish.BootOnce)
 }
 
 func (r *Reconciler) waitForRepaveBoot(ctx context.Context, machine *v1alpha3.Machine, target v1alpha3.MachineOperationTargetStatus, now metav1.Time) targetChange {

--- a/internal/metalman/machineops/controller_test.go
+++ b/internal/metalman/machineops/controller_test.go
@@ -400,7 +400,44 @@ func TestReconcilerFallsBackToBIOSHTTPBootURIForHostReplace(t *testing.T) {
 	require.Len(t, inProgress.Status.Targets, 1)
 	require.Equal(t, v1alpha3.OperationStageWaitingRepave, inProgress.Status.Targets[0].Stage)
 	require.Equal(t, []string{
+		"machine-1:GetBootConfig",
 		"machine-1:SetHTTPBootOverride:http://10.0.0.10:8880/http/shimx64.efi",
+		"machine-1:SetBIOSHTTPBootURI:http://10.0.0.10:8880/http/shimx64.efi",
+		"machine-1:SetBootOverride:UefiHttp:Once",
+		"machine-1:ForceRestart",
+	}, power.calls)
+}
+
+func TestReconcilerUsesBIOSHTTPBootURIWhenStandardURIAbsent(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machine := testBareMetalMachine("machine-1", "rack-a")
+	machine.Spec.PXE.BootProtocol = v1alpha3.PXEBootProtocolHTTP
+	op := testOperation("op-replace-http-bios", v1alpha3.OperationHostReplace)
+	op.Spec.MachineRef = machine.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, op, testRedfishSecret()).WithStatusSubresource(op, machine).Build()
+	power := &recordingPowerClient{httpBootURIAbsent: map[string]bool{machine.Name: true}}
+	reconciler := testReconciler(c, power, "rack-a")
+	reconciler.HTTPBootURL = func(m *v1alpha3.Machine) (string, error) {
+		require.Equal(t, machine.Name, m.Name)
+
+		return "http://10.0.0.10:8880/http/shimx64.efi", nil
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+
+	var inProgress v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &inProgress))
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, inProgress.Status.Phase)
+	require.Len(t, inProgress.Status.Targets, 1)
+	require.Equal(t, v1alpha3.OperationStageWaitingRepave, inProgress.Status.Targets[0].Stage)
+	require.Equal(t, []string{
+		"machine-1:GetBootConfig",
 		"machine-1:SetBIOSHTTPBootURI:http://10.0.0.10:8880/http/shimx64.efi",
 		"machine-1:SetBootOverride:UefiHttp:Once",
 		"machine-1:ForceRestart",
@@ -860,6 +897,7 @@ type recordingPowerClient struct {
 	states                 map[string]redfish.PowerState
 	disableBootUnsupported map[string]bool
 	httpBootUnsupported    map[string]bool
+	httpBootURIAbsent      map[string]bool
 	calls                  []string
 }
 
@@ -924,6 +962,15 @@ func (c *recordingMachinePowerClient) SetBootOverride(_ context.Context, target 
 	c.parent.calls = append(c.parent.calls, fmt.Sprintf("%s:SetBootOverride:%s:%s", c.machine, target, enabled))
 
 	return nil
+}
+
+func (c *recordingMachinePowerClient) GetBootConfig(context.Context) (redfish.BootConfig, error) {
+	c.parent.mu.Lock()
+	defer c.parent.mu.Unlock()
+
+	c.parent.calls = append(c.parent.calls, fmt.Sprintf("%s:GetBootConfig", c.machine))
+
+	return redfish.BootConfig{HasHTTPBootURI: !c.parent.httpBootURIAbsent[c.machine]}, nil
 }
 
 func (c *recordingMachinePowerClient) SetHTTPBootOverride(_ context.Context, bootURL string) error {

--- a/internal/metalman/machineops/controller_test.go
+++ b/internal/metalman/machineops/controller_test.go
@@ -371,6 +371,42 @@ func TestReconcilerPowersOnHostReplaceTargetWhenOff(t *testing.T) {
 	require.Equal(t, []string{"machine-1:SetBootOverride:Pxe:Continuous", "machine-1:On"}, power.calls)
 }
 
+func TestReconcilerFallsBackToBIOSHTTPBootURIForHostReplace(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machine := testBareMetalMachine("machine-1", "rack-a")
+	machine.Spec.PXE.BootProtocol = v1alpha3.PXEBootProtocolHTTP
+	op := testOperation("op-replace-http", v1alpha3.OperationHostReplace)
+	op.Spec.MachineRef = machine.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, op, testRedfishSecret()).WithStatusSubresource(op, machine).Build()
+	power := &recordingPowerClient{httpBootUnsupported: map[string]bool{machine.Name: true}}
+	reconciler := testReconciler(c, power, "rack-a")
+	reconciler.HTTPBootURL = func(m *v1alpha3.Machine) (string, error) {
+		require.Equal(t, machine.Name, m.Name)
+
+		return "http://10.0.0.10:8880/http/shimx64.efi", nil
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+
+	var inProgress v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &inProgress))
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, inProgress.Status.Phase)
+	require.Len(t, inProgress.Status.Targets, 1)
+	require.Equal(t, v1alpha3.OperationStageWaitingRepave, inProgress.Status.Targets[0].Stage)
+	require.Equal(t, []string{
+		"machine-1:SetHTTPBootOverride:http://10.0.0.10:8880/http/shimx64.efi",
+		"machine-1:SetBIOSHTTPBootURI:http://10.0.0.10:8880/http/shimx64.efi",
+		"machine-1:SetBootOverride:UefiHttp:Once",
+		"machine-1:ForceRestart",
+	}, power.calls)
+}
+
 func TestReconcilerRestoresMissingHostReplaceTriggerConditions(t *testing.T) {
 	t.Parallel()
 
@@ -823,6 +859,7 @@ type recordingPowerClient struct {
 	mu                     sync.Mutex
 	states                 map[string]redfish.PowerState
 	disableBootUnsupported map[string]bool
+	httpBootUnsupported    map[string]bool
 	calls                  []string
 }
 
@@ -894,6 +931,18 @@ func (c *recordingMachinePowerClient) SetHTTPBootOverride(_ context.Context, boo
 	defer c.parent.mu.Unlock()
 
 	c.parent.calls = append(c.parent.calls, fmt.Sprintf("%s:SetHTTPBootOverride:%s", c.machine, bootURL))
+	if c.parent.httpBootUnsupported[c.machine] {
+		return fmt.Errorf("http boot unsupported: %w", redfish.ErrUnsupported)
+	}
+
+	return nil
+}
+
+func (c *recordingMachinePowerClient) SetBIOSHTTPBootURI(_ context.Context, bootURL string) error {
+	c.parent.mu.Lock()
+	defer c.parent.mu.Unlock()
+
+	c.parent.calls = append(c.parent.calls, fmt.Sprintf("%s:SetBIOSHTTPBootURI:%s", c.machine, bootURL))
 
 	return nil
 }

--- a/internal/metalman/netboot/http.go
+++ b/internal/metalman/netboot/http.go
@@ -151,6 +151,12 @@ func (h *HTTPServer) handleFile(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if node.Spec.PXE.TargetBootProtocol() == v1alpha3.PXEBootProtocolHTTP && isOptionalShimRevocationsFile(path) {
+			serveMissingShimRevocationsFile(w, log, node, path)
+
+			return
+		}
+
 		log.Warn("resolving file", "node", node.Name, "err", err)
 		http.NotFound(w, r)
 
@@ -169,6 +175,33 @@ func (h *HTTPServer) handleFile(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", resolved.ContentType)
 	w.Write(resolved.Data) //nolint:errcheck // Best-effort HTTP response write.
 	h.recordHTTPBootLoaderDownloaded(r.Context(), log, node, imageRef, path)
+}
+
+const shimRevocationsNotPresentBody = "unbounded: no optional shim revocations file is present\n"
+
+func isOptionalShimRevocationsFile(path string) bool {
+	path = strings.Trim(path, "/")
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		path = path[i+1:]
+	}
+
+	switch strings.ToLower(path) {
+	case "revocations.efi", "revocations_sbat.efi", "revocations_sku.efi":
+		return true
+	default:
+		return false
+	}
+}
+
+func serveMissingShimRevocationsFile(w http.ResponseWriter, log *slog.Logger, node *v1alpha3.Machine, path string) {
+	// shim treats these files as optional for netboot, but its HTTP fetch path
+	// requires a 200 response with a non-empty body. Returning a small invalid
+	// EFI payload preserves the "not present" semantics without sending a 404.
+	log.Info("serving no-op body for missing optional shim revocations file", "node", node.Name, "path", path)
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", fmt.Sprint(len(shimRevocationsNotPresentBody)))
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(shimRevocationsNotPresentBody)) //nolint:errcheck // Best-effort HTTP response write.
 }
 
 func (h *HTTPServer) handleCloudInitLog(w http.ResponseWriter, r *http.Request) {

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -303,6 +303,119 @@ func TestHTTPServer_HTTPBootLoaderRequiresActiveInstallOperation(t *testing.T) {
 	}
 }
 
+func TestHTTPServer_MissingOptionalShimRevocationsFilesHTTPBoot(t *testing.T) {
+	cache := setupOCICache(t, "ghcr.io/test/image:v1", "revocations123", map[string][]byte{
+		"metadata.yaml": []byte("dhcpBootImageName: shimx64.efi\nhttpBootPath: shimx64.efi\n"),
+		"shimx64.efi":   []byte("shim"),
+	})
+
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-revocations"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:        "ghcr.io/test/image:v1",
+				BootProtocol: v1alpha3.PXEBootProtocolHTTP,
+				DHCPLeases:   []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:11", IPv4: "10.0.1.61", SubnetMask: "255.255.255.0"}},
+			},
+		},
+	}
+
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+	srv := &HTTPServer{
+		FileResolver: FileResolver{
+			Cache:  cache,
+			Reader: fc,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", srv.handleFile)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	tests := []struct {
+		path       string
+		wantStatus int
+		wantBody   []byte
+	}{
+		{path: "revocations.efi", wantStatus: http.StatusOK, wantBody: []byte(shimRevocationsNotPresentBody)},
+		{path: "revocations_sbat.efi", wantStatus: http.StatusOK, wantBody: []byte(shimRevocationsNotPresentBody)},
+		{path: "revocations_sku.efi", wantStatus: http.StatusOK, wantBody: []byte(shimRevocationsNotPresentBody)},
+		{path: "nested/revocations.efi", wantStatus: http.StatusOK, wantBody: []byte(shimRevocationsNotPresentBody)},
+		{path: "missing.efi", wantStatus: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", ts.URL+"/"+tt.path, nil)
+			req.Header.Set("X-Forwarded-For", "10.0.1.61")
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			require.NoError(t, err)
+
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			if tt.wantBody != nil {
+				require.Equal(t, tt.wantBody, body)
+				require.Equal(t, fmt.Sprint(len(tt.wantBody)), resp.Header.Get("Content-Length"))
+			}
+		})
+	}
+}
+
+func TestHTTPServer_MissingShimRevocationsFilePXEStill404(t *testing.T) {
+	cache := setupOCICache(t, "ghcr.io/test/image:v1", "pxerevocations123", map[string][]byte{
+		"metadata.yaml": []byte("dhcpBootImageName: shimx64.efi\n"),
+		"shimx64.efi":   []byte("shim"),
+	})
+
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-pxe-revocations"},
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				Image:      "ghcr.io/test/image:v1",
+				DHCPLeases: []v1alpha3.DHCPLease{{MAC: "aa:bb:cc:dd:ee:12", IPv4: "10.0.1.62", SubnetMask: "255.255.255.0"}},
+			},
+		},
+	}
+
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+	srv := &HTTPServer{
+		FileResolver: FileResolver{
+			Cache:  cache,
+			Reader: fc,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", srv.handleFile)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/revocations.efi", nil)
+	req.Header.Set("X-Forwarded-For", "10.0.1.62")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 func TestHTTPServer_TemplateRendered(t *testing.T) {
 	bootTemplate := `set default=0
 menuentry "Install" {

--- a/internal/metalman/redfish/client.go
+++ b/internal/metalman/redfish/client.go
@@ -20,6 +20,36 @@ import (
 // ErrUnsupported indicates the BMC does not support the requested operation.
 var ErrUnsupported = errors.New("not supported by BMC")
 
+type responseError struct {
+	method string
+	path   string
+	status int
+	body   []byte
+	cause  error
+}
+
+func redfishResponseError(method, path string, status int, body []byte, cause error) error {
+	return &responseError{
+		method: method,
+		path:   path,
+		status: status,
+		body:   append([]byte(nil), body...),
+		cause:  cause,
+	}
+}
+
+func (e *responseError) Error() string {
+	if len(e.body) == 0 {
+		return fmt.Sprintf("Redfish %s %s returned HTTP %d", e.method, e.path, e.status)
+	}
+
+	return fmt.Sprintf("Redfish %s %s returned HTTP %d: %s", e.method, e.path, e.status, e.body)
+}
+
+func (e *responseError) Unwrap() error {
+	return e.cause
+}
+
 // PowerState represents the power state of a Redfish system.
 type PowerState string
 
@@ -121,7 +151,7 @@ func (c *Client) PowerState(ctx context.Context) (PowerState, error) {
 	}
 
 	if status != http.StatusOK {
-		return "", fmt.Errorf("unexpected status %d from %s: %s", status, path, data)
+		return "", redfishResponseError(http.MethodGet, path, status, data, nil)
 	}
 
 	var result struct {
@@ -145,7 +175,7 @@ func (c *Client) Reset(ctx context.Context, resetType ResetType) error {
 	}
 
 	if !isSuccessStatus(status) {
-		return fmt.Errorf("unexpected status %d from reset %s: %s", status, resetType, data)
+		return fmt.Errorf("reset %s failed: %w", resetType, redfishResponseError(http.MethodPost, path, status, data, nil))
 	}
 
 	return nil
@@ -161,7 +191,7 @@ func (c *Client) GetBootConfig(ctx context.Context) (BootConfig, error) {
 	}
 
 	if status != http.StatusOK {
-		return BootConfig{}, fmt.Errorf("unexpected status %d from %s: %s", status, path, data)
+		return BootConfig{}, redfishResponseError(http.MethodGet, path, status, data, nil)
 	}
 
 	var system struct {
@@ -196,17 +226,17 @@ func (c *Client) SetBootOverride(ctx context.Context, target BootTarget, enabled
 		},
 	}
 
-	_, status, err := c.session.do(ctx, http.MethodPatch, path, body)
+	data, status, err := c.session.do(ctx, http.MethodPatch, path, body)
 	if err != nil {
 		return err
 	}
 
 	if isUnsupportedStatus(status) {
-		return fmt.Errorf("boot override PATCH returned %d: %w", status, ErrUnsupported)
+		return redfishResponseError(http.MethodPatch, path, status, data, ErrUnsupported)
 	}
 
 	if !isSuccessStatus(status) {
-		return fmt.Errorf("unexpected status %d from boot override PATCH", status)
+		return redfishResponseError(http.MethodPatch, path, status, data, nil)
 	}
 
 	return nil
@@ -226,17 +256,17 @@ func (c *Client) SetHTTPBootOverride(ctx context.Context, bootURL string) error 
 		},
 	}
 
-	_, status, err := c.session.do(ctx, http.MethodPatch, path, body)
+	data, status, err := c.session.do(ctx, http.MethodPatch, path, body)
 	if err != nil {
 		return err
 	}
 
 	if isUnsupportedStatus(status) {
-		return fmt.Errorf("UEFI HTTP boot override PATCH returned %d: %w", status, ErrUnsupported)
+		return redfishResponseError(http.MethodPatch, path, status, data, ErrUnsupported)
 	}
 
 	if !isSuccessStatus(status) {
-		return fmt.Errorf("unexpected status %d from UEFI HTTP boot override PATCH", status)
+		return redfishResponseError(http.MethodPatch, path, status, data, nil)
 	}
 
 	return nil
@@ -253,20 +283,20 @@ func (c *Client) DisableBootOverride(ctx context.Context) error {
 		},
 	}
 
-	_, status, err := c.session.do(ctx, http.MethodPatch, path, body)
+	data, status, err := c.session.do(ctx, http.MethodPatch, path, body)
 	if err != nil {
 		return err
 	}
 
-	if isSuccessStatus(status) {
-		return nil
-	}
-
 	if isUnsupportedStatus(status) {
-		return fmt.Errorf("disable boot override PATCH returned %d: %w", status, ErrUnsupported)
+		return redfishResponseError(http.MethodPatch, path, status, data, ErrUnsupported)
 	}
 
-	return fmt.Errorf("unexpected status %d from boot override PATCH", status)
+	if !isSuccessStatus(status) {
+		return redfishResponseError(http.MethodPatch, path, status, data, nil)
+	}
+
+	return nil
 }
 
 // CaptureFingerprint connects to a BMC without cert pinning and returns
@@ -339,7 +369,7 @@ func resolveDeviceID(ctx context.Context, s *bmcSession, deviceID string) (strin
 	}
 
 	if status != http.StatusOK {
-		return "", fmt.Errorf("unexpected status %d from /redfish/v1/Systems: %s", status, data)
+		return "", redfishResponseError(http.MethodGet, "/redfish/v1/Systems", status, data, nil)
 	}
 
 	var collection struct {

--- a/internal/metalman/redfish/client.go
+++ b/internal/metalman/redfish/client.go
@@ -98,6 +98,7 @@ type BootConfig struct {
 	Enabled        BootEnabled
 	Mode           BootMode
 	UefiHTTPSource string
+	HasHTTPBootURI bool
 }
 
 const biosHTTPBootURIAttribute = "UrlBootFile"
@@ -198,22 +199,29 @@ func (c *Client) GetBootConfig(ctx context.Context) (BootConfig, error) {
 
 	var system struct {
 		Boot struct {
-			BootSourceOverrideTarget  BootTarget  `json:"BootSourceOverrideTarget"`
-			BootSourceOverrideEnabled BootEnabled `json:"BootSourceOverrideEnabled"`
-			BootSourceOverrideMode    BootMode    `json:"BootSourceOverrideMode"`
-			HTTPBootURI               string      `json:"HttpBootUri"`
+			BootSourceOverrideTarget  BootTarget      `json:"BootSourceOverrideTarget"`
+			BootSourceOverrideEnabled BootEnabled     `json:"BootSourceOverrideEnabled"`
+			BootSourceOverrideMode    BootMode        `json:"BootSourceOverrideMode"`
+			HTTPBootURI               json.RawMessage `json:"HttpBootUri"`
 		} `json:"Boot"`
 	}
 	if err := json.Unmarshal(data, &system); err != nil {
 		return BootConfig{}, fmt.Errorf("parsing system boot config: %w", err)
 	}
 
-	return BootConfig{
+	config := BootConfig{
 		Target:         system.Boot.BootSourceOverrideTarget,
 		Enabled:        system.Boot.BootSourceOverrideEnabled,
 		Mode:           system.Boot.BootSourceOverrideMode,
-		UefiHTTPSource: system.Boot.HTTPBootURI,
-	}, nil
+		HasHTTPBootURI: system.Boot.HTTPBootURI != nil,
+	}
+	if system.Boot.HTTPBootURI != nil && string(system.Boot.HTTPBootURI) != "null" {
+		if err := json.Unmarshal(system.Boot.HTTPBootURI, &config.UefiHTTPSource); err != nil {
+			return BootConfig{}, fmt.Errorf("parsing system HTTP boot URI: %w", err)
+		}
+	}
+
+	return config, nil
 }
 
 // SetBootOverride sets the boot source override target and enabled mode.

--- a/internal/metalman/redfish/client.go
+++ b/internal/metalman/redfish/client.go
@@ -100,6 +100,8 @@ type BootConfig struct {
 	UefiHTTPSource string
 }
 
+const biosHTTPBootURIAttribute = "UrlBootFile"
+
 // Client provides Redfish operations against a single BMC.
 // Created via Pool.Get or Dial. Must be closed when no longer needed.
 type Client struct {
@@ -253,6 +255,62 @@ func (c *Client) SetHTTPBootOverride(ctx context.Context, bootURL string) error 
 			"BootSourceOverrideEnabled": string(BootContinuous),
 			"BootSourceOverrideMode":    string(BootModeUEFI),
 			"HttpBootUri":               bootURL,
+		},
+	}
+
+	data, status, err := c.session.do(ctx, http.MethodPatch, path, body)
+	if err != nil {
+		return err
+	}
+
+	if isUnsupportedStatus(status) {
+		return redfishResponseError(http.MethodPatch, path, status, data, ErrUnsupported)
+	}
+
+	if !isSuccessStatus(status) {
+		return redfishResponseError(http.MethodPatch, path, status, data, nil)
+	}
+
+	return nil
+}
+
+// GetBIOSHTTPBootURI returns the pending BIOS UEFI HTTP boot URI.
+// Returns ErrUnsupported if the BMC does not support BIOS settings.
+func (c *Client) GetBIOSHTTPBootURI(ctx context.Context) (string, error) {
+	path := fmt.Sprintf("/redfish/v1/Systems/%s/Bios/Settings", c.deviceID)
+
+	data, status, err := c.session.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if isUnsupportedStatus(status) {
+		return "", redfishResponseError(http.MethodGet, path, status, data, ErrUnsupported)
+	}
+
+	if status != http.StatusOK {
+		return "", redfishResponseError(http.MethodGet, path, status, data, nil)
+	}
+
+	var result struct {
+		Attributes struct {
+			HTTPBootURI string `json:"UrlBootFile"`
+		} `json:"Attributes"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return "", fmt.Errorf("parsing BIOS HTTP boot URI: %w", err)
+	}
+
+	return result.Attributes.HTTPBootURI, nil
+}
+
+// SetBIOSHTTPBootURI sets the pending BIOS UEFI HTTP boot URI.
+// Returns ErrUnsupported if the BMC does not support BIOS settings.
+func (c *Client) SetBIOSHTTPBootURI(ctx context.Context, bootURL string) error {
+	path := fmt.Sprintf("/redfish/v1/Systems/%s/Bios/Settings", c.deviceID)
+	body := map[string]any{
+		"Attributes": map[string]string{
+			biosHTTPBootURIAttribute: bootURL,
 		},
 	}
 

--- a/internal/metalman/redfish/reconciler.go
+++ b/internal/metalman/redfish/reconciler.go
@@ -83,7 +83,5 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, r.Client.Status().Update(ctx, &machine)
 	}
 
-	_ = log
-
 	return ctrl.Result{}, nil
 }

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -210,6 +210,56 @@ func TestBootOrderConfigTransientError(t *testing.T) {
 	require.Error(t, client.SetBootOverride(t.Context(), BootTargetPxe, BootContinuous))
 }
 
+func TestRedfishErrorIncludesFullResponseBody(t *testing.T) {
+	const responseBody = `{"error":{"message":"reset failed with detailed BMC diagnostics"}}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/Actions/ComputerSystem.Reset"):
+			http.Error(w, responseBody, http.StatusInternalServerError)
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	err := client.Reset(t.Context(), ResetOn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), responseBody)
+}
+
+func TestRedfishUnsupportedErrorIncludesFullResponseBody(t *testing.T) {
+	const responseBody = `{"error":{"message":"BootSourceOverrideTarget is not writable"}}`
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			http.Error(w, responseBody, http.StatusBadRequest)
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	err := client.SetBootOverride(t.Context(), BootTargetPxe, BootContinuous)
+	require.ErrorIs(t, err, ErrUnsupported)
+	require.Contains(t, err.Error(), responseBody)
+}
+
 func TestSessionExpiryRetry(t *testing.T) {
 	var sessions atomic.Int64
 

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -260,6 +260,105 @@ func TestRedfishUnsupportedErrorIncludesFullResponseBody(t *testing.T) {
 	require.Contains(t, err.Error(), responseBody)
 }
 
+func TestClientSetBIOSHTTPBootURI(t *testing.T) {
+	var patchBody map[string]any
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/Bios/Settings"):
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	require.NoError(t, client.SetBIOSHTTPBootURI(t.Context(), "http://192.0.2.1/boot/shimx64.efi"))
+	require.Equal(t, "http://192.0.2.1/boot/shimx64.efi", patchBody["Attributes"].(map[string]any)["UrlBootFile"])
+}
+
+func TestClientGetBIOSHTTPBootURI(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/Bios/Settings"):
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"Attributes": map[string]string{"UrlBootFile": "http://192.0.2.1/boot/shimx64.efi"},
+			}))
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	uri, err := client.GetBIOSHTTPBootURI(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "http://192.0.2.1/boot/shimx64.efi", uri)
+}
+
+func TestClientSetBIOSHTTPBootURIUnsupported(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/Bios/Settings"):
+			http.Error(w, "BIOS settings unsupported", http.StatusNotFound)
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	require.ErrorIs(t, client.SetBIOSHTTPBootURI(t.Context(), "http://192.0.2.1/boot/shimx64.efi"), ErrUnsupported)
+}
+
+func TestClientSetHTTPBootOverrideUnsupportedDoesNotFallback(t *testing.T) {
+	var patchCalls atomic.Int64
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			patchCalls.Add(1)
+			http.Error(w, "HttpBootUri is not writable", http.StatusBadRequest)
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/Bios/Settings"):
+			t.Fatal("SetHTTPBootOverride should not write BIOS settings directly")
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	err := client.SetHTTPBootOverride(t.Context(), "http://192.0.2.1/boot/shimx64.efi")
+	require.ErrorIs(t, err, ErrUnsupported)
+	require.Equal(t, int64(1), patchCalls.Load())
+}
+
 func TestSessionExpiryRetry(t *testing.T) {
 	var sessions atomic.Int64
 

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -143,6 +143,35 @@ func TestBootOrderConfigUEFIHTTPOn(t *testing.T) {
 	require.Equal(t, "http://192.0.2.1/boot/grubx64.efi", boot["HttpBootUri"])
 }
 
+func TestClientGetBootConfigTracksHTTPBootURIFieldPresence(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"PowerState": "On",
+				"Boot": map[string]string{
+					"BootSourceOverrideTarget":  "Hdd",
+					"BootSourceOverrideEnabled": "Disabled",
+				},
+			})
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	config, err := client.GetBootConfig(t.Context())
+	require.NoError(t, err)
+	require.False(t, config.HasHTTPBootURI)
+}
+
 func TestBootOrderConfigUEFIHTTPNoOp(t *testing.T) { TestBootOrderConfigUEFIHTTPOn(t) }
 func TestUEFIHTTPBootEndToEnd(t *testing.T)        { TestBootOrderConfigUEFIHTTPOn(t) }
 func TestBootOrderConfigNoOp(t *testing.T)         { TestBootOrderConfigPxeOff(t) }

--- a/internal/metalman/redfish/session.go
+++ b/internal/metalman/redfish/session.go
@@ -46,13 +46,13 @@ func createSession(ctx context.Context, httpClient *http.Client, baseURL, user, 
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("Redfish %s %s failed: %w", http.MethodPost, "/redfish/v1/SessionService/Sessions", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck // Best-effort close of HTTP response body.
 
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body) //nolint:errcheck // Best-effort read of error body.
-		return "", "", fmt.Errorf("session creation returned %d: %s", resp.StatusCode, body)
+		return "", "", redfishResponseError(http.MethodPost, "/redfish/v1/SessionService/Sessions", resp.StatusCode, body, nil)
 	}
 
 	io.Copy(io.Discard, resp.Body) //nolint:errcheck // Best-effort drain of response body.
@@ -123,13 +123,13 @@ func (s *bmcSession) doOnce(ctx context.Context, method, path string, body any) 
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("Redfish %s %s failed: %w", method, path, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck // Best-effort close of HTTP response body.
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, resp.StatusCode, err
+		return nil, resp.StatusCode, fmt.Errorf("reading Redfish %s %s response body: %w", method, path, err)
 	}
 
 	return data, resp.StatusCode, nil

--- a/internal/metalman/redfish/session.go
+++ b/internal/metalman/redfish/session.go
@@ -46,7 +46,7 @@ func createSession(ctx context.Context, httpClient *http.Client, baseURL, user, 
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", "", fmt.Errorf("Redfish %s %s failed: %w", http.MethodPost, "/redfish/v1/SessionService/Sessions", err)
+		return "", "", fmt.Errorf("redfish %s %s failed: %w", http.MethodPost, "/redfish/v1/SessionService/Sessions", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck // Best-effort close of HTTP response body.
 
@@ -123,7 +123,7 @@ func (s *bmcSession) doOnce(ctx context.Context, method, path string, body any) 
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Redfish %s %s failed: %w", method, path, err)
+		return nil, 0, fmt.Errorf("redfish %s %s failed: %w", method, path, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck // Best-effort close of HTTP response body.
 


### PR DESCRIPTION
HP iLO doesn't support the standard Redfish APIs for configuring UEFI HTTP boot. This PR adds fallback logic to support HP while preferring the standard/spec approach when supported.