### PR TITLE
metalman: fix reimage crash edge case

### DIFF
--- a/internal/metalman/redfish/client.go
+++ b/internal/metalman/redfish/client.go
@@ -212,7 +212,7 @@ func (c *Client) SetBootOverride(ctx context.Context, target BootTarget, enabled
 	return nil
 }
 
-// SetHTTPBootOverride sets a one-time Redfish UEFI HTTP boot override.
+// SetHTTPBootOverride sets a persistent Redfish UEFI HTTP boot override.
 // Returns ErrUnsupported if the BMC does not support the PATCH.
 func (c *Client) SetHTTPBootOverride(ctx context.Context, bootURL string) error {
 	path := fmt.Sprintf("/redfish/v1/Systems/%s", c.deviceID)
@@ -220,7 +220,7 @@ func (c *Client) SetHTTPBootOverride(ctx context.Context, bootURL string) error 
 	body := map[string]any{
 		"Boot": map[string]string{
 			"BootSourceOverrideTarget":  string(BootTargetUefiHTTP),
-			"BootSourceOverrideEnabled": string(BootOnce),
+			"BootSourceOverrideEnabled": string(BootContinuous),
 			"BootSourceOverrideMode":    string(BootModeUEFI),
 			"HttpBootUri":               bootURL,
 		},

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -138,7 +138,7 @@ func TestBootOrderConfigUEFIHTTPOn(t *testing.T) {
 	})
 	boot := patch["Boot"].(map[string]any)
 	require.Equal(t, "UefiHttp", boot["BootSourceOverrideTarget"])
-	require.Equal(t, "Once", boot["BootSourceOverrideEnabled"])
+	require.Equal(t, "Continuous", boot["BootSourceOverrideEnabled"])
 	require.Equal(t, "UEFI", boot["BootSourceOverrideMode"])
 	require.Equal(t, "http://192.0.2.1/boot/grubx64.efi", boot["HttpBootUri"])
 }


### PR DESCRIPTION
Currently replace operations on bare metal will always fail if the machine is rebooted a second time before laying down the host image. The simple fix is to override the boot order continuously, which is safe because we always remove the override once the boot image has been written.