### PR TITLE
storage: simplify bufferpool scheduling

### DIFF
--- a/cmd/unbounded-storage/src/bufferpool/free_list.rs
+++ b/cmd/unbounded-storage/src/bufferpool/free_list.rs
@@ -5,7 +5,7 @@
 //!
 //! When the backing is exhausted, blocking [`FreeList::alloc`] callers
 //! park in FIFO order. A released page is *handed off* directly to the
-//! oldest waiter (recorded in `granted`) rather than being returned to
+//! oldest waiter rather than being returned to
 //! the shared `free` pool. This is load-bearing: speculative prefetch
 //! uses [`FreeList::try_alloc_spare`], which must never steal a page a
 //! blocked head fetch is owed. If `release` instead pushed the page to
@@ -13,7 +13,7 @@
 //! running before the woken head re-polled (the waiter queue is empty
 //! in that window) could pop the page out from under it and deadlock
 //! under free-list pressure. Direct hand-off closes that race: a
-//! promised page lives in `granted`, never in `free`.
+//! promised page lives in the waiter's state, never in `free`.
 //!
 //! The pool runs single-threaded inside its NUMA shard so the
 //! underlying [`RefCell`] is sufficient; no atomics are required.
@@ -31,22 +31,18 @@ pub(super) struct FreeList {
 
 struct Inner {
     free: Vec<u32>,
-    /// FIFO queue of blocked [`AllocFuture`]s, identified by id.
-    waiters: VecDeque<Waiter>,
-    /// Pages handed off to a specific waiter, awaiting its next poll.
-    /// Reserved here so speculation cannot reclaim them.
-    granted: Vec<(u64, u32)>,
+    /// FIFO queue of blocked [`AllocFuture`]s.
+    waiters: VecDeque<Rc<Waiter>>,
     /// Pages withheld from reuse because a fixed-buffer RECV writing
     /// into them was cancelled while still in flight. A quarantined
     /// page returns to circulation only once BOTH the kernel has
     /// finished with it (`kernel_done`, set when its RECV CQE is reaped)
     /// AND the owner has handed it back (`owner_released`, set by the
     /// normal [`FreeList::release`]). Until then it appears neither in
-    /// `free` nor `granted`, so no allocation can hand the page out
+    /// `free` nor a waiter grant, so no allocation can hand the page out
     /// while the kernel may still write into it. This makes cancelling
     /// a fixed RECV sound without blocking the dropping task.
     quarantined: HashMap<u32, QState>,
-    next_id: u64,
 }
 
 #[derive(Default)]
@@ -56,19 +52,29 @@ struct QState {
 }
 
 struct Waiter {
-    id: u64,
-    waker: Waker,
+    state: RefCell<WaiterState>,
+}
+
+enum WaiterState {
+    Queued(Waker),
+    Granted(u32),
+    Done,
 }
 
 impl Inner {
-    /// Give `page` to the oldest waiter (recording it in `granted` and
+    /// Give `page` to the oldest waiter (recording it in the waiter and
     /// returning its waker to wake), or push it onto `free` if there
     /// are no waiters. The caller must wake the returned waker after
     /// dropping the borrow.
     fn hand_off(&mut self, page: u32) -> Option<Waker> {
         if let Some(w) = self.waiters.pop_front() {
-            self.granted.push((w.id, page));
-            Some(w.waker)
+            let queued = std::mem::replace(&mut *w.state.borrow_mut(), WaiterState::Granted(page));
+            match queued {
+                WaiterState::Queued(waker) => Some(waker),
+                WaiterState::Granted(_) | WaiterState::Done => {
+                    unreachable!("only queued waiters may remain in the FIFO")
+                }
+            }
         } else {
             self.free.push(page);
             crate::metrics::bufferpool_free_delta(1);
@@ -89,9 +95,7 @@ impl FreeList {
             inner: RefCell::new(Inner {
                 free,
                 waiters: VecDeque::new(),
-                granted: Vec::new(),
                 quarantined: HashMap::new(),
-                next_id: 0,
             }),
         }
     }
@@ -142,8 +146,8 @@ impl FreeList {
     ///
     /// 1. It fails if any waiter is parked on [`FreeList::alloc`].
     ///    Parked waiters are head fetches with strict priority on
-    ///    scarce pages. (Pages already promised to a waiter live in
-    ///    `granted`, not `free`, so they are never visible here.)
+    ///    scarce pages. Pages already promised to a waiter live in
+    ///    its state, not `free`, so they are never visible here.
     ///
     /// 2. It fails unless strictly more than `reserve` pages remain
     ///    free *after* the pop, i.e. it keeps `reserve` pages in
@@ -176,7 +180,7 @@ impl FreeList {
     pub fn alloc(&self) -> AllocFuture<'_> {
         AllocFuture {
             list: self,
-            id: None,
+            waiter: None,
         }
     }
 
@@ -301,75 +305,196 @@ impl RecvQuarantineHandle {
 
 pub(super) struct AllocFuture<'a> {
     list: &'a FreeList,
-    /// Lazily assigned when this future first has to park, so it can
-    /// receive a hand-off and clean up on drop.
-    id: Option<u64>,
+    /// Lazily allocated only when this future has to park.
+    waiter: Option<Rc<Waiter>>,
 }
 
 impl<'a> Future for AllocFuture<'a> {
     type Output = u32;
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<u32> {
         let this = self.get_mut();
-        let mut g = this.list.inner.borrow_mut();
-
-        // A page handed to us by `release`/drop-reclaim takes priority.
-        if let Some(id) = this.id {
-            if let Some(pos) = g.granted.iter().position(|(wid, _)| *wid == id) {
-                let (_, page) = g.granted.remove(pos);
-                return Poll::Ready(page);
+        if let Some(waiter) = &this.waiter {
+            let mut state = waiter.state.borrow_mut();
+            match &mut *state {
+                WaiterState::Granted(page) => {
+                    let page = *page;
+                    *state = WaiterState::Done;
+                    drop(state);
+                    this.waiter = None;
+                    return Poll::Ready(page);
+                }
+                WaiterState::Queued(waker) => {
+                    let old = std::mem::replace(waker, cx.waker().clone());
+                    drop(state);
+                    drop(old);
+                    return Poll::Pending;
+                }
+                WaiterState::Done => panic!("allocation future polled after completion"),
             }
         }
 
+        let mut g = this.list.inner.borrow_mut();
         // Only jump the queue for a free page if nobody is waiting
         // ahead of us; otherwise we would starve parked heads.
-        if this.id.is_none() && g.waiters.is_empty() {
+        if g.waiters.is_empty() {
             if let Some(p) = g.free.pop() {
                 crate::metrics::bufferpool_free_delta(-1);
                 return Poll::Ready(p);
             }
         }
 
-        // Park (or refresh our parked waker).
-        let id = match this.id {
-            Some(id) => id,
-            None => {
-                let id = g.next_id;
-                g.next_id += 1;
-                this.id = Some(id);
-                id
-            }
-        };
-        if let Some(w) = g.waiters.iter_mut().find(|w| w.id == id) {
-            w.waker = cx.waker().clone();
-        } else {
-            g.waiters.push_back(Waiter {
-                id,
-                waker: cx.waker().clone(),
-            });
-        }
+        let waiter = Rc::new(Waiter {
+            state: RefCell::new(WaiterState::Queued(cx.waker().clone())),
+        });
+        g.waiters.push_back(waiter.clone());
+        this.waiter = Some(waiter);
         Poll::Pending
     }
 }
 
 impl<'a> Drop for AllocFuture<'a> {
     fn drop(&mut self) {
-        let Some(id) = self.id else {
+        let Some(waiter) = self.waiter.take() else {
             return;
         };
-        let waker = {
-            let mut g = self.list.inner.borrow_mut();
-            g.waiters.retain(|w| w.id != id);
-            // If we were handed a page but never polled to take it,
-            // re-offer it so it is not leaked.
-            if let Some(pos) = g.granted.iter().position(|(wid, _)| *wid == id) {
-                let (_, page) = g.granted.remove(pos);
-                g.hand_off(page)
-            } else {
-                None
+        let state = std::mem::replace(&mut *waiter.state.borrow_mut(), WaiterState::Done);
+        let (waker, discarded) = match state {
+            WaiterState::Queued(waker) => {
+                let mut g = self.list.inner.borrow_mut();
+                let pos = g
+                    .waiters
+                    .iter()
+                    .position(|queued| Rc::ptr_eq(queued, &waiter))
+                    .expect("queued allocation waiter must be in the FIFO");
+                g.waiters.remove(pos);
+                (None, Some(waker))
             }
+            WaiterState::Granted(page) => {
+                let waker = self.list.inner.borrow_mut().hand_off(page);
+                (waker, None)
+            }
+            WaiterState::Done => (None, None),
         };
+        drop(discarded);
         if let Some(w) = waker {
             w.wake();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Wake, Waker};
+
+    use super::*;
+
+    struct CountWake(AtomicUsize);
+
+    impl Wake for CountWake {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn waker(counter: &Arc<CountWake>) -> Waker {
+        Waker::from(counter.clone())
+    }
+
+    fn poll(future: &mut AllocFuture<'_>, waker: &Waker) -> Poll<u32> {
+        let mut cx = Context::from_waker(waker);
+        Pin::new(future).poll(&mut cx)
+    }
+
+    #[test]
+    fn handoff_is_fifo_and_hidden_from_nonblocking_allocations() {
+        let free = FreeList::new(1);
+        assert_eq!(free.try_alloc_head(), Some(0));
+        let count = Arc::new(CountWake(AtomicUsize::new(0)));
+        let wake = waker(&count);
+        let mut first = free.alloc();
+        let mut second = free.alloc();
+        assert!(poll(&mut first, &wake).is_pending());
+        assert!(poll(&mut second, &wake).is_pending());
+
+        free.release(0);
+        assert_eq!(count.0.load(Ordering::Relaxed), 1);
+        assert_eq!(free.available(), 0);
+        assert_eq!(free.try_alloc_head(), None);
+        assert_eq!(free.try_alloc_spare(0), None);
+        assert_eq!(poll(&mut first, &wake), Poll::Ready(0));
+
+        drop(first);
+        free.release(0);
+        assert_eq!(poll(&mut second, &wake), Poll::Ready(0));
+    }
+
+    #[test]
+    fn dropping_queued_waiter_preserves_survivor_order() {
+        let free = FreeList::new(1);
+        let page = free.try_alloc_head().unwrap();
+        let count = Arc::new(CountWake(AtomicUsize::new(0)));
+        let wake = waker(&count);
+        let mut first = free.alloc();
+        let mut cancelled = free.alloc();
+        let mut last = free.alloc();
+        assert!(poll(&mut first, &wake).is_pending());
+        assert!(poll(&mut cancelled, &wake).is_pending());
+        assert!(poll(&mut last, &wake).is_pending());
+        drop(cancelled);
+
+        free.release(page);
+        assert_eq!(poll(&mut first, &wake), Poll::Ready(page));
+        drop(first);
+        free.release(page);
+        assert_eq!(poll(&mut last, &wake), Poll::Ready(page));
+    }
+
+    #[test]
+    fn dropping_granted_waiter_forwards_its_page() {
+        let free = FreeList::new(1);
+        let page = free.try_alloc_head().unwrap();
+        let count = Arc::new(CountWake(AtomicUsize::new(0)));
+        let wake = waker(&count);
+        let mut first = free.alloc();
+        let mut second = free.alloc();
+        assert!(poll(&mut first, &wake).is_pending());
+        assert!(poll(&mut second, &wake).is_pending());
+        free.release(page);
+
+        drop(first);
+        assert_eq!(poll(&mut second, &wake), Poll::Ready(page));
+    }
+
+    #[test]
+    fn quarantine_hands_safe_page_to_oldest_waiter() {
+        let free = FreeList::new(1);
+        let page = free.try_alloc_head().unwrap();
+        free.quarantine_recv(page);
+        let count = Arc::new(CountWake(AtomicUsize::new(0)));
+        let wake = waker(&count);
+        let mut waiter = free.alloc();
+        assert!(poll(&mut waiter, &wake).is_pending());
+
+        free.release(page);
+        assert!(poll(&mut waiter, &wake).is_pending());
+        free.reclaim_recv(page);
+        assert_eq!(free.available(), 0);
+        assert_eq!(poll(&mut waiter, &wake), Poll::Ready(page));
+    }
+
+    #[test]
+    fn repeated_poll_replaces_waker() {
+        let free = FreeList::new(0);
+        let old_count = Arc::new(CountWake(AtomicUsize::new(0)));
+        let new_count = Arc::new(CountWake(AtomicUsize::new(0)));
+        let mut waiter = free.alloc();
+        assert!(poll(&mut waiter, &waker(&old_count)).is_pending());
+        assert!(poll(&mut waiter, &waker(&new_count)).is_pending());
+
+        free.release(7);
+        assert_eq!(old_count.0.load(Ordering::Relaxed), 0);
+        assert_eq!(new_count.0.load(Ordering::Relaxed), 1);
     }
 }

--- a/cmd/unbounded-storage/src/bufferpool/pipeline.rs
+++ b/cmd/unbounded-storage/src/bufferpool/pipeline.rs
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Multi-stripe pipelined reader.
+//! Ordered prefetch scheduler for windowed and multi-stripe reads.
 //!
-//! [`PipelinedRead`] generalizes [`crate::bufferpool::WindowedRead`]
-//! from a single stripe to an ordered sequence of per-stripe slices.
-//! Where `WindowedRead` keeps up to `window` fetch futures in flight
-//! within one stripe, `PipelinedRead` keeps `window` fetch futures in
-//! flight across stripe boundaries, so origin (and peer) downloads
-//! pipeline continuously instead of draining one stripe before the
-//! next begins. Pages are still delivered to the consumer strictly in
-//! order, one [`PageGuard`] at a time.
+//! [`PipelinedRead`] schedules ordered prefetch across one or more
+//! per-stripe slices. The public multi-stripe path admits slices
+//! lazily; [`crate::bufferpool::WindowedRead`] uses its private
+//! single-stream mode after eager admission. Pages are delivered to
+//! the consumer strictly in order, one [`PageGuard`] at a time.
 //!
 //! Motivation: the frontends serve a byte range as a contiguous run
 //! of per-stripe slices. Driving each slice's `WindowedRead` to
@@ -120,6 +117,10 @@ pub struct PipelinedRead<'pool> {
     /// Lowest slice index not yet fully consumed; slices below this
     /// have been released. Used as the scan start for `locate`.
     first_active_slice: usize,
+    /// Multi-stripe reads release completed slices eagerly. A
+    /// windowed single-stripe read retains its eager admission until
+    /// reader drop, including for an empty range.
+    release_completed_slices: bool,
 }
 
 impl<'pool> std::fmt::Debug for PipelinedRead<'pool> {
@@ -181,7 +182,36 @@ impl<'pool> PipelinedRead<'pool> {
             pending: Vec::new(),
             ready: HashMap::new(),
             first_active_slice: 0,
+            release_completed_slices: true,
         }
+    }
+
+    /// Build the single-stripe mode used by `WindowedRead`. `src` is
+    /// already admitted and remains owned until this reader drops.
+    pub(super) fn single_stream(
+        src: Rc<dyn StreamSrc + 'pool>,
+        offset: u64,
+        end: u64,
+        page_size: u64,
+        window: usize,
+        max_inflight_pages: usize,
+    ) -> Self {
+        debug_assert!(end >= offset);
+        let slices = if end > offset {
+            vec![(offset, end - offset)]
+        } else {
+            Vec::new()
+        };
+        let retained = src.clone();
+        let admit: AdmitFn<'pool> = Box::new(move |_s| Ok(retained.clone()));
+        let mut read = Self::new(admit, slices, page_size, window, max_inflight_pages);
+        if read.srcs.is_empty() {
+            read.srcs.push(Some(src));
+        } else {
+            read.srcs[0] = Some(src);
+        }
+        read.release_completed_slices = false;
+        read
     }
 
     /// Next page in global order. Returns `None` at EOF. The returned
@@ -275,8 +305,8 @@ impl<'pool> PipelinedRead<'pool> {
         let page_start = page_no * self.page_size;
         let lo = std::cmp::max(page_start, geom.intra_offset);
         let hi = std::cmp::min(
-            page_start + self.page_size,
-            geom.intra_offset + geom.intra_len,
+            page_start.saturating_add(self.page_size),
+            geom.intra_offset.saturating_add(geom.intra_len),
         );
         let intra_off = (lo - page_start) as u32;
         let intra_len = (hi - lo) as u32;
@@ -300,8 +330,7 @@ impl<'pool> PipelinedRead<'pool> {
     /// Ensure the head page has an in-flight (or completed) fetch,
     /// then launch speculative fetches for subsequent global pages
     /// while the window has room and the global prefetch budget
-    /// allows. Mirrors `WindowedRead::ensure_head_and_refill` but
-    /// walks the global index across stripe boundaries.
+    /// allows, walking the global index across slice boundaries.
     fn ensure_head_and_refill(&mut self) {
         if self.head_g >= self.total_g {
             return;
@@ -369,6 +398,9 @@ impl<'pool> PipelinedRead<'pool> {
     /// `head_g` advance: a fully-passed slice can have no outstanding
     /// pending/ready entries (those only exist for `g >= head_g`).
     fn release_passed_slices(&mut self) {
+        if !self.release_completed_slices {
+            return;
+        }
         while self.first_active_slice < self.geom.len() {
             let s = self.first_active_slice;
             let end_g = self.geom[s].cum_before + self.geom[s].pages;
@@ -425,8 +457,7 @@ impl<'pool> Drop for PipelinedRead<'pool> {
 /// Drives every outstanding fetch future concurrently with a single
 /// `cx`, moving completions into `ready`. Polls the head future first
 /// so it wins any free-list allocation race against speculative
-/// siblings. Resolves once the head page is `ready`. Mirrors
-/// `window::DrivePending` over the global index.
+/// siblings. Resolves once the head page is `ready`.
 struct DrivePipeline<'a, 'pool> {
     r: &'a mut PipelinedRead<'pool>,
     head_g: u64,

--- a/cmd/unbounded-storage/src/bufferpool/tests.rs
+++ b/cmd/unbounded-storage/src/bufferpool/tests.rs
@@ -1185,6 +1185,68 @@ fn stream_limit_enforced() {
 }
 
 #[test]
+fn completed_window_retains_stream_slot_until_drop() {
+    const P: usize = 4096;
+    let backing = heap_backing(P, 2);
+    let t = Rc::new(MockTransport::new(backing.base, backing.page_size));
+    let s = Rc::new(MockBlockStore::new());
+    s.preload(key(0), 0, vec![0u8; P]);
+    let pool = Pool::new(
+        PoolConfig {
+            max_concurrent_streams: 1,
+            ..PoolConfig::default()
+        },
+        backing,
+        TransportRc(t),
+        BlockStoreRc(s),
+    )
+    .unwrap();
+    let req = TestReq::new(key(0));
+
+    block_on(async {
+        let mut first = pool.read_windowed(&req, 0, P as u64, 2).unwrap();
+        drop(first.next_page().await.unwrap().unwrap());
+        assert!(first.next_page().await.is_none());
+        assert!(matches!(
+            pool.read_windowed(&req, 0, P as u64, 2),
+            Err(Error::StreamLimit)
+        ));
+
+        drop(first);
+        let _next = pool.read_windowed(&req, 0, P as u64, 2).unwrap();
+    });
+}
+
+#[test]
+fn empty_window_retains_stream_slot_until_drop() {
+    const P: usize = 4096;
+    let backing = heap_backing(P, 1);
+    let t = Rc::new(MockTransport::new(backing.base, backing.page_size));
+    let s = Rc::new(MockBlockStore::new());
+    let pool = Pool::new(
+        PoolConfig {
+            max_concurrent_streams: 1,
+            ..PoolConfig::default()
+        },
+        backing,
+        TransportRc(t),
+        BlockStoreRc(s),
+    )
+    .unwrap();
+    let req = TestReq::new(key(0));
+
+    let mut first = pool.read_windowed(&req, 0, 0, 2).unwrap();
+    assert!(block_on(first.next_page()).is_none());
+    assert!(matches!(
+        pool.read_windowed(&req, 0, P as u64, 2),
+        Err(Error::StreamLimit)
+    ));
+
+    drop(first);
+    let _next = pool.read_windowed(&req, 0, P as u64, 2).unwrap();
+}
+
+#[test]
 fn rejects_bad_backing() {
     let backing = Backing {
         base: 0x1000 as *mut u8,

--- a/cmd/unbounded-storage/src/bufferpool/types.rs
+++ b/cmd/unbounded-storage/src/bufferpool/types.rs
@@ -39,16 +39,11 @@ pub struct PoolConfig {
     /// Caps the number of concurrent `ReadStream`s the pool will
     /// admit. v1 enforces this only at `read()` time.
     pub max_concurrent_streams: usize,
-    /// Global cap, shared across every windowed stream the pool is
-    /// serving, on speculative prefetch pages: pages a
-    /// [`crate::bufferpool::WindowedRead`] has launched a fetch for
-    /// while they sit strictly ahead of that stream's consumer
-    /// cursor and have not yet been consumed. The head-of-line page
-    /// (the one at the cursor) is always fetched and never counts
-    /// against this budget, so forward progress is guaranteed even
-    /// when the budget is fully reserved. Bounding speculation this
-    /// way keeps prefetch from starving the free list out from under
-    /// any stream's head fetch.
+    /// Global cap, shared across windowed and pipelined readers, on
+    /// speculative prefetch pages strictly ahead of a reader's
+    /// consumer cursor. The head-of-line page is always fetched and
+    /// never counts against this budget, so forward progress remains
+    /// possible when the budget is fully reserved.
     pub max_inflight_pages: usize,
 }
 

--- a/cmd/unbounded-storage/src/bufferpool/window.rs
+++ b/cmd/unbounded-storage/src/bufferpool/window.rs
@@ -1,87 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Windowed, internally-prefetching reader over a single stripe.
+//! Single-stripe facade over the ordered prefetch pipeline.
 //!
-//! [`WindowedRead`] is the lifetime-erased sibling of
-//! [`crate::bufferpool::ReadStream`]. Where `ReadStream` awaits one
-//! `fetch_page` at a time, `WindowedRead` keeps up to `window`
-//! `fetch_page` futures outstanding ahead of its consumer cursor
-//! (within one stripe) and drives them concurrently, while still
-//! handing `PageGuard`s back to the caller strictly in cursor order,
-//! one at a time. This lets a downstream consumer saturate the
-//! fabric NIC instead of serializing on per-page round trips.
-//!
-//! Two budgets bound the speculation:
-//!   - `window`: the per-stream depth, clamped by
-//!     `Pool::read_windowed` to `[1, max_inflight_pages + 1]`.
-//!   - the pool's global `max_inflight_pages` prefetch budget,
-//!     reserved through [`StreamSrc::try_reserve_prefetch`].
-//!
-//! Head-of-line guarantee: the page at the cursor is always fetched
-//! and never counts against either budget, and it is polled before
-//! its speculative siblings on every drive pass, so it wins any
-//! free-list allocation race. Speculative pages strictly ahead of
-//! the head are the only ones that consume prefetch budget; bounding
-//! them keeps prefetch from starving the head's `free.alloc().await`.
+//! [`WindowedRead`] preserves eager stream admission and retains that
+//! admission until reader drop, while delegating page scheduling,
+//! speculation, backoff, and cancellation to
+//! [`crate::bufferpool::PipelinedRead`].
 
-use std::collections::HashMap;
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
 use std::rc::Rc;
-use std::task::{Context, Poll};
 
-use crate::bufferpool::stream::{PageGuard, StaticBoxFuture, StreamSrc};
-use crate::bufferpool::types::{Error, PageRef};
+use crate::bufferpool::pipeline::PipelinedRead;
+use crate::bufferpool::stream::{PageGuard, StreamSrc};
+use crate::bufferpool::types::Error;
 
-/// One outstanding fetch future tracked by a [`WindowedRead`].
-struct PendingFetch {
-    page_no: u64,
-    fut: StaticBoxFuture<Result<u32, Error>>,
-    /// Whether this page reserved a slot of the global prefetch
-    /// budget at launch (true for speculative pages, false for the
-    /// head). The reservation is held until the page is consumed by
-    /// `next_page` or released in `Drop`.
-    counted: bool,
-}
-
-/// A completed fetch awaiting consumption in cursor order. For an
-/// `Ok` result the fetch transferred a consumer hold that pins the
-/// slot; it is balanced by the `PageGuard` handed out on consume or
-/// by `release_guard` on `Drop`.
-struct ReadyPage {
-    result: Result<u32, Error>,
-    counted: bool,
-}
-
-/// Windowed consumer surface. Like [`crate::bufferpool::ReadStream`]
-/// it yields one [`PageGuard`] at a time in cursor order; unlike it,
-/// it prefetches ahead.
+/// Windowed consumer surface over one eagerly admitted stripe.
 pub struct WindowedRead<'pool> {
-    src: Rc<dyn StreamSrc + 'pool>,
-    cursor: u64,
-    end: u64,
-    page_size: u64,
-    /// Effective prefetch depth: max pages tracked (pending + ready)
-    /// at once for this stream.
-    window: usize,
-    /// Cap passed to [`StreamSrc::try_reserve_prefetch`].
-    max_inflight_pages: usize,
-    pending: Vec<PendingFetch>,
-    ready: HashMap<u64, ReadyPage>,
-    _life: PhantomData<&'pool ()>,
+    inner: PipelinedRead<'pool>,
 }
 
-impl<'pool> std::fmt::Debug for WindowedRead<'pool> {
+impl std::fmt::Debug for WindowedRead<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WindowedRead")
-            .field("cursor", &self.cursor)
-            .field("end", &self.end)
-            .field("page_size", &self.page_size)
-            .field("window", &self.window)
-            .field("pending", &self.pending.len())
-            .field("ready", &self.ready.len())
+            .field("inner", &self.inner)
             .finish()
     }
 }
@@ -96,251 +37,21 @@ impl<'pool> WindowedRead<'pool> {
         max_inflight_pages: usize,
     ) -> Self {
         Self {
-            src,
-            cursor: offset,
-            end,
-            page_size: page_size as u64,
-            window: window.max(1),
-            max_inflight_pages,
-            pending: Vec::new(),
-            ready: HashMap::new(),
-            _life: PhantomData,
+            inner: PipelinedRead::single_stream(
+                src,
+                offset,
+                end,
+                page_size as u64,
+                window,
+                max_inflight_pages,
+            ),
         }
     }
 
     /// Next page in cursor order. Returns `None` at EOF. The
     /// returned [`PageGuard`] borrows `&mut self`, enforcing the
-    /// one-page-at-a-time contract; the reader keeps prefetching
-    /// ahead internally regardless.
+    /// one-page-at-a-time contract.
     pub async fn next_page<'s>(&'s mut self) -> Option<Result<PageGuard<'s>, Error>> {
-        if self.cursor >= self.end {
-            return None;
-        }
-
-        let page_size = self.page_size;
-        let head = self.cursor / page_size;
-        let intra_off = (self.cursor - head * page_size) as u32;
-        let max_in_page = page_size - intra_off as u64;
-        let remaining = self.end - self.cursor;
-        let intra_len = std::cmp::min(max_in_page, remaining) as u32;
-
-        // Launch the head (always) plus as many speculative pages as
-        // window + global budget permit, then drive every pending
-        // future until the head completes.
-        self.ensure_head_and_refill();
-        DrivePending { w: self, head }.await;
-
-        let entry = self
-            .ready
-            .remove(&head)
-            .expect("head page must be ready after DrivePending resolves");
-        // The page leaves the "ahead, unconsumed" set either way, so
-        // release its budget reservation here (decrement-on-consume).
-        if entry.counted {
-            self.src.release_prefetch();
-        }
-        let page_idx = match entry.result {
-            Ok(pi) => pi,
-            // On error no consumer hold was transferred, so there is
-            // nothing to balance; just surface it in order.
-            Err(e) => return Some(Err(e)),
-        };
-
-        self.cursor += intra_len as u64;
-        // Keep the pipeline full: launch prefetch for the advanced
-        // cursor now. The futures make progress on the next
-        // `next_page` poll.
-        self.ensure_head_and_refill();
-
-        let base = self.src.base();
-        // SAFETY: identical invariants to `ReadStream::next_page`.
-        // `page_idx` names a pinned backing page; the fetch left a
-        // consumer hold pinning the slot for the guard's lifetime,
-        // and `intra_off + intra_len <= page_size`.
-        let bytes =
-            unsafe { base.add(page_idx as usize * page_size as usize + intra_off as usize) };
-        let page_ref = PageRef {
-            page_idx,
-            offset: intra_off,
-            len: intra_len,
-        };
-        let src_for_guard: Rc<dyn StreamSrc + 's> = self.src.clone();
-        let guard = PageGuard::new(src_for_guard, head, bytes, intra_len, page_ref);
-        Some(Ok(guard))
-    }
-
-    /// Test-only: current cursor.
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub(crate) fn cursor(&self) -> u64 {
-        self.cursor
-    }
-
-    fn is_tracked(&self, page_no: u64) -> bool {
-        self.ready.contains_key(&page_no) || self.pending.iter().any(|p| p.page_no == page_no)
-    }
-
-    /// Ensure the head page has an in-flight (or completed) fetch,
-    /// then launch speculative fetches for subsequent pages while
-    /// the window has room and the global prefetch budget allows.
-    fn ensure_head_and_refill(&mut self) {
-        if self.cursor >= self.end {
-            return;
-        }
-        let head = self.cursor / self.page_size;
-        // `end > cursor` here, so `end - 1` does not underflow.
-        let last_page = (self.end - 1) / self.page_size;
-
-        // The head is always fetchable and never counts against the
-        // prefetch budget. It is launched non-speculative, so its
-        // leader allocates blocking (parking on the free list if
-        // needed) and `DrivePending` polls it before any speculative
-        // sibling, so it wins the next free page under pressure. This
-        // is what prevents a speculative fetch from starving the head
-        // and deadlocking.
-        if !self.is_tracked(head) {
-            let fut = self.src.fetch_page_owned(head, false);
-            self.pending.push(PendingFetch {
-                page_no: head,
-                fut,
-                counted: false,
-            });
-        }
-
-        let mut candidate = head + 1;
-        while candidate <= last_page {
-            if self.pending.len() + self.ready.len() >= self.window {
-                break;
-            }
-            if self.is_tracked(candidate) {
-                candidate += 1;
-                continue;
-            }
-            // Speculative pages must reserve global budget; if it is
-            // exhausted, stop speculating (the head still proceeds).
-            if !self.src.try_reserve_prefetch(self.max_inflight_pages) {
-                break;
-            }
-            // Launch speculative. Its leader allocates non-blocking and
-            // backs off (resolving to `Error::PrefetchBackoff`) if no
-            // page is free, so speculation never parks on the free list
-            // ahead of any stream's head. `DrivePending` releases the
-            // budget reservation when it observes that backoff.
-            let fut = self.src.fetch_page_owned(candidate, true);
-            self.pending.push(PendingFetch {
-                page_no: candidate,
-                fut,
-                counted: true,
-            });
-            candidate += 1;
-        }
-    }
-}
-
-impl<'pool> Drop for WindowedRead<'pool> {
-    fn drop(&mut self) {
-        // Balance consumer holds for ready-but-unconsumed `Ok` pages
-        // and release any prefetch budget still reserved for them.
-        let ready = std::mem::take(&mut self.ready);
-        for (page_no, entry) in ready {
-            if entry.result.is_ok() {
-                self.src.release_guard(page_no);
-            }
-            if entry.counted {
-                self.src.release_prefetch();
-            }
-        }
-        // Dropping a pending future runs its own internal RAII
-        // cleanup (LeaderGuard / ConsumerHold inside `fetch_page`);
-        // we only owe back the prefetch-budget reservation it held.
-        let pending = std::mem::take(&mut self.pending);
-        for pf in pending {
-            if pf.counted {
-                self.src.release_prefetch();
-            }
-        }
-        self.src.decrement_stream();
-    }
-}
-
-/// Drives every outstanding fetch future concurrently with a single
-/// `cx`, moving completions into `ready`. Polls the head future
-/// first so it wins any free-list allocation race against
-/// speculative siblings. Resolves once the head page is `ready`.
-struct DrivePending<'a, 'pool> {
-    w: &'a mut WindowedRead<'pool>,
-    head: u64,
-}
-
-impl<'a, 'pool> Future for DrivePending<'a, 'pool> {
-    type Output = ();
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        // `DrivePending` holds only a `&mut` and a `u64`; it is `Unpin`.
-        let this = self.get_mut();
-        let head = this.head;
-        let w = &mut *this.w;
-
-        // Head-of-line: poll the head first so a freshly freed page
-        // is claimed by the head's leader before any speculative
-        // sibling in the same pass.
-        if let Some(i) = w.pending.iter().position(|p| p.page_no == head) {
-            if let Poll::Ready(res) = w.pending[i].fut.as_mut().poll(cx) {
-                let pf = w.pending.swap_remove(i);
-                w.ready.insert(
-                    pf.page_no,
-                    ReadyPage {
-                        result: res,
-                        counted: pf.counted,
-                    },
-                );
-            }
-        }
-
-        // Drive the remaining (speculative) futures.
-        let mut i = 0;
-        while i < w.pending.len() {
-            if w.pending[i].page_no == head {
-                i += 1;
-                continue;
-            }
-            match w.pending[i].fut.as_mut().poll(cx) {
-                Poll::Ready(res) => {
-                    let pf = w.pending.swap_remove(i);
-                    // A speculative leader that found no free page
-                    // backs off rather than parking. That is not a
-                    // consumer-visible error: drop it and return its
-                    // prefetch-budget reservation so it can be retried
-                    // when pages free up. It transferred no consumer
-                    // hold, so there is nothing else to balance. By the
-                    // time the cursor could reach this page it has been
-                    // removed here, so `ensure_head_and_refill`
-                    // relaunches it as a blocking head; a head fetch is
-                    // never speculative and so never backs off, which
-                    // is why the head branch above never sees this.
-                    if matches!(res, Err(Error::PrefetchBackoff)) {
-                        debug_assert!(pf.counted);
-                        if pf.counted {
-                            w.src.release_prefetch();
-                        }
-                        continue;
-                    }
-                    w.ready.insert(
-                        pf.page_no,
-                        ReadyPage {
-                            result: res,
-                            counted: pf.counted,
-                        },
-                    );
-                }
-                Poll::Pending => i += 1,
-            }
-        }
-
-        if w.ready.contains_key(&head) {
-            Poll::Ready(())
-        } else {
-            Poll::Pending
-        }
+        self.inner.next_page().await
     }
 }


### PR DESCRIPTION
- share one ordered prefetch scheduler across windowed and multi-stripe reads
- simplify free-list handoffs with waiter-owned grants while preserving FIFO and cancellation behavior
- retain windowed stream admission through reader drop, including completed and empty reads