### PR TITLE
metalman: support Redfish configured UEFI static IP

### DIFF
--- a/api/machina/v1alpha3/machine_types.go
+++ b/api/machina/v1alpha3/machine_types.go
@@ -212,7 +212,7 @@ type BastionSSHSpec struct {
 	PrivateKeyRef *SecretKeySelector `json:"privateKeyRef,omitempty"`
 }
 
-// DHCPLease defines a static DHCP lease for PXE booting.
+// DHCPLease defines static IPv4 provisioning network settings.
 type DHCPLease struct {
 	// IPv4 is the IP address to assign.
 	IPv4 string `json:"ipv4"`
@@ -293,7 +293,9 @@ type PXESpec struct {
 	// +optional
 	BootProtocol string `json:"bootProtocol,omitempty"`
 
-	// DHCPLeases defines static DHCP leases for PXE booting.
+	// DHCPLeases defines static IPv4 provisioning network settings. PXE boot
+	// uses them as DHCP leases. HTTP boot uses the first entry to configure the
+	// Redfish UEFI HTTP boot client.
 	// +optional
 	DHCPLeases []DHCPLease `json:"dhcpLeases,omitempty"`
 

--- a/cmd/metalman/README.md
+++ b/cmd/metalman/README.md
@@ -52,7 +52,7 @@ everything needed to PXE-boot and manage bare metal hosts:
 
 | Service | Default Port | Protocol | Purpose |
 |---------|-------------|----------|---------|
-| DHCP    | 67/udp      | DHCPv4   | Static leases derived from Machine NIC specs |
+| DHCP    | 67/udp      | DHCPv4   | Static leases derived from Machine NIC specs for PXE or DHCP-assisted HTTP boot |
 | TFTP    | 69/udp      | TFTP     | Initial bootloader delivery (e.g. shimx64.efi) |
 | HTTP    | 8880/tcp    | HTTP     | Artifact serving, templated configs, attestation endpoints |
 | Health  | 8081/tcp    | HTTP     | Liveness/readiness probes |
@@ -204,7 +204,15 @@ boot artifacts from the default netboot image. Set `spec.pxe.netbootImage` only
 when a Machine needs a non-default PXE boot environment. The node must be
 manually PXE-booted (or have PXE as its default boot option).
 
-The default netboot template passes the matching DHCP lease MAC to the installer
+When `spec.pxe.bootProtocol` is `HTTP`, `dhcpLeases` also supplies the static
+UEFI HTTP boot client configuration. Metalman uses Redfish to disable DHCPv4 on
+the host EthernetInterface matching the first lease MAC and writes that lease's
+IPv4 address, subnet mask, gateway, and DNS servers before setting the UEFI HTTP
+boot override. With Redfish access and an HTTP boot URL, repaving can run without
+any DHCP server on the provisioning network. If a host has multiple NICs, put the
+UEFI HTTP boot NIC first in `dhcpLeases`.
+
+The default netboot template passes the selected lease MAC to the installer
 initrd, which uses it to select the provisioning NIC instead of assuming a fixed
 interface name such as `eth0`. If `spec.pxe.targetDisk` is set, the installer
 writes the image to that disk; otherwise it falls back to automatic disk

--- a/deploy/machina/crd/unbounded-cloud.io_machines.yaml
+++ b/deploy/machina/crd/unbounded-cloud.io_machines.yaml
@@ -350,9 +350,13 @@ spec:
                         type: object
                     type: object
                   dhcpLeases:
-                    description: DHCPLeases defines static DHCP leases for PXE booting.
+                    description: |-
+                      DHCPLeases defines static IPv4 provisioning network settings. PXE boot
+                      uses them as DHCP leases. HTTP boot uses the first entry to configure the
+                      Redfish UEFI HTTP boot client.
                     items:
-                      description: DHCPLease defines a static DHCP lease for PXE booting.
+                      description: DHCPLease defines static IPv4 provisioning network
+                        settings.
                       properties:
                         dns:
                           description: DNS is a list of DNS server addresses.

--- a/internal/metalman/machineops/controller.go
+++ b/internal/metalman/machineops/controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 	"sync"
@@ -51,7 +52,9 @@ type PowerClient interface {
 	DisableBootOverride(ctx context.Context) error
 	SetBootOverride(ctx context.Context, target redfish.BootTarget, enabled redfish.BootEnabled) error
 	GetBootConfig(ctx context.Context) (redfish.BootConfig, error)
+	SetStaticIPv4(ctx context.Context, config redfish.StaticIPv4Config) error
 	SetHTTPBootOverride(ctx context.Context, bootURL string) error
+	SetBIOSStaticIPv4(ctx context.Context, config redfish.StaticIPv4Config) error
 	SetBIOSHTTPBootURI(ctx context.Context, bootURL string) error
 }
 
@@ -560,19 +563,6 @@ func (r *Reconciler) waitForPowerAction(target v1alpha3.MachineOperationTargetSt
 }
 
 func (r *Reconciler) advanceReplace(ctx context.Context, op *v1alpha3.MachineOperation, machine *v1alpha3.Machine, target v1alpha3.MachineOperationTargetStatus, now metav1.Time) targetChange {
-	if target.Stage == "" {
-		if err := r.requestRepaveBoot(ctx, machine); err != nil {
-			return retryTarget(target, err, now, r.maxAttempts())
-		}
-
-		target.Stage = v1alpha3.OperationStageWaitingRepave
-		target.Attempts++
-		target.LastAttemptAt = &now
-		target.Message = "requested PXE repave boot"
-
-		return targetChange{target: target}
-	}
-
 	if !apimeta.IsStatusConditionTrue(op.Status.Conditions, v1alpha3.MachineOperationConditionBootImageWritten) {
 		return r.waitForRepaveBoot(ctx, machine, target, now)
 	}
@@ -598,49 +588,82 @@ func (r *Reconciler) advanceReplace(ctx context.Context, op *v1alpha3.MachineOpe
 	return completeTarget(target, "HostReplace completed", now)
 }
 
-func (r *Reconciler) requestRepaveBoot(ctx context.Context, machine *v1alpha3.Machine) error {
-	pc, err := r.PowerClients.ForMachine(ctx, machine)
-	if err != nil {
-		return err
-	}
-
+func (r *Reconciler) configureRepaveBoot(ctx context.Context, pc PowerClient, machine *v1alpha3.Machine) error {
 	if machine.Spec.PXE.TargetBootProtocol() == v1alpha3.PXEBootProtocolHTTP {
-		if r.HTTPBootURL == nil {
-			return fmt.Errorf("HTTP boot URL resolver is not configured")
-		}
-
-		bootURL, err := r.HTTPBootURL(machine)
+		bootURL, staticConfig, err := r.httpBootConfig(machine)
 		if err != nil {
 			return err
 		}
 
-		if err := setHTTPBootOverride(ctx, pc, bootURL); err != nil {
+		if err := setHTTPBootOverride(ctx, pc, bootURL, staticConfig); err != nil {
 			return err
 		}
 	} else if err := pc.SetBootOverride(ctx, redfish.BootTargetPxe, redfish.BootContinuous); err != nil {
 		return err
 	}
 
-	state, err := pc.PowerState(ctx)
-	if err != nil {
-		return err
-	}
-
-	if state == redfish.PowerOff {
-		return pc.Reset(ctx, redfish.ResetOn)
-	}
-
-	return pc.Reset(ctx, redfish.ResetForceRestart)
+	return nil
 }
 
-func setHTTPBootOverride(ctx context.Context, pc PowerClient, bootURL string) error {
+func (r *Reconciler) httpBootConfig(machine *v1alpha3.Machine) (string, redfish.StaticIPv4Config, error) {
+	if r.HTTPBootURL == nil {
+		return "", redfish.StaticIPv4Config{}, fmt.Errorf("HTTP boot URL resolver is not configured")
+	}
+
+	bootURL, err := r.HTTPBootURL(machine)
+	if err != nil {
+		return "", redfish.StaticIPv4Config{}, err
+	}
+
+	staticConfig, err := httpBootStaticNetworkConfig(machine)
+	if err != nil {
+		return "", redfish.StaticIPv4Config{}, err
+	}
+
+	return bootURL, staticConfig, nil
+}
+
+func httpBootStaticNetworkConfig(machine *v1alpha3.Machine) (redfish.StaticIPv4Config, error) {
+	if machine.Spec.PXE == nil || len(machine.Spec.PXE.DHCPLeases) == 0 {
+		return redfish.StaticIPv4Config{}, fmt.Errorf("HTTP boot requires at least one static lease in spec.pxe.dhcpLeases")
+	}
+
+	lease := machine.Spec.PXE.DHCPLeases[0]
+	config := redfish.StaticIPv4Config{
+		MAC:        lease.MAC,
+		Address:    lease.IPv4,
+		SubnetMask: lease.SubnetMask,
+		Gateway:    lease.Gateway,
+		DNS:        lease.DNS,
+	}
+
+	if _, err := net.ParseMAC(config.MAC); err != nil {
+		return redfish.StaticIPv4Config{}, fmt.Errorf("invalid HTTP boot MAC address %q: %w", config.MAC, err)
+	}
+
+	if err := redfish.ValidateStaticIPv4Config(config); err != nil {
+		return redfish.StaticIPv4Config{}, err
+	}
+
+	return config, nil
+}
+
+func setHTTPBootOverride(ctx context.Context, pc PowerClient, bootURL string, staticConfig redfish.StaticIPv4Config) error {
 	config, err := pc.GetBootConfig(ctx)
 	if err != nil {
 		return err
 	}
 
 	if !config.HasHTTPBootURI {
-		return setBIOSHTTPBootOverride(ctx, pc, bootURL)
+		return setBIOSHTTPBootOverride(ctx, pc, bootURL, staticConfig)
+	}
+
+	if err := pc.SetStaticIPv4(ctx, staticConfig); err != nil {
+		if !errors.Is(err, redfish.ErrUnsupported) {
+			return err
+		}
+
+		return setBIOSHTTPBootOverride(ctx, pc, bootURL, staticConfig)
 	}
 
 	if err := pc.SetHTTPBootOverride(ctx, bootURL); err != nil {
@@ -648,13 +671,26 @@ func setHTTPBootOverride(ctx context.Context, pc PowerClient, bootURL string) er
 			return err
 		}
 
-		return setBIOSHTTPBootOverride(ctx, pc, bootURL)
+		return setBIOSHTTPBootOverride(ctx, pc, bootURL, staticConfig)
+	}
+
+	// Some BMCs expose both locations but boot from the vendor BIOS setting.
+	if err := pc.SetBIOSStaticIPv4(ctx, staticConfig); err != nil && !errors.Is(err, redfish.ErrUnsupported) {
+		return err
+	}
+
+	if err := pc.SetBIOSHTTPBootURI(ctx, bootURL); err != nil && !errors.Is(err, redfish.ErrUnsupported) {
+		return err
 	}
 
 	return nil
 }
 
-func setBIOSHTTPBootOverride(ctx context.Context, pc PowerClient, bootURL string) error {
+func setBIOSHTTPBootOverride(ctx context.Context, pc PowerClient, bootURL string, staticConfig redfish.StaticIPv4Config) error {
+	if err := pc.SetBIOSStaticIPv4(ctx, staticConfig); err != nil {
+		return err
+	}
+
 	if err := pc.SetBIOSHTTPBootURI(ctx, bootURL); err != nil {
 		return err
 	}
@@ -673,16 +709,59 @@ func (r *Reconciler) waitForRepaveBoot(ctx context.Context, machine *v1alpha3.Ma
 		if target.Attempts >= r.maxAttempts() {
 			return failTarget(target, reasonExecutionFailed, fmt.Sprintf("timed out waiting for PXE repave after %d attempts", target.Attempts), now)
 		}
+
+		target.Stage = v1alpha3.OperationStagePoweringOff
+		target.LastAttemptAt = nil
 	}
 
-	if err := r.requestRepaveBoot(ctx, machine); err != nil {
+	if machine.Spec.PXE.TargetBootProtocol() == v1alpha3.PXEBootProtocolHTTP {
+		if _, _, err := r.httpBootConfig(machine); err != nil {
+			return retryTarget(target, err, now, r.maxAttempts())
+		}
+	}
+
+	pc, err := r.PowerClients.ForMachine(ctx, machine)
+	if err != nil {
+		return targetChange{target: target, err: err}
+	}
+
+	state, err := pc.PowerState(ctx)
+	if err != nil {
+		return targetChange{target: target, err: err}
+	}
+
+	if state != redfish.PowerOff {
+		if target.Stage == v1alpha3.OperationStageWaitingOff && target.LastAttemptAt != nil {
+			if now.Sub(target.LastAttemptAt.Time) < r.powerActionTimeout() {
+				target.Message = "waiting for power off before configuring repave boot"
+
+				return targetChange{target: target}
+			}
+		}
+
+		if err := pc.Reset(ctx, redfish.ResetForceOff); err != nil {
+			return targetChange{target: target, err: err}
+		}
+
+		target.Stage = v1alpha3.OperationStageWaitingOff
+		target.LastAttemptAt = &now
+		target.Message = "sent ForceOff before configuring repave boot"
+
+		return targetChange{target: target}
+	}
+
+	if err := r.configureRepaveBoot(ctx, pc, machine); err != nil {
 		return retryTarget(target, err, now, r.maxAttempts())
+	}
+
+	if err := pc.Reset(ctx, redfish.ResetOn); err != nil {
+		return targetChange{target: target, err: err}
 	}
 
 	target.Stage = v1alpha3.OperationStageWaitingRepave
 	target.Attempts++
 	target.LastAttemptAt = &now
-	target.Message = "retrying PXE repave boot"
+	target.Message = "requested PXE repave boot"
 
 	return targetChange{target: target}
 }

--- a/internal/metalman/machineops/controller_test.go
+++ b/internal/metalman/machineops/controller_test.go
@@ -5,7 +5,9 @@ package machineops
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -307,6 +309,12 @@ func TestReconcilerRequestsHostReplaceOnceAndCompletesAfterRepave(t *testing.T) 
 
 	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
 	require.NoError(t, err)
+
+	var poweringOff v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &poweringOff))
+	require.Equal(t, v1alpha3.OperationStageWaitingOff, poweringOff.Status.Targets[0].Stage)
+	require.Equal(t, []string{"machine-1:ForceOff"}, power.calls)
+
 	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
 	require.NoError(t, err)
 
@@ -316,7 +324,7 @@ func TestReconcilerRequestsHostReplaceOnceAndCompletesAfterRepave(t *testing.T) 
 	require.Len(t, inProgress.Status.Targets, 1)
 	require.Equal(t, v1alpha3.OperationStageWaitingRepave, inProgress.Status.Targets[0].Stage)
 	require.Equal(t, int32(1), inProgress.Status.Targets[0].Attempts)
-	require.Equal(t, []string{"machine-1:SetBootOverride:Pxe:Continuous", "machine-1:ForceRestart"}, power.calls)
+	require.Equal(t, []string{"machine-1:ForceOff", "machine-1:SetBootOverride:Pxe:Continuous", "machine-1:On"}, power.calls)
 
 	bootLoaderCond := apimeta.FindStatusCondition(inProgress.Status.Conditions, v1alpha3.MachineOperationConditionBootLoaderDownloaded)
 	require.NotNil(t, bootLoaderCond)
@@ -371,12 +379,73 @@ func TestReconcilerPowersOnHostReplaceTargetWhenOff(t *testing.T) {
 	require.Equal(t, []string{"machine-1:SetBootOverride:Pxe:Continuous", "machine-1:On"}, power.calls)
 }
 
+func TestReconcilerRetriesHostReplacePowerOffAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machine := testBareMetalMachine("machine-1", "rack-a")
+	op := testOperation("op-replace-poweroff-failed", v1alpha3.OperationHostReplace)
+	op.Spec.MachineRef = machine.Name
+	op.Status.Phase = v1alpha3.OperationPhaseInProgress
+	op.Status.Targets = []v1alpha3.MachineOperationTargetStatus{{
+		MachineRef:    machine.Name,
+		Phase:         v1alpha3.OperationPhaseInProgress,
+		Stage:         v1alpha3.OperationStageWaitingOff,
+		LastAttemptAt: ptrTo(metav1.NewTime(fixedNow().Add(-2 * time.Minute))),
+		StartedAt:     ptrTo(fixedNow()),
+	}}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, op, testRedfishSecret()).WithStatusSubresource(op, machine).Build()
+	power := &recordingPowerClient{states: map[string]redfish.PowerState{machine.Name: redfish.PowerOn}}
+	reconciler := testReconciler(c, power, "rack-a")
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+
+	var updated v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &updated))
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, updated.Status.Phase)
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, updated.Status.Targets[0].Phase)
+	require.Equal(t, v1alpha3.OperationStageWaitingOff, updated.Status.Targets[0].Stage)
+	require.Zero(t, updated.Status.Targets[0].Attempts)
+	require.Equal(t, "sent ForceOff before configuring repave boot", updated.Status.Targets[0].Message)
+	require.Equal(t, []string{"machine-1:ForceOff"}, power.calls)
+}
+
+func TestReconcilerReturnsHostReplacePowerOnFailure(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machine := testBareMetalMachine("machine-1", "rack-a")
+	op := testOperation("op-replace-poweron-failed", v1alpha3.OperationHostReplace)
+	op.Spec.MachineRef = machine.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, op, testRedfishSecret()).WithStatusSubresource(op, machine).Build()
+	power := &recordingPowerClient{
+		states:      map[string]redfish.PowerState{machine.Name: redfish.PowerOff},
+		resetErrors: map[redfish.ResetType]error{redfish.ResetOn: errors.New("power on failed")},
+	}
+	reconciler := testReconciler(c, power, "rack-a")
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.ErrorContains(t, err, "power on failed")
+
+	var updated v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &updated))
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, updated.Status.Phase)
+	require.Equal(t, v1alpha3.OperationPhasePending, updated.Status.Targets[0].Phase)
+	require.Equal(t, int32(0), updated.Status.Targets[0].Attempts)
+	require.Equal(t, "target snapshotted", updated.Status.Targets[0].Message)
+	require.Equal(t, []string{"machine-1:SetBootOverride:Pxe:Continuous", "machine-1:On"}, power.calls)
+}
+
 func TestReconcilerFallsBackToBIOSHTTPBootURIForHostReplace(t *testing.T) {
 	t.Parallel()
 
 	s := testScheme(t)
 	machine := testBareMetalMachine("machine-1", "rack-a")
 	machine.Spec.PXE.BootProtocol = v1alpha3.PXEBootProtocolHTTP
+	machine.Spec.PXE.DHCPLeases = []v1alpha3.DHCPLease{httpBootLease()}
 	op := testOperation("op-replace-http", v1alpha3.OperationHostReplace)
 	op.Spec.MachineRef = machine.Name
 
@@ -400,11 +469,14 @@ func TestReconcilerFallsBackToBIOSHTTPBootURIForHostReplace(t *testing.T) {
 	require.Len(t, inProgress.Status.Targets, 1)
 	require.Equal(t, v1alpha3.OperationStageWaitingRepave, inProgress.Status.Targets[0].Stage)
 	require.Equal(t, []string{
+		"machine-1:ForceOff",
 		"machine-1:GetBootConfig",
+		"machine-1:SetStaticIPv4:aa:bb:cc:dd:ee:01:10.0.0.20:255.255.255.0:10.0.0.1:10.0.0.53",
 		"machine-1:SetHTTPBootOverride:http://10.0.0.10:8880/http/shimx64.efi",
+		"machine-1:SetBIOSStaticIPv4:10.0.0.20:255.255.255.0:10.0.0.1",
 		"machine-1:SetBIOSHTTPBootURI:http://10.0.0.10:8880/http/shimx64.efi",
 		"machine-1:SetBootOverride:UefiHttp:Once",
-		"machine-1:ForceRestart",
+		"machine-1:On",
 	}, power.calls)
 }
 
@@ -414,6 +486,7 @@ func TestReconcilerUsesBIOSHTTPBootURIWhenStandardURIAbsent(t *testing.T) {
 	s := testScheme(t)
 	machine := testBareMetalMachine("machine-1", "rack-a")
 	machine.Spec.PXE.BootProtocol = v1alpha3.PXEBootProtocolHTTP
+	machine.Spec.PXE.DHCPLeases = []v1alpha3.DHCPLease{httpBootLease()}
 	op := testOperation("op-replace-http-bios", v1alpha3.OperationHostReplace)
 	op.Spec.MachineRef = machine.Name
 
@@ -430,6 +503,8 @@ func TestReconcilerUsesBIOSHTTPBootURIWhenStandardURIAbsent(t *testing.T) {
 	require.NoError(t, err)
 	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
 	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
 
 	var inProgress v1alpha3.MachineOperation
 	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &inProgress))
@@ -437,11 +512,124 @@ func TestReconcilerUsesBIOSHTTPBootURIWhenStandardURIAbsent(t *testing.T) {
 	require.Len(t, inProgress.Status.Targets, 1)
 	require.Equal(t, v1alpha3.OperationStageWaitingRepave, inProgress.Status.Targets[0].Stage)
 	require.Equal(t, []string{
+		"machine-1:ForceOff",
 		"machine-1:GetBootConfig",
+		"machine-1:SetBIOSStaticIPv4:10.0.0.20:255.255.255.0:10.0.0.1",
 		"machine-1:SetBIOSHTTPBootURI:http://10.0.0.10:8880/http/shimx64.efi",
 		"machine-1:SetBootOverride:UefiHttp:Once",
-		"machine-1:ForceRestart",
+		"machine-1:On",
 	}, power.calls)
+}
+
+func TestReconcilerFallsBackToBIOSWhenStaticInterfaceIsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machine := testBareMetalMachine("machine-1", "rack-a")
+	machine.Spec.PXE.BootProtocol = v1alpha3.PXEBootProtocolHTTP
+	machine.Spec.PXE.DHCPLeases = []v1alpha3.DHCPLease{httpBootLease()}
+	op := testOperation("op-replace-http-read-only-nic", v1alpha3.OperationHostReplace)
+	op.Spec.MachineRef = machine.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, op, testRedfishSecret()).WithStatusSubresource(op, machine).Build()
+	power := &recordingPowerClient{staticIPv4Unsupported: map[string]bool{machine.Name: true}}
+	reconciler := testReconciler(c, power, "rack-a")
+	reconciler.HTTPBootURL = func(m *v1alpha3.Machine) (string, error) {
+		require.Equal(t, machine.Name, m.Name)
+
+		return "http://10.0.0.10:8880/http/shimx64.efi", nil
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+
+	var inProgress v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &inProgress))
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, inProgress.Status.Phase)
+	require.Equal(t, v1alpha3.OperationStageWaitingRepave, inProgress.Status.Targets[0].Stage)
+	require.Equal(t, []string{
+		"machine-1:ForceOff",
+		"machine-1:GetBootConfig",
+		"machine-1:SetStaticIPv4:aa:bb:cc:dd:ee:01:10.0.0.20:255.255.255.0:10.0.0.1:10.0.0.53",
+		"machine-1:SetBIOSStaticIPv4:10.0.0.20:255.255.255.0:10.0.0.1",
+		"machine-1:SetBIOSHTTPBootURI:http://10.0.0.10:8880/http/shimx64.efi",
+		"machine-1:SetBootOverride:UefiHttp:Once",
+		"machine-1:On",
+	}, power.calls)
+}
+
+func TestSetHTTPBootOverrideRefreshesStandardAndBIOSURLs(t *testing.T) {
+	t.Parallel()
+
+	power := &recordingPowerClient{}
+	client := &recordingMachinePowerClient{parent: power, machine: "machine-1"}
+	staticConfig := redfish.StaticIPv4Config{
+		MAC:        "aa:bb:cc:dd:ee:01",
+		Address:    "10.0.0.20",
+		SubnetMask: "255.255.255.0",
+		Gateway:    "10.0.0.1",
+		DNS:        []string{"10.0.0.53"},
+	}
+
+	require.NoError(t, setHTTPBootOverride(t.Context(), client, "http://10.0.0.10:8880/http/shimx64.efi", staticConfig))
+	require.Equal(t, []string{
+		"machine-1:GetBootConfig",
+		"machine-1:SetStaticIPv4:aa:bb:cc:dd:ee:01:10.0.0.20:255.255.255.0:10.0.0.1:10.0.0.53",
+		"machine-1:SetHTTPBootOverride:http://10.0.0.10:8880/http/shimx64.efi",
+		"machine-1:SetBIOSStaticIPv4:10.0.0.20:255.255.255.0:10.0.0.1",
+		"machine-1:SetBIOSHTTPBootURI:http://10.0.0.10:8880/http/shimx64.efi",
+	}, power.calls)
+}
+
+func TestSetHTTPBootOverrideAllowsUnsupportedBIOSURL(t *testing.T) {
+	t.Parallel()
+
+	power := &recordingPowerClient{biosHTTPBootUnsupported: map[string]bool{"machine-1": true}}
+	client := &recordingMachinePowerClient{parent: power, machine: "machine-1"}
+
+	require.NoError(t, setHTTPBootOverride(t.Context(), client, "http://10.0.0.10:8880/http/shimx64.efi", redfish.StaticIPv4Config{}))
+	require.Equal(t, []string{
+		"machine-1:GetBootConfig",
+		"machine-1:SetStaticIPv4:::::",
+		"machine-1:SetHTTPBootOverride:http://10.0.0.10:8880/http/shimx64.efi",
+		"machine-1:SetBIOSStaticIPv4:::",
+		"machine-1:SetBIOSHTTPBootURI:http://10.0.0.10:8880/http/shimx64.efi",
+	}, power.calls)
+}
+
+func TestReconcilerRetriesHTTPHostReplaceWithoutStaticLease(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machine := testBareMetalMachine("machine-1", "rack-a")
+	machine.Spec.PXE.BootProtocol = v1alpha3.PXEBootProtocolHTTP
+	op := testOperation("op-replace-http-no-lease", v1alpha3.OperationHostReplace)
+	op.Spec.MachineRef = machine.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, op, testRedfishSecret()).WithStatusSubresource(op, machine).Build()
+	power := &recordingPowerClient{}
+	reconciler := testReconciler(c, power, "rack-a")
+	reconciler.HTTPBootURL = func(m *v1alpha3.Machine) (string, error) {
+		require.Equal(t, machine.Name, m.Name)
+
+		return "http://10.0.0.10:8880/http/shimx64.efi", nil
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+
+	var updated v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &updated))
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, updated.Status.Phase)
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, updated.Status.Targets[0].Phase)
+	require.Equal(t, "HTTP boot requires at least one static lease in spec.pxe.dhcpLeases", updated.Status.Targets[0].Message)
+	require.Empty(t, power.calls)
 }
 
 func TestReconcilerRestoresMissingHostReplaceTriggerConditions(t *testing.T) {
@@ -893,12 +1081,15 @@ func testReconciler(c client.Client, power PowerClientFactory, site string) *Rec
 }
 
 type recordingPowerClient struct {
-	mu                     sync.Mutex
-	states                 map[string]redfish.PowerState
-	disableBootUnsupported map[string]bool
-	httpBootUnsupported    map[string]bool
-	httpBootURIAbsent      map[string]bool
-	calls                  []string
+	mu                      sync.Mutex
+	states                  map[string]redfish.PowerState
+	disableBootUnsupported  map[string]bool
+	httpBootUnsupported     map[string]bool
+	httpBootURIAbsent       map[string]bool
+	staticIPv4Unsupported   map[string]bool
+	biosHTTPBootUnsupported map[string]bool
+	resetErrors             map[redfish.ResetType]error
+	calls                   []string
 }
 
 func (r *recordingPowerClient) ForMachine(_ context.Context, machine *v1alpha3.Machine) (PowerClient, error) {
@@ -933,6 +1124,10 @@ func (c *recordingMachinePowerClient) Reset(_ context.Context, resetType redfish
 	defer c.parent.mu.Unlock()
 
 	c.parent.calls = append(c.parent.calls, fmt.Sprintf("%s:%s", c.machine, resetType))
+	if err := c.parent.resetErrors[resetType]; err != nil {
+		return err
+	}
+
 	switch resetType {
 	case redfish.ResetForceOff:
 		c.parent.states[c.machine] = redfish.PowerOff
@@ -973,6 +1168,26 @@ func (c *recordingMachinePowerClient) GetBootConfig(context.Context) (redfish.Bo
 	return redfish.BootConfig{HasHTTPBootURI: !c.parent.httpBootURIAbsent[c.machine]}, nil
 }
 
+func (c *recordingMachinePowerClient) SetStaticIPv4(_ context.Context, config redfish.StaticIPv4Config) error {
+	c.parent.mu.Lock()
+	defer c.parent.mu.Unlock()
+
+	c.parent.calls = append(c.parent.calls, fmt.Sprintf(
+		"%s:SetStaticIPv4:%s:%s:%s:%s:%s",
+		c.machine,
+		config.MAC,
+		config.Address,
+		config.SubnetMask,
+		config.Gateway,
+		strings.Join(config.DNS, ","),
+	))
+	if c.parent.staticIPv4Unsupported[c.machine] {
+		return fmt.Errorf("static IPv4 unsupported: %w", redfish.ErrUnsupported)
+	}
+
+	return nil
+}
+
 func (c *recordingMachinePowerClient) SetHTTPBootOverride(_ context.Context, bootURL string) error {
 	c.parent.mu.Lock()
 	defer c.parent.mu.Unlock()
@@ -985,11 +1200,29 @@ func (c *recordingMachinePowerClient) SetHTTPBootOverride(_ context.Context, boo
 	return nil
 }
 
+func (c *recordingMachinePowerClient) SetBIOSStaticIPv4(_ context.Context, config redfish.StaticIPv4Config) error {
+	c.parent.mu.Lock()
+	defer c.parent.mu.Unlock()
+
+	c.parent.calls = append(c.parent.calls, fmt.Sprintf(
+		"%s:SetBIOSStaticIPv4:%s:%s:%s",
+		c.machine,
+		config.Address,
+		config.SubnetMask,
+		config.Gateway,
+	))
+
+	return nil
+}
+
 func (c *recordingMachinePowerClient) SetBIOSHTTPBootURI(_ context.Context, bootURL string) error {
 	c.parent.mu.Lock()
 	defer c.parent.mu.Unlock()
 
 	c.parent.calls = append(c.parent.calls, fmt.Sprintf("%s:SetBIOSHTTPBootURI:%s", c.machine, bootURL))
+	if c.parent.biosHTTPBootUnsupported[c.machine] {
+		return fmt.Errorf("BIOS HTTP boot unsupported: %w", redfish.ErrUnsupported)
+	}
 
 	return nil
 }
@@ -1026,6 +1259,16 @@ func testBareMetalMachine(name, site string) *v1alpha3.Machine {
 			},
 		},
 		Status: v1alpha3.MachineStatus{Redfish: &v1alpha3.RedfishStatus{CertFingerprint: "fp"}},
+	}
+}
+
+func httpBootLease() v1alpha3.DHCPLease {
+	return v1alpha3.DHCPLease{
+		MAC:        "aa:bb:cc:dd:ee:01",
+		IPv4:       "10.0.0.20",
+		SubnetMask: "255.255.255.0",
+		Gateway:    "10.0.0.1",
+		DNS:        []string{"10.0.0.53"},
 	}
 }
 

--- a/internal/metalman/redfish/client.go
+++ b/internal/metalman/redfish/client.go
@@ -12,7 +12,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -101,7 +103,25 @@ type BootConfig struct {
 	HasHTTPBootURI bool
 }
 
+// StaticIPv4Config holds static host NIC settings for Redfish EthernetInterface.
+type StaticIPv4Config struct {
+	MAC        string
+	Address    string
+	SubnetMask string
+	Gateway    string
+	DNS        []string
+}
+
 const biosHTTPBootURIAttribute = "UrlBootFile"
+
+const (
+	biosDHCPv4Attribute         = "Dhcpv4"
+	biosDHCPv4DisabledValue     = "Disabled"
+	biosIPv4AddressAttribute    = "Ipv4Address"
+	biosIPv4SubnetMaskAttribute = "Ipv4SubnetMask"
+	biosIPv4GatewayAttribute    = "Ipv4Gateway"
+	biosIPv4PrimaryDNSAttribute = "Ipv4PrimaryDNS"
+)
 
 // Client provides Redfish operations against a single BMC.
 // Created via Pool.Get or Dial. Must be closed when no longer needed.
@@ -338,6 +358,101 @@ func (c *Client) SetBIOSHTTPBootURI(ctx context.Context, bootURL string) error {
 	return nil
 }
 
+// SetBIOSStaticIPv4 sets pending BIOS UEFI HTTP boot IPv4 settings.
+// Returns ErrUnsupported if the BMC does not support BIOS settings.
+func (c *Client) SetBIOSStaticIPv4(ctx context.Context, config StaticIPv4Config) error {
+	if err := ValidateStaticIPv4Config(config); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/redfish/v1/Systems/%s/Bios/Settings", c.deviceID)
+
+	attributes := map[string]string{
+		biosDHCPv4Attribute:         biosDHCPv4DisabledValue,
+		biosIPv4AddressAttribute:    config.Address,
+		biosIPv4SubnetMaskAttribute: config.SubnetMask,
+		biosIPv4GatewayAttribute:    config.Gateway,
+	}
+	for _, dns := range config.DNS {
+		if net.ParseIP(dns).To4() != nil {
+			attributes[biosIPv4PrimaryDNSAttribute] = dns
+
+			break
+		}
+	}
+
+	body := map[string]any{
+		"Attributes": attributes,
+	}
+
+	data, status, err := c.session.do(ctx, http.MethodPatch, path, body)
+	if err != nil {
+		return err
+	}
+
+	if isUnsupportedStatus(status) {
+		return redfishResponseError(http.MethodPatch, path, status, data, ErrUnsupported)
+	}
+
+	if !isSuccessStatus(status) {
+		return redfishResponseError(http.MethodPatch, path, status, data, nil)
+	}
+
+	return nil
+}
+
+// SetStaticIPv4 configures a host EthernetInterface with static IPv4 settings.
+// The interface is selected by MACAddress or PermanentMACAddress.
+// Returns ErrUnsupported if the BMC does not expose writable EthernetInterface resources.
+func (c *Client) SetStaticIPv4(ctx context.Context, config StaticIPv4Config) error {
+	mac, err := normalizeMAC(config.MAC)
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateStaticIPv4Config(config); err != nil {
+		return err
+	}
+
+	path, err := c.findEthernetInterfacePath(ctx, mac)
+	if err != nil {
+		return err
+	}
+
+	address := map[string]string{
+		"Address":    config.Address,
+		"SubnetMask": config.SubnetMask,
+	}
+	if config.Gateway != "" {
+		address["Gateway"] = config.Gateway
+	}
+
+	body := map[string]any{
+		"DHCPv4": map[string]bool{
+			"DHCPEnabled": false,
+		},
+		"IPv4StaticAddresses": []map[string]string{address},
+	}
+	if len(config.DNS) > 0 {
+		body["StaticNameServers"] = config.DNS
+	}
+
+	data, status, err := c.session.do(ctx, http.MethodPatch, path, body)
+	if err != nil {
+		return err
+	}
+
+	if isUnsupportedStatus(status) {
+		return redfishResponseError(http.MethodPatch, path, status, data, ErrUnsupported)
+	}
+
+	if !isSuccessStatus(status) {
+		return redfishResponseError(http.MethodPatch, path, status, data, nil)
+	}
+
+	return nil
+}
+
 // DisableBootOverride disables the boot source override.
 // Returns ErrUnsupported if the BMC does not support disabling.
 func (c *Client) DisableBootOverride(ctx context.Context) error {
@@ -363,6 +478,182 @@ func (c *Client) DisableBootOverride(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (c *Client) findEthernetInterfacePath(ctx context.Context, mac string) (string, error) {
+	systemPath := fmt.Sprintf("/redfish/v1/Systems/%s", c.deviceID)
+
+	data, status, err := c.session.do(ctx, http.MethodGet, systemPath, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if status != http.StatusOK {
+		return "", redfishResponseError(http.MethodGet, systemPath, status, data, nil)
+	}
+
+	var system struct {
+		EthernetInterfaces struct {
+			ODataID string `json:"@odata.id"`
+		} `json:"EthernetInterfaces"`
+	}
+	if err := json.Unmarshal(data, &system); err != nil {
+		return "", fmt.Errorf("parsing system EthernetInterfaces link: %w", err)
+	}
+
+	collectionPath, err := redfishPathFromODataID(system.EthernetInterfaces.ODataID, systemPath)
+	if err != nil {
+		return "", fmt.Errorf("system EthernetInterfaces link missing: %w", ErrUnsupported)
+	}
+
+	data, status, err = c.session.do(ctx, http.MethodGet, collectionPath, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if isUnsupportedStatus(status) {
+		return "", redfishResponseError(http.MethodGet, collectionPath, status, data, ErrUnsupported)
+	}
+
+	if status != http.StatusOK {
+		return "", redfishResponseError(http.MethodGet, collectionPath, status, data, nil)
+	}
+
+	var collection struct {
+		Members []struct {
+			ODataID string `json:"@odata.id"`
+		} `json:"Members"`
+	}
+	if err := json.Unmarshal(data, &collection); err != nil {
+		return "", fmt.Errorf("parsing EthernetInterfaces collection: %w", err)
+	}
+
+	for _, member := range collection.Members {
+		interfacePath, err := redfishPathFromODataID(member.ODataID, collectionPath)
+		if err != nil {
+			return "", fmt.Errorf("parsing EthernetInterface member link: %w", err)
+		}
+
+		data, status, err = c.session.do(ctx, http.MethodGet, interfacePath, nil)
+		if err != nil {
+			return "", err
+		}
+
+		if status != http.StatusOK {
+			return "", redfishResponseError(http.MethodGet, interfacePath, status, data, nil)
+		}
+
+		var ethernetInterface struct {
+			MACAddress          string `json:"MACAddress"`
+			PermanentMACAddress string `json:"PermanentMACAddress"`
+		}
+		if err := json.Unmarshal(data, &ethernetInterface); err != nil {
+			return "", fmt.Errorf("parsing EthernetInterface %s: %w", interfacePath, err)
+		}
+
+		if macMatches(mac, ethernetInterface.MACAddress) || macMatches(mac, ethernetInterface.PermanentMACAddress) {
+			return interfacePath, nil
+		}
+	}
+
+	return "", fmt.Errorf("no Redfish Ethernet interface found for MAC %s", mac)
+}
+
+// ValidateStaticIPv4Config validates the IP fields in a static network configuration.
+func ValidateStaticIPv4Config(config StaticIPv4Config) error {
+	if err := validateIPv4Field("address", config.Address, true); err != nil {
+		return err
+	}
+
+	if err := validateIPv4Field("subnet mask", config.SubnetMask, true); err != nil {
+		return err
+	}
+
+	if err := validateIPv4Field("gateway", config.Gateway, false); err != nil {
+		return err
+	}
+
+	for _, dns := range config.DNS {
+		if err := validateIPField("DNS server", dns); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateIPv4Field(name, value string, required bool) error {
+	if value == "" && !required {
+		return nil
+	}
+
+	if ip := net.ParseIP(value); ip == nil || ip.To4() == nil {
+		return fmt.Errorf("invalid static IPv4 %s %q", name, value)
+	}
+
+	return nil
+}
+
+func validateIPField(name, value string) error {
+	if ip := net.ParseIP(value); ip == nil {
+		return fmt.Errorf("invalid IP %s %q", name, value)
+	}
+
+	return nil
+}
+
+func macMatches(target, candidate string) bool {
+	candidate, err := normalizeMAC(candidate)
+	if err != nil {
+		return false
+	}
+
+	return candidate == target
+}
+
+func normalizeMAC(value string) (string, error) {
+	mac, err := net.ParseMAC(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid MAC address %q: %w", value, err)
+	}
+
+	return mac.String(), nil
+}
+
+func redfishPathFromODataID(id, basePath string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("empty @odata.id")
+	}
+
+	u, err := url.Parse(id)
+	if err != nil {
+		return "", err
+	}
+
+	if !u.IsAbs() && !strings.HasPrefix(id, "/") {
+		base, err := url.Parse(basePath)
+		if err != nil {
+			return "", err
+		}
+
+		u = base.ResolveReference(u)
+	}
+
+	path := u.EscapedPath()
+	if path == "" {
+		return "", fmt.Errorf("empty @odata.id path")
+	}
+
+	if u.RawQuery != "" {
+		path += "?" + u.RawQuery
+	}
+
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	return path, nil
 }
 
 // CaptureFingerprint connects to a BMC without cert pinning and returns

--- a/internal/metalman/redfish/redfish_test.go
+++ b/internal/metalman/redfish/redfish_test.go
@@ -314,6 +314,42 @@ func TestClientSetBIOSHTTPBootURI(t *testing.T) {
 	require.Equal(t, "http://192.0.2.1/boot/shimx64.efi", patchBody["Attributes"].(map[string]any)["UrlBootFile"])
 }
 
+func TestClientSetBIOSStaticIPv4(t *testing.T) {
+	var patchBody map[string]any
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/Bios/Settings"):
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	require.NoError(t, client.SetBIOSStaticIPv4(t.Context(), StaticIPv4Config{
+		Address:    "10.0.0.20",
+		SubnetMask: "255.255.255.0",
+		Gateway:    "10.0.0.1",
+		DNS:        []string{"10.0.0.53", "10.0.0.54"},
+	}))
+
+	attributes := patchBody["Attributes"].(map[string]any)
+	require.Equal(t, "Disabled", attributes["Dhcpv4"])
+	require.Equal(t, "10.0.0.20", attributes["Ipv4Address"])
+	require.Equal(t, "255.255.255.0", attributes["Ipv4SubnetMask"])
+	require.Equal(t, "10.0.0.1", attributes["Ipv4Gateway"])
+	require.Equal(t, "10.0.0.53", attributes["Ipv4PrimaryDNS"])
+}
+
 func TestClientGetBIOSHTTPBootURI(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !testSessionAuth(w, r) {
@@ -386,6 +422,180 @@ func TestClientSetHTTPBootOverrideUnsupportedDoesNotFallback(t *testing.T) {
 	err := client.SetHTTPBootOverride(t.Context(), "http://192.0.2.1/boot/shimx64.efi")
 	require.ErrorIs(t, err, ErrUnsupported)
 	require.Equal(t, int64(1), patchCalls.Load())
+}
+
+func TestClientSetStaticIPv4ByMAC(t *testing.T) {
+	var patchBody map[string]any
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"PowerState": "On",
+				"EthernetInterfaces": map[string]string{
+					"@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces",
+				},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"Members": []map[string]string{
+					{"@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces/NIC.1"},
+					{"@odata.id": "https://bmc.example.com/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces/NIC.2"},
+				},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces/NIC.1"):
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"MACAddress":          "00:11:22:33:44:55",
+				"PermanentMACAddress": "00:11:22:33:44:55",
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces/NIC.2"):
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"MACAddress":          "aa:bb:cc:dd:ee:01",
+				"PermanentMACAddress": "aa:bb:cc:dd:ee:ff",
+			})
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces/NIC.2"):
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	require.NoError(t, client.SetStaticIPv4(t.Context(), StaticIPv4Config{
+		MAC:        "AA-BB-CC-DD-EE-01",
+		Address:    "10.0.0.20",
+		SubnetMask: "255.255.255.0",
+		Gateway:    "10.0.0.1",
+		DNS:        []string{"10.0.0.53", "10.0.0.54"},
+	}))
+
+	require.NotNil(t, patchBody)
+	dhcp := patchBody["DHCPv4"].(map[string]any)
+	require.Equal(t, false, dhcp["DHCPEnabled"])
+
+	addresses := patchBody["IPv4StaticAddresses"].([]any)
+	require.Len(t, addresses, 1)
+	address := addresses[0].(map[string]any)
+	require.Equal(t, "10.0.0.20", address["Address"])
+	require.Equal(t, "255.255.255.0", address["SubnetMask"])
+	require.Equal(t, "10.0.0.1", address["Gateway"])
+	require.Equal(t, []any{"10.0.0.53", "10.0.0.54"}, patchBody["StaticNameServers"])
+}
+
+func TestClientSetStaticIPv4MethodNotAllowedIsUnsupported(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"EthernetInterfaces": map[string]string{
+					"@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces",
+				},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"Members": []map[string]string{{"@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces/NIC.1"}},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces/NIC.1"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"MACAddress": "aa:bb:cc:dd:ee:01"})
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces/NIC.1"):
+			http.Error(w, "PATCH is not supported for this iLO EthernetInterface", http.StatusMethodNotAllowed)
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	err := client.SetStaticIPv4(t.Context(), StaticIPv4Config{
+		MAC:        "aa:bb:cc:dd:ee:01",
+		Address:    "10.0.0.20",
+		SubnetMask: "255.255.255.0",
+		Gateway:    "10.0.0.1",
+	})
+	require.ErrorIs(t, err, ErrUnsupported)
+	require.ErrorContains(t, err, "returned HTTP 405")
+}
+
+func TestRedfishPathFromODataIDResolvesRelativeReferences(t *testing.T) {
+	path, err := redfishPathFromODataID("../Chassis/1?expand=.", "/redfish/v1/Systems/System.Embedded.1")
+	require.NoError(t, err)
+	require.Equal(t, "/redfish/v1/Chassis/1?expand=.", path)
+}
+
+func TestValidateStaticIPv4ConfigAllowsIPv6DNS(t *testing.T) {
+	require.NoError(t, ValidateStaticIPv4Config(StaticIPv4Config{
+		Address:    "10.0.0.20",
+		SubnetMask: "255.255.255.0",
+		Gateway:    "10.0.0.1",
+		DNS:        []string{"10.0.0.53", "2001:db8::53"},
+	}))
+}
+
+func TestValidateStaticIPv4ConfigRejectsInvalidDNS(t *testing.T) {
+	err := ValidateStaticIPv4Config(StaticIPv4Config{
+		Address:    "10.0.0.20",
+		SubnetMask: "255.255.255.0",
+		Gateway:    "10.0.0.1",
+		DNS:        []string{"not-an-ip"},
+	})
+	require.ErrorContains(t, err, `invalid IP DNS server "not-an-ip"`)
+}
+
+func TestClientSetStaticIPv4NoMatchingMAC(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !testSessionAuth(w, r) {
+			return
+		}
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"PowerState": "On",
+				"EthernetInterfaces": map[string]string{
+					"@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces",
+				},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"Members": []map[string]string{{"@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces/NIC.1"}},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/Systems/System.Embedded.1/EthernetInterfaces/NIC.1"):
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"MACAddress":          "00:11:22:33:44:55",
+				"PermanentMACAddress": "00:11:22:33:44:55",
+			})
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/EthernetInterfaces/"):
+			t.Fatal("SetStaticIPv4 should not PATCH when no MAC matches")
+		case strings.Contains(r.URL.Path, "/TrustedComponents"):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := dialTestClient(t, srv)
+	err := client.SetStaticIPv4(t.Context(), StaticIPv4Config{
+		MAC:        "aa:bb:cc:dd:ee:01",
+		Address:    "10.0.0.20",
+		SubnetMask: "255.255.255.0",
+		Gateway:    "10.0.0.1",
+	})
+	require.ErrorContains(t, err, "no Redfish Ethernet interface found for MAC aa:bb:cc:dd:ee:01")
 }
 
 func TestSessionExpiryRetry(t *testing.T) {


### PR DESCRIPTION
Allows booting to the netboot env without DHCP. Also includes a few other small netboot fixes.