### PR TITLE
storage: transact backend, frontend, and disk reloads

### DIFF
--- a/cmd/unbounded-storage/ARCHITECTURE.md
+++ b/cmd/unbounded-storage/ARCHITECTURE.md
@@ -184,10 +184,11 @@ activation. A failed preparation therefore leaves the prior resource, binding,
 and stripe geometry live and retryable. Active frontend entries record the
 binding and stripe geometry they realized, so a failed rebuild is detected and
 retried on the next apply. Replacement uses an undo-log transaction: the old
-driver remains owned until finalization and can be restored if a later local
-activation fails. The current reconciler finalizes each frontend operation
-immediately; cross-resource and cross-shard commit/rollback is not yet wired to
-that transaction boundary.
+backend and frontend remain owned until finalization and can be restored if a
+later local activation fails. A shard commits its complete backend/frontend pass
+together, retiring old frontends before old backends; any failure or deferral
+restores both registries plus their prior geometry and bindings. Cross-shard
+commit/rollback is not yet wired to this transaction boundary.
 
 ### Shutdown
 

--- a/cmd/unbounded-storage/ARCHITECTURE.md
+++ b/cmd/unbounded-storage/ARCHITECTURE.md
@@ -183,12 +183,15 @@ dormant `SO_REUSEPORT` socket, then enter the listening state only during
 activation. A failed preparation therefore leaves the prior resource, binding,
 and stripe geometry live and retryable. Active frontend entries record the
 binding and stripe geometry they realized, so a failed rebuild is detected and
-retried on the next apply. Replacement uses an undo-log transaction: the old
-backend and frontend remain owned until finalization and can be restored if a
-later local activation fails. A shard commits its complete backend/frontend pass
-together, retiring old frontends before old backends; any failure or deferral
-restores both registries plus their prior geometry and bindings. Cross-shard
-commit/rollback is not yet wired to this transaction boundary.
+retried on the next apply. Replacement is coordinated across shards with
+two-phase commit. Prepare stages backend and dormant frontend replacements
+invisibly while the old registries, geometry, and bindings remain live. After
+page-cache drain and disk reconciliation complete when required, routes are
+published and Commit activates frontends first, publishes backends next, then
+updates geometry, bindings, and spec maps. Abort drops staged transactions.
+Transaction-id mismatch or incomplete fan-in is indeterminate and fail-stop.
+Peer and disk reconciliation remain outside this rollback boundary, and route
+publication before Commit is irrevocable.
 
 ### Shutdown
 
@@ -602,7 +605,8 @@ registries are all updated without tearing the shard layer down. Backing
 memory, the topology plan, the fabric max in-flight knob, and the local
 `self` peer identity are fixed at startup (mostly sourced from the
 config `[startup]` section, see the CLI section), not reloadable config
-fields. Shard apply and page-cache-drain fan-in use one 60-second deadline
+fields. Each shard prepare, finish, and page-cache-drain fan-in uses one
+60-second absolute deadline
 for the complete worker set and report outstanding worker identities. A
 timeout, acknowledgement-channel disconnect, or partial broadcast send failure
 requests process shutdown: already-delivered commands may complete later, so
@@ -613,12 +617,13 @@ lifecycle/configuration failures; startup rejects them, while live apply
 requests fail-stop shutdown because remove/add mutations cannot be rolled back.
 All shard transports and fabric RPC handlers share one process-wide
 `RouteTableHandle`. The apply target is its only writer and publishes the new
-snapshot once, after shard acknowledgement, page-cache drain, and disk
-publication succeed. Disk open failures are returned after the realized subset
-is published, leaving the desired config retryable and routing on the prior
-snapshot. This keeps routing on the prior snapshot when an earlier
-apply step reports failure; other resource reconciliation is still not a
-whole-process transaction.
+snapshot after prepare, page-cache drain, and disk publication succeed and
+before the shard Commit decision. Backend/frontend resources remain invisible
+until Commit. A determinate prepare, drain, or disk failure is followed by
+Abort; an indeterminate phase or any failed Commit or Abort requests shutdown.
+Disk reconciliation still publishes its realized subset and peer reconciliation
+still mutates shared fabric state outside this transaction, so this is not
+whole-process transactionality.
 
 Sections (all optional, each falling back to defaults):
 
@@ -667,12 +672,11 @@ Sections (all optional, each falling back to defaults):
 After defaults and validation, loading constructs one immutable `LoadedConfig`:
 the raw `Config`, one owned `RuntimeGraph`, and one route snapshot built from
 that graph. The watcher (`notify`-based) emits these loaded snapshots; main's
-`wait_for_shutdown_with_updates` reconciles peers (remove + add on address/numa
-drift, via a `last_applied` cache), disks, and - by broadcasting the applied
-config to every shard - each shard's backend and frontend registries plus the
-routing snapshot. The apply target and shards consume the same loaded graph and
-routes; this is coherent preparation, not whole-process transactionality. It
-republishes the channel snapshot each update, logs
+`wait_for_shutdown_with_updates` reconciles peers, coordinates cross-shard
+backend/frontend two-phase commit, reconciles disks, and publishes routes. The
+apply target and shards consume the same loaded graph and transaction id. Peer
+and disk changes remain outside rollback, so this is not whole-process
+transactionality. It republishes the channel snapshot each update, logs
 `config gen=N ...`, and sets `SHUTDOWN` if the watcher disconnects.
 
 ### 7.12 `tls/` - the shared TLS transport

--- a/cmd/unbounded-storage/ARCHITECTURE.md
+++ b/cmd/unbounded-storage/ARCHITECTURE.md
@@ -184,12 +184,14 @@ binding and stripe geometry they realized, so a failed rebuild is detected and
 retried on the next apply. Replacement is coordinated across shards with
 two-phase commit. Prepare stages backend and dormant frontend replacements
 invisibly while the old registries, geometry, and bindings remain live. After
-page-cache drain and disk reconciliation complete when required, routes are
-published and Commit activates frontends first, publishes backends next, then
-updates geometry, bindings, and spec maps. Abort drops staged transactions.
-Transaction-id mismatch or incomplete fan-in is indeterminate and fail-stop.
-Peer and disk reconciliation remain outside this rollback boundary, and route
-publication before Commit is irrevocable.
+page-cache drain, disk reconciliation crosses the fail-stop boundary because
+opening a disk may provision or format it. Routes are then published and Commit
+activates frontends first, publishes backends next, then updates geometry,
+bindings, and spec maps. Abort drops staged transactions only before disk
+reconciliation begins. Transaction-id mismatch or incomplete fan-in is
+indeterminate and fail-stop. Peer and disk reconciliation remain outside this
+rollback boundary. Disk reconciliation begins the fail-stop region, and route
+publication before Commit is also irrevocable.
 
 ### Shutdown
 
@@ -567,10 +569,11 @@ path-sorted for stable hashing; `drain()` clears channels before handles.
 `DiskChannelDirectory` is the Arc'd hot-swap publication surface, and
 `LiveShardLocalStore` is a per-shard view over the live directory that
 re-registers buffers when it observes a swap (`current_or_replay`).
-Every reconcile publishes the realized open subset. A live open failure aborts
-config convergence so the same desired snapshot remains retryable; a startup
-open failure retires the parked shard layer. Same-path drift remains remove then
-add because provisioning and recovery cannot safely run beside the old engine.
+A successful reconcile publishes the new open set. A live open failure requests
+fail-stop shutdown because an earlier staged open may already have provisioned
+or formatted storage; a startup open failure retires the parked shard layer.
+Same-path drift requires restart because provisioning and recovery cannot safely
+run beside the old engine.
 
 **Stripe keys**: `stripe_key` derives the 32-byte content-addressed key;
 `METADATA_STRIPE_IDX` and `OriginRef`/`StripeReq` describe the request shape.
@@ -619,11 +622,12 @@ All shard transports and fabric RPC handlers share one process-wide
 `RouteTableHandle`. The apply target is its only writer and publishes the new
 snapshot after prepare, page-cache drain, and disk publication succeed and
 before the shard Commit decision. Backend/frontend resources remain invisible
-until Commit. A determinate prepare, drain, or disk failure is followed by
-Abort; an indeterminate phase or any failed Commit or Abort requests shutdown.
-Disk reconciliation still publishes its realized subset and peer reconciliation
-still mutates shared fabric state outside this transaction, so this is not
-whole-process transactionality.
+until Commit. A determinate prepare or drain failure is followed by Abort; a
+disk failure, an indeterminate phase, or any failed Commit or Abort requests
+shutdown.
+Disk reconciliation may mutate storage media and peer reconciliation mutates
+shared fabric state outside this transaction, so this is not whole-process
+transactionality.
 
 Sections (all optional, each falling back to defaults):
 

--- a/cmd/unbounded-storage/ARCHITECTURE.md
+++ b/cmd/unbounded-storage/ARCHITECTURE.md
@@ -161,15 +161,13 @@ excluded from the live-reload diff.
 
 ### Shard readiness and panic safety
 
-Each shard owns a phase-A reporter that emits exactly one `ShardReady` message:
-`Up { worker_idx, publish }` or `Failed(String)`. Its Drop fallback covers an
-early return or panic before the explicit report. Phase B uses the same
-consuming-report/Drop pattern. Main performs a bounded `recv()` exactly
-`joins.len()` times (it does **not** drain to disconnect, because live shards
-retain channel senders). Preparation returns a `PreparedShardLayer` only after
-all phase-B reports succeed. Activation starts RPC and releases the parked
-shards; on failure it sets the layer stop flag, drops the serve gates, joins
-shards in reverse order, and tears down fabric and backing keepalives.
+Each shard owns a phase-A reporter that emits exactly one worker-identified
+`ShardReady` message. Its Drop fallback covers an early return or panic before
+the explicit report. Phase B uses the same consuming-report/Drop pattern. Each
+collector has one absolute 60-second deadline, rejects duplicate or unexpected
+worker identities, and reports sorted outstanding workers. Preparation returns
+a `PreparedShardLayer` only after all phase-B reports succeed. Activation starts
+RPC and releases the parked shards.
 
 Shard panics are logged and resumed so the native join handle remains failed.
 Once serving starts, a lifetime guard balances the live-shard metric and sends
@@ -201,7 +199,9 @@ Every thread polls this flag.
 
 Teardown order is deliberate: join shard threads in reverse (releasing
 `Arc<engine>` references) **first**, clear disk channel publications, then
-`disk_registry.drain()`.
+`disk_registry.drain()`. All shard cleanup paths share the same ordered cleanup
+routine. A 60-second watchdog hard-exits with status 1 if shard cleanup stalls;
+it never detaches shard threads or drops registered memory while they may run.
 
 ## 5. Shard Bring-up (`run_shard`)
 

--- a/cmd/unbounded-storage/README.md
+++ b/cmd/unbounded-storage/README.md
@@ -64,6 +64,9 @@ cleared, and disks are drained last. At startup shards complete both readiness
 phases while parked; initial disks are reconciled and published before RPC
 servers and shard serving are activated. A startup disk-open failure retires
 the prepared shard layer rather than reporting a partial startup configuration.
+Each shard startup phase has a 60-second worker-identified deadline, and shard
+cleanup hard-exits after 60 seconds rather than detaching threads from registered
+memory.
 
 ## Configuration file
 

--- a/cmd/unbounded-storage/src/backend/mod.rs
+++ b/cmd/unbounded-storage/src/backend/mod.rs
@@ -47,7 +47,7 @@ pub use limiter::{Acquire, FetchLimiter, FetchPermit};
 pub use origin::{OriginBackend, OriginStream};
 
 #[cfg(target_os = "linux")]
-pub use registry::{BackendRegistry, RegistryFetchStream};
+pub use registry::{BackendRegistry, BackendRegistryTransaction, RegistryFetchStream};
 
 #[cfg(target_os = "linux")]
 pub use s3::S3Backend;

--- a/cmd/unbounded-storage/src/backend/registry.rs
+++ b/cmd/unbounded-storage/src/backend/registry.rs
@@ -59,6 +59,13 @@ pub struct BackendRegistry {
     ctx: BuildCtx,
 }
 
+pub struct BackendRegistryTransaction {
+    backends: Rc<RefCell<HashMap<String, Rc<OriginBackend>>>>,
+    ctx: BuildCtx,
+    originals: RefCell<HashMap<String, Option<Rc<OriginBackend>>>>,
+    completed: bool,
+}
+
 impl BackendRegistry {
     /// Build a registry seeded from `specs`, fetching through `handle`
     /// into the region based at `backing_base`. A spec that fails to
@@ -96,6 +103,53 @@ impl BackendRegistry {
     #[cfg(test)]
     pub fn contains(&self, id: &str) -> bool {
         self.backends.borrow().contains_key(id)
+    }
+
+    pub fn transaction(&self) -> BackendRegistryTransaction {
+        BackendRegistryTransaction {
+            backends: self.backends.clone(),
+            ctx: self.ctx.clone(),
+            originals: RefCell::new(HashMap::new()),
+            completed: false,
+        }
+    }
+}
+
+impl BackendRegistryTransaction {
+    pub fn finalize(mut self) {
+        self.completed = true;
+        self.originals.get_mut().clear();
+    }
+
+    pub fn rollback(mut self) {
+        self.rollback_inner();
+        self.completed = true;
+    }
+
+    fn record_original(&self, id: &str) {
+        let mut originals = self.originals.borrow_mut();
+        if originals.contains_key(id) {
+            return;
+        }
+        originals.insert(id.to_string(), self.backends.borrow_mut().remove(id));
+    }
+
+    fn rollback_inner(&mut self) {
+        let mut backends = self.backends.borrow_mut();
+        for (id, original) in self.originals.get_mut().drain() {
+            backends.remove(&id);
+            if let Some(original) = original {
+                backends.insert(id, original);
+            }
+        }
+    }
+}
+
+impl Drop for BackendRegistryTransaction {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.rollback_inner();
+        }
     }
 }
 
@@ -259,11 +313,31 @@ impl BackendReconcileTarget for BackendRegistry {
     }
 
     fn add(&self, spec: &BackendSpec) -> Result<(), String> {
-        // Build before mutating so a failed build leaves the live map untouched.
+        let transaction = self.transaction();
+        transaction.add(spec)?;
+        transaction.finalize();
+        Ok(())
+    }
+
+    fn remove(&self, id: &str) -> Result<(), String> {
+        let transaction = self.transaction();
+        transaction.remove(id)?;
+        transaction.finalize();
+        Ok(())
+    }
+}
+
+impl BackendReconcileTarget for BackendRegistryTransaction {
+    fn list(&self) -> Vec<String> {
+        self.backends.borrow().keys().cloned().collect()
+    }
+
+    fn add(&self, spec: &BackendSpec) -> Result<(), String> {
         let backend = self
             .ctx
             .build(spec)
             .map_err(|e| format!("build backend {}: {e}", spec.name))?;
+        self.record_original(&spec.name);
         self.backends
             .borrow_mut()
             .insert(spec.name.clone(), Rc::new(backend));
@@ -271,6 +345,7 @@ impl BackendReconcileTarget for BackendRegistry {
     }
 
     fn remove(&self, id: &str) -> Result<(), String> {
+        self.record_original(id);
         self.backends.borrow_mut().remove(id);
         Ok(())
     }
@@ -493,5 +568,48 @@ mod tests {
 
         drop(stream);
         assert!(selected.upgrade().is_none());
+    }
+
+    #[test]
+    fn transaction_drop_restores_all_backend_changes() {
+        let reg = registry(&[fake_spec("keep", 1), fake_spec("remove", 2)]);
+        {
+            let transaction = reg.transaction();
+            transaction.add(&fake_spec("keep", 3)).unwrap();
+            transaction.add(&fake_spec("new", 4)).unwrap();
+            transaction.remove("remove").unwrap();
+            assert!(reg.contains("new"));
+            assert!(!reg.contains("remove"));
+        }
+
+        assert!(reg.contains("keep"));
+        assert!(!reg.contains("new"));
+        assert!(reg.contains("remove"));
+    }
+
+    #[test]
+    fn transaction_finalize_commits_all_backend_changes() {
+        let reg = registry(&[fake_spec("keep", 1), fake_spec("remove", 2)]);
+        let transaction = reg.transaction();
+        transaction.add(&fake_spec("keep", 3)).unwrap();
+        transaction.add(&fake_spec("new", 4)).unwrap();
+        transaction.remove("remove").unwrap();
+        transaction.finalize();
+
+        assert!(reg.contains("keep"));
+        assert!(reg.contains("new"));
+        assert!(!reg.contains("remove"));
+    }
+
+    #[test]
+    fn failed_transaction_build_leaves_original_for_rollback() {
+        let reg = registry(&[fake_spec("keep", 1)]);
+        let transaction = reg.transaction();
+        transaction.add(&fake_spec("new", 2)).unwrap();
+        assert!(transaction.add(&http_spec("keep", "://bad")).is_err());
+        transaction.rollback();
+
+        assert!(reg.contains("keep"));
+        assert!(!reg.contains("new"));
     }
 }

--- a/cmd/unbounded-storage/src/backend/registry.rs
+++ b/cmd/unbounded-storage/src/backend/registry.rs
@@ -20,7 +20,7 @@
 //! the same way it drives the peer fabric.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -62,8 +62,8 @@ pub struct BackendRegistry {
 pub struct BackendRegistryTransaction {
     backends: Rc<RefCell<HashMap<String, Rc<OriginBackend>>>>,
     ctx: BuildCtx,
-    originals: RefCell<HashMap<String, Option<Rc<OriginBackend>>>>,
-    completed: bool,
+    projected: RefCell<HashSet<String>>,
+    replacements: RefCell<HashMap<String, Rc<OriginBackend>>>,
 }
 
 impl BackendRegistry {
@@ -106,50 +106,30 @@ impl BackendRegistry {
     }
 
     pub fn transaction(&self) -> BackendRegistryTransaction {
+        let projected = self.backends.borrow().keys().cloned().collect();
         BackendRegistryTransaction {
             backends: self.backends.clone(),
             ctx: self.ctx.clone(),
-            originals: RefCell::new(HashMap::new()),
-            completed: false,
+            projected: RefCell::new(projected),
+            replacements: RefCell::new(HashMap::new()),
         }
     }
 }
 
 impl BackendRegistryTransaction {
-    pub fn finalize(mut self) {
-        self.completed = true;
-        self.originals.get_mut().clear();
-    }
-
-    pub fn rollback(mut self) {
-        self.rollback_inner();
-        self.completed = true;
-    }
-
-    fn record_original(&self, id: &str) {
-        let mut originals = self.originals.borrow_mut();
-        if originals.contains_key(id) {
-            return;
-        }
-        originals.insert(id.to_string(), self.backends.borrow_mut().remove(id));
-    }
-
-    fn rollback_inner(&mut self) {
+    pub fn finalize(self) {
+        let projected = self.projected.into_inner();
+        let replacements = self.replacements.into_inner();
         let mut backends = self.backends.borrow_mut();
-        for (id, original) in self.originals.get_mut().drain() {
-            backends.remove(&id);
-            if let Some(original) = original {
-                backends.insert(id, original);
-            }
+        backends.retain(|id, _| projected.contains(id));
+        for (id, backend) in replacements {
+            backends.insert(id, backend);
         }
     }
-}
 
-impl Drop for BackendRegistryTransaction {
-    fn drop(&mut self) {
-        if !self.completed {
-            self.rollback_inner();
-        }
+    pub fn rollback(self) {
+        // Staged backends have never been published, so dropping the
+        // transaction is the complete rollback operation.
     }
 }
 
@@ -329,7 +309,7 @@ impl BackendReconcileTarget for BackendRegistry {
 
 impl BackendReconcileTarget for BackendRegistryTransaction {
     fn list(&self) -> Vec<String> {
-        self.backends.borrow().keys().cloned().collect()
+        self.projected.borrow().iter().cloned().collect()
     }
 
     fn add(&self, spec: &BackendSpec) -> Result<(), String> {
@@ -337,16 +317,16 @@ impl BackendReconcileTarget for BackendRegistryTransaction {
             .ctx
             .build(spec)
             .map_err(|e| format!("build backend {}: {e}", spec.name))?;
-        self.record_original(&spec.name);
-        self.backends
+        self.projected.borrow_mut().insert(spec.name.clone());
+        self.replacements
             .borrow_mut()
             .insert(spec.name.clone(), Rc::new(backend));
         Ok(())
     }
 
     fn remove(&self, id: &str) -> Result<(), String> {
-        self.record_original(id);
-        self.backends.borrow_mut().remove(id);
+        self.projected.borrow_mut().remove(id);
+        self.replacements.borrow_mut().remove(id);
         Ok(())
     }
 }
@@ -571,15 +551,17 @@ mod tests {
     }
 
     #[test]
-    fn transaction_drop_restores_all_backend_changes() {
+    fn transaction_stages_all_backend_changes_invisibly() {
         let reg = registry(&[fake_spec("keep", 1), fake_spec("remove", 2)]);
         {
             let transaction = reg.transaction();
             transaction.add(&fake_spec("keep", 3)).unwrap();
             transaction.add(&fake_spec("new", 4)).unwrap();
             transaction.remove("remove").unwrap();
-            assert!(reg.contains("new"));
-            assert!(!reg.contains("remove"));
+            assert!(transaction.list().contains(&"new".to_string()));
+            assert!(!transaction.list().contains(&"remove".to_string()));
+            assert!(!reg.contains("new"));
+            assert!(reg.contains("remove"));
         }
 
         assert!(reg.contains("keep"));
@@ -611,5 +593,18 @@ mod tests {
 
         assert!(reg.contains("keep"));
         assert!(!reg.contains("new"));
+    }
+
+    #[test]
+    fn remove_then_add_stages_a_replacement() {
+        let reg = registry(&[fake_spec("replace", 1)]);
+        let original = reg.backends.borrow()["replace"].clone();
+        let transaction = reg.transaction();
+        transaction.remove("replace").unwrap();
+        transaction.add(&fake_spec("replace", 2)).unwrap();
+
+        assert!(Rc::ptr_eq(&reg.backends.borrow()["replace"], &original));
+        transaction.finalize();
+        assert!(!Rc::ptr_eq(&reg.backends.borrow()["replace"], &original));
     }
 }

--- a/cmd/unbounded-storage/src/config/control.rs
+++ b/cmd/unbounded-storage/src/config/control.rs
@@ -45,24 +45,36 @@ use crate::runtime::WorkerIdx;
 /// command there (so all `!Send` per-shard state stays thread-local),
 /// then acknowledges.
 pub enum ShardCommand {
-    /// Apply a new configuration in place: republish routing and
-    /// reconcile this shard's backend registry, frontend registry, and
-    /// any disk-policy side effects.
-    ApplyConfig(ShardApply),
-    /// Drop all retained in-memory page-cache entries after process-level
-    /// disk policy publication has landed.
+    /// Stage a new backend/frontend configuration without publishing it.
+    PrepareConfig(ShardPrepare),
+    /// Commit or discard a previously prepared configuration.
+    FinishConfig(ShardFinish),
+    /// Drop retained in-memory page-cache entries before process-level
+    /// disk reconciliation and publication.
     DrainPageCache(ShardDrainPageCache),
 }
 
 /// Payload of [`ShardCommand::DrainPageCache`].
 pub struct ShardDrainPageCache {
+    pub id: ShardTransactionId,
     /// Channel the shard sends its [`ShardAck`] on once the drain has
     /// completed on the shard thread.
     pub ack: Sender<ShardAck>,
 }
 
-/// Payload of [`ShardCommand::ApplyConfig`].
-pub struct ShardApply {
+/// Identifier shared by every command and acknowledgement in one apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShardTransactionId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShardDecision {
+    Commit,
+    Abort,
+}
+
+/// Payload of [`ShardCommand::PrepareConfig`].
+pub struct ShardPrepare {
+    pub id: ShardTransactionId,
     /// The new finalized config, runtime graph, and route table.
     pub loaded: Arc<LoadedConfig>,
     /// Section-level diff that selected this apply path.
@@ -72,9 +84,17 @@ pub struct ShardApply {
     pub ack: Sender<ShardAck>,
 }
 
+/// Payload of [`ShardCommand::FinishConfig`].
+pub struct ShardFinish {
+    pub id: ShardTransactionId,
+    pub decision: ShardDecision,
+    pub ack: Sender<ShardAck>,
+}
+
 /// A shard's acknowledgement that it finished (or failed) applying a
 /// [`ShardCommand`].
 pub struct ShardAck {
+    pub id: ShardTransactionId,
     pub worker: WorkerIdx,
     pub result: Result<(), String>,
 }
@@ -100,8 +120,15 @@ pub enum ApplyError {
         received: usize,
         outstanding: Vec<WorkerIdx>,
     },
+    /// A shard acknowledged a different transaction, so the requested
+    /// transaction's state cannot be established safely.
+    AckTransactionMismatch {
+        worker: WorkerIdx,
+        expected: ShardTransactionId,
+        received: ShardTransactionId,
+    },
     /// One or more shards reported a failure while applying.
-    ShardApply(Vec<(WorkerIdx, String)>),
+    ShardFailure(Vec<(WorkerIdx, String)>),
     /// The process-level apply target rejected the config.
     Target(String),
 }
@@ -130,7 +157,16 @@ impl fmt::Display for ApplyError {
                 "ack deadline expired after {received}/{expected} shards reported; outstanding workers: {}",
                 format_workers(outstanding),
             ),
-            ApplyError::ShardApply(failures) => {
+            ApplyError::AckTransactionMismatch {
+                worker,
+                expected,
+                received,
+            } => write!(
+                f,
+                "shard {} acknowledged transaction {} while transaction {} was expected",
+                worker.0, received.0, expected.0,
+            ),
+            ApplyError::ShardFailure(failures) => {
                 write!(f, "{} shard(s) failed to apply config:", failures.len())?;
                 for (w, e) in failures {
                     write!(f, " [shard {}: {e}]", w.0)?;
@@ -151,7 +187,10 @@ impl ApplyError {
     pub fn apply_state_is_indeterminate(&self) -> bool {
         matches!(
             self,
-            Self::ShardSend(_) | Self::AckDisconnected { .. } | Self::AckTimeout { .. }
+            Self::ShardSend(_)
+                | Self::AckDisconnected { .. }
+                | Self::AckTimeout { .. }
+                | Self::AckTransactionMismatch { .. }
         )
     }
 }
@@ -382,8 +421,8 @@ impl<T: ConfigApplyTarget> ConfigController<T> {
 /// A reusable blocking fan-out/fan-in primitive over a set of shard
 /// control channels.
 ///
-/// [`broadcast_apply`](Self::broadcast_apply) sends one
-/// [`ShardCommand::ApplyConfig`] to every shard and blocks until each
+/// [`broadcast_prepare`](Self::broadcast_prepare) sends one
+/// [`ShardCommand::PrepareConfig`] to every shard and blocks until each
 /// has acknowledged or the group's absolute deadline expires, so the caller
 /// can guarantee the change has landed on every shard thread before returning
 /// success. This is the concrete
@@ -410,8 +449,7 @@ impl ShardControlGroup {
         self.senders.is_empty()
     }
 
-    /// Send one loaded snapshot to every shard and block until all of
-    /// them acknowledge.
+    /// Stage one loaded snapshot on every shard and block until all acknowledge.
     ///
     /// Returns `Ok(())` only when every shard reports success. If a
     /// channel is closed at send time, the ack deadline expires, the ack
@@ -419,13 +457,15 @@ impl ShardControlGroup {
     /// failure, the corresponding [`ApplyError`] is returned. Until a terminal
     /// channel/deadline error, fan-in keeps collecting reports so one failing
     /// shard does not mask failures from the others.
-    pub fn broadcast_apply(
+    pub fn broadcast_prepare(
         &self,
+        id: ShardTransactionId,
         loaded: Arc<LoadedConfig>,
         diff: ConfigDiff,
     ) -> Result<(), ApplyError> {
-        self.broadcast(|ack| {
-            ShardCommand::ApplyConfig(ShardApply {
+        self.broadcast(id, |ack| {
+            ShardCommand::PrepareConfig(ShardPrepare {
+                id,
                 loaded: loaded.clone(),
                 diff,
                 ack,
@@ -433,13 +473,26 @@ impl ShardControlGroup {
         })
     }
 
-    /// Ask every shard to drain retained RAM page-cache entries and block
-    /// until all have acknowledged.
-    pub fn broadcast_drain_page_cache(&self) -> Result<(), ApplyError> {
-        self.broadcast(|ack| ShardCommand::DrainPageCache(ShardDrainPageCache { ack }))
+    /// Commit or abort a prepared transaction on every shard.
+    pub fn broadcast_finish(
+        &self,
+        id: ShardTransactionId,
+        decision: ShardDecision,
+    ) -> Result<(), ApplyError> {
+        self.broadcast(id, |ack| {
+            ShardCommand::FinishConfig(ShardFinish { id, decision, ack })
+        })
     }
 
-    fn broadcast<F>(&self, make_cmd: F) -> Result<(), ApplyError>
+    /// Ask every shard to drain retained RAM page-cache entries and block
+    /// until all have acknowledged.
+    pub fn broadcast_drain_page_cache(&self, id: ShardTransactionId) -> Result<(), ApplyError> {
+        self.broadcast(id, |ack| {
+            ShardCommand::DrainPageCache(ShardDrainPageCache { id, ack })
+        })
+    }
+
+    fn broadcast<F>(&self, id: ShardTransactionId, make_cmd: F) -> Result<(), ApplyError>
     where
         F: Fn(Sender<ShardAck>) -> ShardCommand,
     {
@@ -471,6 +524,13 @@ impl ShardControlGroup {
             };
             match ack_rx.recv_timeout(remaining) {
                 Ok(ack) => {
+                    if ack.id != id {
+                        return Err(ApplyError::AckTransactionMismatch {
+                            worker: ack.worker,
+                            expected: id,
+                            received: ack.id,
+                        });
+                    }
                     if outstanding.remove(&ack.worker) {
                         received += 1;
                         if let Err(e) = ack.result {
@@ -498,7 +558,7 @@ impl ShardControlGroup {
         if failures.is_empty() {
             Ok(())
         } else {
-            Err(ApplyError::ShardApply(failures))
+            Err(ApplyError::ShardFailure(failures))
         }
     }
 }
@@ -536,7 +596,8 @@ mod tests {
 
     fn ack_sender(cmd: ShardCommand) -> Sender<ShardAck> {
         match cmd {
-            ShardCommand::ApplyConfig(apply) => apply.ack,
+            ShardCommand::PrepareConfig(prepare) => prepare.ack,
+            ShardCommand::FinishConfig(finish) => finish.ack,
             ShardCommand::DrainPageCache(drain) => drain.ack,
         }
     }
@@ -560,9 +621,18 @@ mod tests {
                 let mut applied = 0usize;
                 while let Ok(cmd) = rx.recv() {
                     match cmd {
-                        ShardCommand::ApplyConfig(apply) => {
+                        ShardCommand::PrepareConfig(apply) => {
                             applied += 1;
                             let _ = apply.ack.send(ShardAck {
+                                id: apply.id,
+                                worker: widx,
+                                result: result.clone(),
+                            });
+                        }
+                        ShardCommand::FinishConfig(finish) => {
+                            applied += 1;
+                            let _ = finish.ack.send(ShardAck {
+                                id: finish.id,
                                 worker: widx,
                                 result: result.clone(),
                             });
@@ -570,6 +640,7 @@ mod tests {
                         ShardCommand::DrainPageCache(drain) => {
                             applied += 1;
                             let _ = drain.ack.send(ShardAck {
+                                id: drain.id,
                                 worker: widx,
                                 result: result.clone(),
                             });
@@ -583,11 +654,15 @@ mod tests {
     }
 
     #[test]
-    fn broadcast_apply_blocks_until_every_shard_acks() {
+    fn broadcast_prepare_blocks_until_every_shard_acks() {
         let (senders, joins) = spawn_mock_shards(vec![Ok(()), Ok(()), Ok(())]);
         let group = control_group(senders);
 
-        let out = group.broadcast_apply(loaded(Config::default()), ConfigDiff::default());
+        let out = group.broadcast_prepare(
+            ShardTransactionId(1),
+            loaded(Config::default()),
+            ConfigDiff::default(),
+        );
         assert!(out.is_ok(), "expected success, got {out:?}");
 
         // Closing the group drops the senders so the mock shard threads
@@ -599,19 +674,21 @@ mod tests {
     }
 
     #[test]
-    fn broadcast_apply_delivers_the_same_loaded_snapshot() {
+    fn broadcast_prepare_delivers_the_same_id_and_loaded_snapshot() {
         let (tx, rx) = mpsc::channel::<ShardCommand>();
         let group = control_group(vec![(WorkerIdx(0), tx)]);
         let loaded = loaded(Config::default());
         let expected = loaded.clone();
         let join = thread::spawn(move || {
-            let ShardCommand::ApplyConfig(apply) = rx.recv().unwrap() else {
+            let ShardCommand::PrepareConfig(apply) = rx.recv().unwrap() else {
                 panic!("expected config apply");
             };
+            assert_eq!(apply.id, ShardTransactionId(17));
             assert!(Arc::ptr_eq(&apply.loaded, &expected));
             apply
                 .ack
                 .send(ShardAck {
+                    id: apply.id,
                     worker: WorkerIdx(0),
                     result: Ok(()),
                 })
@@ -619,21 +696,96 @@ mod tests {
         });
 
         group
-            .broadcast_apply(loaded, ConfigDiff::default())
+            .broadcast_prepare(ShardTransactionId(17), loaded, ConfigDiff::default())
             .unwrap();
         join.join().unwrap();
     }
 
     #[test]
-    fn broadcast_apply_reports_shard_failures() {
+    fn broadcast_finish_and_drain_carry_transaction_id() {
+        let (tx, rx) = mpsc::channel::<ShardCommand>();
+        let group = control_group(vec![(WorkerIdx(0), tx)]);
+        let join = thread::spawn(move || {
+            let ShardCommand::DrainPageCache(drain) = rx.recv().unwrap() else {
+                panic!("expected page-cache drain");
+            };
+            assert_eq!(drain.id, ShardTransactionId(23));
+            drain
+                .ack
+                .send(ShardAck {
+                    id: drain.id,
+                    worker: WorkerIdx(0),
+                    result: Ok(()),
+                })
+                .unwrap();
+
+            let ShardCommand::FinishConfig(finish) = rx.recv().unwrap() else {
+                panic!("expected config finish");
+            };
+            assert_eq!(finish.id, ShardTransactionId(23));
+            assert_eq!(finish.decision, ShardDecision::Commit);
+            finish
+                .ack
+                .send(ShardAck {
+                    id: finish.id,
+                    worker: WorkerIdx(0),
+                    result: Ok(()),
+                })
+                .unwrap();
+        });
+
+        group
+            .broadcast_drain_page_cache(ShardTransactionId(23))
+            .unwrap();
+        group
+            .broadcast_finish(ShardTransactionId(23), ShardDecision::Commit)
+            .unwrap();
+        join.join().unwrap();
+    }
+
+    #[test]
+    fn mismatched_ack_transaction_is_indeterminate() {
+        let (tx, rx) = mpsc::channel::<ShardCommand>();
+        let group = control_group(vec![(WorkerIdx(4), tx)]);
+        let join = thread::spawn(move || {
+            let ack = ack_sender(rx.recv().unwrap());
+            ack.send(ShardAck {
+                id: ShardTransactionId(99),
+                worker: WorkerIdx(4),
+                result: Ok(()),
+            })
+            .unwrap();
+        });
+
+        let error = group
+            .broadcast_finish(ShardTransactionId(3), ShardDecision::Abort)
+            .expect_err("mismatched transaction must fail fan-in");
+        assert!(matches!(
+            error,
+            ApplyError::AckTransactionMismatch {
+                worker: WorkerIdx(4),
+                expected: ShardTransactionId(3),
+                received: ShardTransactionId(99),
+            }
+        ));
+        assert!(error.apply_state_is_indeterminate());
+        join.join().unwrap();
+    }
+
+    #[test]
+    fn broadcast_prepare_reports_shard_failures() {
         let (senders, joins) = spawn_mock_shards(vec![Ok(()), Err("boom".to_string()), Ok(())]);
         let group = control_group(senders);
 
         let err = group
-            .broadcast_apply(loaded(Config::default()), ConfigDiff::default())
+            .broadcast_prepare(
+                ShardTransactionId(1),
+                loaded(Config::default()),
+                ConfigDiff::default(),
+            )
             .expect_err("a failing shard must surface as an error");
         match err {
-            ApplyError::ShardApply(failures) => {
+            ApplyError::ShardFailure(failures) => {
                 assert_eq!(failures.len(), 1);
                 assert_eq!(failures[0].0, WorkerIdx(1));
                 assert_eq!(failures[0].1, "boom");
@@ -648,18 +800,22 @@ mod tests {
     }
 
     #[test]
-    fn broadcast_apply_on_empty_group_is_a_noop() {
+    fn broadcast_prepare_on_empty_group_is_a_noop() {
         let group = control_group(Vec::new());
         assert!(group.is_empty());
         assert!(
             group
-                .broadcast_apply(loaded(Config::default()), ConfigDiff::default(),)
+                .broadcast_prepare(
+                    ShardTransactionId(1),
+                    loaded(Config::default()),
+                    ConfigDiff::default(),
+                )
                 .is_ok()
         );
     }
 
     #[test]
-    fn broadcast_apply_errors_when_a_shard_channel_is_closed() {
+    fn broadcast_prepare_errors_when_a_shard_channel_is_closed() {
         let (mut senders, joins) = spawn_mock_shards(vec![Ok(())]);
         // Add a dead channel whose receiver has already been dropped.
         let (dead_tx, dead_rx) = mpsc::channel::<ShardCommand>();
@@ -668,7 +824,11 @@ mod tests {
         let group = control_group(senders);
 
         let err = group
-            .broadcast_apply(loaded(Config::default()), ConfigDiff::default())
+            .broadcast_prepare(
+                ShardTransactionId(1),
+                loaded(Config::default()),
+                ConfigDiff::default(),
+            )
             .expect_err("closed channel must error");
         assert!(matches!(err, ApplyError::ShardSend(WorkerIdx(99))));
         assert!(err.apply_state_is_indeterminate());
@@ -682,19 +842,20 @@ mod tests {
     #[test]
     fn reported_shard_failure_is_not_indeterminate() {
         assert!(
-            !ApplyError::ShardApply(vec![(WorkerIdx(1), "failed".to_string())])
+            !ApplyError::ShardFailure(vec![(WorkerIdx(1), "failed".to_string())])
                 .apply_state_is_indeterminate()
         );
         assert!(!ApplyError::Target("rejected".to_string()).apply_state_is_indeterminate());
     }
 
     #[test]
-    fn broadcast_apply_timeout_lists_outstanding_workers() {
+    fn broadcast_prepare_timeout_lists_outstanding_workers() {
         let (tx0, rx0) = mpsc::channel::<ShardCommand>();
         let (tx1, rx1) = mpsc::channel::<ShardCommand>();
         let join0 = thread::spawn(move || {
             let ack = ack_sender(rx0.recv().unwrap());
             ack.send(ShardAck {
+                id: ShardTransactionId(1),
                 worker: WorkerIdx(0),
                 result: Ok(()),
             })
@@ -704,6 +865,7 @@ mod tests {
             let ack = ack_sender(rx1.recv().unwrap());
             thread::sleep(Duration::from_millis(100));
             let _ = ack.send(ShardAck {
+                id: ShardTransactionId(1),
                 worker: WorkerIdx(1),
                 result: Ok(()),
             });
@@ -714,7 +876,11 @@ mod tests {
         );
 
         let error = group
-            .broadcast_apply(loaded(Config::default()), ConfigDiff::default())
+            .broadcast_prepare(
+                ShardTransactionId(1),
+                loaded(Config::default()),
+                ConfigDiff::default(),
+            )
             .expect_err("missing acknowledgement must time out");
         assert!(matches!(
             error,
@@ -737,6 +903,7 @@ mod tests {
             let ack = ack_sender(rx0.recv().unwrap());
             for _ in 0..2 {
                 ack.send(ShardAck {
+                    id: ShardTransactionId(1),
                     worker: WorkerIdx(0),
                     result: Ok(()),
                 })
@@ -754,7 +921,7 @@ mod tests {
         );
 
         let error = group
-            .broadcast_drain_page_cache()
+            .broadcast_drain_page_cache(ShardTransactionId(1))
             .expect_err("duplicate acknowledgement must not complete fan-in");
         assert!(matches!(
             error,
@@ -776,7 +943,7 @@ mod tests {
         let group = control_group(vec![(WorkerIdx(7), tx)]);
 
         let error = group
-            .broadcast_drain_page_cache()
+            .broadcast_drain_page_cache(ShardTransactionId(1))
             .expect_err("dropped acknowledgement sender must disconnect fan-in");
         assert!(matches!(
             error,
@@ -807,7 +974,10 @@ mod tests {
         ) -> Result<(), ApplyError> {
             self.last_diff = Some(*diff);
             if self.fail_in_place {
-                return Err(ApplyError::ShardApply(vec![(WorkerIdx(0), "nope".into())]));
+                return Err(ApplyError::ShardFailure(vec![(
+                    WorkerIdx(0),
+                    "nope".into(),
+                )]));
             }
             self.in_place += 1;
             Ok(())

--- a/cmd/unbounded-storage/src/config/mod.rs
+++ b/cmd/unbounded-storage/src/config/mod.rs
@@ -15,8 +15,8 @@ pub mod watch;
 pub use apply::peer_spec_to_connection;
 pub use control::{
     ApplyError, ApplyOutcome, ApplyTier, ConfigApplyTarget, ConfigController,
-    ConfigVersionSnapshot, ConfigVersionStatus, ShardAck, ShardApply, ShardCommand,
-    ShardControlGroup,
+    ConfigVersionSnapshot, ConfigVersionStatus, ShardAck, ShardCommand, ShardControlGroup,
+    ShardDecision, ShardDrainPageCache, ShardFinish, ShardPrepare, ShardTransactionId,
 };
 pub use diff::ConfigDiff;
 pub use graph::{

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -954,8 +954,20 @@ fn run_shard(
                         failures.extend(combined.frontends.failures.clone());
                         let commit = failures.is_empty() && combined.frontends.deferred.is_empty();
                         let result = if commit {
-                            // Retire old frontends before their old backends.
-                            frontend_transaction.finalize();
+                            // Activate and retire old frontends before their
+                            // old backends. A local activation failure leaves
+                            // both live registries unchanged.
+                            if let Err(error) = frontend_transaction.finalize() {
+                                backend_transaction.rollback();
+                                *geometry.borrow_mut() = prior_geometry;
+                                *bindings.borrow_mut() = prior_bindings;
+                                let _ = apply.ack.send(config::ShardAck {
+                                    worker: widx,
+                                    result: Err(error),
+                                });
+                                did_work = true;
+                                continue;
+                            }
                             backend_transaction.finalize();
                             last_backends = combined.backends.applied;
                             last_frontends = combined.frontends.applied;
@@ -1426,48 +1438,61 @@ impl FrontendBuildCtx {
 struct FrontendRegistryTransaction {
     ctx: FrontendBuildCtx,
     frontends: Rc<RefCell<HashMap<String, ActiveShardFrontend>>>,
-    entries: RefCell<Option<RegistryTransaction<ActiveShardFrontend>>>,
+    projected: RefCell<HashSet<String>>,
+    replacements: RefCell<HashMap<String, PreparedShardFrontend>>,
 }
 
 impl FrontendRegistryTransaction {
-    fn finalize(self) {
-        self.entries
-            .borrow_mut()
-            .take()
-            .expect("frontend transaction active")
-            .finalize();
+    fn finalize(self) -> Result<(), String> {
+        let projected = self.projected.into_inner();
+        let mut replacements: Vec<_> = self.replacements.into_inner().into_iter().collect();
+        replacements.sort_by(|a, b| a.0.cmp(&b.0));
+
+        // Activate every replacement before touching the live registry.
+        // If one listen/driver construction fails, the temporary drivers
+        // drop and every old frontend remains installed.
+        let mut activated = Vec::with_capacity(replacements.len());
+        for (id, prepared) in replacements {
+            activated.push((id.clone(), self.ctx.activate(&id, prepared)?));
+        }
+
+        let mut entries = RegistryTransaction::new(self.frontends.clone());
+        let current: Vec<_> = self.frontends.borrow().keys().cloned().collect();
+        for id in current {
+            if !projected.contains(&id) {
+                entries.remove(&id);
+            }
+        }
+        for (id, frontend) in activated {
+            entries.replace(id, frontend);
+        }
+        entries.finalize();
+        Ok(())
     }
 
     fn rollback(self) {
-        self.entries
-            .borrow_mut()
-            .take()
-            .expect("frontend transaction active")
-            .rollback();
+        // Prepared frontends have never listened or entered the live map.
+        // Dropping them closes dormant bound sockets.
     }
 }
 
 impl config::reconcile::FrontendReconcileTarget for FrontendRegistryTransaction {
     fn list(&self) -> Vec<String> {
-        self.frontends.borrow().keys().cloned().collect()
+        self.projected.borrow().iter().cloned().collect()
     }
 
     fn add(&self, spec: &FrontendSpec) -> Result<(), String> {
-        let frontend = self.ctx.build(spec)?;
-        self.entries
+        let frontend = self.ctx.prepare(spec)?;
+        self.projected.borrow_mut().insert(spec.name.clone());
+        self.replacements
             .borrow_mut()
-            .as_mut()
-            .expect("frontend transaction active")
-            .replace(spec.name.clone(), frontend);
+            .insert(spec.name.clone(), frontend);
         Ok(())
     }
 
     fn remove(&self, id: &str) -> Result<(), String> {
-        self.entries
-            .borrow_mut()
-            .as_mut()
-            .expect("frontend transaction active")
-            .remove(id);
+        self.projected.borrow_mut().remove(id);
+        self.replacements.borrow_mut().remove(id);
         Ok(())
     }
 }
@@ -1518,10 +1543,12 @@ impl FrontendRegistry {
     }
 
     fn transaction(&self) -> FrontendRegistryTransaction {
+        let projected = self.frontends.borrow().keys().cloned().collect();
         FrontendRegistryTransaction {
             ctx: self.ctx.clone(),
             frontends: self.frontends.clone(),
-            entries: RefCell::new(Some(RegistryTransaction::new(self.frontends.clone()))),
+            projected: RefCell::new(projected),
+            replacements: RefCell::new(HashMap::new()),
         }
     }
 
@@ -1542,15 +1569,13 @@ impl config::reconcile::FrontendReconcileTarget for FrontendRegistry {
     fn add(&self, spec: &FrontendSpec) -> Result<(), String> {
         let transaction = self.transaction();
         config::reconcile::FrontendReconcileTarget::add(&transaction, spec)?;
-        transaction.finalize();
-        Ok(())
+        transaction.finalize()
     }
 
     fn remove(&self, id: &str) -> Result<(), String> {
         let transaction = self.transaction();
         config::reconcile::FrontendReconcileTarget::remove(&transaction, id)?;
-        transaction.finalize();
-        Ok(())
+        transaction.finalize()
     }
 }
 

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use clap::Parser;
 
-use unbounded_storage::backend::BackendRegistry;
+use unbounded_storage::backend::{BackendRegistry, BackendRegistryTransaction};
 use unbounded_storage::bufferpool::{Pool, PoolConfig};
 use unbounded_storage::config::{
     self, BackendSpec, Config, FrontendSpec, LoadedConfig, ResolvedFrontendBinding, frontend_spec,
@@ -698,9 +698,8 @@ fn run_shard(
     // Shared, live-reloadable routing surface. Built once from the
     // startup config and handed (by cheap clone) to every p2p consumer
     // on this shard: the pool transport, the recursive RPC handler, and
-    // the control-drain tick hook below. A `ShardCommand::ApplyConfig`
-    // republishes through this single handle so all consumers observe
-    // the new finger table atomically without a restart.
+    // the control-drain tick hook below. Process-level route publication
+    // updates this handle atomically for all consumers.
     let transport = match RoutedTransport::with_routes(
         fabric.clone(),
         mr,
@@ -875,18 +874,8 @@ fn run_shard(
         }
     };
 
-    // Control-drain tick hook: applies live config changes on this
-    // shard's own thread so all `!Send` per-shard state stays
-    // thread-local. Each `ShardCommand::ApplyConfig` republishes the
-    // routing surface through this shard's `RouteTableHandle` (observed
-    // atomically by its transport; the fabric RPC handlers are reloaded
-    // separately by the `FabricGroup`), refreshes the stripe geometry,
-    // reconciles the transport origin-backend registry and the frontend
-    // registry toward the new config, applies disk-policy side effects,
-    // and then acknowledges so the coordinator's blocking apply can
-    // complete. Everything is driven from this one thread, and the
-    // build-from-spec work (DNS resolve, listener bind) stays off the
-    // fast path.
+    // Control-drain tick hook: stages and finishes backend/frontend changes
+    // on this shard's thread so the `!Send` transactions remain thread-local.
     {
         let transport_registry = transport_registry.clone();
         let frontend_registry = frontend_registry.clone();
@@ -901,113 +890,165 @@ fn run_shard(
             .iter()
             .map(|f| (f.name.clone(), f.clone()))
             .collect();
+        let mut transaction = PendingShardState::Idle;
         shard_loop.add_tick_hook(move || {
             let mut did_work = false;
             while let Ok(cmd) = ctrl_rx.try_recv() {
                 match cmd {
-                    config::ShardCommand::ApplyConfig(apply) => {
-                        let desired_backends = apply.loaded.config().backends.as_slice();
-                        let desired_frontends = apply.loaded.config().frontends.as_slice();
-                        let desired_frontend_backends =
-                            config::frontend_backend_map(&apply.loaded.runtime().frontends);
-                        let prior_geometry = geometry.borrow().clone();
-                        let prior_bindings = bindings.borrow().clone();
-                        // Refresh stripe geometry before building any
-                        // frontend so a co-applied backend stripe change
-                        // is visible to a frontend add in the same pass.
-                        {
-                            let mut g = geometry.borrow_mut();
-                            g.clear();
-                            for b in desired_backends {
-                                g.insert(b.name.clone(), b.stripe_size_bytes());
-                            }
-                        }
-
-                        let desired_activations = frontend_activations(
-                            &apply.loaded.runtime().frontends,
-                            desired_backends,
-                        );
-                        let frontends_to_rebuild = frontend_rebuild_ids(
-                            &frontend_registry.realized_activations(),
-                            &desired_activations,
-                        );
-                        let forced_frontend_updates: HashSet<String> =
-                            frontends_to_rebuild.into_iter().collect();
-                        *bindings.borrow_mut() = apply.loaded.runtime().frontends.clone();
-
-                        let backend_transaction = transport_registry.transaction();
-                        let frontend_transaction = frontend_registry.transaction();
-
-                        // Drive provisional backend and frontend maps together
-                        // so frontend adds are gated on the desired backend.
-                        let combined = config::reconcile::reconcile_backends_and_frontends(
-                            &backend_transaction,
-                            &frontend_transaction,
-                            desired_backends,
-                            desired_frontends,
-                            &desired_frontend_backends,
-                            &forced_frontend_updates,
-                            Some(&last_backends),
-                            Some(&last_frontends),
-                        );
-                        let mut failures = combined.backends.failures.clone();
-                        failures.extend(combined.frontends.failures.clone());
-                        let commit = failures.is_empty() && combined.frontends.deferred.is_empty();
-                        let result = if commit {
-                            // Activate and retire old frontends before their
-                            // old backends. A local activation failure leaves
-                            // both live registries unchanged.
-                            if let Err(error) = frontend_transaction.finalize() {
-                                backend_transaction.rollback();
-                                *geometry.borrow_mut() = prior_geometry;
-                                *bindings.borrow_mut() = prior_bindings;
-                                let _ = apply.ack.send(config::ShardAck {
-                                    worker: widx,
-                                    result: Err(error),
-                                });
-                                did_work = true;
-                                continue;
-                            }
-                            backend_transaction.finalize();
-                            last_backends = combined.backends.applied;
-                            last_frontends = combined.frontends.applied;
+                    config::ShardCommand::PrepareConfig(prepare) => {
+                        let result = if !matches!(transaction, PendingShardState::Idle) {
+                            Err(format!(
+                                "cannot prepare transaction {} while {}",
+                                prepare.id.0,
+                                transaction.description()
+                            ))
+                        } else {
+                            let desired_backends = prepare.loaded.config().backends.as_slice();
+                            let desired_frontends = prepare.loaded.config().frontends.as_slice();
+                            let desired_frontend_backends =
+                                config::frontend_backend_map(&prepare.loaded.runtime().frontends);
+                            let prior_geometry = geometry.borrow().clone();
+                            let prior_bindings = bindings.borrow().clone();
+                            // Refresh stripe geometry before building any
+                            // frontend so a co-applied backend stripe change
+                            // is visible to a frontend add in the same pass.
                             {
                                 let mut g = geometry.borrow_mut();
                                 g.clear();
-                                for spec in last_backends.values() {
-                                    g.insert(spec.name.clone(), spec.stripe_size_bytes());
+                                for b in desired_backends {
+                                    g.insert(b.name.clone(), b.stripe_size_bytes());
                                 }
                             }
-                            *bindings.borrow_mut() = frontend_registry
-                                .realized_activations()
-                                .into_iter()
-                                .map(|(id, activation)| (id, activation.binding))
-                                .collect();
-                            Ok(())
-                        } else {
-                            // Restore backends before frontends that reference
-                            // them, then restore the auxiliary build surfaces.
-                            backend_transaction.rollback();
-                            frontend_transaction.rollback();
+
+                            let desired_activations = frontend_activations(
+                                &prepare.loaded.runtime().frontends,
+                                desired_backends,
+                            );
+                            let frontends_to_rebuild = frontend_rebuild_ids(
+                                &frontend_registry.realized_activations(),
+                                &desired_activations,
+                            );
+                            let forced_frontend_updates: HashSet<String> =
+                                frontends_to_rebuild.into_iter().collect();
+                            *bindings.borrow_mut() = prepare.loaded.runtime().frontends.clone();
+
+                            let backend_transaction = transport_registry.transaction();
+                            let frontend_transaction = frontend_registry.transaction();
+
+                            // Drive provisional backend and frontend maps together
+                            // so frontend adds are gated on the desired backend.
+                            let combined = config::reconcile::reconcile_backends_and_frontends(
+                                &backend_transaction,
+                                &frontend_transaction,
+                                desired_backends,
+                                desired_frontends,
+                                &desired_frontend_backends,
+                                &forced_frontend_updates,
+                                Some(&last_backends),
+                                Some(&last_frontends),
+                            );
+                            let mut failures = combined.backends.failures.clone();
+                            failures.extend(combined.frontends.failures.clone());
                             *geometry.borrow_mut() = prior_geometry;
                             *bindings.borrow_mut() = prior_bindings;
-                            Err(format!(
-                                "config reconcile failed: failures={failures:?} deferred={:?}",
-                                combined.frontends.deferred
-                            ))
+                            if failures.is_empty() && combined.frontends.deferred.is_empty() {
+                                transaction = PendingShardState::Prepared(PendingShardApply {
+                                    id: prepare.id,
+                                    backend: backend_transaction,
+                                    frontend: frontend_transaction,
+                                    backends: combined.backends.applied,
+                                    frontends: combined.frontends.applied,
+                                });
+                                Ok(())
+                            } else {
+                                backend_transaction.rollback();
+                                frontend_transaction.rollback();
+                                transaction = PendingShardState::Rejected(prepare.id);
+                                Err(format!(
+                                    "config reconcile failed: failures={failures:?} deferred={:?}",
+                                    combined.frontends.deferred
+                                ))
+                            }
                         };
 
-                        let _ = apply.ack.send(config::ShardAck {
+                        let _ = prepare.ack.send(config::ShardAck {
+                            id: prepare.id,
+                            worker: widx,
+                            result,
+                        });
+                        did_work = true;
+                    }
+                    config::ShardCommand::FinishConfig(finish) => {
+                        let result = if !transaction.matches(finish.id) {
+                            Err(format!(
+                                "cannot finish transaction {} while {}",
+                                finish.id.0,
+                                transaction.description()
+                            ))
+                        } else if matches!(transaction, PendingShardState::Rejected(_)) {
+                            if finish.decision == config::ShardDecision::Abort {
+                                transaction = PendingShardState::Idle;
+                                Ok(())
+                            } else {
+                                Err("cannot commit a rejected transaction".to_string())
+                            }
+                        } else {
+                            match std::mem::replace(&mut transaction, PendingShardState::Idle) {
+                                PendingShardState::Prepared(pending) => match finish.decision {
+                                    config::ShardDecision::Abort => {
+                                        pending.backend.rollback();
+                                        pending.frontend.rollback();
+                                        Ok(())
+                                    }
+                                    config::ShardDecision::Commit => {
+                                        if let Err(error) = pending.frontend.finalize() {
+                                            pending.backend.rollback();
+                                            Err(error)
+                                        } else {
+                                            pending.backend.finalize();
+                                            last_backends = pending.backends;
+                                            last_frontends = pending.frontends;
+                                            *geometry.borrow_mut() = last_backends
+                                                .values()
+                                                .map(|spec| {
+                                                    (spec.name.clone(), spec.stripe_size_bytes())
+                                                })
+                                                .collect();
+                                            *bindings.borrow_mut() = frontend_registry
+                                                .realized_activations()
+                                                .into_iter()
+                                                .map(|(id, activation)| (id, activation.binding))
+                                                .collect();
+                                            Ok(())
+                                        }
+                                    }
+                                },
+                                PendingShardState::Rejected(_) => unreachable!(),
+                                PendingShardState::Idle => unreachable!(),
+                            }
+                        };
+                        let _ = finish.ack.send(config::ShardAck {
+                            id: finish.id,
                             worker: widx,
                             result,
                         });
                         did_work = true;
                     }
                     config::ShardCommand::DrainPageCache(drain) => {
-                        pool.drain_page_cache();
+                        let result = if transaction.is_prepared(drain.id) {
+                            pool.drain_page_cache();
+                            Ok(())
+                        } else {
+                            Err(format!(
+                                "cannot drain transaction {} while {}",
+                                drain.id.0,
+                                transaction.description()
+                            ))
+                        };
                         let _ = drain.ack.send(config::ShardAck {
+                            id: drain.id,
                             worker: widx,
-                            result: Ok(()),
+                            result,
                         });
                         did_work = true;
                     }
@@ -1064,6 +1105,42 @@ fn run_shard(
     drop(pool);
     drop(socket);
     serving_guard.complete();
+}
+
+struct PendingShardApply {
+    id: config::ShardTransactionId,
+    backend: BackendRegistryTransaction,
+    frontend: FrontendRegistryTransaction,
+    backends: HashMap<String, BackendSpec>,
+    frontends: HashMap<String, FrontendSpec>,
+}
+
+enum PendingShardState {
+    Idle,
+    Prepared(PendingShardApply),
+    Rejected(config::ShardTransactionId),
+}
+
+impl PendingShardState {
+    fn matches(&self, id: config::ShardTransactionId) -> bool {
+        match self {
+            Self::Idle => false,
+            Self::Prepared(pending) => pending.id == id,
+            Self::Rejected(rejected) => *rejected == id,
+        }
+    }
+
+    fn is_prepared(&self, id: config::ShardTransactionId) -> bool {
+        matches!(self, Self::Prepared(pending) if pending.id == id)
+    }
+
+    fn description(&self) -> String {
+        match self {
+            Self::Idle => "idle".to_string(),
+            Self::Prepared(pending) => format!("transaction {} is prepared", pending.id.0),
+            Self::Rejected(id) => format!("transaction {} is rejected", id.0),
+        }
+    }
 }
 
 /// Log a shard panic and preserve it for the owning join handle.

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -888,7 +888,6 @@ fn run_shard(
     // build-from-spec work (DNS resolve, listener bind) stays off the
     // fast path.
     {
-        let routes = routes.clone();
         let transport_registry = transport_registry.clone();
         let frontend_registry = frontend_registry.clone();
         let pool = pool.clone();
@@ -911,6 +910,8 @@ fn run_shard(
                         let desired_frontends = apply.loaded.config().frontends.as_slice();
                         let desired_frontend_backends =
                             config::frontend_backend_map(&apply.loaded.runtime().frontends);
+                        let prior_geometry = geometry.borrow().clone();
+                        let prior_bindings = bindings.borrow().clone();
                         // Refresh stripe geometry before building any
                         // frontend so a co-applied backend stripe change
                         // is visible to a frontend add in the same pass.
@@ -934,12 +935,14 @@ fn run_shard(
                             frontends_to_rebuild.into_iter().collect();
                         *bindings.borrow_mut() = apply.loaded.runtime().frontends.clone();
 
-                        // Drive the transport backend registry and the
-                        // frontend registry together so frontend adds are
-                        // gated on their referenced backend being present.
+                        let backend_transaction = transport_registry.transaction();
+                        let frontend_transaction = frontend_registry.transaction();
+
+                        // Drive provisional backend and frontend maps together
+                        // so frontend adds are gated on the desired backend.
                         let combined = config::reconcile::reconcile_backends_and_frontends(
-                            &transport_registry,
-                            &frontend_registry,
+                            &backend_transaction,
+                            &frontend_transaction,
                             desired_backends,
                             desired_frontends,
                             &desired_frontend_backends,
@@ -947,31 +950,39 @@ fn run_shard(
                             Some(&last_backends),
                             Some(&last_frontends),
                         );
-                        last_backends = combined.backends.applied;
-                        last_frontends = combined.frontends.applied;
-
-                        // Replacement construction happens against desired
-                        // geometry/bindings, then failed replacements retain
-                        // their prior live resource and prior auxiliary state.
-                        {
-                            let mut g = geometry.borrow_mut();
-                            g.clear();
-                            for spec in last_backends.values() {
-                                g.insert(spec.name.clone(), spec.stripe_size_bytes());
+                        let mut failures = combined.backends.failures.clone();
+                        failures.extend(combined.frontends.failures.clone());
+                        let commit = failures.is_empty() && combined.frontends.deferred.is_empty();
+                        let result = if commit {
+                            // Retire old frontends before their old backends.
+                            frontend_transaction.finalize();
+                            backend_transaction.finalize();
+                            last_backends = combined.backends.applied;
+                            last_frontends = combined.frontends.applied;
+                            {
+                                let mut g = geometry.borrow_mut();
+                                g.clear();
+                                for spec in last_backends.values() {
+                                    g.insert(spec.name.clone(), spec.stripe_size_bytes());
+                                }
                             }
-                        }
-                        *bindings.borrow_mut() = frontend_registry
-                            .realized_activations()
-                            .into_iter()
-                            .map(|(id, activation)| (id, activation.binding))
-                            .collect();
-
-                        let mut failures = combined.backends.failures;
-                        failures.extend(combined.frontends.failures);
-                        let result = if failures.is_empty() {
+                            *bindings.borrow_mut() = frontend_registry
+                                .realized_activations()
+                                .into_iter()
+                                .map(|(id, activation)| (id, activation.binding))
+                                .collect();
                             Ok(())
                         } else {
-                            Err(format!("config reconcile failed: {failures:?}"))
+                            // Restore backends before frontends that reference
+                            // them, then restore the auxiliary build surfaces.
+                            backend_transaction.rollback();
+                            frontend_transaction.rollback();
+                            *geometry.borrow_mut() = prior_geometry;
+                            *bindings.borrow_mut() = prior_bindings;
+                            Err(format!(
+                                "config reconcile failed: failures={failures:?} deferred={:?}",
+                                combined.frontends.deferred
+                            ))
                         };
 
                         let _ = apply.ack.send(config::ShardAck {
@@ -1414,27 +1425,50 @@ impl FrontendBuildCtx {
 
 struct FrontendRegistryTransaction {
     ctx: FrontendBuildCtx,
-    entries: RegistryTransaction<ActiveShardFrontend>,
+    frontends: Rc<RefCell<HashMap<String, ActiveShardFrontend>>>,
+    entries: RefCell<Option<RegistryTransaction<ActiveShardFrontend>>>,
 }
 
 impl FrontendRegistryTransaction {
-    fn add(&mut self, spec: &FrontendSpec) -> Result<(), String> {
+    fn finalize(self) {
+        self.entries
+            .borrow_mut()
+            .take()
+            .expect("frontend transaction active")
+            .finalize();
+    }
+
+    fn rollback(self) {
+        self.entries
+            .borrow_mut()
+            .take()
+            .expect("frontend transaction active")
+            .rollback();
+    }
+}
+
+impl config::reconcile::FrontendReconcileTarget for FrontendRegistryTransaction {
+    fn list(&self) -> Vec<String> {
+        self.frontends.borrow().keys().cloned().collect()
+    }
+
+    fn add(&self, spec: &FrontendSpec) -> Result<(), String> {
         let frontend = self.ctx.build(spec)?;
-        self.entries.replace(spec.name.clone(), frontend);
+        self.entries
+            .borrow_mut()
+            .as_mut()
+            .expect("frontend transaction active")
+            .replace(spec.name.clone(), frontend);
         Ok(())
     }
 
-    fn remove(&mut self, id: &str) {
-        self.entries.remove(id);
-    }
-
-    fn finalize(self) {
-        self.entries.finalize();
-    }
-
-    #[cfg(test)]
-    fn rollback(self) {
-        self.entries.rollback();
+    fn remove(&self, id: &str) -> Result<(), String> {
+        self.entries
+            .borrow_mut()
+            .as_mut()
+            .expect("frontend transaction active")
+            .remove(id);
+        Ok(())
     }
 }
 
@@ -1486,7 +1520,8 @@ impl FrontendRegistry {
     fn transaction(&self) -> FrontendRegistryTransaction {
         FrontendRegistryTransaction {
             ctx: self.ctx.clone(),
-            entries: RegistryTransaction::new(self.frontends.clone()),
+            frontends: self.frontends.clone(),
+            entries: RefCell::new(Some(RegistryTransaction::new(self.frontends.clone()))),
         }
     }
 
@@ -1505,15 +1540,15 @@ impl config::reconcile::FrontendReconcileTarget for FrontendRegistry {
     }
 
     fn add(&self, spec: &FrontendSpec) -> Result<(), String> {
-        let mut transaction = self.transaction();
-        transaction.add(spec)?;
+        let transaction = self.transaction();
+        config::reconcile::FrontendReconcileTarget::add(&transaction, spec)?;
         transaction.finalize();
         Ok(())
     }
 
     fn remove(&self, id: &str) -> Result<(), String> {
-        let mut transaction = self.transaction();
-        transaction.remove(id);
+        let transaction = self.transaction();
+        config::reconcile::FrontendReconcileTarget::remove(&transaction, id)?;
         transaction.finalize();
         Ok(())
     }

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -1668,7 +1668,10 @@ enum ShardReady {
         /// peers' backings and build its [`FanoutTable`].
         publish: ShardPublish,
     },
-    Failed(String),
+    Failed {
+        worker_idx: WorkerIdx,
+        message: String,
+    },
 }
 
 /// Owning phase-A reporter. Consuming report methods and the Drop
@@ -1697,7 +1700,10 @@ impl PhaseAReporter {
 
     fn report_failed(mut self, message: String) {
         if let Some(tx) = self.tx.take() {
-            let _ = tx.send(ShardReady::Failed(message));
+            let _ = tx.send(ShardReady::Failed {
+                worker_idx: self.worker_idx,
+                message,
+            });
         }
     }
 }
@@ -1705,10 +1711,13 @@ impl PhaseAReporter {
 impl Drop for PhaseAReporter {
     fn drop(&mut self) {
         if let Some(tx) = self.tx.take() {
-            let _ = tx.send(ShardReady::Failed(format!(
-                "worker={}: aborted during phase A bring-up",
-                self.worker_idx.0
-            )));
+            let _ = tx.send(ShardReady::Failed {
+                worker_idx: self.worker_idx,
+                message: format!(
+                    "worker={}: aborted during phase A bring-up",
+                    self.worker_idx.0
+                ),
+            });
         }
     }
 }
@@ -1761,7 +1770,10 @@ struct PeerPublish {
 /// registration) independently of the first (fabric/pool bring-up).
 enum PhaseBReport {
     Ready(WorkerIdx),
-    Failed(String),
+    Failed {
+        worker_idx: WorkerIdx,
+        message: String,
+    },
 }
 
 /// RAII guard ensuring a shard that has entered phase B reports exactly
@@ -1790,7 +1802,10 @@ impl PhaseBGuard {
 
     fn report_failed(mut self, msg: String) {
         self.reported = true;
-        let _ = self.tx.send(PhaseBReport::Failed(msg));
+        let _ = self.tx.send(PhaseBReport::Failed {
+            worker_idx: self.widx,
+            message: msg,
+        });
     }
 }
 
@@ -1848,10 +1863,10 @@ impl Drop for ServingGuard {
 impl Drop for PhaseBGuard {
     fn drop(&mut self) {
         if !self.reported {
-            let _ = self.tx.send(PhaseBReport::Failed(format!(
-                "worker={}: aborted during phase B bring-up",
-                self.widx.0
-            )));
+            let _ = self.tx.send(PhaseBReport::Failed {
+                worker_idx: self.widx,
+                message: format!("worker={}: aborted during phase B bring-up", self.widx.0),
+            });
         }
     }
 }
@@ -2476,9 +2491,13 @@ mod tests {
         let (tx, rx) = mpsc::channel::<ShardReady>();
         drop(PhaseAReporter::new(WorkerIdx(7), tx));
         match rx.recv() {
-            Ok(ShardReady::Failed(msg)) => {
-                assert!(msg.contains("worker=7"), "got: {msg}");
-                assert!(msg.contains("aborted during phase A"), "got: {msg}");
+            Ok(ShardReady::Failed {
+                worker_idx,
+                message,
+            }) => {
+                assert_eq!(worker_idx, WorkerIdx(7));
+                assert!(message.contains("worker=7"), "got: {message}");
+                assert!(message.contains("aborted during phase A"), "got: {message}");
             }
             other => panic!("expected Failed, got {:?}", other.is_ok()),
         }

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -512,6 +512,10 @@ fn main() -> ExitCode {
                                     "config: apply gen={} version={} failed: {e}",
                                     update.generation, version
                                 );
+                                mark_fatal_apply_failure(
+                                    &mut exit_code,
+                                    SHUTDOWN.load(Ordering::Acquire),
+                                );
                             }
                         }
                     }
@@ -1182,7 +1186,6 @@ fn reconcile_cache_disks(
 ) -> DiskReport {
     let mut cache_ids: Vec<String> = projection.caches.keys().cloned().collect();
     cache_ids.sort();
-    cache_directories.reconcile(cache_ids.iter().cloned());
 
     let disks = config::runtime_disks(projection);
     let report = disk_registry.reconcile(&disks);
@@ -1196,9 +1199,12 @@ fn reconcile_cache_disks(
         eprintln!("disk {}: open failed: {msg}", path.display());
     }
 
-    let channels = disk_registry.channels_snapshot();
-    for cache_id in cache_ids {
-        cache_directories.apply_channels(&cache_id, channels.clone());
+    if report.failures.is_empty() {
+        cache_directories.reconcile(cache_ids.iter().cloned());
+        let channels = disk_registry.channels_snapshot();
+        for cache_id in cache_ids {
+            cache_directories.apply_channels(&cache_id, channels.clone());
+        }
     }
 
     report
@@ -1956,6 +1962,12 @@ fn shutdown_on_watcher_error(err: mpsc::RecvTimeoutError) -> bool {
     matches!(err, mpsc::RecvTimeoutError::Disconnected)
 }
 
+fn mark_fatal_apply_failure(exit_code: &mut ExitCode, shutdown_requested: bool) {
+    if shutdown_requested {
+        *exit_code = ExitCode::FAILURE;
+    }
+}
+
 /// Install a SIGINT/SIGTERM handler that flips [`SHUTDOWN`]. The
 /// handler is async-signal-safe (only a relaxed atomic store).
 /// All threads observe the flag via their poll loops.
@@ -2557,5 +2569,19 @@ mod tests {
             mpsc::RecvTimeoutError::Disconnected
         ));
         assert!(!shutdown_on_watcher_error(mpsc::RecvTimeoutError::Timeout));
+    }
+
+    #[test]
+    fn fatal_apply_failure_sets_failure_exit_status() {
+        let mut exit_code = ExitCode::SUCCESS;
+        mark_fatal_apply_failure(&mut exit_code, true);
+        assert_eq!(exit_code, ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn rollback_safe_apply_failure_keeps_success_exit_status() {
+        let mut exit_code = ExitCode::SUCCESS;
+        mark_fatal_apply_failure(&mut exit_code, false);
+        assert_eq!(exit_code, ExitCode::SUCCESS);
     }
 }

--- a/cmd/unbounded-storage/src/registry_transaction.rs
+++ b/cmd/unbounded-storage/src/registry_transaction.rs
@@ -35,7 +35,6 @@ impl<T> RegistryTransaction<T> {
         self.originals.clear();
     }
 
-    #[cfg(test)]
     pub(crate) fn rollback(mut self) {
         self.rollback_inner();
         self.completed = true;

--- a/cmd/unbounded-storage/src/shard_layer.rs
+++ b/cmd/unbounded-storage/src/shard_layer.rs
@@ -777,6 +777,16 @@ impl ProcessApplyTarget {
     }
 }
 
+fn fail_stop_disk_reconcile<T>(
+    result: Result<T, ApplyError>,
+    shutdown: &AtomicBool,
+) -> Result<T, ApplyError> {
+    if result.is_err() {
+        shutdown.store(true, Ordering::Release);
+    }
+    result
+}
+
 impl ConfigApplyTarget for ProcessApplyTarget {
     fn apply_in_place(
         &mut self,
@@ -855,25 +865,19 @@ impl ConfigApplyTarget for ProcessApplyTarget {
                 }
             }
 
+            // Opening a disk may provision a file or format metadata. Cross
+            // the fail-stop boundary before reconciliation because closing a
+            // staged handle cannot undo either operation.
             if diff.caches_changed || diff.disks_changed {
-                if let Err(error) = self.reconcile_disks(new.runtime()) {
-                    let layer = self
-                        .layer
-                        .as_ref()
-                        .expect("shard layer present between applies");
-                    if let Err(abort_error) =
-                        layer.control.broadcast_finish(id, ShardDecision::Abort)
-                    {
-                        crate::SHUTDOWN.store(true, Ordering::Release);
-                        return Err(abort_error);
-                    }
+                if let Err(error) =
+                    fail_stop_disk_reconcile(self.reconcile_disks(new.runtime()), &crate::SHUTDOWN)
+                {
                     return Err(error);
                 }
             }
 
-            // Shared fabric state cannot be rolled back. Reconcile it only
-            // after every abortable shard and disk preparation has succeeded;
-            // failures from this point onward are fail-stop.
+            // Shared fabric state cannot be rolled back either. Reconcile it
+            // only after shard preparation and disk reconciliation succeed.
             {
                 let layer = self
                     .layer
@@ -918,10 +922,9 @@ impl ConfigApplyTarget for ProcessApplyTarget {
             // Keep non-shard process surfaces correct if a future diff flag
             // stops requiring a shard transaction.
             if diff.caches_changed || diff.disks_changed {
-                if let Err(error) = self.reconcile_disks(new.runtime()) {
-                    if error.apply_state_is_indeterminate() {
-                        crate::SHUTDOWN.store(true, Ordering::Release);
-                    }
+                if let Err(error) =
+                    fail_stop_disk_reconcile(self.reconcile_disks(new.runtime()), &crate::SHUTDOWN)
+                {
                     return Err(error);
                 }
             }
@@ -1054,6 +1057,20 @@ mod tests {
         watchdog.disarm();
 
         assert_eq!(terminated.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn disk_reconcile_failure_is_fail_stop() {
+        let shutdown = AtomicBool::new(false);
+        let result: Result<(), ApplyError> = fail_stop_disk_reconcile(
+            Err(ApplyError::Target(
+                "later disk failed after destructive open".into(),
+            )),
+            &shutdown,
+        );
+
+        assert!(result.is_err());
+        assert!(shutdown.load(Ordering::Acquire));
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/shard_layer.rs
+++ b/cmd/unbounded-storage/src/shard_layer.rs
@@ -33,6 +33,7 @@ use std::time::Duration;
 
 use unbounded_storage::config::{
     self, ApplyError, ConfigApplyTarget, ConfigDiff, LoadedConfig, ShardControlGroup,
+    ShardDecision, ShardTransactionId,
 };
 use unbounded_storage::fabric::PeerId;
 use unbounded_storage::memory::HUGEPAGE_2MB;
@@ -559,6 +560,7 @@ pub struct ProcessApplyTarget {
     layer: Option<ShardLayer>,
     disk_registry: DiskRegistry<UringDiskTarget>,
     cache_directories: Arc<CacheDirectorySet>,
+    next_transaction_id: u64,
 }
 
 impl ProcessApplyTarget {
@@ -571,6 +573,7 @@ impl ProcessApplyTarget {
             layer: Some(layer),
             disk_registry,
             cache_directories,
+            next_transaction_id: 1,
         }
     }
 
@@ -607,6 +610,14 @@ impl ProcessApplyTarget {
     pub fn into_parts(self) -> (Option<ShardLayer>, DiskRegistry<UringDiskTarget>) {
         (self.layer, self.disk_registry)
     }
+
+    fn allocate_transaction_id(&mut self) -> Result<ShardTransactionId, ApplyError> {
+        let id = ShardTransactionId(self.next_transaction_id);
+        self.next_transaction_id = self.next_transaction_id.checked_add(1).ok_or_else(|| {
+            ApplyError::Target("shard transaction id space exhausted".to_string())
+        })?;
+        Ok(id)
+    }
 }
 
 impl ConfigApplyTarget for ProcessApplyTarget {
@@ -632,80 +643,141 @@ impl ConfigApplyTarget for ProcessApplyTarget {
             || diff.frontends_changed;
 
         if needs_broadcast {
-            let layer = self
+            {
+                let layer = self
+                    .layer
+                    .as_mut()
+                    .expect("shard layer present between applies");
+
+                // Peer connections live on the shared fabric endpoints, not
+                // on individual shards, so they are reconciled once per
+                // endpoint here.
+                if diff.requires_peer_reconcile() {
+                    let runtime_peers = config::runtime_peers(new.runtime());
+                    if let Err(failures) = layer.fabric_group.reconcile_peers(&runtime_peers) {
+                        crate::SHUTDOWN.store(true, Ordering::Release);
+                        return Err(ApplyError::Target(format!(
+                            "hard peer reconciliation failure(s): {}",
+                            failures.join("; ")
+                        )));
+                    }
+                }
+
+                // The RPC-side backend registries also live on the shared
+                // endpoints; reconcile them before broadcasting so the shards
+                // rebuild their own transport registries against an already
+                // up-to-date origin surface.
+                if diff.backends_changed {
+                    layer
+                        .fabric_group
+                        .reconcile_backends(&new.config().backends);
+                }
+            }
+
+            let id = self.allocate_transaction_id()?;
+
+            let prepare = self
                 .layer
-                .as_mut()
-                .expect("shard layer present between applies");
-
-            // Peer connections live on the shared fabric endpoints, not
-            // on individual shards, so they are reconciled once per
-            // endpoint here.
-            if diff.requires_peer_reconcile() {
-                let runtime_peers = config::runtime_peers(new.runtime());
-                if let Err(failures) = layer.fabric_group.reconcile_peers(&runtime_peers) {
-                    crate::SHUTDOWN.store(true, Ordering::Release);
-                    return Err(ApplyError::Target(format!(
-                        "hard peer reconciliation failure(s): {}",
-                        failures.join("; ")
-                    )));
-                }
-            }
-
-            // The RPC-side backend registries also live on the shared
-            // endpoints; reconcile them before broadcasting so the shards
-            // rebuild their own transport registries against an already
-            // up-to-date origin surface.
-            if diff.backends_changed {
-                layer
-                    .fabric_group
-                    .reconcile_backends(&new.config().backends);
-            }
-
-            // Republish config + routing to every shard and block until
-            // each has acked, so the routing surface and per-shard
-            // backend/frontend reconcile each shard performs on receipt
-            // have provably landed.
-            if let Err(error) = layer.control.broadcast_apply(new.clone(), *diff) {
-                if error.apply_state_is_indeterminate() {
-                    crate::SHUTDOWN.store(true, Ordering::Release);
-                }
-                return Err(error);
-            }
-        }
-
-        if diff.disks_changed {
-            let layer = self
-                .layer
-                .as_mut()
-                .expect("shard layer present between applies");
-            if let Err(error) = layer.control.broadcast_drain_page_cache() {
-                if error.apply_state_is_indeterminate() {
-                    crate::SHUTDOWN.store(true, Ordering::Release);
-                }
-                return Err(error);
-            }
-        }
-
-        // Disk/channel changes mutate live registries and directories, so
-        // all fallible shard broadcasts must complete before this point.
-        // If a broadcast fails, ConfigController keeps the old config as
-        // current and disk reconciliation does not begin. Once reconciliation
-        // begins, its realized subset is published even when an open fails;
-        // returning that failure keeps the desired snapshot retryable.
-        if diff.caches_changed || diff.disks_changed {
-            self.reconcile_disks(new.runtime())?;
-        }
-
-        // Routing is the process-wide visibility point for a successful
-        // apply. Publish it only after every fallible shard broadcast and
-        // the disk update have completed, so failed applies retain the
-        // prior route snapshot everywhere.
-        if diff.requires_routing_reload() {
-            self.layer
                 .as_ref()
                 .expect("shard layer present between applies")
-                .routes
-                .store_snapshot(new.routes().clone());
+                .control
+                .broadcast_prepare(id, new.clone(), *diff);
+            if let Err(error) = prepare {
+                if error.apply_state_is_indeterminate() {
+                    crate::SHUTDOWN.store(true, Ordering::Release);
+                    return Err(error);
+                }
+                if let Err(abort_error) = self
+                    .layer
+                    .as_ref()
+                    .expect("shard layer present between applies")
+                    .control
+                    .broadcast_finish(id, ShardDecision::Abort)
+                {
+                    crate::SHUTDOWN.store(true, Ordering::Release);
+                    return Err(abort_error);
+                }
+                return Err(error);
+            }
+
+            if diff.disks_changed {
+                let drain = self
+                    .layer
+                    .as_ref()
+                    .expect("shard layer present between applies")
+                    .control
+                    .broadcast_drain_page_cache(id);
+                if let Err(error) = drain {
+                    if error.apply_state_is_indeterminate() {
+                        crate::SHUTDOWN.store(true, Ordering::Release);
+                        return Err(error);
+                    }
+                    if let Err(abort_error) = self
+                        .layer
+                        .as_ref()
+                        .expect("shard layer present between applies")
+                        .control
+                        .broadcast_finish(id, ShardDecision::Abort)
+                    {
+                        crate::SHUTDOWN.store(true, Ordering::Release);
+                        return Err(abort_error);
+                    }
+                    return Err(error);
+                }
+            }
+
+            if diff.caches_changed || diff.disks_changed {
+                if let Err(error) = self.reconcile_disks(new.runtime()) {
+                    let layer = self
+                        .layer
+                        .as_ref()
+                        .expect("shard layer present between applies");
+                    if let Err(abort_error) =
+                        layer.control.broadcast_finish(id, ShardDecision::Abort)
+                    {
+                        crate::SHUTDOWN.store(true, Ordering::Release);
+                        return Err(abort_error);
+                    }
+                    return Err(error);
+                }
+            }
+
+            // Route publication is irrevocable. A subsequent commit failure
+            // therefore makes the process unsafe to continue.
+            if diff.requires_routing_reload() {
+                self.layer
+                    .as_ref()
+                    .expect("shard layer present between applies")
+                    .routes
+                    .store_snapshot(new.routes().clone());
+            }
+
+            let layer = self
+                .layer
+                .as_ref()
+                .expect("shard layer present between applies");
+            if let Err(error) = layer.control.broadcast_finish(id, ShardDecision::Commit) {
+                crate::SHUTDOWN.store(true, Ordering::Release);
+                return Err(error);
+            }
+        } else {
+            // Keep non-shard process surfaces correct if a future diff flag
+            // stops requiring a shard transaction.
+            if diff.caches_changed || diff.disks_changed {
+                if let Err(error) = self.reconcile_disks(new.runtime()) {
+                    if error.apply_state_is_indeterminate() {
+                        crate::SHUTDOWN.store(true, Ordering::Release);
+                    }
+                    return Err(error);
+                }
+            }
+            if diff.requires_routing_reload() {
+                self.layer
+                    .as_ref()
+                    .expect("shard layer present between applies")
+                    .routes
+                    .store_snapshot(new.routes().clone());
+            }
         }
 
         Ok(())

--- a/cmd/unbounded-storage/src/shard_layer.rs
+++ b/cmd/unbounded-storage/src/shard_layer.rs
@@ -784,9 +784,12 @@ impl ConfigApplyTarget for ProcessApplyTarget {
         diff: &ConfigDiff,
     ) -> Result<(), ApplyError> {
         if diff.requires_restart() {
-            return Err(ApplyError::Target(
-                "self peer identity changed; restart required".to_string(),
-            ));
+            let reason = if diff.identity_changed {
+                "self peer identity changed"
+            } else {
+                "backend stripe geometry changed"
+            };
+            return Err(ApplyError::Target(format!("{reason}; restart required")));
         }
 
         // The shards must see a new config whenever their routing surface,
@@ -800,37 +803,6 @@ impl ConfigApplyTarget for ProcessApplyTarget {
             || diff.frontends_changed;
 
         if needs_broadcast {
-            {
-                let layer = self
-                    .layer
-                    .as_mut()
-                    .expect("shard layer present between applies");
-
-                // Peer connections live on the shared fabric endpoints, not
-                // on individual shards, so they are reconciled once per
-                // endpoint here.
-                if diff.requires_peer_reconcile() {
-                    let runtime_peers = config::runtime_peers(new.runtime());
-                    if let Err(failures) = layer.fabric_group.reconcile_peers(&runtime_peers) {
-                        crate::SHUTDOWN.store(true, Ordering::Release);
-                        return Err(ApplyError::Target(format!(
-                            "hard peer reconciliation failure(s): {}",
-                            failures.join("; ")
-                        )));
-                    }
-                }
-
-                // The RPC-side backend registries also live on the shared
-                // endpoints; reconcile them before broadcasting so the shards
-                // rebuild their own transport registries against an already
-                // up-to-date origin surface.
-                if diff.backends_changed {
-                    layer
-                        .fabric_group
-                        .reconcile_backends(&new.config().backends);
-                }
-            }
-
             let id = self.allocate_transaction_id()?;
 
             let prepare = self
@@ -896,6 +868,31 @@ impl ConfigApplyTarget for ProcessApplyTarget {
                         return Err(abort_error);
                     }
                     return Err(error);
+                }
+            }
+
+            // Shared fabric state cannot be rolled back. Reconcile it only
+            // after every abortable shard and disk preparation has succeeded;
+            // failures from this point onward are fail-stop.
+            {
+                let layer = self
+                    .layer
+                    .as_mut()
+                    .expect("shard layer present between applies");
+                if diff.requires_peer_reconcile() {
+                    let runtime_peers = config::runtime_peers(new.runtime());
+                    if let Err(failures) = layer.fabric_group.reconcile_peers(&runtime_peers) {
+                        crate::SHUTDOWN.store(true, Ordering::Release);
+                        return Err(ApplyError::Target(format!(
+                            "hard peer reconciliation failure(s): {}",
+                            failures.join("; ")
+                        )));
+                    }
+                }
+                if diff.backends_changed {
+                    layer
+                        .fabric_group
+                        .reconcile_backends(&new.config().backends);
                 }
             }
 

--- a/cmd/unbounded-storage/src/shard_layer.rs
+++ b/cmd/unbounded-storage/src/shard_layer.rs
@@ -26,10 +26,12 @@
 //! [`ConfigController`]: crate::config::ConfigController
 //! [`ConfigApplyTarget`]: crate::config::ConfigApplyTarget
 
-use std::sync::Arc;
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use unbounded_storage::config::{
     self, ApplyError, ConfigApplyTarget, ConfigDiff, LoadedConfig, ShardControlGroup,
@@ -46,6 +48,127 @@ use crate::StartupSettings;
 use crate::fabric_group::{FabricGroup, FabricPlan, FabricUnitAddress, RpcShardPublish};
 
 const SHARD_CONTROL_TIMEOUT: Duration = Duration::from_secs(60);
+const SHARD_PHASE_TIMEOUT: Duration = Duration::from_secs(60);
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(60);
+
+struct ShardJoin {
+    worker_idx: WorkerIdx,
+    handle: JoinHandle,
+}
+
+struct CleanupWatchdog {
+    disarm_tx: mpsc::Sender<()>,
+    join: thread::JoinHandle<()>,
+}
+
+struct CleanupProgress {
+    stage: &'static str,
+    outstanding_workers: Vec<u16>,
+}
+
+struct CollectedReports<R> {
+    reports: Vec<R>,
+    errors: Vec<String>,
+}
+
+fn collect_worker_reports<R, F>(
+    phase: &str,
+    rx: &mpsc::Receiver<R>,
+    expected: &[WorkerIdx],
+    timeout: Duration,
+    worker_of: F,
+) -> CollectedReports<R>
+where
+    F: Fn(&R) -> WorkerIdx,
+{
+    let deadline = Instant::now() + timeout;
+    let expected: HashSet<WorkerIdx> = expected.iter().copied().collect();
+    let mut outstanding = expected.clone();
+    let mut reports = Vec::with_capacity(expected.len());
+    let mut errors = Vec::new();
+
+    while !outstanding.is_empty() {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            errors.push(format_outstanding(phase, "timed out", &outstanding));
+            break;
+        };
+        match rx.recv_timeout(remaining) {
+            Ok(report) => {
+                let worker_idx = worker_of(&report);
+                if !expected.contains(&worker_idx) {
+                    errors.push(format!(
+                        "{phase} received unexpected report from worker={}",
+                        worker_idx.0
+                    ));
+                } else if !outstanding.remove(&worker_idx) {
+                    errors.push(format!(
+                        "{phase} received duplicate report from worker={}",
+                        worker_idx.0
+                    ));
+                } else {
+                    reports.push(report);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                errors.push(format_outstanding(phase, "timed out", &outstanding));
+                break;
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                errors.push(format_outstanding(
+                    phase,
+                    "report channel disconnected",
+                    &outstanding,
+                ));
+                break;
+            }
+        }
+    }
+
+    CollectedReports { reports, errors }
+}
+
+fn format_outstanding(phase: &str, reason: &str, outstanding: &HashSet<WorkerIdx>) -> String {
+    let mut workers: Vec<u16> = outstanding.iter().map(|worker| worker.0).collect();
+    workers.sort_unstable();
+    format!("{phase} {reason}; outstanding workers={workers:?}")
+}
+
+impl CleanupWatchdog {
+    fn spawn<F, T>(timeout: Duration, on_timeout: F, terminate: T) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+        T: FnOnce() + Send + 'static,
+    {
+        let (disarm_tx, disarm_rx) = mpsc::channel();
+        let join = thread::spawn(move || match disarm_rx.recv_timeout(timeout) {
+            Ok(()) => {}
+            Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => {
+                on_timeout();
+                terminate();
+            }
+        });
+        Self { disarm_tx, join }
+    }
+
+    fn production(progress: Arc<Mutex<CleanupProgress>>) -> Self {
+        Self::spawn(
+            CLEANUP_TIMEOUT,
+            move || {
+                let progress = progress.lock().unwrap_or_else(|error| error.into_inner());
+                eprintln!(
+                    "fatal: shard cleanup stalled for 60 seconds during {}; outstanding workers={:?}; forcing process exit because registered memory cannot be released safely",
+                    progress.stage, progress.outstanding_workers
+                );
+            },
+            || std::process::exit(1),
+        )
+    }
+
+    fn disarm(self) {
+        let _ = self.disarm_tx.send(());
+        let _ = self.join.join();
+    }
+}
 
 /// Inputs that are constant across the life of the process and used to
 /// spawn the shard layer. Cloned cheaply into every shard thread.
@@ -72,7 +195,7 @@ pub struct ShardSpawnDeps {
 /// A prepared set of shard threads parked after phase B, before RPC
 /// startup and serving activation.
 pub struct PreparedShardLayer {
-    joins: Vec<JoinHandle>,
+    joins: Vec<ShardJoin>,
     fabric_group: FabricGroup,
     control: ShardControlGroup,
     layer_stop: Arc<AtomicBool>,
@@ -88,7 +211,7 @@ pub struct PreparedShardLayer {
 /// [`teardown_shard_layer`].
 pub struct ShardLayer {
     /// Join handles for every shard thread, in spawn order.
-    joins: Vec<JoinHandle>,
+    joins: Vec<ShardJoin>,
     /// Owns every shared fabric endpoint (and its RPC server) the shards
     /// run on. Drives in-place peer and RPC-side backend reconcile, and
     /// is dropped during teardown after all shard threads have joined but
@@ -228,7 +351,10 @@ pub fn prepare_shard_layer(
                 });
             }),
         );
-        joins.push(handle);
+        joins.push(ShardJoin {
+            worker_idx: widx,
+            handle,
+        });
     }
     drop(ready_tx);
     // The layer keeps no phase-B sender of its own: collection below is
@@ -237,26 +363,31 @@ pub fn prepare_shard_layer(
     drop(phaseb_tx);
     drop(terminal_tx);
 
-    // Bounded readiness collection: read exactly one message per spawned
-    // thread. Shards that come up park holding their sender, so they
-    // never close the channel; only a panic-before-report or a clean
-    // failure surfaces here.
+    let expected_workers: Vec<WorkerIdx> = joins.iter().map(|join| join.worker_idx).collect();
     let mut publishes = Vec::new();
-    let mut errors = Vec::new();
-    for _ in 0..joins.len() {
-        match ready_rx.recv() {
-            Ok(crate::ShardReady::Up {
+    let collected = collect_worker_reports(
+        "shard phase A",
+        &ready_rx,
+        &expected_workers,
+        SHARD_PHASE_TIMEOUT,
+        |report| match report {
+            crate::ShardReady::Up { worker_idx, .. }
+            | crate::ShardReady::Failed { worker_idx, .. } => *worker_idx,
+        },
+    );
+    let mut errors = collected.errors;
+    for report in collected.reports {
+        match report {
+            crate::ShardReady::Up {
                 worker_idx,
                 publish,
-            }) => {
-                publishes.push((worker_idx, publish));
-            }
-            Ok(crate::ShardReady::Failed(err)) => {
-                eprintln!("shard failed: {err}");
-                errors.push(err);
-            }
-            Err(_) => {
-                errors.push("shard thread exited without reporting readiness".to_string());
+            } => publishes.push((worker_idx, publish)),
+            crate::ShardReady::Failed {
+                worker_idx: _,
+                message,
+            } => {
+                eprintln!("shard failed: {message}");
+                errors.push(message);
             }
         }
     }
@@ -267,14 +398,20 @@ pub fn prepare_shard_layer(
         // Dropping the peer senders unblocks any up-shard parked on
         // `peer_rx.recv()` so it can exit and be joined.
         drop(peer_txs);
-        drop(serve_start_txs);
-        layer_stop.store(true, Ordering::Relaxed);
-        for h in joins.into_iter().rev() {
-            let _ = h.join();
-        }
-        drop(control_senders);
-        drop(fabric_group);
-        drop(publishes);
+        let backing_keepalives = publishes
+            .into_iter()
+            .map(|(_, publish)| publish.backing_keepalive)
+            .collect();
+        cleanup_shards(
+            joins,
+            fabric_group,
+            ShardControlGroup::new(control_senders, SHARD_CONTROL_TIMEOUT),
+            layer_stop,
+            backing_keepalives,
+            serve_start_txs,
+            terminal_rx,
+            routes,
+        );
         return Err(errors);
     }
 
@@ -320,7 +457,6 @@ pub fn prepare_shard_layer(
             })
             .collect(),
     );
-    let up_count = peer_list.len();
     for tx in &peer_txs {
         // A send error means that shard died after phase A; it will be
         // surfaced as a missing/closed phase-B report below.
@@ -328,25 +464,30 @@ pub fn prepare_shard_layer(
     }
 
     // Phase-B collection: every up-shard reports exactly once (the
-    // `PhaseBGuard` guarantees this even on early return or panic), so
-    // this is bounded by `up_count`.
-    let mut phaseb_errors = Vec::new();
-    for _ in 0..up_count {
-        match phaseb_rx.recv() {
-            Ok(crate::PhaseBReport::Ready(_)) => {}
-            Ok(crate::PhaseBReport::Failed(err)) => {
-                eprintln!("shard phase-B failed: {err}");
-                phaseb_errors.push(err);
-            }
-            Err(_) => {
-                phaseb_errors
-                    .push("shard thread exited without reporting phase-B readiness".to_string());
-                break;
-            }
+    // `PhaseBGuard` guarantees this even on early return or panic).
+    let collected = collect_worker_reports(
+        "shard phase B",
+        &phaseb_rx,
+        &expected_workers,
+        SHARD_PHASE_TIMEOUT,
+        |report| match report {
+            crate::PhaseBReport::Ready(worker_idx)
+            | crate::PhaseBReport::Failed { worker_idx, .. } => *worker_idx,
+        },
+    );
+    let mut phaseb_errors = collected.errors;
+    for report in collected.reports {
+        if let crate::PhaseBReport::Failed {
+            worker_idx: _,
+            message,
+        } = report
+        {
+            eprintln!("shard phase-B failed: {message}");
+            phaseb_errors.push(message);
         }
     }
     if !phaseb_errors.is_empty() {
-        retire_failed_activation(
+        cleanup_shards(
             joins,
             fabric_group,
             ShardControlGroup::new(control_senders, SHARD_CONTROL_TIMEOUT),
@@ -389,7 +530,7 @@ pub fn activate_shard_layer(prepared: PreparedShardLayer) -> Result<ShardLayer, 
     } = prepared;
 
     if let Err(errors) = fabric_group.start_rpc_servers(&rpc_shards) {
-        retire_failed_activation(
+        cleanup_shards(
             joins,
             fabric_group,
             control,
@@ -403,7 +544,7 @@ pub fn activate_shard_layer(prepared: PreparedShardLayer) -> Result<ShardLayer, 
     }
     for tx in &serve_start_txs {
         if tx.send(()).is_err() {
-            retire_failed_activation(
+            cleanup_shards(
                 joins,
                 fabric_group,
                 control,
@@ -444,7 +585,7 @@ pub fn retire_prepared_shard_layer(prepared: PreparedShardLayer) {
         terminal_rx,
         routes,
     } = prepared;
-    retire_failed_activation(
+    cleanup_shards(
         joins,
         fabric_group,
         control,
@@ -456,8 +597,8 @@ pub fn retire_prepared_shard_layer(prepared: PreparedShardLayer) {
     );
 }
 
-fn retire_failed_activation(
-    joins: Vec<JoinHandle>,
+fn cleanup_shards(
+    joins: Vec<ShardJoin>,
     fabric_group: FabricGroup,
     control: ShardControlGroup,
     layer_stop: Arc<AtomicBool>,
@@ -465,17 +606,56 @@ fn retire_failed_activation(
     serve_start_txs: Vec<mpsc::Sender<()>>,
     terminal_rx: mpsc::Receiver<crate::ShardTerminalReport>,
     routes: RouteTableHandle,
-) {
+) -> bool {
+    let mut outstanding_workers: Vec<u16> = joins.iter().map(|join| join.worker_idx.0).collect();
+    outstanding_workers.sort_unstable();
+    let cleanup_progress = Arc::new(Mutex::new(CleanupProgress {
+        stage: "shard joins",
+        outstanding_workers,
+    }));
+    let watchdog = CleanupWatchdog::production(cleanup_progress.clone());
     layer_stop.store(true, Ordering::Relaxed);
     drop(serve_start_txs);
-    for h in joins.into_iter().rev() {
-        let _ = h.join();
+    // Reverse joins mirror spawn order. Only after every shard is gone may
+    // control, fabric, routes, and finally registered backing ownership drop.
+    let mut failed = false;
+    for join in joins.into_iter().rev() {
+        let worker_idx = join.worker_idx;
+        if let Err(error) = join.handle.join() {
+            eprintln!(
+                "shard worker={} panicked during cleanup: {error:?}",
+                worker_idx.0
+            );
+            failed = true;
+        }
+        cleanup_progress
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .outstanding_workers
+            .retain(|worker| *worker != worker_idx.0);
+    }
+    for report in terminal_rx.try_iter() {
+        eprintln!(
+            "shard worker={} terminal failure: {}",
+            report.worker_idx.0, report.message
+        );
+        failed = true;
     }
     drop(control);
+    cleanup_progress
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .stage = "fabric teardown";
     drop(fabric_group);
+    cleanup_progress
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .stage = "registered backing teardown";
     drop(routes);
     drop(backing_keepalives);
     drop(terminal_rx);
+    watchdog.disarm();
+    failed
 }
 
 fn shard_backing_sizes(
@@ -516,39 +696,16 @@ pub fn teardown_shard_layer(layer: ShardLayer) -> bool {
         terminal_rx,
         routes,
     } = layer;
-    layer_stop.store(true, Ordering::Relaxed);
-    let mut failed = false;
-    for h in joins.into_iter().rev() {
-        if let Err(e) = h.join() {
-            eprintln!("shard thread panicked during teardown: {e:?}");
-            failed = true;
-        }
-    }
-    for report in terminal_rx.try_iter() {
-        eprintln!(
-            "shard worker={} terminal failure: {}",
-            report.worker_idx.0, report.message
-        );
-        failed = true;
-    }
-    // Drop the control senders only after every shard thread has
-    // exited, so nothing observes a half-torn layer.
-    drop(control);
-    // Now retire the shared fabric endpoints. Each unit drops its RPC
-    // server first (signalling shutdown and joining the RPC worker
-    // pool), then its `Fabric`, which closes every memory region
-    // registered against the domain: the shared RPC scratch and every
-    // assigned shard's data backing. The shard threads have already
-    // joined, so nothing still touches those regions.
-    drop(fabric_group);
-    drop(routes);
-    // Free every shard's backing only now: the fabrics above have closed
-    // their MRs, and all shard threads (and thus every io_uring ring that
-    // may still reference a peer's pages as a `SEND_ZC` source) have
-    // joined, so no mapping is unmapped out from under a live ring or an
-    // open MR.
-    drop(_backing_keepalives);
-    failed
+    cleanup_shards(
+        joins,
+        fabric_group,
+        control,
+        layer_stop,
+        _backing_keepalives,
+        Vec::new(),
+        terminal_rx,
+        routes,
+    )
 }
 
 /// The binary's [`ConfigApplyTarget`]: owns the live shard layer and
@@ -787,6 +944,7 @@ impl ConfigApplyTarget for ProcessApplyTarget {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::atomic::AtomicUsize;
 
     use super::*;
     use unbounded_storage::p2p::NodeId;
@@ -814,6 +972,91 @@ mod tests {
         let graph = graph_with_self_peer(PeerId(7));
 
         assert_eq!(local_self_peer(&graph).unwrap(), PeerId(7));
+    }
+
+    #[test]
+    fn collector_timeout_reports_sorted_outstanding_workers() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(WorkerIdx(1)).unwrap();
+
+        let collected = collect_worker_reports(
+            "test phase",
+            &rx,
+            &[WorkerIdx(2), WorkerIdx(0), WorkerIdx(1)],
+            Duration::from_millis(1),
+            |worker| *worker,
+        );
+
+        assert_eq!(collected.reports, vec![WorkerIdx(1)]);
+        assert_eq!(
+            collected.errors,
+            vec!["test phase timed out; outstanding workers=[0, 2]"]
+        );
+    }
+
+    #[test]
+    fn collector_rejects_duplicate_worker_report() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(WorkerIdx(0)).unwrap();
+        tx.send(WorkerIdx(0)).unwrap();
+        tx.send(WorkerIdx(1)).unwrap();
+
+        let collected = collect_worker_reports(
+            "test phase",
+            &rx,
+            &[WorkerIdx(0), WorkerIdx(1)],
+            Duration::from_secs(1),
+            |worker| *worker,
+        );
+
+        assert_eq!(collected.reports, vec![WorkerIdx(0), WorkerIdx(1)]);
+        assert_eq!(
+            collected.errors,
+            vec!["test phase received duplicate report from worker=0"]
+        );
+    }
+
+    #[test]
+    fn cleanup_watchdog_disarms_without_firing() {
+        let fired = Arc::new(AtomicUsize::new(0));
+        let terminated = Arc::new(AtomicUsize::new(0));
+        let fired_for_watchdog = fired.clone();
+        let terminated_for_watchdog = terminated.clone();
+        let watchdog = CleanupWatchdog::spawn(
+            Duration::from_secs(1),
+            move || {
+                fired_for_watchdog.fetch_add(1, Ordering::Relaxed);
+            },
+            move || {
+                terminated_for_watchdog.fetch_add(1, Ordering::Relaxed);
+            },
+        );
+
+        watchdog.disarm();
+
+        assert_eq!(fired.load(Ordering::Relaxed), 0);
+        assert_eq!(terminated.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn cleanup_watchdog_fires_and_terminates() {
+        let (fired_tx, fired_rx) = mpsc::channel();
+        let terminated = Arc::new(AtomicUsize::new(0));
+        let terminated_for_watchdog = terminated.clone();
+        let watchdog = CleanupWatchdog::spawn(
+            Duration::from_millis(1),
+            move || {
+                fired_tx.send(()).unwrap();
+            },
+            move || {
+                terminated_for_watchdog.fetch_add(1, Ordering::Relaxed);
+            },
+        );
+
+        fired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        watchdog.disarm();
+
+        assert_eq!(terminated.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/storage/disks/mod.rs
+++ b/cmd/unbounded-storage/src/storage/disks/mod.rs
@@ -390,6 +390,7 @@ mod tests {
     #[derive(Default)]
     struct MockState {
         opened: HashSet<PathBuf>,
+        durably_mutated: HashSet<PathBuf>,
         fail_on: HashSet<PathBuf>,
         open_calls: usize,
     }
@@ -432,6 +433,7 @@ mod tests {
                 return Err(DiskError::Open("injected".into()));
             }
             s.opened.insert(PathBuf::from(path));
+            s.durably_mutated.insert(PathBuf::from(path));
             drop(s);
             Ok((
                 MockHandle {
@@ -563,6 +565,25 @@ mod tests {
         assert_eq!(report.failures[0].0, PathBuf::from("/bad"));
         assert!(state.lock().unwrap().opened.is_empty());
         assert!(reg.channels_snapshot().is_empty());
+    }
+
+    #[test]
+    fn failed_staging_cannot_undo_destructive_open() {
+        let (target, state) = MockDiskTarget::new();
+        state
+            .lock()
+            .unwrap()
+            .fail_on
+            .insert(PathBuf::from("/later-fails"));
+        let mut reg = DiskRegistry::new(target, vec![]);
+
+        let report = reg.reconcile(&[spec("/destructive", None), spec("/later-fails", None)]);
+
+        assert_eq!(report.failures.len(), 1);
+        assert!(reg.current_paths().is_empty());
+        let state = state.lock().unwrap();
+        assert!(state.opened.is_empty());
+        assert!(state.durably_mutated.contains(Path::new("/destructive")));
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/storage/disks/mod.rs
+++ b/cmd/unbounded-storage/src/storage/disks/mod.rs
@@ -133,15 +133,10 @@ impl<T: DiskTarget> DiskRegistry<T> {
 
     /// Reconcile the open set against `desired`.
     ///
-    /// Paths missing from `desired` are dropped (closing the handle).
-    /// Paths present in `desired` but not currently open are opened.
-    /// Paths whose [`DiskSpec`] drifted in any field that affects how
-    /// the disk is opened (config / queue_depth / page_size_bytes /
-    /// skip_recovery_scan / force_format / bypass_admission /
-    /// bypass_index_read / bypass_checksum) are treated as a remove followed by an add.
-    /// Partial failures during opens are reported after all desired paths
-    /// have been attempted. Callers publish the realized open subset before
-    /// deciding whether the desired configuration converged.
+    /// New disks are staged before the live set is changed. If any open fails,
+    /// all staged handles are closed and the old set remains intact. Changes to
+    /// open-time settings on an existing path require a restart because the old
+    /// handle cannot be safely closed before its replacement is known to open.
     pub fn reconcile(&mut self, desired: &[DiskSpec]) -> DiskReport {
         let mut report = DiskReport::default();
 
@@ -150,20 +145,18 @@ impl<T: DiskTarget> DiskRegistry<T> {
             desired_paths.insert(Path::new(disk_path(spec)), spec);
         }
 
-        let to_remove: Vec<PathBuf> = self
-            .entries
-            .keys()
-            .filter(|p| match desired_paths.get(p.as_path()) {
-                None => true,
-                Some(spec) => specs_drifted(self.entries.get(*p).map(|entry| &entry.spec), spec),
-            })
-            .cloned()
-            .collect();
-        for path in to_remove {
-            if let Some(entry) = self.entries.remove(&path) {
-                entry.close();
-                report.removed += 1;
+        for (path, entry) in &self.entries {
+            if let Some(spec) = desired_paths.get(path.as_path())
+                && specs_drifted(Some(&entry.spec), spec)
+            {
+                report.failures.push((
+                    path.clone(),
+                    "open-time disk settings changed; restart required".to_string(),
+                ));
             }
+        }
+        if !report.failures.is_empty() {
+            return report;
         }
 
         // Compute the slot assignment over the FULL desired set rather
@@ -177,20 +170,21 @@ impl<T: DiskTarget> DiskRegistry<T> {
         let open_placements: HashMap<PathBuf, Option<DiskCpuSlot>> = self
             .entries
             .iter()
+            .filter(|(path, _)| desired_paths.contains_key(path.as_path()))
             .map(|(path, entry)| (path.clone(), entry.placement))
             .collect();
         let assignment = assign_disk_cpus(desired, &self.disk_slots, &open_placements);
 
+        let mut staged = HashMap::new();
         for spec in desired {
             let path = disk_path(spec);
-            if let Some(entry) = self.entries.get_mut(Path::new(path)) {
-                entry.spec = spec.clone();
+            if self.entries.contains_key(Path::new(path)) {
                 continue;
             }
             let pin = assignment.get(Path::new(path)).copied().flatten();
             match self.target.open(spec, pin) {
                 Ok((handle, channel)) => {
-                    self.entries.insert(
+                    staged.insert(
                         PathBuf::from(path),
                         OpenDiskEntry {
                             channel,
@@ -199,13 +193,39 @@ impl<T: DiskTarget> DiskRegistry<T> {
                             handle,
                         },
                     );
-                    report.added += 1;
                 }
                 Err(e) => {
                     report.failures.push((PathBuf::from(path), e.to_string()));
                 }
             }
         }
+
+        if !report.failures.is_empty() {
+            for (_, entry) in staged {
+                entry.close();
+            }
+            return report;
+        }
+
+        let to_remove: Vec<PathBuf> = self
+            .entries
+            .keys()
+            .filter(|path| !desired_paths.contains_key(path.as_path()))
+            .cloned()
+            .collect();
+        for path in to_remove {
+            if let Some(entry) = self.entries.remove(&path) {
+                entry.close();
+                report.removed += 1;
+            }
+        }
+        for spec in desired {
+            if let Some(entry) = self.entries.get_mut(Path::new(disk_path(spec))) {
+                entry.spec = spec.clone();
+            }
+        }
+        report.added = staged.len();
+        self.entries.extend(staged);
 
         report
     }
@@ -509,14 +529,15 @@ mod tests {
     }
 
     #[test]
-    fn queue_depth_drift_triggers_remove_add() {
+    fn queue_depth_drift_requires_restart_and_preserves_old_disk() {
         let (target, _state) = MockDiskTarget::new();
         let mut reg = DiskRegistry::new(target, vec![]);
         reg.reconcile(&[spec("/a", Some(8))]);
         let report = reg.reconcile(&[spec("/a", Some(32))]);
-        assert_eq!(report.added, 1);
-        assert_eq!(report.removed, 1);
-        assert_eq!(reg.entries[&PathBuf::from("/a")].spec.queue_depth, Some(32));
+        assert_eq!(report.added, 0);
+        assert_eq!(report.removed, 0);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(reg.entries[&PathBuf::from("/a")].spec.queue_depth, Some(8));
     }
 
     #[test]
@@ -532,24 +553,16 @@ mod tests {
     }
 
     #[test]
-    fn failure_injection_does_not_block_others() {
+    fn failed_staging_rolls_back_other_new_disks() {
         let (target, state) = MockDiskTarget::new();
         state.lock().unwrap().fail_on.insert(PathBuf::from("/bad"));
         let mut reg = DiskRegistry::new(target, vec![]);
         let report = reg.reconcile(&[spec("/bad", None), spec("/good", None)]);
-        assert_eq!(report.added, 1);
+        assert_eq!(report.added, 0);
         assert_eq!(report.failures.len(), 1);
         assert_eq!(report.failures[0].0, PathBuf::from("/bad"));
-        assert!(
-            state
-                .lock()
-                .unwrap()
-                .opened
-                .contains(&PathBuf::from("/good"))
-        );
-        // Failed open must not pollute the channel map.
-        assert_eq!(reg.channels_snapshot().len(), 1);
-        assert_eq!(reg.channels_snapshot()[0].0, PathBuf::from("/good"));
+        assert!(state.lock().unwrap().opened.is_empty());
+        assert!(reg.channels_snapshot().is_empty());
     }
 
     #[test]
@@ -571,23 +584,18 @@ mod tests {
     }
 
     #[test]
-    fn failed_drift_replacement_remains_retryable() {
+    fn open_time_drift_is_rejected_without_closing_old_disk() {
         let (target, state) = MockDiskTarget::new();
         let mut reg = DiskRegistry::new(target, vec![]);
         reg.reconcile(&[spec("/a", Some(8))]);
 
-        state.lock().unwrap().fail_on.insert(PathBuf::from("/a"));
         let desired = [spec("/a", Some(32))];
         let failed = reg.reconcile(&desired);
-        assert_eq!(failed.removed, 1);
+        assert_eq!(failed.removed, 0);
+        assert_eq!(failed.added, 0);
         assert_eq!(failed.failures.len(), 1);
-        assert!(!reg.entries.contains_key(&PathBuf::from("/a")));
-
-        state.lock().unwrap().fail_on.clear();
-        let retried = reg.reconcile(&desired);
-        assert_eq!(retried.added, 1);
-        assert!(retried.failures.is_empty());
-        assert_eq!(reg.entries[&PathBuf::from("/a")].spec.queue_depth, Some(32));
+        assert_eq!(reg.entries[&PathBuf::from("/a")].spec.queue_depth, Some(8));
+        assert!(state.lock().unwrap().opened.contains(&PathBuf::from("/a")));
     }
 
     /// Records the per-disk `(path, cpu_hint)` decisions so tests can
@@ -772,19 +780,17 @@ mod tests {
     }
 
     #[test]
-    fn page_size_drift_triggers_remove_add() {
+    fn page_size_drift_requires_restart() {
         let (target, _state) = MockDiskTarget::new();
         let mut reg = DiskRegistry::new(target, vec![]);
         reg.reconcile(&[spec("/a", None)]);
         let mut next = spec("/a", None);
         next.page_size_bytes = Some(4096);
         let report = reg.reconcile(&[next]);
-        assert_eq!(report.added, 1);
-        assert_eq!(report.removed, 1);
-        assert_eq!(
-            reg.entries[&PathBuf::from("/a")].spec.page_size_bytes,
-            Some(4096)
-        );
+        assert_eq!(report.added, 0);
+        assert_eq!(report.removed, 0);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(reg.entries[&PathBuf::from("/a")].spec.page_size_bytes, None);
     }
 
     /// A file-backed spec that differs only in `size` must be detected
@@ -818,68 +824,63 @@ mod tests {
     }
 
     #[test]
-    fn skip_recovery_scan_drift_triggers_remove_add() {
+    fn skip_recovery_scan_drift_requires_restart() {
         let (target, _state) = MockDiskTarget::new();
         let mut reg = DiskRegistry::new(target, vec![]);
         reg.reconcile(&[spec("/a", None)]);
         let mut next = spec("/a", None);
         next.skip_recovery_scan = true;
         let report = reg.reconcile(&[next]);
-        assert_eq!(report.added, 1);
-        assert_eq!(report.removed, 1);
-        assert!(reg.entries[&PathBuf::from("/a")].spec.skip_recovery_scan);
+        assert_eq!(report.failures.len(), 1);
+        assert!(!reg.entries[&PathBuf::from("/a")].spec.skip_recovery_scan);
     }
 
     #[test]
-    fn force_format_drift_triggers_remove_add() {
+    fn force_format_drift_requires_restart() {
         let (target, _state) = MockDiskTarget::new();
         let mut reg = DiskRegistry::new(target, vec![]);
         reg.reconcile(&[spec("/a", None)]);
         let mut next = spec("/a", None);
         next.force_format = true;
         let report = reg.reconcile(&[next]);
-        assert_eq!(report.added, 1);
-        assert_eq!(report.removed, 1);
-        assert!(reg.entries[&PathBuf::from("/a")].spec.force_format);
+        assert_eq!(report.failures.len(), 1);
+        assert!(!reg.entries[&PathBuf::from("/a")].spec.force_format);
     }
 
     #[test]
-    fn bypass_admission_drift_triggers_remove_add() {
+    fn bypass_admission_drift_requires_restart() {
         let (target, _state) = MockDiskTarget::new();
         let mut reg = DiskRegistry::new(target, vec![]);
         reg.reconcile(&[spec("/a", None)]);
         let mut next = spec("/a", None);
         next.bypass_admission = true;
         let report = reg.reconcile(&[next]);
-        assert_eq!(report.added, 1);
-        assert_eq!(report.removed, 1);
-        assert!(reg.entries[&PathBuf::from("/a")].spec.bypass_admission);
+        assert_eq!(report.failures.len(), 1);
+        assert!(!reg.entries[&PathBuf::from("/a")].spec.bypass_admission);
     }
 
     #[test]
-    fn bypass_index_read_drift_triggers_remove_add() {
+    fn bypass_index_read_drift_requires_restart() {
         let (target, _state) = MockDiskTarget::new();
         let mut reg = DiskRegistry::new(target, vec![]);
         reg.reconcile(&[spec("/a", None)]);
         let mut next = spec("/a", None);
         next.bypass_index_read = true;
         let report = reg.reconcile(&[next]);
-        assert_eq!(report.added, 1);
-        assert_eq!(report.removed, 1);
-        assert!(reg.entries[&PathBuf::from("/a")].spec.bypass_index_read);
+        assert_eq!(report.failures.len(), 1);
+        assert!(!reg.entries[&PathBuf::from("/a")].spec.bypass_index_read);
     }
 
     #[test]
-    fn bypass_checksum_drift_triggers_remove_add() {
+    fn bypass_checksum_drift_requires_restart() {
         let (target, _state) = MockDiskTarget::new();
         let mut reg = DiskRegistry::new(target, vec![]);
         reg.reconcile(&[spec("/a", None)]);
         let mut next = spec("/a", None);
         next.bypass_checksum = true;
         let report = reg.reconcile(&[next]);
-        assert_eq!(report.added, 1);
-        assert_eq!(report.removed, 1);
-        assert!(reg.entries[&PathBuf::from("/a")].spec.bypass_checksum);
+        assert_eq!(report.failures.len(), 1);
+        assert!(!reg.entries[&PathBuf::from("/a")].spec.bypass_checksum);
     }
 
     #[test]


### PR DESCRIPTION
- transact shard config reloads with coordinated prepare, commit, and abort
- stage backend, frontend, and disk changes before publishing them to live registries
- defer irrevocable fabric and route updates until abortable preparation succeeds
- bound shard startup and cleanup coordination and fail stop on indeterminate apply state
- reject restart-only backend geometry and open-time disk changes without disrupting live resources