### PR TITLE
Add MachineOperation kubectl commands

### DIFF
--- a/cmd/kubectl-unbounded/app/cmd_machine.go
+++ b/cmd/kubectl-unbounded/app/cmd_machine.go
@@ -6,6 +6,10 @@ package app
 import "github.com/spf13/cobra"
 
 func machineCommandGroup() *cobra.Command {
+	return newMachineCommandGroup(newMachineCommandRuntime())
+}
+
+func newMachineCommandGroup(rt *machineCommandRuntime) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "machine",
 		Short: "Manage unbounded-kube machines",
@@ -13,8 +17,15 @@ func machineCommandGroup() *cobra.Command {
 
 	cmd.AddCommand(
 		configCommandGroup(),
+		newMachineOperationCommandGroup(rt),
 		machineRegisterCommand(),
-		machineReplaceCommand(),
+		newMachineNodeRebootCommand(rt),
+		newMachineHostRebootCommand(rt),
+		newMachinePowerOffCommand(rt),
+		newMachinePowerOnCommand(rt),
+		newMachineAgentUpgradeCommand(rt),
+		newMachineAgentResetCommand(rt),
+		newMachineReplaceCommand(rt),
 		machineRebootCommand(),
 		machineHardRebootCommand(),
 		machineRepaveCommand(),

--- a/cmd/kubectl-unbounded/app/machine_operation.go
+++ b/cmd/kubectl-unbounded/app/machine_operation.go
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+const (
+	operationOutputName = "name"
+	operationOutputYAML = "yaml"
+	operationOutputJSON = "json"
+
+	dryRunNone   = "none"
+	dryRunClient = "client"
+	dryRunServer = "server"
+)
+
+func newMachineOperationCommandGroup(rt *machineCommandRuntime) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "operation",
+		Aliases: []string{"operations"},
+		Short:   "Create and watch MachineOperation resources",
+	}
+
+	cmd.AddCommand(
+		newMachineOperationCreateCommand(rt),
+		newMachineOperationWaitCommand(rt),
+	)
+
+	return cmd
+}
+
+func addMachineOperationOwnerReference(ctx context.Context, c client.WithWatch, op *v1alpha3.MachineOperation, machineName string) error {
+	machine, err := getMachine(ctx, c, machineName)
+	if err != nil {
+		return err
+	}
+
+	op.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: v1alpha3.GroupVersion.String(),
+			Kind:       "Machine",
+			Name:       machine.Name,
+			UID:        machine.UID,
+		},
+	}
+
+	return nil
+}
+
+func printMachineOperation(w io.Writer, op *v1alpha3.MachineOperation, output string) error {
+	ensureMachineOperationTypeMeta(op)
+
+	switch output {
+	case "", operationOutputName:
+		_, err := fmt.Fprintf(w, "machineoperations/%s created\n", op.Name)
+		return err
+	case operationOutputYAML:
+		p := printers.YAMLPrinter{}
+		return p.PrintObj(op, w)
+	case operationOutputJSON:
+		p := printers.JSONPrinter{}
+		return p.PrintObj(op, w)
+	default:
+		return fmt.Errorf("unsupported output format %q", output)
+	}
+}
+
+func ensureMachineOperationTypeMeta(op *v1alpha3.MachineOperation) {
+	if op.APIVersion == "" {
+		op.APIVersion = v1alpha3.GroupVersion.String()
+	}
+
+	if op.Kind == "" {
+		op.Kind = "MachineOperation"
+	}
+}
+
+func contextWithOptionalTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, timeout)
+}
+
+func isSupportedOperationKind(kind v1alpha3.OperationKind) bool {
+	switch kind {
+	case v1alpha3.OperationNodeReboot,
+		v1alpha3.OperationAgentUpgrade,
+		v1alpha3.OperationAgentReset,
+		v1alpha3.OperationHostReboot,
+		v1alpha3.OperationHostPowerOff,
+		v1alpha3.OperationHostPowerOn,
+		v1alpha3.OperationHostReplace:
+		return true
+	default:
+		return false
+	}
+}
+
+func generateMachineOperationName(machineName, operationNamePart string, now time.Time) string {
+	suffix := fmt.Sprintf("-%s-%s", operationNamePart, now.UTC().Format("20060102-150405"))
+	maxPrefixLen := validation.DNS1123SubdomainMaxLength - len(suffix)
+	prefix := strings.Trim(machineName, "-")
+
+	if len(prefix) > maxPrefixLen {
+		prefix = strings.TrimRight(prefix[:maxPrefixLen], "-")
+	}
+
+	if prefix == "" {
+		prefix = "machine"
+	}
+
+	return prefix + suffix
+}
+
+func newMachineClientWithKubeconfig(kubeconfig string) (client.WithWatch, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		loadingRules.ExplicitPath = kubeconfig
+	}
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("loading kubeconfig: %w", err)
+	}
+
+	c, err := client.NewWithWatch(config, client.Options{Scheme: buildScheme()})
+	if err != nil {
+		return nil, fmt.Errorf("creating client: %w", err)
+	}
+
+	return c, nil
+}

--- a/cmd/kubectl-unbounded/app/machine_operation_aliases.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_aliases.go
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+type machineOperationAliasOptions struct {
+	kind              v1alpha3.OperationKind
+	operationNamePart string
+	machine           string
+	operationName     string
+	parameters        map[string]string
+	ttlSeconds        int32
+	wait              bool
+	timeout           time.Duration
+	kubeconfig        string
+	clientFactory     machineClientFactory
+}
+
+type machineOperationParametersKey struct{}
+
+func newMachineNodeRebootCommand(rt *machineCommandRuntime) *cobra.Command {
+	return newMachineOperationAliasCommand(
+		rt,
+		"node-reboot NAME",
+		"Reboot the nspawn-backed Kubernetes node through MachineOperation",
+		v1alpha3.OperationNodeReboot,
+		"node-reboot",
+	)
+}
+
+func newMachineHostRebootCommand(rt *machineCommandRuntime) *cobra.Command {
+	return newMachineOperationAliasCommand(
+		rt,
+		"host-reboot NAME",
+		"Reboot the host through MachineOperation",
+		v1alpha3.OperationHostReboot,
+		"host-reboot",
+	)
+}
+
+func newMachinePowerOffCommand(rt *machineCommandRuntime) *cobra.Command {
+	return newMachineOperationAliasCommand(
+		rt,
+		"power-off NAME",
+		"Power off the host through MachineOperation",
+		v1alpha3.OperationHostPowerOff,
+		"power-off",
+	)
+}
+
+func newMachinePowerOnCommand(rt *machineCommandRuntime) *cobra.Command {
+	return newMachineOperationAliasCommand(
+		rt,
+		"power-on NAME",
+		"Power on the host through MachineOperation",
+		v1alpha3.OperationHostPowerOn,
+		"power-on",
+	)
+}
+
+func newMachineAgentUpgradeCommand(rt *machineCommandRuntime) *cobra.Command {
+	var downloadURL string
+
+	cmd := newMachineOperationAliasCommand(
+		rt,
+		"agent-upgrade NAME",
+		"Upgrade the host-side unbounded-agent through MachineOperation",
+		v1alpha3.OperationAgentUpgrade,
+		"agent-upgrade",
+	)
+
+	cmd.Flags().StringVar(&downloadURL, "download-url", "", "URL of the unbounded-agent release tarball")
+
+	oldRunE := cmd.RunE
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if downloadURL == "" {
+			return fmt.Errorf("--download-url is required")
+		}
+
+		cmd.SetContext(context.WithValue(cmd.Context(), machineOperationParametersKey{}, map[string]string{
+			"downloadURL": downloadURL,
+		}))
+
+		return oldRunE(cmd, args)
+	}
+
+	return cmd
+}
+
+func newMachineAgentResetCommand(rt *machineCommandRuntime) *cobra.Command {
+	var force bool
+
+	cmd := newMachineOperationAliasCommand(
+		rt,
+		"agent-reset NAME",
+		"Reset the host-side unbounded-agent through MachineOperation",
+		v1alpha3.OperationAgentReset,
+		"agent-reset",
+	)
+
+	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation for destructive agent reset")
+
+	oldRunE := cmd.RunE
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if !force {
+			if err := confirmAgentReset(args[0], os.Stdin, os.Stderr); err != nil {
+				return err
+			}
+		}
+
+		return oldRunE(cmd, args)
+	}
+
+	return cmd
+}
+
+func newMachineOperationAliasCommand(rt *machineCommandRuntime, use, short string, kind v1alpha3.OperationKind, operationNamePart string) *cobra.Command {
+	o := &machineOperationAliasOptions{
+		kind:              kind,
+		operationNamePart: operationNamePart,
+		ttlSeconds:        defaultTTLSeconds,
+		wait:              true,
+		clientFactory:     rt.clientWithKubeconfig,
+	}
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.machine = args[0]
+			if params, ok := cmd.Context().Value(machineOperationParametersKey{}).(map[string]string); ok {
+				o.parameters = params
+			}
+
+			return runMachineOperationAlias(cmd.Context(), *o, cmd.OutOrStdout())
+		},
+	}
+
+	addMachineOperationAliasFlags(cmd, o)
+
+	return cmd
+}
+
+func addMachineOperationAliasFlags(cmd *cobra.Command, o *machineOperationAliasOptions) {
+	cmd.Flags().StringVar(&o.operationName, "operation-name", "", "Name for the MachineOperation resource")
+	cmd.Flags().Int32Var(&o.ttlSeconds, "ttl", defaultTTLSeconds, "Seconds after completion before cleanup (0 keeps indefinitely)")
+	cmd.Flags().BoolVar(&o.wait, "wait", true, "Wait until the operation reaches Complete or Failed")
+	cmd.Flags().DurationVar(&o.timeout, "timeout", 0, "Time to wait for completion when --wait is set (0 waits indefinitely)")
+	cmd.Flags().StringVar(&o.kubeconfig, "kubeconfig", "", "Path to kubeconfig file")
+}
+
+func runMachineOperationAlias(ctx context.Context, o machineOperationAliasOptions, out io.Writer) error {
+	return newMachineOperationAliasCreateOptions(o, out, time.Now()).run(ctx)
+}
+
+func newMachineOperationAliasCreateOptions(o machineOperationAliasOptions, out io.Writer, now time.Time) *machineOperationCreateOptions {
+	opName := o.operationName
+	if opName == "" {
+		opName = generateMachineOperationName(o.machine, o.operationNamePart, now)
+	}
+
+	return &machineOperationCreateOptions{
+		name:          opName,
+		kind:          o.kind,
+		machine:       o.machine,
+		parameters:    o.parameters,
+		ttlSeconds:    o.ttlSeconds,
+		wait:          o.wait,
+		timeout:       o.timeout,
+		output:        operationOutputName,
+		dryRun:        dryRunNone,
+		fieldManager:  fieldManagerID,
+		kubeconfig:    o.kubeconfig,
+		clientFactory: o.clientFactory,
+		out:           out,
+		printCreated:  true,
+
+		ownerReferenceMachine: true,
+	}
+}

--- a/cmd/kubectl-unbounded/app/machine_operation_aliases.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_aliases.go
@@ -146,6 +146,7 @@ func newMachineOperationAliasCommand(rt *machineCommandRuntime, use, short strin
 			}
 
 			baseCtx := rt.context(cmd.Context())
+
 			return runMachineOperationAlias(baseCtx, *o, cmd.OutOrStdout())
 		},
 	}

--- a/cmd/kubectl-unbounded/app/machine_operation_aliases.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_aliases.go
@@ -145,7 +145,8 @@ func newMachineOperationAliasCommand(rt *machineCommandRuntime, use, short strin
 				o.parameters = params
 			}
 
-			return runMachineOperationAlias(cmd.Context(), *o, cmd.OutOrStdout())
+			baseCtx := rt.context(cmd.Context())
+			return runMachineOperationAlias(baseCtx, *o, cmd.OutOrStdout())
 		},
 	}
 

--- a/cmd/kubectl-unbounded/app/machine_operation_confirm.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_confirm.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func confirmAgentReset(name string, in *os.File, out io.Writer) error {
+	return confirmAgentResetWithTerminal(name, in, out, isTerminal(in))
+}
+
+func confirmAgentResetWithTerminal(name string, in io.Reader, out io.Writer, terminal bool) error {
+	if !terminal {
+		return fmt.Errorf("agent-reset removes the unbounded-agent and managed resources; rerun with --force to confirm")
+	}
+
+	if _, err := fmt.Fprintf(out, "This will remove the unbounded-agent and managed resources from host %q. Type the machine name to continue: ", name); err != nil {
+		return fmt.Errorf("write confirmation prompt: %w", err)
+	}
+
+	line, err := bufio.NewReader(io.LimitReader(in, 4096)).ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w; rerun with --force to confirm", err)
+	}
+
+	if strings.TrimSpace(line) != name {
+		return fmt.Errorf("confirmation did not match machine name %q", name)
+	}
+
+	return nil
+}

--- a/cmd/kubectl-unbounded/app/machine_operation_create.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_create.go
@@ -1,0 +1,296 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+type machineOperationCreateOptions struct {
+	name          string
+	kind          v1alpha3.OperationKind
+	machine       string
+	selector      string
+	parameterArgs []string
+	parameters    map[string]string
+	ttlSeconds    int32
+	ttlSet        bool
+
+	wait    bool
+	timeout time.Duration
+
+	output        string
+	dryRun        string
+	fieldManager  string
+	kubeconfig    string
+	clientFactory machineClientFactory
+
+	out          io.Writer
+	printCreated bool
+
+	ownerReferenceMachine bool
+}
+
+func machineOperationCreateCommand() *cobra.Command {
+	return newMachineOperationCreateCommand(newMachineCommandRuntime())
+}
+
+func newMachineOperationCreateCommand(rt *machineCommandRuntime) *cobra.Command {
+	o := &machineOperationCreateOptions{
+		ttlSeconds:    -1,
+		output:        operationOutputName,
+		dryRun:        dryRunNone,
+		fieldManager:  fieldManagerID,
+		clientFactory: rt.clientWithKubeconfig,
+		printCreated:  true,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create NAME",
+		Short: "Create a MachineOperation resource",
+		Long: `Create a MachineOperation resource that targets one Machine or a
+Machine selector. Use --wait to stream status until the operation reaches a
+terminal phase.`,
+		Example: `  kubectl unbounded machine operation create reboot-worker-01 \
+    --kind HostReboot --machine worker-01
+
+  kubectl unbounded machine operation create reboot-gpu \
+    --kind NodeReboot --selector role=gpu --wait
+
+  kubectl unbounded machine operation create upgrade-worker-01 \
+    --kind AgentUpgrade --machine worker-01 \
+    --param downloadURL=https://example.com/unbounded-agent-linux-amd64.tar.gz`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.name = args[0]
+			o.out = cmd.OutOrStdout()
+			o.ttlSet = cmd.Flags().Changed("ttl")
+
+			return o.run(cmd.Context())
+		},
+	}
+
+	addMachineOperationCreateFlags(cmd, o)
+
+	return cmd
+}
+
+func addMachineOperationCreateFlags(cmd *cobra.Command, o *machineOperationCreateOptions) {
+	cmd.Flags().StringVar((*string)(&o.kind), "kind", "", "Operation kind: NodeReboot, AgentUpgrade, AgentReset, HostReboot, HostPowerOff, HostPowerOn, or HostReplace")
+	cmd.Flags().StringVar(&o.machine, "machine", "", "Target Machine name")
+	cmd.Flags().StringVarP(&o.selector, "selector", "l", "", "Machine label selector")
+	cmd.Flags().StringArrayVar(&o.parameterArgs, "param", nil, "Operation parameter as key=value (repeatable)")
+	cmd.Flags().Int32Var(&o.ttlSeconds, "ttl", -1, "Seconds after completion before cleanup (0 keeps indefinitely, default keeps indefinitely)")
+	cmd.Flags().Lookup("ttl").DefValue = "unset"
+	cmd.Flags().BoolVar(&o.wait, "wait", false, "Wait until the operation reaches Complete or Failed")
+	cmd.Flags().DurationVar(&o.timeout, "timeout", 0, "Time to wait for completion when --wait is set (0 waits indefinitely)")
+	cmd.Flags().StringVarP(&o.output, "output", "o", operationOutputName, "Output format. One of: name|yaml|json")
+	cmd.Flags().StringVar(&o.dryRun, "dry-run", dryRunNone, "Must be \"none\", \"client\", or \"server\"")
+	cmd.Flags().StringVar(&o.fieldManager, "field-manager", fieldManagerID, "Name associated with managed fields for create requests")
+	cmd.Flags().StringVar(&o.kubeconfig, "kubeconfig", "", "Path to kubeconfig file")
+
+	_ = cmd.RegisterFlagCompletionFunc("kind", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) { //nolint:errcheck
+		return []string{
+			string(v1alpha3.OperationNodeReboot),
+			string(v1alpha3.OperationAgentUpgrade),
+			string(v1alpha3.OperationAgentReset),
+			string(v1alpha3.OperationHostReboot),
+			string(v1alpha3.OperationHostPowerOff),
+			string(v1alpha3.OperationHostPowerOn),
+			string(v1alpha3.OperationHostReplace),
+		}, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("output", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) { //nolint:errcheck
+		return []string{operationOutputName, operationOutputYAML, operationOutputJSON}, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("dry-run", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) { //nolint:errcheck
+		return []string{dryRunNone, dryRunClient, dryRunServer}, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
+func (o *machineOperationCreateOptions) run(ctx context.Context) error {
+	if o.out == nil {
+		o.out = os.Stdout
+	}
+
+	if err := o.validate(); err != nil {
+		return err
+	}
+
+	op, err := o.build()
+	if err != nil {
+		return err
+	}
+
+	if o.dryRun == dryRunClient {
+		return printMachineOperation(o.out, op, o.output)
+	}
+
+	clientFactory := o.clientFactory
+	if clientFactory == nil {
+		clientFactory = newMachineClientWithKubeconfig
+	}
+
+	c, err := clientFactory(o.kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	return o.runWithClient(ctx, c, op)
+}
+
+func (o *machineOperationCreateOptions) runWithClient(ctx context.Context, c client.WithWatch, op *v1alpha3.MachineOperation) error {
+	if o.ownerReferenceMachine {
+		if err := addMachineOperationOwnerReference(ctx, c, op, o.machine); err != nil {
+			return err
+		}
+	}
+
+	createOpts := []client.CreateOption{&client.CreateOptions{FieldManager: o.fieldManager}}
+	if o.dryRun == dryRunServer {
+		createOpts = append(createOpts, client.DryRunAll)
+	}
+
+	if err := c.Create(ctx, op, createOpts...); err != nil {
+		return fmt.Errorf("creating MachineOperation: %w", err)
+	}
+
+	ensureMachineOperationTypeMeta(op)
+
+	if o.printCreated {
+		if err := printMachineOperation(o.out, op, o.output); err != nil {
+			return err
+		}
+	}
+
+	if !o.wait {
+		return nil
+	}
+
+	waitCtx, cancel := contextWithOptionalTimeout(ctx, o.timeout)
+	defer cancel()
+
+	return waitForMachineOperation(waitCtx, c, op.Name)
+}
+
+func (o *machineOperationCreateOptions) validate() error {
+	if errs := validation.IsDNS1123Subdomain(o.name); len(errs) > 0 {
+		return fmt.Errorf("invalid operation name %q: %s", o.name, strings.Join(errs, "; "))
+	}
+
+	if !isSupportedOperationKind(o.kind) {
+		return fmt.Errorf("unsupported operation kind %q", o.kind)
+	}
+
+	if (o.machine == "") == (o.selector == "") {
+		return fmt.Errorf("exactly one of --machine or --selector is required")
+	}
+
+	if o.ttlSeconds < 0 && (o.ttlSeconds != -1 || o.ttlSet) {
+		return fmt.Errorf("--ttl must be 0 or greater")
+	}
+
+	switch o.output {
+	case "", operationOutputName, operationOutputYAML, operationOutputJSON:
+	default:
+		return fmt.Errorf("unsupported output %q, expected one of: name|yaml|json", o.output)
+	}
+
+	switch o.dryRun {
+	case "", dryRunNone, dryRunClient, dryRunServer:
+	default:
+		return fmt.Errorf("unsupported dry-run mode %q, expected one of: none|client|server", o.dryRun)
+	}
+
+	if o.wait && o.dryRun != "" && o.dryRun != dryRunNone {
+		return fmt.Errorf("--wait cannot be used with --dry-run")
+	}
+
+	if o.wait && (o.output == operationOutputYAML || o.output == operationOutputJSON) {
+		return fmt.Errorf("--wait cannot be used with -o %s because progress output is not machine-readable", o.output)
+	}
+
+	parameters, err := o.operationParameters()
+	if err != nil {
+		return err
+	}
+
+	if o.kind == v1alpha3.OperationAgentUpgrade && parameters["downloadURL"] == "" {
+		return fmt.Errorf("AgentUpgrade requires --param downloadURL=<url>")
+	}
+
+	return nil
+}
+
+func (o *machineOperationCreateOptions) build() (*v1alpha3.MachineOperation, error) {
+	parameters, err := o.operationParameters()
+	if err != nil {
+		return nil, err
+	}
+
+	op := &v1alpha3.MachineOperation{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha3.GroupVersion.String(),
+			Kind:       "MachineOperation",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: o.name,
+		},
+		Spec: v1alpha3.MachineOperationSpec{
+			MachineRef:    o.machine,
+			OperationKind: o.kind,
+			Parameters:    parameters,
+		},
+	}
+
+	if len(parameters) == 0 {
+		op.Spec.Parameters = nil
+	}
+
+	if o.selector != "" {
+		selector, err := metav1.ParseToLabelSelector(o.selector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid selector %q: %w", o.selector, err)
+		}
+
+		op.Spec.MachineSelector = selector
+	}
+
+	if o.ttlSeconds > 0 {
+		ttl := o.ttlSeconds
+		op.Spec.TTLSecondsAfterFinished = &ttl
+	}
+
+	return op, nil
+}
+
+func (o *machineOperationCreateOptions) operationParameters() (map[string]string, error) {
+	parameters := map[string]string{}
+	for key, value := range o.parameters {
+		parameters[key] = value
+	}
+
+	for _, parameter := range o.parameterArgs {
+		key, value, ok := strings.Cut(parameter, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid --param value %q, expected key=value", parameter)
+		}
+
+		parameters[key] = value
+	}
+
+	return parameters, nil
+}

--- a/cmd/kubectl-unbounded/app/machine_operation_create.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_create.go
@@ -44,10 +44,6 @@ type machineOperationCreateOptions struct {
 	ownerReferenceMachine bool
 }
 
-func machineOperationCreateCommand() *cobra.Command {
-	return newMachineOperationCreateCommand(newMachineCommandRuntime())
-}
-
 func newMachineOperationCreateCommand(rt *machineCommandRuntime) *cobra.Command {
 	o := &machineOperationCreateOptions{
 		ttlSeconds:    -1,
@@ -80,6 +76,7 @@ terminal phase.`,
 			o.ttlSet = cmd.Flags().Changed("ttl")
 
 			ctx := rt.context(cmd.Context())
+
 			return o.run(ctx)
 		},
 	}

--- a/cmd/kubectl-unbounded/app/machine_operation_create.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_create.go
@@ -79,7 +79,8 @@ terminal phase.`,
 			o.out = cmd.OutOrStdout()
 			o.ttlSet = cmd.Flags().Changed("ttl")
 
-			return o.run(cmd.Context())
+			ctx := rt.context(cmd.Context())
+			return o.run(ctx)
 		},
 	}
 

--- a/cmd/kubectl-unbounded/app/machine_operation_e2e_test.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_e2e_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+func TestMachineOperationCommandsEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	s := newMachineOperationTestScheme(t)
+
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-01",
+			UID:  types.UID("worker-01-uid"),
+		},
+	}
+	completeOp := &v1alpha3.MachineOperation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wait-complete"},
+		Spec: v1alpha3.MachineOperationSpec{
+			MachineRef:    "worker-01",
+			OperationKind: v1alpha3.OperationHostReboot,
+		},
+		Status: v1alpha3.MachineOperationStatus{
+			Phase: v1alpha3.OperationPhaseComplete,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, completeOp).Build()
+	rt := newMachineOperationE2ERuntime(c)
+
+	out, err := executeKubectlUnboundedMachineCommand(
+		ctx, rt,
+		"machine", "operation", "create", "upgrade-worker-01",
+		"--kind", string(v1alpha3.OperationAgentUpgrade),
+		"--machine", "worker-01",
+		"--param", "downloadURL=https://example.com/agent.tar.gz",
+		"--ttl", "900",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "machineoperations/upgrade-worker-01 created\n", out)
+	assertMachineOperation(t, ctx, c, "upgrade-worker-01", func(op v1alpha3.MachineOperation) {
+		require.Equal(t, "worker-01", op.Spec.MachineRef)
+		require.Nil(t, op.Spec.MachineSelector)
+		require.Equal(t, v1alpha3.OperationAgentUpgrade, op.Spec.OperationKind)
+		require.Equal(t, "https://example.com/agent.tar.gz", op.Spec.Parameters["downloadURL"])
+		require.NotNil(t, op.Spec.TTLSecondsAfterFinished)
+		require.Equal(t, int32(900), *op.Spec.TTLSecondsAfterFinished)
+	})
+
+	out, err = executeKubectlUnboundedMachineCommand(
+		ctx, rt,
+		"machine", "operation", "create", "reboot-gpu-workers",
+		"--kind", string(v1alpha3.OperationNodeReboot),
+		"--selector", "role=gpu,site=edge-1",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "machineoperations/reboot-gpu-workers created\n", out)
+	assertMachineOperation(t, ctx, c, "reboot-gpu-workers", func(op v1alpha3.MachineOperation) {
+		require.Empty(t, op.Spec.MachineRef)
+		require.NotNil(t, op.Spec.MachineSelector)
+		require.Equal(t, map[string]string{
+			"role": "gpu",
+			"site": "edge-1",
+		}, op.Spec.MachineSelector.MatchLabels)
+		require.Equal(t, v1alpha3.OperationNodeReboot, op.Spec.OperationKind)
+		require.Nil(t, op.Spec.TTLSecondsAfterFinished)
+	})
+
+	out, err = executeKubectlUnboundedMachineCommand(
+		ctx, rt,
+		"machine", "host-reboot", "worker-01",
+		"--operation-name", "worker-01-host-reboot",
+		"--wait=false",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "machineoperations/worker-01-host-reboot created\n", out)
+	assertMachineOperation(t, ctx, c, "worker-01-host-reboot", func(op v1alpha3.MachineOperation) {
+		require.Equal(t, "worker-01", op.Spec.MachineRef)
+		require.Equal(t, v1alpha3.OperationHostReboot, op.Spec.OperationKind)
+		require.NotNil(t, op.Spec.TTLSecondsAfterFinished)
+		require.Equal(t, int32(defaultTTLSeconds), *op.Spec.TTLSecondsAfterFinished)
+		require.Len(t, op.OwnerReferences, 1)
+		require.Equal(t, "worker-01", op.OwnerReferences[0].Name)
+		require.Equal(t, types.UID("worker-01-uid"), op.OwnerReferences[0].UID)
+	})
+
+	out, err = executeKubectlUnboundedMachineCommand(
+		ctx, rt,
+		"machine", "agent-upgrade", "worker-01",
+		"--operation-name", "worker-01-agent-upgrade",
+		"--download-url", "https://example.com/new-agent.tar.gz",
+		"--wait=false",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "machineoperations/worker-01-agent-upgrade created\n", out)
+	assertMachineOperation(t, ctx, c, "worker-01-agent-upgrade", func(op v1alpha3.MachineOperation) {
+		require.Equal(t, "worker-01", op.Spec.MachineRef)
+		require.Equal(t, v1alpha3.OperationAgentUpgrade, op.Spec.OperationKind)
+		require.Equal(t, "https://example.com/new-agent.tar.gz", op.Spec.Parameters["downloadURL"])
+		require.NotNil(t, op.Spec.TTLSecondsAfterFinished)
+		require.Equal(t, int32(defaultTTLSeconds), *op.Spec.TTLSecondsAfterFinished)
+		require.Len(t, op.OwnerReferences, 1)
+		require.Equal(t, "worker-01", op.OwnerReferences[0].Name)
+	})
+
+	replaceStdout := captureStdout(t, func() {
+		out, err = executeKubectlUnboundedMachineCommand(
+			ctx, rt,
+			"machine", "replace", "worker-01",
+			"--force",
+			"--operation-name", "replace-worker-01",
+			"--wait=false",
+		)
+	})
+	require.NoError(t, err)
+	require.Empty(t, out)
+	require.Contains(t, replaceStdout, "Replacing Machine worker-01")
+	assertMachineOperation(t, ctx, c, "replace-worker-01", func(op v1alpha3.MachineOperation) {
+		require.Equal(t, "worker-01", op.Spec.MachineRef)
+		require.Equal(t, v1alpha3.OperationHostReplace, op.Spec.OperationKind)
+		require.Len(t, op.OwnerReferences, 1)
+		require.Equal(t, "worker-01", op.OwnerReferences[0].Name)
+	})
+
+	var waitOut string
+
+	stdout := captureStdout(t, func() {
+		waitOut, err = executeKubectlUnboundedMachineCommand(
+			ctx, rt,
+			"machine", "operation", "wait", "wait-complete",
+		)
+	})
+	require.NoError(t, err)
+	require.Empty(t, waitOut)
+	require.Contains(t, strings.TrimSpace(stdout), "ready")
+}
+
+func newMachineOperationE2ERuntime(c client.WithWatch) *machineCommandRuntime {
+	return &machineCommandRuntime{
+		newClientWithKubeconfig: func(string) (client.WithWatch, error) {
+			return c, nil
+		},
+		commandContext: func(ctx context.Context) context.Context {
+			return ctx
+		},
+	}
+}
+
+func executeKubectlUnboundedMachineCommand(ctx context.Context, rt *machineCommandRuntime, args ...string) (string, error) {
+	var out bytes.Buffer
+
+	root := &cobra.Command{
+		Use:          "kubectl-unbounded",
+		SilenceUsage: true,
+	}
+	root.AddCommand(newMachineCommandGroup(rt))
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(args)
+
+	err := root.ExecuteContext(ctx)
+
+	return out.String(), err
+}
+
+func assertMachineOperation(
+	t *testing.T,
+	ctx context.Context,
+	c client.Client,
+	name string,
+	assert func(v1alpha3.MachineOperation),
+) {
+	t.Helper()
+
+	var op v1alpha3.MachineOperation
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: name}, &op))
+	assert(op)
+}

--- a/cmd/kubectl-unbounded/app/machine_operation_test.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_test.go
@@ -6,6 +6,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -386,7 +387,14 @@ func executeMachineOperationCreateCommand(t *testing.T, args ...string) (string,
 
 	var out bytes.Buffer
 
-	cmd := machineOperationCreateCommand()
+	cmd := newMachineOperationCreateCommand(&machineCommandRuntime{
+		newClientWithKubeconfig: func(string) (client.WithWatch, error) {
+			return nil, errors.New("unexpected kube client")
+		},
+		commandContext: func(ctx context.Context) context.Context {
+			return ctx
+		},
+	})
 	cmd.SetOut(&out)
 	cmd.SetArgs(args)
 	cmd.SilenceErrors = true

--- a/cmd/kubectl-unbounded/app/machine_operation_test.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_test.go
@@ -1,0 +1,398 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+func TestBuildMachineOperationWithMachineRef(t *testing.T) {
+	t.Parallel()
+
+	opts := &machineOperationCreateOptions{
+		name:       "reboot-worker-01",
+		kind:       v1alpha3.OperationHostReboot,
+		machine:    "worker-01",
+		ttlSeconds: 3600,
+		output:     operationOutputName,
+		dryRun:     dryRunNone,
+	}
+
+	require.NoError(t, opts.validate())
+
+	op, err := opts.build()
+	require.NoError(t, err)
+	require.Equal(t, "reboot-worker-01", op.Name)
+	require.Equal(t, "worker-01", op.Spec.MachineRef)
+	require.Nil(t, op.Spec.MachineSelector)
+	require.Equal(t, v1alpha3.OperationHostReboot, op.Spec.OperationKind)
+	require.NotNil(t, op.Spec.TTLSecondsAfterFinished)
+	require.Equal(t, int32(3600), *op.Spec.TTLSecondsAfterFinished)
+}
+
+func TestBuildMachineOperationWithSelector(t *testing.T) {
+	t.Parallel()
+
+	opts := &machineOperationCreateOptions{
+		name:     "reboot-gpu",
+		kind:     v1alpha3.OperationNodeReboot,
+		selector: "role=gpu,zone in (east,west)",
+		output:   operationOutputName,
+		dryRun:   dryRunNone,
+	}
+
+	require.NoError(t, opts.validate())
+
+	op, err := opts.build()
+	require.NoError(t, err)
+	require.Empty(t, op.Spec.MachineRef)
+	require.NotNil(t, op.Spec.MachineSelector)
+	require.Equal(t, "gpu", op.Spec.MachineSelector.MatchLabels["role"])
+	require.Len(t, op.Spec.MachineSelector.MatchExpressions, 1)
+	require.Equal(t, "zone", op.Spec.MachineSelector.MatchExpressions[0].Key)
+}
+
+func TestBuildMachineOperationParameters(t *testing.T) {
+	t.Parallel()
+
+	opts := &machineOperationCreateOptions{
+		name:          "upgrade-worker-01",
+		kind:          v1alpha3.OperationAgentUpgrade,
+		machine:       "worker-01",
+		parameterArgs: []string{"downloadURL=https://example.com/agent.tar.gz"},
+		output:        operationOutputName,
+		dryRun:        dryRunNone,
+	}
+
+	require.NoError(t, opts.validate())
+
+	op, err := opts.build()
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/agent.tar.gz", op.Spec.Parameters["downloadURL"])
+}
+
+func TestValidateMachineOperationRequiresTarget(t *testing.T) {
+	t.Parallel()
+
+	opts := &machineOperationCreateOptions{
+		name:   "missing-target",
+		kind:   v1alpha3.OperationNodeReboot,
+		output: operationOutputName,
+		dryRun: dryRunNone,
+	}
+
+	err := opts.validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exactly one of --machine or --selector")
+}
+
+func TestValidateAgentUpgradeRequiresDownloadURL(t *testing.T) {
+	t.Parallel()
+
+	opts := &machineOperationCreateOptions{
+		name:    "upgrade-worker-01",
+		kind:    v1alpha3.OperationAgentUpgrade,
+		machine: "worker-01",
+		output:  operationOutputName,
+		dryRun:  dryRunNone,
+	}
+
+	err := opts.validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "downloadURL")
+}
+
+func TestValidateWaitRejectsStructuredOutput(t *testing.T) {
+	t.Parallel()
+
+	for _, output := range []string{operationOutputYAML, operationOutputJSON} {
+		t.Run(output, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &machineOperationCreateOptions{
+				name:    "reboot-worker-01",
+				kind:    v1alpha3.OperationHostReboot,
+				machine: "worker-01",
+				wait:    true,
+				output:  output,
+				dryRun:  dryRunNone,
+			}
+
+			err := opts.validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "--wait cannot be used")
+		})
+	}
+}
+
+func TestMachineOperationDryRunClientYAML(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	opts := &machineOperationCreateOptions{
+		name:       "poweroff-worker-01",
+		kind:       v1alpha3.OperationHostPowerOff,
+		machine:    "worker-01",
+		ttlSeconds: -1,
+		output:     operationOutputYAML,
+		dryRun:     dryRunClient,
+		out:        &out,
+	}
+
+	require.NoError(t, opts.run(context.Background()))
+	require.Contains(t, out.String(), "kind: MachineOperation")
+	require.Contains(t, out.String(), "operationKind: HostPowerOff")
+	require.Contains(t, out.String(), "machineRef: worker-01")
+	require.NotContains(t, out.String(), "ttlSecondsAfterFinished")
+}
+
+func TestMachineOperationCreateCommandDryRunYAML(t *testing.T) {
+	t.Parallel()
+
+	out, err := executeMachineOperationCreateCommand(
+		t,
+		"upgrade-worker-01",
+		"--kind", string(v1alpha3.OperationAgentUpgrade),
+		"--machine", "worker-01",
+		"--param", "downloadURL=https://example.com/agent.tar.gz",
+		"--ttl", "900",
+		"--dry-run=client",
+		"-o", "yaml",
+	)
+
+	require.NoError(t, err)
+	require.Contains(t, out, "kind: MachineOperation")
+	require.Contains(t, out, "operationKind: AgentUpgrade")
+	require.Contains(t, out, "machineRef: worker-01")
+	require.Contains(t, out, "downloadURL: https://example.com/agent.tar.gz")
+	require.Contains(t, out, "ttlSecondsAfterFinished: 900")
+}
+
+func TestMachineOperationCreateCommandRejectsNegativeTTLFlag(t *testing.T) {
+	t.Parallel()
+
+	out, err := executeMachineOperationCreateCommand(
+		t,
+		"reboot-worker-01",
+		"--kind", string(v1alpha3.OperationHostReboot),
+		"--machine", "worker-01",
+		"--ttl=-1",
+		"--dry-run=client",
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--ttl must be 0 or greater")
+	require.Empty(t, out)
+}
+
+func TestMachineOperationCreateSmokeCreatesMachineRefOperation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := newMachineOperationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	opts := &machineOperationCreateOptions{
+		name:          "upgrade-worker-01",
+		kind:          v1alpha3.OperationAgentUpgrade,
+		machine:       "worker-01",
+		parameterArgs: []string{"downloadURL=https://example.com/agent.tar.gz"},
+		ttlSeconds:    900,
+		output:        operationOutputName,
+		dryRun:        dryRunNone,
+		fieldManager:  fieldManagerID,
+		printCreated:  false,
+	}
+
+	require.NoError(t, opts.validate())
+	op, err := opts.build()
+	require.NoError(t, err)
+	require.NoError(t, opts.runWithClient(ctx, c, op))
+
+	var got v1alpha3.MachineOperation
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "upgrade-worker-01"}, &got))
+	require.Equal(t, "worker-01", got.Spec.MachineRef)
+	require.Nil(t, got.Spec.MachineSelector)
+	require.Equal(t, v1alpha3.OperationAgentUpgrade, got.Spec.OperationKind)
+	require.Equal(t, "https://example.com/agent.tar.gz", got.Spec.Parameters["downloadURL"])
+	require.NotNil(t, got.Spec.TTLSecondsAfterFinished)
+	require.Equal(t, int32(900), *got.Spec.TTLSecondsAfterFinished)
+}
+
+func TestMachineOperationCreateSmokeCreatesSelectorOperation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := newMachineOperationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	opts := &machineOperationCreateOptions{
+		name:         "reboot-gpu-workers",
+		kind:         v1alpha3.OperationNodeReboot,
+		selector:     "role=gpu,site=edge-1",
+		ttlSeconds:   -1,
+		output:       operationOutputName,
+		dryRun:       dryRunNone,
+		fieldManager: fieldManagerID,
+		printCreated: false,
+	}
+
+	require.NoError(t, opts.validate())
+	op, err := opts.build()
+	require.NoError(t, err)
+	require.NoError(t, opts.runWithClient(ctx, c, op))
+
+	var got v1alpha3.MachineOperation
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "reboot-gpu-workers"}, &got))
+	require.Empty(t, got.Spec.MachineRef)
+	require.NotNil(t, got.Spec.MachineSelector)
+	require.Equal(t, map[string]string{
+		"role": "gpu",
+		"site": "edge-1",
+	}, got.Spec.MachineSelector.MatchLabels)
+	require.Equal(t, v1alpha3.OperationNodeReboot, got.Spec.OperationKind)
+	require.Nil(t, got.Spec.TTLSecondsAfterFinished)
+}
+
+func TestMachineOperationAliasSmokeCreatesOwnedOperation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := newMachineOperationTestScheme(t)
+	machine := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-01",
+			UID:  types.UID("worker-01-uid"),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine).Build()
+
+	var out bytes.Buffer
+
+	createOptions := newMachineOperationAliasCreateOptions(machineOperationAliasOptions{
+		kind:              v1alpha3.OperationHostReboot,
+		operationNamePart: "host-reboot",
+		machine:           "worker-01",
+		operationName:     "worker-01-host-reboot",
+		ttlSeconds:        defaultTTLSeconds,
+		wait:              false,
+	}, &out, time.Date(2026, 7, 8, 15, 30, 12, 0, time.UTC))
+
+	require.NoError(t, createOptions.validate())
+	op, err := createOptions.build()
+	require.NoError(t, err)
+	require.NoError(t, createOptions.runWithClient(ctx, c, op))
+
+	var got v1alpha3.MachineOperation
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "worker-01-host-reboot"}, &got))
+	require.Equal(t, "worker-01", got.Spec.MachineRef)
+	require.Equal(t, v1alpha3.OperationHostReboot, got.Spec.OperationKind)
+	require.NotNil(t, got.Spec.TTLSecondsAfterFinished)
+	require.Equal(t, int32(defaultTTLSeconds), *got.Spec.TTLSecondsAfterFinished)
+	require.Equal(t, "machineoperations/worker-01-host-reboot created\n", out.String())
+	require.Len(t, got.OwnerReferences, 1)
+	require.Equal(t, "Machine", got.OwnerReferences[0].Kind)
+	require.Equal(t, "worker-01", got.OwnerReferences[0].Name)
+	require.Equal(t, types.UID("worker-01-uid"), got.OwnerReferences[0].UID)
+}
+
+func TestGenerateMachineOperationName(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 15, 30, 12, 0, time.UTC)
+
+	require.Equal(t, "worker-01-host-reboot-20260708-153012",
+		generateMachineOperationName("worker-01", "host-reboot", now))
+}
+
+func TestConfirmAgentReset(t *testing.T) {
+	t.Parallel()
+
+	err := confirmAgentResetWithTerminal("machine-1", strings.NewReader("machine-1\n"), ioDiscard{}, true)
+	require.NoError(t, err)
+}
+
+func TestConfirmAgentResetRejectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	err := confirmAgentResetWithTerminal("machine-1", strings.NewReader("wrong\n"), ioDiscard{}, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "confirmation did not match")
+}
+
+func TestConfirmAgentResetRequiresForceInNonInteractiveMode(t *testing.T) {
+	t.Parallel()
+
+	err := confirmAgentResetWithTerminal("machine-1", strings.NewReader("machine-1\n"), ioDiscard{}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--force")
+}
+
+func TestWatchMachineOperationUsesResourceVersion(t *testing.T) {
+	t.Parallel()
+
+	c := &recordingWatchClient{}
+
+	err := watchMachineOperationFromResourceVersion(context.Background(), c, "op-1", "12345")
+	require.Error(t, err)
+	require.Equal(t, "12345", c.resourceVersion)
+	require.Equal(t, "metadata.name=op-1", c.fieldSelector)
+}
+
+type recordingWatchClient struct {
+	client.WithWatch
+
+	resourceVersion string
+	fieldSelector   string
+}
+
+func (c *recordingWatchClient) Watch(_ context.Context, _ client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	listOpts := (&client.ListOptions{}).ApplyOptions(opts)
+	raw := listOpts.AsListOptions()
+
+	c.resourceVersion = raw.ResourceVersion
+	c.fieldSelector = raw.FieldSelector
+
+	return watch.NewEmptyWatch(), nil
+}
+
+func newMachineOperationTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	require.NoError(t, v1alpha3.AddToScheme(s))
+
+	return s
+}
+
+func executeMachineOperationCreateCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var out bytes.Buffer
+
+	cmd := machineOperationCreateCommand()
+	cmd.SetOut(&out)
+	cmd.SetArgs(args)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.ExecuteContext(context.Background())
+
+	return out.String(), err
+}

--- a/cmd/kubectl-unbounded/app/machine_operation_wait.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_wait.go
@@ -24,17 +24,18 @@ func newMachineOperationWaitCommand(rt *machineCommandRuntime) *cobra.Command {
 		Use:   "wait NAME",
 		Short: "Wait for a MachineOperation to complete",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := contextWithOptionalTimeout(cmd.Context(), timeout)
-			defer cancel()
+RunE: func(cmd *cobra.Command, args []string) error {
+	baseCtx := rt.context(cmd.Context())
+	ctx, cancel := contextWithOptionalTimeout(baseCtx, timeout)
+	defer cancel()
 
-			c, err := rt.clientWithKubeconfig(kubeconfig)
-			if err != nil {
-				return err
-			}
+	c, err := rt.clientWithKubeconfig(kubeconfig)
+	if err != nil {
+		return err
+	}
 
-			return waitForMachineOperation(ctx, c, args[0])
-		},
+	return waitForMachineOperation(ctx, c, args[0])
+},
 	}
 
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Time to wait for completion (0 waits indefinitely)")

--- a/cmd/kubectl-unbounded/app/machine_operation_wait.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_wait.go
@@ -24,18 +24,18 @@ func newMachineOperationWaitCommand(rt *machineCommandRuntime) *cobra.Command {
 		Use:   "wait NAME",
 		Short: "Wait for a MachineOperation to complete",
 		Args:  cobra.ExactArgs(1),
-RunE: func(cmd *cobra.Command, args []string) error {
-	baseCtx := rt.context(cmd.Context())
-	ctx, cancel := contextWithOptionalTimeout(baseCtx, timeout)
-	defer cancel()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			baseCtx := rt.context(cmd.Context())
+			ctx, cancel := contextWithOptionalTimeout(baseCtx, timeout)
+			defer cancel()
 
-	c, err := rt.clientWithKubeconfig(kubeconfig)
-	if err != nil {
-		return err
-	}
+			c, err := rt.clientWithKubeconfig(kubeconfig)
+			if err != nil {
+				return err
+			}
 
-	return waitForMachineOperation(ctx, c, args[0])
-},
+			return waitForMachineOperation(ctx, c, args[0])
+		},
 	}
 
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Time to wait for completion (0 waits indefinitely)")

--- a/cmd/kubectl-unbounded/app/machine_operation_wait.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_wait.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+func newMachineOperationWaitCommand(rt *machineCommandRuntime) *cobra.Command {
+	var (
+		timeout    time.Duration
+		kubeconfig string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "wait NAME",
+		Short: "Wait for a MachineOperation to complete",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := contextWithOptionalTimeout(cmd.Context(), timeout)
+			defer cancel()
+
+			c, err := rt.clientWithKubeconfig(kubeconfig)
+			if err != nil {
+				return err
+			}
+
+			return waitForMachineOperation(ctx, c, args[0])
+		},
+	}
+
+	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Time to wait for completion (0 waits indefinitely)")
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file")
+
+	return cmd
+}
+
+func waitForMachineOperation(ctx context.Context, c client.WithWatch, opName string) error {
+	return watchMachineOperation(ctx, c, opName)
+}
+
+func finishMachineOperationWait(op *v1alpha3.MachineOperation) error {
+	if op.Status.Phase == v1alpha3.OperationPhaseFailed {
+		return fmt.Errorf("operation failed: %s", op.Status.Message)
+	}
+
+	printReady()
+
+	return nil
+}

--- a/cmd/kubectl-unbounded/app/machine_operation_wait.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_wait.go
@@ -26,6 +26,7 @@ func newMachineOperationWaitCommand(rt *machineCommandRuntime) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			baseCtx := rt.context(cmd.Context())
+
 			ctx, cancel := contextWithOptionalTimeout(baseCtx, timeout)
 			defer cancel()
 

--- a/cmd/kubectl-unbounded/app/machine_replace.go
+++ b/cmd/kubectl-unbounded/app/machine_replace.go
@@ -13,16 +13,19 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 )
 
-func machineReplaceCommand() *cobra.Command {
+func newMachineReplaceCommand(rt *machineCommandRuntime) *cobra.Command {
 	var (
-		ttl   int32
-		force bool
+		ttl           int32
+		force         bool
+		wait          bool
+		timeout       time.Duration
+		operationName string
+		kubeconfig    string
 	)
 
 	cmd := &cobra.Command{
@@ -34,34 +37,86 @@ provider by deleting and recreating the host VM with fresh bootstrap data.
 Host-local OS disk state is destroyed.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := ctrl.SetupSignalHandler()
+			ctx := rt.context(cmd.Context())
 
-			c, err := newMachineClient()
+			c, err := rt.clientWithKubeconfig(kubeconfig)
 			if err != nil {
 				return err
 			}
 
-			return runReplace(ctx, c, args[0], ttl, force)
+			return runReplaceWithOptions(ctx, c, args[0], machineReplaceOptions{
+				ttlSeconds:    ttl,
+				force:         force,
+				wait:          wait,
+				timeout:       timeout,
+				operationName: operationName,
+			})
 		},
 	}
 
 	cmd.Flags().Int32Var(&ttl, "ttl", defaultTTLSeconds,
 		"Seconds after completion before the MachineOperation CR is automatically deleted (0 to disable)")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation for destructive VM replacement")
+	cmd.Flags().StringVar(&operationName, "operation-name", "", "Name for the MachineOperation resource")
+	cmd.Flags().BoolVar(&wait, "wait", true, "Wait until the operation reaches Complete or Failed")
+	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Time to wait for completion when --wait is set (0 waits indefinitely)")
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file")
 
 	return cmd
 }
 
+type machineReplaceOptions struct {
+	ttlSeconds    int32
+	force         bool
+	wait          bool
+	timeout       time.Duration
+	operationName string
+}
+
 func runReplace(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32, force bool) error {
-	if !force {
+	return runReplaceWithOptions(ctx, c, name, machineReplaceOptions{
+		ttlSeconds: ttlSeconds,
+		force:      force,
+		wait:       true,
+	})
+}
+
+func runReplaceWithOptions(ctx context.Context, c client.WithWatch, name string, opts machineReplaceOptions) error {
+	if !opts.force {
 		if err := confirmReplace(name, os.Stdin, os.Stderr); err != nil {
 			return err
 		}
 	}
 
-	opName := fmt.Sprintf("%s-replace-%d", name, time.Now().Unix())
+	opName := opts.operationName
+	if opName == "" {
+		opName = generateMachineOperationName(name, "replace", time.Now())
+	}
 
-	if err := createMachineOperation(ctx, c, name, opName, v1alpha3.OperationHostReplace, ttlSeconds); err != nil {
+	createOptions := &machineOperationCreateOptions{
+		name:         opName,
+		kind:         v1alpha3.OperationHostReplace,
+		machine:      name,
+		ttlSeconds:   opts.ttlSeconds,
+		output:       operationOutputName,
+		dryRun:       dryRunNone,
+		fieldManager: fieldManagerID,
+		printCreated: false,
+	}
+	if err := createOptions.validate(); err != nil {
+		return err
+	}
+
+	op, err := createOptions.build()
+	if err != nil {
+		return err
+	}
+
+	if err := addMachineOperationOwnerReference(ctx, c, op, name); err != nil {
+		return err
+	}
+
+	if err := createOptions.runWithClient(ctx, c, op); err != nil {
 		return err
 	}
 
@@ -69,7 +124,14 @@ func runReplace(ctx context.Context, c client.WithWatch, name string, ttlSeconds
 	printConfig("operation", opName)
 	fmt.Println()
 
-	return watchMachineOperation(ctx, c, opName)
+	if !opts.wait {
+		return nil
+	}
+
+	waitCtx, cancel := contextWithOptionalTimeout(ctx, opts.timeout)
+	defer cancel()
+
+	return waitForMachineOperation(waitCtx, c, opName)
 }
 
 func confirmReplace(name string, in *os.File, out io.Writer) error {

--- a/cmd/kubectl-unbounded/app/machine_replace_test.go
+++ b/cmd/kubectl-unbounded/app/machine_replace_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
@@ -28,6 +29,34 @@ func TestRunReplaceRequiresForceInNonInteractiveMode(t *testing.T) {
 	err := runReplace(context.Background(), c, "machine-1", 0, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "--force")
+}
+
+func TestRunReplaceCreatesNamedOperationWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	s := runtime.NewScheme()
+	require.NoError(t, v1alpha3.AddToScheme(s))
+
+	machine := &v1alpha3.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-1"}}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine).Build()
+
+	var err error
+
+	_ = captureStdout(t, func() {
+		err = runReplaceWithOptions(context.Background(), c, "machine-1", machineReplaceOptions{
+			force:         true,
+			wait:          false,
+			operationName: "replace-machine-1",
+		})
+	})
+	require.NoError(t, err)
+
+	var op v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "replace-machine-1"}, &op))
+	require.Equal(t, "machine-1", op.Spec.MachineRef)
+	require.Equal(t, v1alpha3.OperationHostReplace, op.Spec.OperationKind)
+	require.Len(t, op.OwnerReferences, 1)
+	require.Equal(t, "machine-1", op.OwnerReferences[0].Name)
 }
 
 func TestConfirmReplace(t *testing.T) {

--- a/cmd/kubectl-unbounded/app/machine_runtime.go
+++ b/cmd/kubectl-unbounded/app/machine_runtime.go
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type machineClientFactory func(kubeconfig string) (client.WithWatch, error)
+
+type machineCommandRuntime struct {
+	newClientWithKubeconfig machineClientFactory
+	commandContext          func(context.Context) context.Context
+}
+
+func newMachineCommandRuntime() *machineCommandRuntime {
+	return &machineCommandRuntime{
+		newClientWithKubeconfig: newMachineClientWithKubeconfig,
+		commandContext: func(context.Context) context.Context {
+			return ctrl.SetupSignalHandler()
+		},
+	}
+}
+
+func (rt *machineCommandRuntime) clientWithKubeconfig(kubeconfig string) (client.WithWatch, error) {
+	if rt == nil || rt.newClientWithKubeconfig == nil {
+		return newMachineClientWithKubeconfig(kubeconfig)
+	}
+
+	return rt.newClientWithKubeconfig(kubeconfig)
+}
+
+func (rt *machineCommandRuntime) context(ctx context.Context) context.Context {
+	if rt == nil || rt.commandContext == nil {
+		return ctx
+	}
+
+	return rt.commandContext(ctx)
+}

--- a/cmd/kubectl-unbounded/app/machine_soft_reboot.go
+++ b/cmd/kubectl-unbounded/app/machine_soft_reboot.go
@@ -108,8 +108,33 @@ func createMachineOperation(ctx context.Context, c client.WithWatch, name, opNam
 // watchMachineOperation watches a MachineOperation CR until it reaches a
 // terminal phase (Complete or Failed).
 func watchMachineOperation(ctx context.Context, c client.WithWatch, opName string) error {
-	watcher, err := c.Watch(ctx, &v1alpha3.MachineOperationList{},
+	var initial v1alpha3.MachineOperation
+	if err := c.Get(ctx, client.ObjectKey{Name: opName}, &initial); err != nil {
+		return fmt.Errorf("getting MachineOperation: %w", err)
+	}
+
+	if initial.Status.IsTerminal() {
+		return finishMachineOperationWait(&initial)
+	}
+
+	return watchMachineOperationFromResourceVersion(ctx, c, opName, initial.ResourceVersion)
+}
+
+func watchMachineOperationFromResourceVersion(ctx context.Context, c client.WithWatch, opName, resourceVersion string) error {
+	listOptions := []client.ListOption{
 		client.MatchingFields{"metadata.name": opName},
+	}
+	if resourceVersion != "" {
+		listOptions = append(listOptions, &client.ListOptions{
+			Raw: &metav1.ListOptions{
+				ResourceVersion: resourceVersion,
+			},
+		})
+	}
+
+	watcher, err := c.Watch(
+		ctx, &v1alpha3.MachineOperationList{},
+		listOptions...,
 	)
 	if err != nil {
 		return fmt.Errorf("watching MachineOperation: %w", err)
@@ -161,6 +186,10 @@ func watchMachineOperation(ctx context.Context, c client.WithWatch, opName strin
 
 			return nil
 		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	return fmt.Errorf("watch closed before operation completed")

--- a/docs/content/guides/operations/_index.md
+++ b/docs/content/guides/operations/_index.md
@@ -68,6 +68,26 @@ spec:
 kubectl apply -f reboot-worker-01.yaml
 ```
 
+If you have the kubectl plugin installed, you can create the same operation
+imperatively:
+
+```bash
+kubectl unbounded machine operation create reboot-worker-01 \
+  --kind HostReboot \
+  --machine worker-01
+```
+
+Convenience commands are also available for common single-machine operations:
+
+```bash
+kubectl unbounded machine node-reboot worker-01
+kubectl unbounded machine host-reboot worker-01
+kubectl unbounded machine power-off worker-01
+kubectl unbounded machine power-on worker-01
+kubectl unbounded machine agent-upgrade worker-01 --download-url https://example.com/agent.tar.gz
+kubectl unbounded machine agent-reset worker-01 --force
+```
+
 ## Checking Status
 
 Operations move through phases: `Pending`, `InProgress`, `Complete`, or

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -218,6 +218,149 @@ kubectl unbounded machine register \
 
 ---
 
+### `kubectl unbounded machine operation`
+
+Create and watch `MachineOperation` resources.
+
+This command group is the resource-oriented surface for day-2 machine
+operations. It creates the same `MachineOperation` CRD you can manage directly
+with `kubectl get mop`, `kubectl describe mop`, and `kubectl delete mop`.
+
+---
+
+### `kubectl unbounded machine operation create`
+
+Create a `MachineOperation`.
+
+#### Required Arguments and Flags
+
+| Name | Type | Description |
+|------|------|-------------|
+| `NAME` | argument | Name of the `MachineOperation` resource |
+| `--kind` | string | Operation kind: `NodeReboot`, `AgentUpgrade`, `AgentReset`, `HostReboot`, `HostPowerOff`, `HostPowerOn`, or `HostReplace` |
+| `--machine` or `--selector` | string | Target one Machine by name or select Machines by label selector |
+
+`AgentUpgrade` also requires `--param downloadURL=<url>`.
+
+#### Optional Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--param` | `key=value` | none | Operation parameter. Repeat for multiple parameters. |
+| `--ttl` | `int32` | unset | Seconds after completion before cleanup. `0` keeps the operation indefinitely. |
+| `--wait` | `bool` | `false` | Wait until the operation reaches `Complete` or `Failed`. |
+| `--timeout` | duration | `0` | Client-side wait timeout. `0` waits indefinitely. |
+| `--dry-run` | string | `none` | `none`, `client`, or `server`. |
+| `-o`, `--output` | string | `name` | `name`, `yaml`, or `json`. |
+| `--field-manager` | string | `kubectl-unbounded` | Field manager used on create. |
+| `--kubeconfig` | string | `$KUBECONFIG` or default | Path to kubeconfig file. |
+
+`--wait` streams progress output and can only be used with the default
+`-o name` output.
+
+#### Examples
+
+Create a host reboot operation:
+
+```bash
+kubectl unbounded machine operation create reboot-worker-01 \
+  --kind HostReboot \
+  --machine worker-01
+```
+
+Create and wait for a node reboot operation selected by labels:
+
+```bash
+kubectl unbounded machine operation create reboot-gpu \
+  --kind NodeReboot \
+  --selector role=gpu \
+  --wait
+```
+
+Generate YAML without creating the operation:
+
+```bash
+kubectl unbounded machine operation create poweroff-worker-01 \
+  --kind HostPowerOff \
+  --machine worker-01 \
+  --dry-run=client \
+  -o yaml
+```
+
+Upgrade the agent:
+
+```bash
+kubectl unbounded machine operation create upgrade-worker-01 \
+  --kind AgentUpgrade \
+  --machine worker-01 \
+  --param downloadURL=https://example.com/unbounded-agent-linux-amd64.tar.gz
+```
+
+Selector support is implemented at the CRD level. Agent operations support
+selectors. Metalman bare-metal host operations support selectors when the
+selector includes `unbounded-cloud.io/site=<site>`. Cloud VM host operations
+currently require one operation per Machine.
+
+---
+
+### `kubectl unbounded machine operation wait`
+
+Wait for an existing `MachineOperation` to reach `Complete` or `Failed`.
+
+```bash
+kubectl unbounded machine operation wait reboot-worker-01 --timeout 5m
+```
+
+Use native kubectl commands for listing and inspection:
+
+```bash
+kubectl get mop
+kubectl describe mop reboot-worker-01
+kubectl get mop reboot-worker-01 -o yaml
+```
+
+---
+
+### Machine Operation Convenience Commands
+
+Convenience commands create a `MachineOperation` with a generated operation
+name, default `--ttl 300`, and `--wait=true`.
+
+| Command | Operation kind | Notes |
+|---------|----------------|-------|
+| `kubectl unbounded machine node-reboot NAME` | `NodeReboot` | Restarts the nspawn-backed Kubernetes node. |
+| `kubectl unbounded machine host-reboot NAME` | `HostReboot` | Reboots or power-cycles the host through the owning backend. |
+| `kubectl unbounded machine power-off NAME` | `HostPowerOff` | Powers off the host. |
+| `kubectl unbounded machine power-on NAME` | `HostPowerOn` | Powers on the host. |
+| `kubectl unbounded machine agent-upgrade NAME --download-url URL` | `AgentUpgrade` | Upgrades the host-side agent binary. |
+| `kubectl unbounded machine agent-reset NAME --force` | `AgentReset` | Removes the agent and managed resources from the host. Requires confirmation unless `--force` is set. |
+| `kubectl unbounded machine replace NAME --force` | `HostReplace` | Destructively replaces the host. Requires confirmation unless `--force` is set. |
+
+Common flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--operation-name` | generated | Explicit `MachineOperation` name. |
+| `--ttl` | `300` | Seconds after completion before cleanup. `0` keeps indefinitely. |
+| `--wait` | `true` | Wait for terminal operation phase. |
+| `--timeout` | `0` | Client-side wait timeout. |
+| `--kubeconfig` | `$KUBECONFIG` or default | Path to kubeconfig file. |
+
+---
+
+### Legacy Machine Operation Commands
+
+The older counter-backed commands remain available for compatibility:
+
+| Command | Mechanism |
+|---------|-----------|
+| `kubectl unbounded machine reboot NAME` | Patches `Machine.spec.operations.rebootCounter`. |
+| `kubectl unbounded machine repave NAME` | Patches `Machine.spec.operations.repaveCounter` and `rebootCounter`. |
+
+These commands do not create `MachineOperation` resources.
+
+---
+
 ## Environment Variables
 
 | Variable | Description |


### PR DESCRIPTION
## Summary
- add `kubectl unbounded machine operation create/wait` for MachineOperation resources
- add friendly machine operation aliases for node reboot, host power, agent upgrade/reset, and replace wiring
- split MachineOperation command implementation by responsibility and document the new CLI surface

## Tests
- `go test ./cmd/kubectl-unbounded/app -run 'TestMachineOperationCommandsEndToEnd' -count=1`\n- `go test ./cmd/kubectl-unbounded/app -count=1`\n- `go test ./cmd/kubectl-unbounded -run '^$' -count=1`\n- `git diff --check`