### PR TITLE
storage: version stripe geometry in cache identity

### DIFF
--- a/cmd/unbounded-storage/src/config/diff.rs
+++ b/cmd/unbounded-storage/src/config/diff.rs
@@ -62,6 +62,9 @@ pub struct ConfigDiff {
     /// `[[backends]]` changed. Broadcast to every shard, which rebuilds
     /// its origin-backend registry in place (no shard restart).
     pub backends_changed: bool,
+    /// An existing backend's stripe geometry changed. This moves the backend
+    /// to a new cache keyspace and is restart-only.
+    pub backend_geometry_changed: bool,
     /// `[[frontends]]` changed. Broadcast to every shard, which binds or
     /// closes the affected listener in place (no shard restart).
     pub frontends_changed: bool,
@@ -83,6 +86,11 @@ impl ConfigDiff {
                 || old.topology_weighting != new.topology_weighting,
             peers_changed: old.peers != new.peers,
             backends_changed: old.backends != new.backends,
+            backend_geometry_changed: new.backends.iter().any(|next| {
+                old.backends.iter().any(|prev| {
+                    prev.name == next.name && prev.stripe_size_bytes() != next.stripe_size_bytes()
+                })
+            }),
             frontends_changed: old.frontends != new.frontends,
         }
     }
@@ -96,6 +104,7 @@ impl ConfigDiff {
             || self.routing_changed
             || self.peers_changed
             || self.backends_changed
+            || self.backend_geometry_changed
             || self.frontends_changed
     }
 
@@ -110,7 +119,7 @@ impl ConfigDiff {
 
     /// Whether the process must restart before the new config can be applied.
     pub fn requires_restart(&self) -> bool {
-        self.identity_changed
+        self.identity_changed || self.backend_geometry_changed
     }
 
     /// Whether fabric peer connections must be reconciled.
@@ -263,6 +272,50 @@ mod tests {
         assert!(d.backends_changed);
         assert!(d.any());
         assert!(!d.requires_routing_reload());
+        assert!(!d.requires_restart());
+    }
+
+    #[test]
+    fn existing_backend_stripe_geometry_change_requires_restart() {
+        let mut a = base();
+        a.backends.push(http_backend("b", 4 * 1024 * 1024, 64));
+        let mut b = a.clone();
+        b.backends[0] = http_backend("b", 8 * 1024 * 1024, 64);
+
+        let d = ConfigDiff::between(&a, &b);
+
+        assert!(d.backends_changed);
+        assert!(d.backend_geometry_changed);
+        assert!(d.requires_restart());
+    }
+
+    #[test]
+    fn existing_backend_non_geometry_change_remains_live() {
+        let mut a = base();
+        a.backends.push(http_backend("b", 4 * 1024 * 1024, 64));
+        let mut b = a.clone();
+        b.backends[0] = http_backend("b", 4 * 1024 * 1024, 128);
+
+        let d = ConfigDiff::between(&a, &b);
+
+        assert!(d.backends_changed);
+        assert!(!d.backend_geometry_changed);
+        assert!(!d.requires_restart());
+    }
+
+    fn http_backend(name: &str, stripe_size_bytes: u64, http_concurrency: u32) -> BackendSpec {
+        BackendSpec {
+            name: name.to_string(),
+            config: Some(backend_spec::Config::Http(HttpBackendConfig {
+                url: "https://example.com".to_string(),
+                stripe_size_bytes: Some(stripe_size_bytes),
+                http_concurrency: Some(http_concurrency),
+                ca_cert_path: None,
+                insecure_skip_verify: false,
+                client_cert_path: None,
+                client_key_path: None,
+            })),
+        }
     }
 
     #[test]

--- a/cmd/unbounded-storage/src/frontend/http_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/http_serve.rs
@@ -440,7 +440,17 @@ async fn serve_request<P: BufferPool<Req = StripeReq>>(
     // metadata entry through the pool. The HTTP backend fills it from
     // an origin HEAD on a miss; local-disk and peer hits skip the
     // origin entirely.
-    let len = match read_object_length(pool, backend_id, cache_id, &path, page_size, bypass).await {
+    let len = match read_object_length(
+        pool,
+        backend_id,
+        cache_id,
+        &path,
+        stripe_size,
+        page_size,
+        bypass,
+    )
+    .await
+    {
         LenResult::Len(len) => len,
         LenResult::NotFound => {
             let _ = send_all(handle, conn_fd, status_line_response(404, keep_alive)).await;
@@ -544,6 +554,7 @@ fn stripe_request(
     backend_id: &str,
     cache_id: Option<&str>,
     path: &str,
+    stripe_size: u64,
     slice: StripeSlice,
     bypass: bool,
 ) -> (StripeKey, StripeReq) {
@@ -553,7 +564,7 @@ fn stripe_request(
         stripe_idx: slice.stripe_idx,
     };
     let key = cache_id
-        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id, stripe_size))
         .unwrap_or_else(|| origin_ref.stripe_key());
     let req = StripeReq::new(key)
         .with_origin(origin_ref)
@@ -683,10 +694,11 @@ async fn dispatch_ticket(
     backend_id: &str,
     cache_id: Option<&str>,
     path: &str,
+    stripe_size: u64,
     slice: StripeSlice,
     bypass: bool,
 ) -> Ticket {
-    let (key, req) = stripe_request(backend_id, cache_id, path, slice, bypass);
+    let (key, req) = stripe_request(backend_id, cache_id, path, stripe_size, slice, bypass);
     match fanout.owner_of_cache(&key, cache_id, slice.intra_offset) {
         Owner::Local => Ticket::Local { slice },
         Owner::Peer(peer) => {
@@ -733,7 +745,8 @@ async fn stream_body<P: BufferPool<Req = StripeReq>>(
         let plans: Vec<StripePlan<StripeReq>> = slices
             .into_iter()
             .map(|slice| {
-                let (_key, req) = stripe_request(backend_id, cache_id, path, slice, bypass);
+                let (_key, req) =
+                    stripe_request(backend_id, cache_id, path, stripe_size, slice, bypass);
                 StripePlan {
                     req,
                     intra_offset: slice.intra_offset,
@@ -756,13 +769,22 @@ async fn stream_body<P: BufferPool<Req = StripeReq>>(
     let mut window: VecDeque<Ticket> = VecDeque::new();
     while next < slices.len() && window.len() < multi_shard_window() {
         window.push_back(
-            dispatch_ticket(fanout, backend_id, cache_id, path, slices[next], bypass).await,
+            dispatch_ticket(
+                fanout,
+                backend_id,
+                cache_id,
+                path,
+                stripe_size,
+                slices[next],
+                bypass,
+            )
+            .await,
         );
         next += 1;
     }
 
     let local_plan = |slice: StripeSlice| {
-        let (_key, req) = stripe_request(backend_id, cache_id, path, slice, bypass);
+        let (_key, req) = stripe_request(backend_id, cache_id, path, stripe_size, slice, bypass);
         StripePlan {
             req,
             intra_offset: slice.intra_offset,
@@ -808,7 +830,16 @@ async fn stream_body<P: BufferPool<Req = StripeReq>>(
 
         while next < slices.len() && window.len() < multi_shard_window() {
             window.push_back(
-                dispatch_ticket(fanout, backend_id, cache_id, path, slices[next], bypass).await,
+                dispatch_ticket(
+                    fanout,
+                    backend_id,
+                    cache_id,
+                    path,
+                    stripe_size,
+                    slices[next],
+                    bypass,
+                )
+                .await,
             );
             next += 1;
         }
@@ -830,12 +861,13 @@ async fn read_object_length<P: BufferPool<Req = StripeReq>>(
     backend_id: &str,
     cache_id: Option<&str>,
     path: &str,
+    stripe_size: u64,
     page_size: usize,
     bypass: bool,
 ) -> LenResult {
     let origin_ref = OriginRef::metadata_entry(backend_id, path);
     let key = cache_id
-        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id, stripe_size))
         .unwrap_or_else(|| origin_ref.stripe_key());
     let req = StripeReq::new(key)
         .with_origin(origin_ref)
@@ -1224,11 +1256,11 @@ mod tests {
             intra_len: 4,
         };
         // Non-bypass requests carry the cache path (bypass == false).
-        let (_k, normal) = stripe_request("primary", Some("cache-a"), "/o", slice, false);
+        let (_k, normal) = stripe_request("primary", Some("cache-a"), "/o", 4096, slice, false);
         assert!(!normal.bypass());
         assert_eq!(normal.cache_id(), Some("cache-a"));
         // Bridge-mode frontends stamp bypass == true onto every request.
-        let (k, bridged) = stripe_request("primary", None, "/o", slice, true);
+        let (k, bridged) = stripe_request("primary", None, "/o", 4096, slice, true);
         assert!(bridged.bypass());
         // Cache id is the only logical key prefix, so cached and uncached
         // requests for the same origin intentionally use different keys.
@@ -1252,10 +1284,13 @@ mod tests {
         let origin_ref = OriginRef::metadata_entry("primary", "/o");
         assert!(origin_ref.is_metadata_entry());
 
-        let req =
-            StripeReq::new(origin_ref.stripe_key_for_cache("cache-a")).with_origin(origin_ref);
+        let req = StripeReq::new(origin_ref.stripe_key_for_cache("cache-a", 4096))
+            .with_origin(origin_ref);
         assert!(req.origin().unwrap().is_metadata_entry());
-        assert_eq!(req.key(), stripe_key("cache-a", "/o", METADATA_STRIPE_IDX));
+        assert_eq!(
+            req.key(),
+            stripe_key("cache-a", 4096, "/o", METADATA_STRIPE_IDX)
+        );
         assert_eq!(METADATA_STRIPE_IDX, u64::MAX);
     }
 
@@ -1318,7 +1353,13 @@ mod tests {
         });
 
         let result = block_on(read_object_length(
-            &pool, "primary", None, "/missing", 4096, false,
+            &pool,
+            "primary",
+            None,
+            "/missing",
+            4 * 1024 * 1024,
+            4096,
+            false,
         ));
 
         assert_eq!(result, LenResult::NotFound);
@@ -1331,7 +1372,13 @@ mod tests {
         });
 
         let result = block_on(read_object_length(
-            &pool, "primary", None, "/broken", 4096, false,
+            &pool,
+            "primary",
+            None,
+            "/broken",
+            4 * 1024 * 1024,
+            4096,
+            false,
         ));
 
         assert_eq!(result, LenResult::Other);

--- a/cmd/unbounded-storage/src/frontend/loadgen_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/loadgen_serve.rs
@@ -387,7 +387,7 @@ fn request_from_origin(origin_ref: OriginRef, cfg: &LoadgenRun) -> StripeReq {
     let key = cfg
         .cache_id
         .as_deref()
-        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id, cfg.stripe_size))
         .unwrap_or_else(|| origin_ref.stripe_key());
     StripeReq::new(key)
         .with_origin(origin_ref)
@@ -785,7 +785,7 @@ mod tests {
         cfg.fabric_only = true;
         cfg.skip_local_disk = true;
         let origin = OriginRef::new("fake", "obj", 3);
-        let key = origin.stripe_key_for_cache("cache");
+        let key = origin.stripe_key_for_cache("cache", cfg.stripe_size);
         let req = request_from_origin(origin, &cfg);
         assert_eq!(req.key(), key);
         assert_eq!(req.origin().unwrap().backend_id, "fake");

--- a/cmd/unbounded-storage/src/frontend/s3_serve.rs
+++ b/cmd/unbounded-storage/src/frontend/s3_serve.rs
@@ -380,30 +380,39 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
     // (404 NoSuchKey) from any other failure (500 InternalError). Unlike
     // the plain HTTP frontend, a length-read failure is never a silently
     // dropped connection.
-    let len =
-        match read_object_length_s3(pool, backend_id, cache_id, &path, page_size, bypass).await {
-            LenResult::Len(l) => l,
-            LenResult::NotFound => {
-                let bytes = error_bytes(S3ErrorCode::NoSuchKey, &path, &request_id, is_head, None);
-                let _ = send_all(handle, conn_fd, bytes).await;
-                log.field("status", 404);
-                outcome.status = 404;
-                return Ok(());
-            }
-            LenResult::Other => {
-                let bytes = error_bytes(
-                    S3ErrorCode::InternalError,
-                    &path,
-                    &request_id,
-                    is_head,
-                    None,
-                );
-                let _ = send_all(handle, conn_fd, bytes).await;
-                log.field("status", 500);
-                outcome.status = 500;
-                return Ok(());
-            }
-        };
+    let len = match read_object_length_s3(
+        pool,
+        backend_id,
+        cache_id,
+        &path,
+        stripe_size,
+        page_size,
+        bypass,
+    )
+    .await
+    {
+        LenResult::Len(l) => l,
+        LenResult::NotFound => {
+            let bytes = error_bytes(S3ErrorCode::NoSuchKey, &path, &request_id, is_head, None);
+            let _ = send_all(handle, conn_fd, bytes).await;
+            log.field("status", 404);
+            outcome.status = 404;
+            return Ok(());
+        }
+        LenResult::Other => {
+            let bytes = error_bytes(
+                S3ErrorCode::InternalError,
+                &path,
+                &request_id,
+                is_head,
+                None,
+            );
+            let _ = send_all(handle, conn_fd, bytes).await;
+            log.field("status", 500);
+            outcome.status = 500;
+            return Ok(());
+        }
+    };
 
     // 6. Resolve the requested range against the length.
     let resolved = match range {
@@ -489,7 +498,7 @@ async fn serve_request_s3<P: BufferPool<Req = StripeReq>>(
                 stripe_idx: slice.stripe_idx,
             };
             let key = cache_id
-                .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+                .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id, stripe_size))
                 .unwrap_or_else(|| origin_ref.stripe_key());
             StripePlan {
                 req: StripeReq::new(key)
@@ -561,12 +570,13 @@ async fn read_object_length_s3<P: BufferPool<Req = StripeReq>>(
     backend_id: &str,
     cache_id: Option<&str>,
     path: &str,
+    stripe_size: u64,
     page_size: usize,
     bypass: bool,
 ) -> LenResult {
     let origin_ref = OriginRef::metadata_entry(backend_id, path);
     let key = cache_id
-        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id))
+        .map(|cache_id| origin_ref.stripe_key_for_cache(cache_id, stripe_size))
         .unwrap_or_else(|| origin_ref.stripe_key());
     let req = StripeReq::new(key)
         .with_origin(origin_ref)

--- a/cmd/unbounded-storage/src/storage/origin.rs
+++ b/cmd/unbounded-storage/src/storage/origin.rs
@@ -4,9 +4,10 @@
 //! Stripe-to-origin mapping.
 //!
 //! The P2P cache is keyspace-addressed: a cached stripe is identified
-//! by its cache id, logical object id, and stripe index. That key is
-//! sufficient for peer routing and dedup inside one cache, but it
-//! carries no information about *where the bytes came from*. When a
+//! by its cache id, stripe geometry, logical object id, and stripe
+//! index. That key is sufficient for peer routing and dedup inside one
+//! cache, but it carries no information about *where the bytes came
+//! from*. When a
 //! read misses all the way through to the origin tier, the backend
 //! needs to map a [`StripeKey`] back to a concrete origin object and
 //! byte range so it can issue (for example) an S3 `GET` with the right
@@ -114,9 +115,10 @@ impl OriginRef {
     /// 1. `cache_id.len()` as 8 little-endian bytes
     ///    (`u64::to_le_bytes`).
     /// 2. `cache_id` as raw UTF-8 bytes.
-    /// 3. `origin_object_id.len()` as 8 little-endian bytes.
-    /// 4. `origin_object_id` as raw UTF-8 bytes.
-    /// 5. `stripe_idx` as 8 little-endian bytes (`u64::to_le_bytes`).
+    /// 3. `stripe_size_bytes` as 8 little-endian bytes.
+    /// 4. `origin_object_id.len()` as 8 little-endian bytes.
+    /// 5. `origin_object_id` as raw UTF-8 bytes.
+    /// 6. `stripe_idx` as 8 little-endian bytes (`u64::to_le_bytes`).
     ///
     /// The 32-byte blake3 digest is the [`StripeKey`]. blake3's output
     /// is already 32 bytes, so no truncation or expansion is needed.
@@ -127,8 +129,13 @@ impl OriginRef {
     /// split between `cache_id` and `origin_object_id` need not be
     /// pinned out-of-band for correctness. The 8-byte little-endian
     /// `stripe_idx` suffix is fixed width.
-    pub fn stripe_key_for_cache(&self, cache_id: &str) -> StripeKey {
-        stripe_key(cache_id, &self.origin_object_id, self.stripe_idx)
+    pub fn stripe_key_for_cache(&self, cache_id: &str, stripe_size_bytes: u64) -> StripeKey {
+        stripe_key(
+            cache_id,
+            stripe_size_bytes,
+            &self.origin_object_id,
+            self.stripe_idx,
+        )
     }
 
     /// Whether this reference names an object's metadata entry rather
@@ -269,10 +276,16 @@ impl Req for StripeReq {
 /// Free-function form of [`OriginRef::stripe_key_for_cache`], for callers that
 /// have the parts in hand without an `OriginRef` value. See
 /// [`OriginRef::stripe_key_for_cache`] for the exact byte layout.
-pub fn stripe_key(cache_id: &str, origin_object_id: &str, stripe_idx: u64) -> StripeKey {
+pub fn stripe_key(
+    cache_id: &str,
+    stripe_size_bytes: u64,
+    origin_object_id: &str,
+    stripe_idx: u64,
+) -> StripeKey {
     let mut hasher = blake3::Hasher::new();
     hasher.update(&(cache_id.len() as u64).to_le_bytes());
     hasher.update(cache_id.as_bytes());
+    hasher.update(&stripe_size_bytes.to_le_bytes());
     hasher.update(&(origin_object_id.len() as u64).to_le_bytes());
     hasher.update(origin_object_id.as_bytes());
     hasher.update(&stripe_idx.to_le_bytes());
@@ -298,13 +311,13 @@ mod tests {
         let a = OriginRef::new("primary-s3", "models/llama.bin", 12);
         let b = OriginRef::new("secondary-s3", "models/llama.bin", 12);
         assert_eq!(
-            a.stripe_key_for_cache("cache-a"),
-            b.stripe_key_for_cache("cache-a")
+            a.stripe_key_for_cache("cache-a", 4096),
+            b.stripe_key_for_cache("cache-a", 4096)
         );
         // Free function agrees with the method.
         assert_eq!(
-            a.stripe_key_for_cache("cache-a"),
-            stripe_key("cache-a", "models/llama.bin", 12)
+            a.stripe_key_for_cache("cache-a", 4096),
+            stripe_key("cache-a", 4096, "models/llama.bin", 12)
         );
     }
 
@@ -315,17 +328,18 @@ mod tests {
         let diff_object = OriginRef::new("primary-s3", "models/other.bin", 12);
         let diff_idx = OriginRef::new("primary-s3", "models/llama.bin", 13);
 
-        let k = base.stripe_key_for_cache("cache-a");
-        assert_eq!(k, diff_cache.stripe_key_for_cache("cache-a"));
-        assert_ne!(k, base.stripe_key_for_cache("cache-b"));
-        assert_ne!(k, diff_object.stripe_key_for_cache("cache-a"));
-        assert_ne!(k, diff_idx.stripe_key_for_cache("cache-a"));
+        let k = base.stripe_key_for_cache("cache-a", 4096);
+        assert_eq!(k, diff_cache.stripe_key_for_cache("cache-a", 4096));
+        assert_ne!(k, base.stripe_key_for_cache("cache-b", 4096));
+        assert_ne!(k, base.stripe_key_for_cache("cache-a", 8192));
+        assert_ne!(k, diff_object.stripe_key_for_cache("cache-a", 4096));
+        assert_ne!(k, diff_idx.stripe_key_for_cache("cache-a", 4096));
     }
 
     #[test]
     fn stripe_key_matches_documented_byte_layout() {
         // Reconstruct the digest by hand from the documented layout:
-        // cache_len_le || cache_id bytes || object_len_le ||
+        // cache_len_le || cache_id bytes || stripe_size_le || object_len_le ||
         // origin_object_id bytes || idx_le.
         let cache = "c";
         let object = "obj";
@@ -334,12 +348,13 @@ mod tests {
         let mut expected_input = Vec::new();
         expected_input.extend_from_slice(&(cache.len() as u64).to_le_bytes());
         expected_input.extend_from_slice(cache.as_bytes());
+        expected_input.extend_from_slice(&4096u64.to_le_bytes());
         expected_input.extend_from_slice(&(object.len() as u64).to_le_bytes());
         expected_input.extend_from_slice(object.as_bytes());
         expected_input.extend_from_slice(&idx.to_le_bytes());
         let expected = StripeKey(*blake3::hash(&expected_input).as_bytes());
 
-        assert_eq!(stripe_key(cache, object, idx), expected);
+        assert_eq!(stripe_key(cache, 4096, object, idx), expected);
     }
 
     #[test]
@@ -347,18 +362,21 @@ mod tests {
         // The length prefix on each variable-length field must make
         // distinct (cache_id, origin_object_id) splits unambiguous:
         // without it, "ab"+"c" and "a"+"bc" hash the same bytes.
-        assert_ne!(stripe_key("ab", "c", 0), stripe_key("a", "bc", 0));
+        assert_ne!(
+            stripe_key("ab", 4096, "c", 0),
+            stripe_key("a", 4096, "bc", 0)
+        );
 
         // Moving a byte across the field boundary changes the key even
         // when the concatenation is otherwise identical.
         assert_ne!(
-            stripe_key("foo", "barbaz", 7),
-            stripe_key("foobar", "baz", 7)
+            stripe_key("foo", 4096, "barbaz", 7),
+            stripe_key("foobar", 4096, "baz", 7)
         );
 
         // Empty-vs-nonempty split of the same concatenation also
         // differs.
-        assert_ne!(stripe_key("", "x", 0), stripe_key("x", "", 0));
+        assert_ne!(stripe_key("", 4096, "x", 0), stripe_key("x", 4096, "", 0));
     }
 
     #[test]
@@ -368,21 +386,23 @@ mod tests {
         let mut input = Vec::new();
         input.extend_from_slice(&1u64.to_le_bytes());
         input.extend_from_slice(b"b");
+        input.extend_from_slice(&4096u64.to_le_bytes());
         input.extend_from_slice(&3u64.to_le_bytes());
         input.extend_from_slice(b"obj");
         input.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0]);
         let expected = StripeKey(*blake3::hash(&input).as_bytes());
-        assert_eq!(stripe_key("b", "obj", 1), expected);
+        assert_eq!(stripe_key("b", 4096, "obj", 1), expected);
 
         // And that little-endian 1 differs from big-endian 1 framing.
         let mut be_input = Vec::new();
         be_input.extend_from_slice(&1u64.to_le_bytes());
         be_input.extend_from_slice(b"b");
+        be_input.extend_from_slice(&4096u64.to_le_bytes());
         be_input.extend_from_slice(&3u64.to_le_bytes());
         be_input.extend_from_slice(b"obj");
         be_input.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 1]);
         let be = StripeKey(*blake3::hash(&be_input).as_bytes());
-        assert_ne!(stripe_key("b", "obj", 1), be);
+        assert_ne!(stripe_key("b", 4096, "obj", 1), be);
     }
 
     #[test]
@@ -414,7 +434,7 @@ mod tests {
         assert_eq!(a.stripe_key(), b.stripe_key());
         // The metadata entry rides the same keying machinery as a data
         // stripe at the sentinel index.
-        assert_eq!(a.stripe_key(), stripe_key("b", "obj", u64::MAX));
+        assert_eq!(a.stripe_key(), origin_stripe_key("b", "obj", u64::MAX));
     }
 
     #[test]


### PR DESCRIPTION
- include stripe size in cached data and metadata keys across HTTP, S3, and loadgen frontends
- require a restart when an existing backend's stripe size changes