### PR TITLE
metalman: dhcp-free host provisioning

### DIFF
--- a/.github/workflows/smoke-metalman.yaml
+++ b/.github/workflows/smoke-metalman.yaml
@@ -14,6 +14,9 @@ on:
       - images/agent-ubuntu2404/**
       - images/host-ubuntu2404/**
       - images/netboot/**
+      - hack/metalman-redfish-fixture.py
+      - hack/smoke-metalman-http.py
+      - .github/workflows/smoke-metalman.yaml
   push:
     branches: [main]
     paths:
@@ -25,6 +28,9 @@ on:
       - images/agent-ubuntu2404/**
       - images/host-ubuntu2404/**
       - images/netboot/**
+      - hack/metalman-redfish-fixture.py
+      - hack/smoke-metalman-http.py
+      - .github/workflows/smoke-metalman.yaml
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:
@@ -33,7 +39,7 @@ permissions:
   contents: read
 
 jobs:
-  smoke:
+  pxe-smoke:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -73,17 +79,11 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          # Install sushy-tools via pip in the background while apt-get
-          # installs system packages.  pip3 is already available on the
-          # runner image so this does not depend on apt-get.
-          sudo pip3 install --break-system-packages --ignore-installed sushy-tools &
-          PIP_PID=$!
           sudo apt-get install -y --no-install-recommends \
             dnsmasq qemu-kvm libvirt-daemon-system libvirt-clients virtinst \
             ovmf qemu-utils swtpm swtpm-tools \
-            python3-pip python3-yaml cpio iptables
+            python3-yaml cpio iptables
           sudo systemctl start libvirtd
-          wait "$PIP_PID"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -139,3 +139,96 @@ jobs:
           sudo cp "${KUBECONFIG:-$HOME/.kube/config}" /root/.kube/config
           sudo -E env "PATH=$PATH" \
             python3 hack/smoke-metalman.py
+
+  layered-http-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet \
+                      /opt/ghc /usr/local/share/boost /opt/hostedtoolcache/CodeQL &
+          sudo docker image prune -af &
+          wait
+          df -h /
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Cache apt packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives
+          key: apt-smoke-http-noble-${{ hashFiles('.github/workflows/smoke-metalman.yaml') }}
+          restore-keys: apt-smoke-http-noble-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-kvm libvirt-daemon-system libvirt-clients ovmf qemu-utils \
+            swtpm swtpm-tools python3-yaml cpio iptables tcpdump \
+            dosfstools mtools curl
+          sudo systemctl start libvirtd
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver-opts: network=host
+
+      - name: Build host-ubuntu2404 image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: images/host-ubuntu2404/Containerfile
+          load: true
+          tags: localhost:5556/unbounded/host-ubuntu2404:http-smoke
+          cache-from: type=gha,scope=host-ubuntu2404
+          cache-to: type=gha,mode=max,scope=host-ubuntu2404
+          provenance: false
+
+      - name: Build netboot image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: images/netboot/Containerfile
+          load: true
+          tags: localhost:5556/unbounded/netboot:http-smoke
+          cache-from: type=gha,scope=netboot
+          cache-to: type=gha,mode=max,scope=netboot
+          provenance: false
+
+      - name: Build agent image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: images/agent-ubuntu2404
+          file: images/agent-ubuntu2404/Containerfile
+          load: true
+          tags: localhost:5556/unbounded/agent-ubuntu2404:http-smoke
+          cache-from: type=gha,scope=agent-ubuntu2404
+          cache-to: type=gha,mode=max,scope=agent-ubuntu2404
+          provenance: false
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: kind
+          # Each job has an isolated runner, so both can use the same smoke SAN.
+          config: hack/kind-smoke-config.yaml
+
+      - name: Run layered DHCP-free HTTP smoke test
+        run: |
+          sudo mkdir -p /root/.kube
+          sudo cp "${KUBECONFIG:-$HOME/.kube/config}" /root/.kube/config
+          sudo -E env "PATH=$PATH" KUBECONFIG=/root/.kube/config \
+            python3 hack/smoke-metalman-http.py

--- a/.github/workflows/smoke-metalman.yaml
+++ b/.github/workflows/smoke-metalman.yaml
@@ -16,6 +16,7 @@ on:
       - images/netboot/**
       - hack/metalman-redfish-fixture.py
       - hack/smoke-metalman-http.py
+      - hack/smoke-metalman.py
       - .github/workflows/smoke-metalman.yaml
   push:
     branches: [main]
@@ -30,6 +31,7 @@ on:
       - images/netboot/**
       - hack/metalman-redfish-fixture.py
       - hack/smoke-metalman-http.py
+      - hack/smoke-metalman.py
       - .github/workflows/smoke-metalman.yaml
   schedule:
     - cron: "0 7 * * *"
@@ -142,7 +144,7 @@ jobs:
 
   layered-http-smoke:
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Free disk space
         run: |

--- a/.github/workflows/smoke-metalman.yaml
+++ b/.github/workflows/smoke-metalman.yaml
@@ -177,7 +177,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             qemu-kvm libvirt-daemon-system libvirt-clients ovmf qemu-utils \
-            swtpm swtpm-tools python3-yaml cpio iptables tcpdump \
+            swtpm swtpm-tools python3-yaml cpio iptables tcpdump dnsmasq \
             dosfstools mtools curl
           sudo systemctl start libvirtd
 

--- a/cmd/metalman/README.md
+++ b/cmd/metalman/README.md
@@ -214,9 +214,21 @@ UEFI HTTP boot NIC first in `dhcpLeases`.
 
 The default netboot template passes the selected lease MAC to the installer
 initrd, which uses it to select the provisioning NIC instead of assuming a fixed
-interface name such as `eth0`. If `spec.pxe.targetDisk` is set, the installer
-writes the image to that disk; otherwise it falls back to automatic disk
-selection.
+interface name such as `eth0`. It also passes the lease DNS servers, configures
+the installer network without DHCP, and writes matching MAC-based static netplan
+configuration into the installed system before its first boot. It disables
+cloud-init network rendering so fallback DHCP configuration cannot conflict with
+that file. The default netboot image serves the same lease as NoCloud
+`network-config`. If `spec.pxe.targetDisk` is
+set, the installer writes the image to that disk; otherwise it falls back to
+automatic disk selection.
+
+Stock Ubuntu OVMF and sushy-emulator cannot emulate the complete DHCP-free
+Redfish-to-firmware UEFI HTTP path. Repository CI therefore tests Metalman's
+Redfish writes and then starts at a staged post-firmware EFI boundary, while
+capturing the guest's traffic through installation and reboot to prove it emits
+no DHCP packets. Applying Redfish settings and fetching the first EFI binary
+remain firmware and BMC hardware-conformance responsibilities.
 
 #### BMC
 

--- a/docs/content/guides/pxe.md
+++ b/docs/content/guides/pxe.md
@@ -171,10 +171,11 @@ If the referenced ConfigMap does not exist, metalman falls back to the default m
 ## Boot Flow
 
 1. **Repave requested.** A `HostReplace` `MachineOperation` targets the Machine. Metalman sets the boot override and force-restarts the server. For `bootProtocol: PXE`, it selects PXE boot. For `bootProtocol: HTTP`, it sets a Redfish UEFI HTTP boot URL from the netboot image metadata.
-2. **Network boot.** DHCP assigns the static IP by MAC. In PXE mode, DHCP also advertises the TFTP bootfile and TFTP serves `shimx64.efi`. In HTTP mode, the firmware downloads the Redfish-supplied URL from metalman's HTTP server.
+2. **Network boot.** In PXE mode, DHCP assigns the static IP by MAC, advertises the TFTP bootfile, and TFTP serves `shimx64.efi`. In HTTP mode, Metalman configures the first lease as a static Redfish EthernetInterface and the firmware downloads the Redfish-supplied URL from Metalman's HTTP server; DHCP is not required for this path.
 3. **GRUB decision.** A rendered `grub.cfg` checks for an active `HostReplace` `MachineOperation` targeting the Machine. If a repave is requested, GRUB boots the PXE installer; otherwise it chainloads the local OS. When a Machine has multiple DHCP leases, metalman renders the lease matching the request source IP and passes that lease's MAC as `unbounded.boot_mac`.
 4. **Installer (initrd overlay).** An init script in the initrd:
-   - Loads storage and network drivers, selects the provisioning NIC by MAC, and configures the static IP from kernel cmdline.
+   - Loads storage and network drivers, selects the provisioning NIC by MAC, and configures the static IP and DNS from kernel cmdline.
+   - Writes matching MAC-based static netplan configuration into the installed system before reboot and disables cloud-init network rendering so fallback DHCP configuration cannot conflict with it. The default netboot image also serves the selected lease as NoCloud `network-config`.
    - Downloads the gzip-compressed raw disk image from the machine image over HTTP (retries up to 120 times).
    - Writes the image to `spec.pxe.targetDisk` when set, otherwise to an automatically selected block device.
    - Mounts the root filesystem and injects cloud-init config and the agent configuration.

--- a/docs/content/reference/machina-crd.md
+++ b/docs/content/reference/machina-crd.md
@@ -56,7 +56,7 @@ PXE boot configuration consumed by the metalman controller.
 | `pxe.architecture` | string | No | `amd64` | Target CPU architecture for PXE boot artifacts and machine images. Allowed values: `amd64`, `arm64`. |
 | `pxe.netbootImage` | string | No | Metalman default | OCI netboot image reference containing PXE boot artifacts. |
 | `pxe.bootProtocol` | string | No | `PXE` | Network boot trigger protocol for repaves. `PXE` uses DHCP/TFTP bootfile options. `HTTP` uses Redfish UEFI HTTP boot with a URL derived from the netboot image metadata. Allowed values: `PXE`, `HTTP`. |
-| `pxe.dhcpLeases` | []DHCPLease | No | - | Static DHCP leases served during PXE boot. |
+| `pxe.dhcpLeases` | []DHCPLease | No | - | Provisioning network settings. They are served as static DHCP leases during PXE boot and used for Redfish firmware, installer, NoCloud, and installed-system static configuration during HTTP boot. |
 | `pxe.dhcpLeases[].ipv4` | string | Yes | - | Static IPv4 address to assign. |
 | `pxe.dhcpLeases[].mac` | string | Yes | - | NIC MAC address (matched case-insensitively). |
 | `pxe.dhcpLeases[].subnetMask` | string | Yes | - | Subnet mask. |
@@ -419,7 +419,7 @@ Templates receive the following data object:
 | Field | Type | Description |
 |-------|------|-------------|
 | `.Machine` | *Machine | The Machine CR that initiated the request. |
-| `.BootLease` | *DHCPLease | The DHCP lease matching the request source IP, or the first lease when no match is available. Netboot templates use this to pass the provisioning NIC MAC and static IP to the installer. |
+| `.BootLease` | *DHCPLease | The DHCP lease matching the request source IP, or the first lease when no match is available. Netboot templates use this to pass the provisioning NIC MAC, static IP, gateway, and DNS to the installer and NoCloud network configuration. |
 | `.ApiserverURL` | string | External Kubernetes API server URL. |
 | `.ServeURL` | string | External metalman HTTP URL. |
 | `.KubernetesVersion` | string | Resolved Kubernetes version for the machine. |

--- a/hack/metalman-redfish-fixture.py
+++ b/hack/metalman-redfish-fixture.py
@@ -95,15 +95,19 @@ class State:
             try:
                 with subprocess.Popen(["mktemp", "-d"], stdout=subprocess.PIPE, text=True) as proc:
                     artifact_dir = Path(proc.communicate()[0].strip())
-                for path in (
-                    "shimx64.efi", "grubx64.efi", "vmlinuz", "initrd",
-                    "init.cpio", "grub/grub.cfg",
+                for path, url in (
+                    ("http-entrypoint.efi", boot_url),
+                    ("grubx64.efi", f"{base_url}/grubx64.efi"),
+                    ("vmlinuz", f"{base_url}/vmlinuz"),
+                    ("initrd", f"{base_url}/initrd"),
+                    ("init.cpio", f"{base_url}/init.cpio"),
+                    ("grub/grub.cfg", f"{base_url}/grub/grub.cfg"),
                 ):
                     target = artifact_dir / path
                     target.parent.mkdir(parents=True, exist_ok=True)
                     subprocess.run(
                         ["curl", "--fail", "--silent", "--show-error", "--interface", self.client_ip,
-                         "--output", str(target), f"{base_url}/{path}"],
+                         "--output", str(target), url],
                         check=True,
                     )
                 boundary = artifact_dir / "boundary.img"
@@ -114,7 +118,7 @@ class State:
                 subprocess.run(["mkfs.vfat", "-n", "HTTPBOOT", str(boundary)], check=True)
                 subprocess.run(["mmd", "-i", str(boundary), "::/EFI", "::/EFI/BOOT", "::/grub"], check=True)
                 for source, target in (
-                    ("shimx64.efi", "::/EFI/BOOT/BOOTX64.EFI"),
+                    ("http-entrypoint.efi", "::/EFI/BOOT/BOOTX64.EFI"),
                     ("grubx64.efi", "::/EFI/BOOT/grubx64.efi"),
                     ("vmlinuz", "::/vmlinuz"),
                     ("initrd", "::/initrd"),

--- a/hack/metalman-redfish-fixture.py
+++ b/hack/metalman-redfish-fixture.py
@@ -13,8 +13,9 @@ DHCP-free UEFI HTTP boot.
 from __future__ import annotations
 
 import argparse
+import base64
+import hmac
 import json
-import os
 import shutil
 import ssl
 import subprocess
@@ -44,8 +45,10 @@ class State:
         self.efi_source = Path(args.efi_source) if args.efi_source else None
         self.efi_active = Path(args.efi_active) if args.efi_active else None
         self.bridge = args.bridge
-        self.client_ip = args.client_ip
+        self.cache_dir = Path(args.cache_dir) if args.cache_dir else None
         self.manage_boot_order = args.manage_boot_order
+        self.username = args.username
+        self.password = args.password
         self.lock = threading.Lock()
         self.boot: dict[str, Any] = {
             "BootSourceOverrideTarget": "None",
@@ -60,6 +63,38 @@ class State:
             "IPv4StaticAddresses": [],
             "StaticNameServers": [],
         }
+
+    def authorized(self, value: str | None) -> bool:
+        if not self.username:
+            return True
+        expected = "Basic " + base64.b64encode(
+            f"{self.username}:{self.password}".encode()
+        ).decode()
+        return hmac.compare_digest(value or "", expected)
+
+    def static_address(self) -> str:
+        if self.nic.get("DHCPv4") != {"DHCPEnabled": False}:
+            raise ValueError("UefiHttp requested before DHCPv4 was disabled")
+        addresses = self.nic.get("IPv4StaticAddresses")
+        if not isinstance(addresses, list) or len(addresses) != 1:
+            raise ValueError("UefiHttp requires exactly one accepted static IPv4 address")
+        address = addresses[0]
+        if not isinstance(address, dict) or not address.get("Address") or not address.get("SubnetMask"):
+            raise ValueError("UefiHttp static IPv4 address is incomplete")
+        return str(address["Address"])
+
+    def with_client_address(self, action: Any) -> None:
+        if not self.bridge:
+            raise ValueError("UefiHttp requested without an HTTP boundary bridge")
+        client_ip = self.static_address()
+        subprocess.run(["ip", "address", "add", f"{client_ip}/32", "dev", self.bridge], check=True)
+        try:
+            action(client_ip)
+        finally:
+            subprocess.run(
+                ["ip", "address", "delete", f"{client_ip}/32", "dev", self.bridge],
+                check=False,
+            )
 
     def append(self, method: str, path: str, body: Any, status: int) -> None:
         entry = {
@@ -78,7 +113,7 @@ class State:
         return "On" if result.returncode == 0 and "running" in result.stdout else "Off"
 
     def set_efi_boundary(self, enabled: bool) -> None:
-        if not all((self.efi_source, self.efi_active, self.bridge, self.client_ip)):
+        if not all((self.efi_source, self.efi_active, self.bridge, self.cache_dir)):
             raise ValueError("UefiHttp requested without HTTP boundary arguments")
 
         assert self.efi_source is not None
@@ -88,15 +123,18 @@ class State:
             if not boot_url:
                 raise ValueError("UefiHttp override has no HttpBootUri")
             base_url = boot_url.rsplit("/", 1)[0]
-            subprocess.run(
-                ["ip", "address", "add", f"{self.client_ip}/32", "dev", self.bridge],
-                check=True,
-            )
-            try:
+
+            def stage(client_ip: str) -> None:
                 with subprocess.Popen(["mktemp", "-d"], stdout=subprocess.PIPE, text=True) as proc:
                     artifact_dir = Path(proc.communicate()[0].strip())
+                entrypoint = boot_url.rsplit("/", 1)[-1]
+                candidates = list(self.cache_dir.glob(f"oci/*/amd64/disk/{entrypoint}"))
+                if len(candidates) != 1:
+                    raise ValueError(
+                        f"expected one cached HTTP entrypoint {entrypoint}, found {len(candidates)}"
+                    )
+                shutil.copyfile(candidates[0], artifact_dir / "http-entrypoint.efi")
                 for path, url in (
-                    ("http-entrypoint.efi", boot_url),
                     ("grubx64.efi", f"{base_url}/grubx64.efi"),
                     ("vmlinuz", f"{base_url}/vmlinuz"),
                     ("initrd", f"{base_url}/initrd"),
@@ -106,7 +144,7 @@ class State:
                     target = artifact_dir / path
                     target.parent.mkdir(parents=True, exist_ok=True)
                     subprocess.run(
-                        ["curl", "--fail", "--silent", "--show-error", "--interface", self.client_ip,
+                        ["curl", "--fail", "--silent", "--show-error", "--interface", client_ip,
                          "--output", str(target), url],
                         check=True,
                     )
@@ -128,14 +166,24 @@ class State:
                 ):
                     subprocess.run(["mcopy", "-o", "-i", str(boundary), str(artifact_dir / source), target], check=True)
                 shutil.copyfile(boundary, self.efi_active)
-                shutil.rmtree(artifact_dir)
-            finally:
-                subprocess.run(
-                    ["ip", "address", "delete", f"{self.client_ip}/32", "dev", self.bridge],
-                    check=False,
-                )
+                shutil.rmtree(artifact_dir, ignore_errors=True)
+
+            self.with_client_address(stage)
         else:
             shutil.copyfile(self.efi_source, self.efi_active)
+
+    def fetch_boot_entrypoint(self) -> None:
+        boot_url = str(self.boot.get("HttpBootUri", ""))
+
+        def fetch(client_ip: str) -> None:
+            subprocess.run(
+                ["curl", "--fail", "--silent", "--show-error", "--interface", client_ip,
+                 "--output", "/dev/null", boot_url],
+                check=True,
+            )
+            self.append("FIRMWARE_FETCH", boot_url, {"source": client_ip}, 200)
+
+        self.with_client_address(fetch)
 
     def set_boot_order(self, target: str) -> None:
         if not self.manage_boot_order:
@@ -159,6 +207,10 @@ class State:
             virsh("destroy", self.domain, check=False)
         elif reset_type == "On":
             virsh("start", self.domain)
+            # OVMF cannot consume Redfish static NIC settings. Emulate only its
+            # initial fetch after power-on; EFI boundary preparation must not
+            # advance Metalman's boot status.
+            self.fetch_boot_entrypoint()
             # The staged disk substitutes only for firmware's initial HTTP
             # fetch. Remove it from the persistent domain after OVMF has loaded
             # shim/GRUB so the installer's reboot starts the written OS disk.
@@ -207,6 +259,9 @@ class Handler(BaseHTTPRequestHandler):
         status = 200
         response: Any | None = None
         try:
+            if not state.authorized(self.headers.get("Authorization")):
+                self.reply(401, {"error": {"message": "invalid Redfish credentials"}})
+                return
             if method in ("PATCH", "POST"):
                 body = self.body()
 
@@ -225,6 +280,12 @@ class Handler(BaseHTTPRequestHandler):
                 }
             elif method == "PATCH" and self.path == f"/redfish/v1/Systems/{state.domain}":
                 boot = body.get("Boot", {})
+                if boot.get("BootSourceOverrideTarget") == "UefiHttp":
+                    if boot.get("BootSourceOverrideMode") != "UEFI":
+                        raise ValueError("UefiHttp override must explicitly select UEFI mode")
+                    if boot.get("BootSourceOverrideEnabled") != "Continuous":
+                        raise ValueError("standard UefiHttp override must be continuous")
+                    state.static_address()
                 state.boot.update(boot)
                 if boot.get("BootSourceOverrideTarget") == "UefiHttp":
                     state.set_efi_boundary(True)
@@ -240,6 +301,11 @@ class Handler(BaseHTTPRequestHandler):
             elif method == "GET" and self.path.endswith("/EthernetInterfaces/NIC.1"):
                 response = state.nic
             elif method == "PATCH" and self.path.endswith("/EthernetInterfaces/NIC.1"):
+                if body.get("DHCPv4") != {"DHCPEnabled": False}:
+                    raise ValueError("static EthernetInterface PATCH must disable DHCPv4")
+                addresses = body.get("IPv4StaticAddresses")
+                if not isinstance(addresses, list) or len(addresses) != 1:
+                    raise ValueError("static EthernetInterface PATCH must contain one IPv4 address")
                 state.nic.update(body)
                 status = 204
             elif method == "POST" and self.path.endswith("/Actions/ComputerSystem.Reset"):
@@ -291,13 +357,15 @@ def main() -> None:
     parser.add_argument("--efi-source")
     parser.add_argument("--efi-active")
     parser.add_argument("--bridge")
-    parser.add_argument("--client-ip")
+    parser.add_argument("--cache-dir")
+    parser.add_argument("--username", default="")
+    parser.add_argument("--password", default="")
     parser.add_argument("--manage-boot-order", action="store_true")
     args = parser.parse_args()
 
-    boundary_values = (args.efi_source, args.efi_active, args.bridge, args.client_ip)
+    boundary_values = (args.efi_source, args.efi_active, args.bridge, args.cache_dir)
     if any(boundary_values) and not all(boundary_values):
-        parser.error("--efi-source, --efi-active, --bridge, and --client-ip must be used together")
+        parser.error("--efi-source, --efi-active, --bridge, and --cache-dir must be used together")
 
     state = State(args)
     state.record.parent.mkdir(parents=True, exist_ok=True)

--- a/hack/metalman-redfish-fixture.py
+++ b/hack/metalman-redfish-fixture.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Recording Redfish fixture backed by one libvirt domain.
+
+PXE overrides can update the libvirt boot order directly. When the optional
+HTTP boundary arguments are supplied, a UefiHttp PATCH makes a prebuilt EFI
+disk visible at the next power-on. That disk is the HTTP smoke test's documented
+post-firmware boundary; the fixture does not pretend that OVMF implements native
+DHCP-free UEFI HTTP boot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import ssl
+import subprocess
+import tempfile
+import threading
+import time
+import xml.etree.ElementTree as ET
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+def virsh(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["virsh", "--connect", "qemu:///system", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+class State:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.domain = args.domain
+        self.mac = args.mac.lower()
+        self.record = Path(args.record)
+        self.efi_source = Path(args.efi_source) if args.efi_source else None
+        self.efi_active = Path(args.efi_active) if args.efi_active else None
+        self.bridge = args.bridge
+        self.client_ip = args.client_ip
+        self.manage_boot_order = args.manage_boot_order
+        self.lock = threading.Lock()
+        self.boot: dict[str, Any] = {
+            "BootSourceOverrideTarget": "None",
+            "BootSourceOverrideEnabled": "Disabled",
+            "BootSourceOverrideMode": "UEFI",
+            "HttpBootUri": "",
+        }
+        self.nic: dict[str, Any] = {
+            "MACAddress": self.mac,
+            "PermanentMACAddress": self.mac,
+            "DHCPv4": {"DHCPEnabled": True},
+            "IPv4StaticAddresses": [],
+            "StaticNameServers": [],
+        }
+
+    def append(self, method: str, path: str, body: Any, status: int) -> None:
+        entry = {
+            "time": time.time(),
+            "method": method,
+            "path": path,
+            "body": body,
+            "status": status,
+        }
+        with self.lock:
+            with self.record.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(entry, sort_keys=True) + "\n")
+
+    def power_state(self) -> str:
+        result = virsh("domstate", self.domain, check=False)
+        return "On" if result.returncode == 0 and "running" in result.stdout else "Off"
+
+    def set_efi_boundary(self, enabled: bool) -> None:
+        if not all((self.efi_source, self.efi_active, self.bridge, self.client_ip)):
+            raise ValueError("UefiHttp requested without HTTP boundary arguments")
+
+        assert self.efi_source is not None
+        assert self.efi_active is not None
+        if enabled:
+            boot_url = str(self.boot.get("HttpBootUri", ""))
+            if not boot_url:
+                raise ValueError("UefiHttp override has no HttpBootUri")
+            base_url = boot_url.rsplit("/", 1)[0]
+            subprocess.run(
+                ["ip", "address", "add", f"{self.client_ip}/32", "dev", self.bridge],
+                check=True,
+            )
+            try:
+                with subprocess.Popen(["mktemp", "-d"], stdout=subprocess.PIPE, text=True) as proc:
+                    artifact_dir = Path(proc.communicate()[0].strip())
+                for path in (
+                    "shimx64.efi", "grubx64.efi", "vmlinuz", "initrd",
+                    "init.cpio", "grub/grub.cfg",
+                ):
+                    target = artifact_dir / path
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    subprocess.run(
+                        ["curl", "--fail", "--silent", "--show-error", "--interface", self.client_ip,
+                         "--output", str(target), f"{base_url}/{path}"],
+                        check=True,
+                    )
+                boundary = artifact_dir / "boundary.img"
+                artifact_size = sum(path.stat().st_size for path in artifact_dir.rglob("*") if path.is_file())
+                boundary_size = max(64 * 1024 * 1024, artifact_size + max(32 * 1024 * 1024, artifact_size // 4))
+                with boundary.open("wb") as stream:
+                    stream.truncate(boundary_size)
+                subprocess.run(["mkfs.vfat", "-n", "HTTPBOOT", str(boundary)], check=True)
+                subprocess.run(["mmd", "-i", str(boundary), "::/EFI", "::/EFI/BOOT", "::/grub"], check=True)
+                for source, target in (
+                    ("shimx64.efi", "::/EFI/BOOT/BOOTX64.EFI"),
+                    ("grubx64.efi", "::/EFI/BOOT/grubx64.efi"),
+                    ("vmlinuz", "::/vmlinuz"),
+                    ("initrd", "::/initrd"),
+                    ("init.cpio", "::/init.cpio"),
+                    ("grub/grub.cfg", "::/grub/grub.cfg"),
+                    ("grub/grub.cfg", "::/EFI/BOOT/grub.cfg"),
+                ):
+                    subprocess.run(["mcopy", "-o", "-i", str(boundary), str(artifact_dir / source), target], check=True)
+                shutil.copyfile(boundary, self.efi_active)
+                shutil.rmtree(artifact_dir)
+            finally:
+                subprocess.run(
+                    ["ip", "address", "delete", f"{self.client_ip}/32", "dev", self.bridge],
+                    check=False,
+                )
+        else:
+            shutil.copyfile(self.efi_source, self.efi_active)
+
+    def set_boot_order(self, target: str) -> None:
+        if not self.manage_boot_order:
+            return
+        result = virsh("dumpxml", self.domain)
+        root = ET.fromstring(result.stdout)
+        os_element = root.find("os")
+        if os_element is None:
+            raise ValueError("libvirt domain has no os element")
+        for element in os_element.findall("boot"):
+            os_element.remove(element)
+        devices = ("network", "hd") if target == "Pxe" else ("hd", "network")
+        for device in devices:
+            ET.SubElement(os_element, "boot", {"dev": device})
+        with tempfile.NamedTemporaryFile(suffix=".xml") as stream:
+            ET.ElementTree(root).write(stream.name, encoding="unicode")
+            virsh("define", stream.name)
+
+    def reset(self, reset_type: str) -> None:
+        if reset_type == "ForceOff":
+            virsh("destroy", self.domain, check=False)
+        elif reset_type == "On":
+            virsh("start", self.domain)
+            # The staged disk substitutes only for firmware's initial HTTP
+            # fetch. Remove it from the persistent domain after OVMF has loaded
+            # shim/GRUB so the installer's reboot starts the written OS disk.
+            threading.Thread(target=self.detach_efi_boundary, daemon=True).start()
+        elif reset_type == "ForceRestart":
+            if self.power_state() == "On":
+                virsh("reset", self.domain)
+            else:
+                virsh("start", self.domain)
+        else:
+            raise ValueError(f"unsupported ResetType {reset_type!r}")
+
+    def detach_efi_boundary(self) -> None:
+        time.sleep(60)
+        virsh("detach-disk", self.domain, "vdb", "--live", "--config", check=False)
+
+
+class Handler(BaseHTTPRequestHandler):
+    server: "Server"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        print(f"redfish: {fmt % args}", flush=True)
+
+    def body(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0"))
+        if not length:
+            return {}
+        value = json.loads(self.rfile.read(length))
+        if not isinstance(value, dict):
+            raise ValueError("request body must be a JSON object")
+        return value
+
+    def reply(self, status: int, value: Any | None = None) -> None:
+        data = b"" if value is None else json.dumps(value).encode()
+        self.send_response(status)
+        if data:
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        if data:
+            self.wfile.write(data)
+
+    def dispatch(self, method: str) -> None:
+        state = self.server.state
+        body: dict[str, Any] = {}
+        status = 200
+        response: Any | None = None
+        try:
+            if method in ("PATCH", "POST"):
+                body = self.body()
+
+            if method == "GET" and self.path == "/redfish/v1/":
+                response = {"Systems": {"@odata.id": "/redfish/v1/Systems"}}
+            elif method == "GET" and self.path == "/redfish/v1/Systems":
+                response = {"Members": [{"@odata.id": f"/redfish/v1/Systems/{state.domain}"}]}
+            elif method == "GET" and self.path == f"/redfish/v1/Systems/{state.domain}":
+                response = {
+                    "Id": state.domain,
+                    "PowerState": state.power_state(),
+                    "Boot": state.boot,
+                    "EthernetInterfaces": {
+                        "@odata.id": f"/redfish/v1/Systems/{state.domain}/EthernetInterfaces"
+                    },
+                }
+            elif method == "PATCH" and self.path == f"/redfish/v1/Systems/{state.domain}":
+                boot = body.get("Boot", {})
+                state.boot.update(boot)
+                if boot.get("BootSourceOverrideTarget") == "UefiHttp":
+                    state.set_efi_boundary(True)
+                elif boot.get("BootSourceOverrideTarget") in ("Pxe", "Hdd"):
+                    state.set_boot_order(str(boot["BootSourceOverrideTarget"]))
+                if boot.get("BootSourceOverrideEnabled") == "Disabled":
+                    if state.efi_source is not None:
+                        state.set_efi_boundary(False)
+                    state.set_boot_order("Hdd")
+                status = 204
+            elif method == "GET" and self.path.endswith("/EthernetInterfaces"):
+                response = {"Members": [{"@odata.id": self.path + "/NIC.1"}]}
+            elif method == "GET" and self.path.endswith("/EthernetInterfaces/NIC.1"):
+                response = state.nic
+            elif method == "PATCH" and self.path.endswith("/EthernetInterfaces/NIC.1"):
+                state.nic.update(body)
+                status = 204
+            elif method == "POST" and self.path.endswith("/Actions/ComputerSystem.Reset"):
+                state.reset(str(body.get("ResetType", "")))
+                status = 204
+            elif self.path.endswith("/Bios/Settings"):
+                # Standard EthernetInterface + ComputerSystem.HttpBootUri is the
+                # contract under test. Report vendor BIOS settings unsupported.
+                status = 404
+                response = {"error": {"message": "vendor BIOS settings unsupported"}}
+            elif self.path.startswith("/redfish/v1/SessionService/"):
+                status = 404
+                response = {"error": {"message": "use basic authentication"}}
+            else:
+                status = 404
+                response = {"error": {"message": "resource not found"}}
+        except (OSError, ValueError, subprocess.CalledProcessError) as error:
+            status = 500
+            response = {"error": {"message": str(error)}}
+
+        state.append(method, self.path, body, status)
+        self.reply(status, response)
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        self.dispatch("GET")
+
+    def do_PATCH(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        self.dispatch("PATCH")
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        self.dispatch("POST")
+
+
+class Server(ThreadingHTTPServer):
+    def __init__(self, address: tuple[str, int], state: State) -> None:
+        super().__init__(address, Handler)
+        self.state = state
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bind", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8443)
+    parser.add_argument("--cert", required=True)
+    parser.add_argument("--key", required=True)
+    parser.add_argument("--domain", required=True)
+    parser.add_argument("--mac", required=True)
+    parser.add_argument("--record", required=True)
+    parser.add_argument("--efi-source")
+    parser.add_argument("--efi-active")
+    parser.add_argument("--bridge")
+    parser.add_argument("--client-ip")
+    parser.add_argument("--manage-boot-order", action="store_true")
+    args = parser.parse_args()
+
+    boundary_values = (args.efi_source, args.efi_active, args.bridge, args.client_ip)
+    if any(boundary_values) and not all(boundary_values):
+        parser.error("--efi-source, --efi-active, --bridge, and --client-ip must be used together")
+
+    state = State(args)
+    state.record.parent.mkdir(parents=True, exist_ok=True)
+    state.record.touch()
+    if state.efi_source is not None:
+        state.set_efi_boundary(False)
+    server = Server((args.bind, args.port), state)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(args.cert, args.key)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/smoke-metalman-http.py
+++ b/hack/smoke-metalman-http.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Layered DHCP-free Metalman HTTP provisioning contract smoke test.
+
+Stock Noble OVMF and sushy cannot emulate firmware-native DHCP-free UEFI HTTP.
+The VM therefore starts at the post-firmware EFI boundary: after Metalman has
+written standard Redfish static IPv4 and UefiHttp settings, the recording BMC
+fetches the real Metalman boot artifacts with the VM's source IP and exposes
+them on an EFI disk. From shim/GRUB onward the real kernel, installer initrd,
+machine image, cloud-init, and branch-built agent path runs unchanged.
+"""
+
+from __future__ import annotations
+
+import atexit
+import importlib.util
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tarfile
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("metalman_pxe_smoke", ROOT / "hack/smoke-metalman.py")
+assert spec and spec.loader
+smoke = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(smoke)
+
+TMP = Path(tempfile.mkdtemp(prefix="metalman-http-"))
+os.chmod(TMP, 0o755)
+VM = "unbounded-metal-http-smoke"
+NETWORK = "unbounded-metal-http-smoke"
+BRIDGE = "virbr-http"
+SITE = "http-smoke"
+NODE = "http-smoke-node"
+MAC = "52:54:00:aa:bc:01"
+SERVER_IP = "192.168.200.1"
+NODE_IP = "192.168.200.10"
+KIND_IP = "192.168.200.2"
+HTTP_PORT = 8882
+AGENT_PORT = 8883
+REDFISH_PORT = 8444
+REGISTRY_PORT = 5556
+DHCP_PORT = 6768
+REGISTRY = "unbounded-http-smoke-registry"
+HOST_IMAGE = "localhost:5556/unbounded/host-ubuntu2404:http-smoke"
+NETBOOT_IMAGE = "localhost:5556/unbounded/netboot:http-smoke"
+AGENT_IMAGE = "localhost:5556/unbounded/agent-ubuntu2404:http-smoke"
+AGENT_IMAGE_VM = f"{SERVER_IP}:{REGISTRY_PORT}/unbounded/agent-ubuntu2404:http-smoke"
+SERVE_URL = f"http://{SERVER_IP}:{HTTP_PORT}"
+RECORD = TMP / "redfish.jsonl"
+PCAP = TMP / "traffic.pcap"
+VIRSH = ["virsh", "--connect", "qemu:///system"]
+PROCS: list[subprocess.Popen[Any]] = []
+PASSED = False
+
+# Point reused wait/guest helpers at this isolated test's resources.
+smoke.TMPDIR = TMP
+smoke.VM_NAME = VM
+smoke.NET_NAME = NETWORK
+smoke.NODE_NAME = NODE
+smoke.SITE = SITE
+smoke.SERVER_IP = SERVER_IP
+smoke.NODE_IP = NODE_IP
+smoke.KIND_SMOKE_IP = KIND_IP
+smoke.MAC_ADDRESS = MAC
+smoke.VIRSH = VIRSH
+smoke._procs = PROCS
+
+
+def log(message: str) -> None:
+    print(f"==> {message}", file=sys.stderr, flush=True)
+
+
+def run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=True, **kwargs)
+
+
+def quiet(args: list[str]) -> None:
+    subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+
+
+def spawn(args: list[str], name: str) -> subprocess.Popen[Any]:
+    process = smoke.spawn(args, TMP / name)
+    return process
+
+
+def cleanup() -> None:
+    log("Cleaning up HTTP smoke resources")
+    for process in PROCS:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except OSError:
+            pass
+    for process in PROCS:
+        try:
+            process.wait(timeout=5)
+        except (OSError, subprocess.TimeoutExpired):
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                pass
+    for args in (
+        [*VIRSH, "destroy", VM],
+        [*VIRSH, "undefine", VM, "--nvram"],
+        [*VIRSH, "net-destroy", NETWORK],
+        [*VIRSH, "net-undefine", NETWORK],
+        ["sudo", "ip", "link", "delete", "veth-kind-http"],
+        ["docker", "rm", "-f", REGISTRY],
+    ):
+        quiet(args)
+    for table_args in (
+        ["sudo", "iptables", "-D", "FORWARD", "-i", BRIDGE, "-j", "ACCEPT"],
+        ["sudo", "iptables", "-D", "FORWARD", "-o", BRIDGE, "-j", "ACCEPT"],
+        ["sudo", "iptables", "-t", "raw", "-D", "PREROUTING", "-i", BRIDGE, "-j", "ACCEPT"],
+    ):
+        quiet(table_args)
+    if PASSED:
+        shutil.rmtree(TMP, ignore_errors=True)
+    else:
+        log(f"Preserving failure diagnostics in {TMP}")
+
+
+def write(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def setup_network() -> None:
+    log("Creating DHCP-free libvirt network")
+    network_xml = TMP / "network.xml"
+    write(network_xml, f"""
+        <network>
+          <name>{NETWORK}</name>
+          <forward mode='nat'/>
+          <bridge name='{BRIDGE}'/>
+          <ip address='{SERVER_IP}' netmask='255.255.255.0'/>
+        </network>
+    """)
+    run([*VIRSH, "net-define", str(network_xml)])
+    run([*VIRSH, "net-start", NETWORK])
+    for args in (
+        ["sudo", "iptables", "-I", "FORWARD", "-i", BRIDGE, "-j", "ACCEPT"],
+        ["sudo", "iptables", "-I", "FORWARD", "-o", BRIDGE, "-j", "ACCEPT"],
+        ["sudo", "iptables", "-t", "raw", "-I", "PREROUTING", "-i", BRIDGE, "-j", "ACCEPT"],
+    ):
+        run(args)
+    kind_pid = run(
+        ["docker", "inspect", "kind-control-plane", "--format", "{{.State.Pid}}"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    run(["sudo", "ip", "link", "add", "veth-kind-http", "type", "veth", "peer", "name", "eth-http"])
+    run(["sudo", "ip", "link", "set", "veth-kind-http", "master", BRIDGE])
+    run(["sudo", "ip", "link", "set", "veth-kind-http", "up"])
+    run(["sudo", "ip", "link", "set", "eth-http", "netns", kind_pid])
+    run(["sudo", "nsenter", "-t", kind_pid, "-n", "ip", "addr", "add", f"{KIND_IP}/24", "dev", "eth-http"])
+    run(["sudo", "nsenter", "-t", kind_pid, "-n", "ip", "link", "set", "eth-http", "up"])
+    smoke.configure_kind_control_plane_node_ip("kind-control-plane", KIND_IP)
+    patch = json.dumps({"spec": {"template": {"spec": {"containers": [{
+        "name": "kindnet-cni",
+        "env": [{"name": "CONTROL_PLANE_ENDPOINT", "value": f"{KIND_IP}:6443"}],
+    }]}}}})
+    run(["kubectl", "-n", "kube-system", "patch", "daemonset", "kindnet", "--type=strategic", "-p", patch])
+    smoke.configure_kind_kube_proxy_apiserver(f"https://{KIND_IP}:6443")
+
+
+def create_vm() -> tuple[Path, Path]:
+    log("Defining powered-off VM at the documented post-firmware EFI boundary")
+    os_disk = TMP / "os.qcow2"
+    blank_efi = TMP / "blank-efi.img"
+    active_efi = TMP / "active-efi.img"
+    nvram = TMP / "OVMF_VARS.fd"
+    run(["qemu-img", "create", "-f", "qcow2", str(os_disk), "20G"])
+    run(["truncate", "-s", "128M", str(blank_efi)])
+    run(["mkfs.vfat", "-n", "HTTPBOOT", str(blank_efi)])
+    shutil.copyfile(blank_efi, active_efi)
+    shutil.copyfile("/usr/share/OVMF/OVMF_VARS_4M.fd", nvram)
+    domain = TMP / "domain.xml"
+    write(domain, f"""
+        <domain type='kvm'>
+          <name>{VM}</name><memory unit='MiB'>4096</memory><vcpu>2</vcpu>
+          <os><type arch='x86_64' machine='q35'>hvm</type>
+            <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
+            <nvram>{nvram}</nvram>
+          </os>
+          <features><acpi/><apic/></features><cpu mode='host-passthrough'/>
+          <devices>
+            <disk type='file' device='disk'><driver name='qemu' type='raw'/><source file='{active_efi}'/><target dev='vdb' bus='virtio'/><boot order='1'/></disk>
+            <disk type='file' device='disk'><driver name='qemu' type='qcow2'/><source file='{os_disk}'/><target dev='vda' bus='virtio'/><boot order='2'/></disk>
+            <interface type='network'><mac address='{MAC}'/><source network='{NETWORK}'/><model type='virtio'/></interface>
+            <tpm model='tpm-tis'><backend type='emulator' version='2.0'/></tpm>
+            <serial type='file'><source path='{TMP / "console.log"}'/><target port='0'/></serial>
+            <channel type='unix'><source mode='bind' path='{TMP / "qga.sock"}'/><target type='virtio' name='org.qemu.guest_agent.0'/></channel>
+          </devices>
+        </domain>
+    """)
+    run([*VIRSH, "define", str(domain)])
+    return blank_efi, active_efi
+
+
+def setup_kubernetes_and_images() -> None:
+    log("Building binaries and applying Metalman RBAC/CRDs")
+    run(["make", "machina-manifests"], cwd=ROOT)
+    for output, package in (("metalman", "./cmd/metalman"), ("unbounded-agent", "./cmd/agent")):
+        run(["go", "build", "-o", str(ROOT / "bin" / output), package], cwd=ROOT)
+    run(["kubectl", "apply", "--server-side", "--force-conflicts", "-f", str(ROOT / "deploy/machina/rendered/01-namespace.yaml")])
+    run(["kubectl", "apply", "--server-side", "--force-conflicts", "-f", str(ROOT / "deploy/machina/crd")])
+    run(["kubectl", "apply", "--server-side", "--force-conflicts", "-f", str(ROOT / "deploy/machina/rendered/06-metalman-rbac.yaml")])
+    for resource in (
+        f"machineoperation/http-smoke-host-replace",
+        f"machine/{NODE}",
+        f"node/{NODE}",
+        "secret/http-bmc-pass",
+        "configmap/http-smoke-user-data",
+    ):
+        subprocess.run(
+            ["kubectl", "delete", resource, "--ignore-not-found", "--wait=true"],
+            stdout=subprocess.DEVNULL,
+            check=False,
+        )
+    run(["kubectl", "-n", "default", "create", "secret", "generic", "http-bmc-pass", "--from-literal=password=smoke"])
+    user_data = TMP / "user-data.yaml"
+    write(user_data, """
+        #cloud-config
+        packages:
+          - qemu-guest-agent
+        runcmd:
+          - [systemctl, start, qemu-guest-agent]
+          - [/bin/bash, -c, "export UNBOUNDED_AGENT_CONFIG_FILE=/etc/unbounded/agent/config.json; bash /usr/local/bin/unbounded-agent-install.sh"]
+    """)
+    run(["kubectl", "-n", "default", "create", "configmap", "http-smoke-user-data",
+         f"--from-file=user-data={user_data}"])
+    run(["docker", "run", "-d", "--name", REGISTRY, "-p", f"{REGISTRY_PORT}:5000", "registry:2"])
+    for _ in range(30):
+        probe = subprocess.run(
+            ["curl", "--fail", "--silent", f"http://127.0.0.1:{REGISTRY_PORT}/v2/"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if probe.returncode == 0:
+            break
+        time.sleep(0.5)
+    else:
+        raise RuntimeError("local OCI registry did not become ready")
+    for image in (HOST_IMAGE, NETBOOT_IMAGE, AGENT_IMAGE):
+        run(["docker", "push", image])
+    artifact_dir = TMP / "agent"
+    artifact_dir.mkdir()
+    tarball = artifact_dir / "unbounded-agent-linux-amd64.tar.gz"
+    with tarfile.open(tarball, "w:gz") as archive:
+        archive.add(ROOT / "bin/unbounded-agent", arcname="unbounded-agent")
+    spawn([sys.executable, "-m", "http.server", str(AGENT_PORT), "--bind", SERVER_IP,
+           "--directory", str(artifact_dir)], "agent-http.log")
+
+
+def start_fixture(blank_efi: Path, active_efi: Path) -> None:
+    run(["openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes", "-days", "1",
+         "-subj", "/CN=metalman-http-fixture", "-addext", "subjectAltName=IP:127.0.0.1",
+         "-keyout", str(TMP / "redfish.key"), "-out", str(TMP / "redfish.crt")])
+    spawn([sys.executable, str(ROOT / "hack/metalman-redfish-fixture.py"),
+           "--domain", VM, "--mac", MAC, "--port", str(REDFISH_PORT),
+           "--cert", str(TMP / "redfish.crt"), "--key", str(TMP / "redfish.key"),
+           "--record", str(RECORD), "--efi-source", str(blank_efi),
+           "--efi-active", str(active_efi), "--bridge", BRIDGE, "--client-ip", NODE_IP],
+          "redfish.log")
+    time.sleep(1)
+
+
+def start_metalman_and_replace() -> None:
+    kubeconfig = TMP / "metalman.kubeconfig"
+    smoke.write_service_account_kubeconfig("unbounded-kube", "metalman-controller", kubeconfig)
+    # The guest cannot resolve Docker's kind-control-plane hostname. Use the
+    # control-plane address attached directly to this test's L2 network.
+    api_url = f"https://{KIND_IP}:6443"
+    spawn(["sudo", "env", f"PATH={os.environ['PATH']}", f"KUBECONFIG={kubeconfig}",
+           f"METALMAN_APISERVER_URL={api_url}", str(ROOT / "bin/metalman"), "serve-pxe",
+            f"--site={SITE}", f"--bind-address={SERVER_IP}", f"--serve-url={SERVE_URL}",
+            f"--http-port={HTTP_PORT}",
+            f"--dhcp-port={DHCP_PORT}",
+            f"--cache-dir={TMP / 'cache'}", f"--default-netboot-image={NETBOOT_IMAGE}"],
+          "metalman.log")
+    machine = {
+        "apiVersion": "unbounded-cloud.io/v1alpha3", "kind": "Machine",
+        "metadata": {"name": NODE, "labels": {"unbounded-cloud.io/site": SITE}},
+        "spec": {
+            "pxe": {
+                "image": HOST_IMAGE, "netbootImage": NETBOOT_IMAGE, "bootProtocol": "HTTP",
+                "targetDisk": "/dev/vda",
+                "dhcpLeases": [{"mac": MAC, "ipv4": NODE_IP, "subnetMask": "255.255.255.0",
+                                "gateway": SERVER_IP, "dns": ["8.8.8.8"]}],
+                "redfish": {"url": f"https://127.0.0.1:{REDFISH_PORT}", "username": "smoke",
+                             "deviceID": VM, "passwordRef": {"name": "http-bmc-pass",
+                             "namespace": "default", "key": "password"}},
+                "cloudInit": {"userDataConfigMapRef": {"name": "http-smoke-user-data",
+                                                        "namespace": "default", "key": "user-data"}},
+            },
+            "agent": {"image": AGENT_IMAGE_VM,
+                      "url": f"http://{SERVER_IP}:{AGENT_PORT}/unbounded-agent-linux-amd64.tar.gz"},
+        },
+    }
+    run(["kubectl", "apply", "-f", "-"], input=json.dumps(machine), text=True)
+    for _ in range(120):
+        fingerprint = subprocess.run(
+            ["kubectl", "get", "machine", NODE, "-o", "jsonpath={.status.redfish.certFingerprint}"],
+            capture_output=True, text=True,
+        ).stdout.strip()
+        if fingerprint:
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError("Redfish certificate fingerprint was not recorded")
+
+    log("Waiting for host and netboot OCI images to be cached")
+    cache_dir = TMP / "cache" / "oci"
+    for _ in range(300):
+        disk_dirs = list(cache_dir.glob("*/amd64/disk"))
+        host_ready = any((path / "disk.img.gz").is_file() for path in disk_dirs)
+        netboot_ready = any((path / "shimx64.efi").is_file() for path in disk_dirs)
+        if host_ready and netboot_ready:
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError("host and netboot OCI images were not cached within 5 minutes")
+
+    operation = smoke.create_machine_operation(
+        "http-smoke-host-replace", "HostReplace", machine_ref=NODE
+    )
+    smoke.wait_machine_operation_complete(operation, timeout=1800)
+
+
+def fixture_writes() -> list[dict[str, Any]]:
+    return [json.loads(line) for line in RECORD.read_text(encoding="utf-8").splitlines()]
+
+
+def assert_contract() -> None:
+    writes = fixture_writes()
+    nic_patches = [entry["body"] for entry in writes
+                   if entry["method"] == "PATCH" and entry["path"].endswith("EthernetInterfaces/NIC.1")]
+    expected_address = {"Address": NODE_IP, "SubnetMask": "255.255.255.0", "Gateway": SERVER_IP}
+    if not any(body.get("DHCPv4") == {"DHCPEnabled": False}
+               and body.get("IPv4StaticAddresses") == [expected_address]
+               and body.get("StaticNameServers") == ["8.8.8.8"] for body in nic_patches):
+        raise AssertionError(f"standard static EthernetInterface PATCH not recorded: {nic_patches}")
+    boot_patches = [entry["body"].get("Boot", {}) for entry in writes
+                    if entry["method"] == "PATCH" and entry["path"] == f"/redfish/v1/Systems/{VM}"]
+    if not any(boot.get("BootSourceOverrideTarget") == "UefiHttp"
+               and boot.get("BootSourceOverrideEnabled") == "Continuous"
+               and boot.get("HttpBootUri") == f"{SERVE_URL}/shimx64.efi" for boot in boot_patches):
+        raise AssertionError(f"standard UefiHttp PATCH not recorded: {boot_patches}")
+
+
+def assert_guest_network() -> str:
+    smoke.wait_guest_agent(timeout=600)
+    command = f"""
+        set -eu
+        ip -4 address show | grep -F '{NODE_IP}/24'
+        ip route show default | grep -F 'via {SERVER_IP}'
+        grep -R -F '{NODE_IP}/24' /etc/netplan /etc/cloud/cloud.cfg.d
+        ! grep -R -E '(^|[^a-z])dhcp4:[[:space:]]*true' /etc/netplan /etc/cloud/cloud.cfg.d
+        test ! -s /var/lib/dhcp/dhclient.leases
+        test -z "$(find /run/systemd/netif/leases /var/lib/NetworkManager -type f \\
+          \\( -name '*.lease' -o -name 'lease-*' \\) -size +0c 2>/dev/null)"
+        cat /proc/sys/kernel/random/boot_id
+    """
+    code, stdout, stderr = smoke.guest_exec(command, timeout=60)
+    if code != 0:
+        raise AssertionError(f"guest static network assertion failed: {stdout}\n{stderr}")
+    return stdout.splitlines()[-1].strip()
+
+
+def assert_no_dhcp() -> None:
+    result = run(
+        ["sudo", "tcpdump", "-nn", "-r", str(PCAP), "ether", "src", MAC, "and",
+         "(udp port 67 or udp port 68 or udp port 546 or udp port 547)"],
+        capture_output=True, text=True,
+    )
+    if result.stdout.strip():
+        raise AssertionError(f"DHCP traffic emitted by {MAC}:\n{result.stdout}")
+
+
+def main() -> None:
+    global PASSED
+
+    atexit.register(cleanup)
+    setup_network()
+    blank_efi, active_efi = create_vm()
+    # Capture starts while the domain is still off and remains active through
+    # installer power-on, installer reboot, OS validation, and the final reboot.
+    tcpdump = spawn(["sudo", "tcpdump", "-U", "-i", BRIDGE, "-w", str(PCAP)], "tcpdump.log")
+    time.sleep(1)
+    setup_kubernetes_and_images()
+    start_fixture(blank_efi, active_efi)
+    start_metalman_and_replace()
+    assert_contract()
+    first_boot = assert_guest_network()
+    log("Rebooting the installed guest and reasserting static networking")
+    code, _, stderr = smoke.guest_exec(
+        "nohup sh -c 'sleep 1; systemctl reboot' >/dev/null 2>&1 &", timeout=30
+    )
+    if code != 0:
+        raise AssertionError(f"guest reboot failed: {stderr}")
+    time.sleep(10)
+    smoke.wait_vm_state("running", timeout=180)
+    smoke.wait_guest_agent(timeout=600)
+    second_boot = assert_guest_network()
+    if first_boot == second_boot:
+        raise AssertionError("guest boot ID did not change after reboot")
+    tcpdump.send_signal(signal.SIGINT)
+    tcpdump.wait(timeout=15)
+    PROCS.remove(tcpdump)
+    assert_no_dhcp()
+    PASSED = True
+    log("Layered DHCP-free HTTP provisioning smoke PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/smoke-metalman-http.py
+++ b/hack/smoke-metalman-http.py
@@ -322,7 +322,7 @@ def start_metalman_and_replace() -> None:
     for _ in range(300):
         disk_dirs = list(cache_dir.glob("*/amd64/disk"))
         host_ready = any((path / "disk.img.gz").is_file() for path in disk_dirs)
-        netboot_ready = any((path / "grubx64.efi").is_file() for path in disk_dirs)
+        netboot_ready = any((path / "bootx64.efi").is_file() for path in disk_dirs)
         if host_ready and netboot_ready:
             break
         time.sleep(1)
@@ -352,7 +352,7 @@ def assert_contract() -> None:
                     if entry["method"] == "PATCH" and entry["path"] == f"/redfish/v1/Systems/{VM}"]
     if not any(boot.get("BootSourceOverrideTarget") == "UefiHttp"
                and boot.get("BootSourceOverrideEnabled") == "Continuous"
-               and boot.get("HttpBootUri") == f"{SERVE_URL}/grubx64.efi" for boot in boot_patches):
+               and boot.get("HttpBootUri") == f"{SERVE_URL}/bootx64.efi" for boot in boot_patches):
         raise AssertionError(f"standard UefiHttp PATCH not recorded: {boot_patches}")
 
 

--- a/hack/smoke-metalman-http.py
+++ b/hack/smoke-metalman-http.py
@@ -322,7 +322,7 @@ def start_metalman_and_replace() -> None:
     for _ in range(300):
         disk_dirs = list(cache_dir.glob("*/amd64/disk"))
         host_ready = any((path / "disk.img.gz").is_file() for path in disk_dirs)
-        netboot_ready = any((path / "shimx64.efi").is_file() for path in disk_dirs)
+        netboot_ready = any((path / "grubx64.efi").is_file() for path in disk_dirs)
         if host_ready and netboot_ready:
             break
         time.sleep(1)
@@ -352,7 +352,7 @@ def assert_contract() -> None:
                     if entry["method"] == "PATCH" and entry["path"] == f"/redfish/v1/Systems/{VM}"]
     if not any(boot.get("BootSourceOverrideTarget") == "UefiHttp"
                and boot.get("BootSourceOverrideEnabled") == "Continuous"
-               and boot.get("HttpBootUri") == f"{SERVE_URL}/shimx64.efi" for boot in boot_patches):
+               and boot.get("HttpBootUri") == f"{SERVE_URL}/grubx64.efi" for boot in boot_patches):
         raise AssertionError(f"standard UefiHttp PATCH not recorded: {boot_patches}")
 
 

--- a/hack/smoke-metalman-http.py
+++ b/hack/smoke-metalman-http.py
@@ -98,8 +98,8 @@ def cleanup() -> None:
     for process in PROCS:
         try:
             os.killpg(process.pid, signal.SIGTERM)
-        except OSError:
-            pass
+        except OSError as exc:
+            log(f"Could not send SIGTERM to process group {process.pid}; continuing cleanup: {exc}")
     for process in PROCS:
         try:
             process.wait(timeout=5)
@@ -107,6 +107,7 @@ def cleanup() -> None:
             try:
                 os.killpg(process.pid, signal.SIGKILL)
             except OSError:
+                # The process group may already have exited during teardown.
                 pass
     for args in (
         [*VIRSH, "destroy", VM],
@@ -181,16 +182,16 @@ def create_vm() -> tuple[Path, Path]:
     run(["truncate", "-s", "128M", str(blank_efi)])
     run(["mkfs.vfat", "-n", "HTTPBOOT", str(blank_efi)])
     shutil.copyfile(blank_efi, active_efi)
-    shutil.copyfile("/usr/share/OVMF/OVMF_VARS_4M.fd", nvram)
+    shutil.copyfile("/usr/share/OVMF/OVMF_VARS_4M.ms.fd", nvram)
     domain = TMP / "domain.xml"
     write(domain, f"""
         <domain type='kvm'>
           <name>{VM}</name><memory unit='MiB'>4096</memory><vcpu>2</vcpu>
           <os><type arch='x86_64' machine='q35'>hvm</type>
-            <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
+            <loader readonly='yes' secure='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.ms.fd</loader>
             <nvram>{nvram}</nvram>
           </os>
-          <features><acpi/><apic/></features><cpu mode='host-passthrough'/>
+          <features><acpi/><apic/><smm state='on'/></features><cpu mode='host-passthrough'/>
           <devices>
             <disk type='file' device='disk'><driver name='qemu' type='raw'/><source file='{active_efi}'/><target dev='vdb' bus='virtio'/><boot order='1'/></disk>
             <disk type='file' device='disk'><driver name='qemu' type='qcow2'/><source file='{os_disk}'/><target dev='vda' bus='virtio'/><boot order='2'/></disk>
@@ -266,9 +267,10 @@ def start_fixture(blank_efi: Path, active_efi: Path) -> None:
          "-keyout", str(TMP / "redfish.key"), "-out", str(TMP / "redfish.crt")])
     spawn([sys.executable, str(ROOT / "hack/metalman-redfish-fixture.py"),
            "--domain", VM, "--mac", MAC, "--port", str(REDFISH_PORT),
-           "--cert", str(TMP / "redfish.crt"), "--key", str(TMP / "redfish.key"),
-           "--record", str(RECORD), "--efi-source", str(blank_efi),
-           "--efi-active", str(active_efi), "--bridge", BRIDGE, "--client-ip", NODE_IP],
+            "--cert", str(TMP / "redfish.crt"), "--key", str(TMP / "redfish.key"),
+            "--record", str(RECORD), "--efi-source", str(blank_efi),
+            "--efi-active", str(active_efi), "--bridge", BRIDGE,
+            "--cache-dir", str(TMP / "cache"), "--username", "smoke", "--password", "smoke"],
           "redfish.log")
     time.sleep(1)
 
@@ -319,11 +321,17 @@ def start_metalman_and_replace() -> None:
 
     log("Waiting for host and netboot OCI images to be cached")
     cache_dir = TMP / "cache" / "oci"
+    metalman_log = TMP / "metalman.log"
     for _ in range(300):
         disk_dirs = list(cache_dir.glob("*/amd64/disk"))
         host_ready = any((path / "disk.img.gz").is_file() for path in disk_dirs)
         netboot_ready = any((path / "bootx64.efi").is_file() for path in disk_dirs)
-        if host_ready and netboot_ready:
+        log_text = metalman_log.read_text(encoding="utf-8") if metalman_log.exists() else ""
+        host_published = any("OCI image cached" in line and f"image={HOST_IMAGE}" in line
+                             for line in log_text.splitlines())
+        netboot_published = any("OCI image cached" in line and f"image={NETBOOT_IMAGE}" in line
+                                for line in log_text.splitlines())
+        if host_ready and netboot_ready and host_published and netboot_published:
             break
         time.sleep(1)
     else:
@@ -351,9 +359,14 @@ def assert_contract() -> None:
     boot_patches = [entry["body"].get("Boot", {}) for entry in writes
                     if entry["method"] == "PATCH" and entry["path"] == f"/redfish/v1/Systems/{VM}"]
     if not any(boot.get("BootSourceOverrideTarget") == "UefiHttp"
-               and boot.get("BootSourceOverrideEnabled") == "Continuous"
-               and boot.get("HttpBootUri") == f"{SERVE_URL}/bootx64.efi" for boot in boot_patches):
+                and boot.get("BootSourceOverrideEnabled") == "Continuous"
+                and boot.get("BootSourceOverrideMode") == "UEFI"
+                and boot.get("HttpBootUri") == f"{SERVE_URL}/bootx64.efi" for boot in boot_patches):
         raise AssertionError(f"standard UefiHttp PATCH not recorded: {boot_patches}")
+    firmware_fetches = [entry for entry in writes if entry["method"] == "FIRMWARE_FETCH"]
+    if not any(entry["path"] == f"{SERVE_URL}/bootx64.efi"
+               and entry["body"] == {"source": NODE_IP} for entry in firmware_fetches):
+        raise AssertionError(f"state-derived post-power-on firmware fetch not recorded: {firmware_fetches}")
 
 
 def assert_guest_network() -> str:
@@ -362,6 +375,8 @@ def assert_guest_network() -> str:
         set -eu
         ip -4 address show | grep -F '{NODE_IP}/24'
         ip route show default | grep -F 'via {SERVER_IP}'
+        test "$(od -An -t u1 -j 4 -N 1 /sys/firmware/efi/efivars/SecureBoot-* | tr -d ' ')" = 1
+        test "$(od -An -t u1 -j 4 -N 1 /sys/firmware/efi/efivars/SetupMode-* | tr -d ' ')" = 0
         grep -R -F '{NODE_IP}/24' /etc/netplan /etc/cloud/cloud.cfg.d
         ! grep -R -E '(^|[^a-z])dhcp4:[[:space:]]*true' /etc/netplan /etc/cloud/cloud.cfg.d
         test ! -s /var/lib/dhcp/dhclient.leases
@@ -376,6 +391,13 @@ def assert_guest_network() -> str:
 
 
 def assert_no_dhcp() -> None:
+    guest_traffic = run(
+        ["sudo", "tcpdump", "-nn", "-r", str(PCAP), "ether", "src", MAC, "and", "not",
+         "(udp port 67 or udp port 68 or udp port 546 or udp port 547)"],
+        capture_output=True, text=True,
+    )
+    if not guest_traffic.stdout.strip():
+        raise AssertionError(f"packet capture contains no non-DHCP traffic from {MAC}")
     result = run(
         ["sudo", "tcpdump", "-nn", "-r", str(PCAP), "ether", "src", MAC, "and",
          "(udp port 67 or udp port 68 or udp port 546 or udp port 547)"],

--- a/hack/smoke-metalman.py
+++ b/hack/smoke-metalman.py
@@ -42,7 +42,7 @@ KIND_SMOKE_IP = f"{SUBNET}.2"  # IP assigned to the kind container on virbr-smok
 GATEWAY = SERVER_IP
 DNS_SERVER = "8.8.8.8"
 MAC_ADDRESS = "52:54:00:aa:bb:01"
-SUSHY_PORT = 8443
+REDFISH_PORT = 8443
 HTTP_PORT = 8880
 AGENT_DOWNLOAD_PORT = 8881
 CACHE_DIR = TMPDIR / "cache"
@@ -353,8 +353,8 @@ def clean_libvirt() -> None:
     run_quiet(["sudo", "ip", "link", "delete", "virbr-smoke"])
     # Remove veth pair used to connect kind container to virbr-smoke.
     run_quiet(["sudo", "ip", "link", "delete", "veth-kind-smoke"])
-    # Kill any leftover sushy-emulator from a previous run.
-    run_quiet(["sudo", "pkill", "-f", "sushy-emulator"])
+    # Kill any leftover Redfish fixture from a previous run.
+    run_quiet(["sudo", "pkill", "-f", "metalman-redfish-fixture.py"])
     # Kill any leftover metalman serve-pxe from a previous run.
     # Use the binary path to avoid matching this script (smoke-metalman.py).
     run_quiet(["sudo", "pkill", "-f", "bin/metalman"])
@@ -518,6 +518,31 @@ def configure_kind_control_plane_node_ip(container: str, node_ip: str) -> None:
         time.sleep(1)
 
     die(f"Timed out waiting for Node '{container}' to advertise only InternalIP {node_ip}")
+
+
+def configure_kind_kube_proxy_apiserver(api_server: str) -> None:
+    """Make newly scheduled kind kube-proxy pods use the VM-reachable API URL."""
+    log(f"Configuring kind kube-proxy API server as {api_server}")
+    result = run(
+        [KUBECTL, "-n", "kube-system", "get", "configmap", "kube-proxy", "-o", "json"],
+        capture_output=True,
+        text=True,
+    )
+    config_map = json.loads(result.stdout)
+    kubeconfig = config_map["data"]["kubeconfig.conf"]
+    lines = kubeconfig.splitlines()
+    server_lines = [index for index, line in enumerate(lines) if line.lstrip().startswith("server:")]
+    if len(server_lines) != 1:
+        die(f"Expected one kube-proxy API server entry, got {len(server_lines)}")
+    index = server_lines[0]
+    indentation = lines[index][:-len(lines[index].lstrip())]
+    lines[index] = f"{indentation}server: {api_server}"
+    config_map["data"]["kubeconfig.conf"] = "\n".join(lines) + "\n"
+    run(
+        [KUBECTL, "replace", "-f", "-"],
+        input=json.dumps(config_map),
+        text=True,
+    )
 
 
 def _probe_vm_network() -> None:
@@ -1022,6 +1047,7 @@ def main() -> None:
     })
     kubectl(["-n", "kube-system", "patch", "daemonset", "kindnet",
              "--type=strategic", "-p", patch])
+    configure_kind_kube_proxy_apiserver(f"https://{KIND_SMOKE_IP}:6443")
 
     log("Creating UEFI VM (powered off, with TPM)")
     ovmf_vars = TMPDIR / "OVMF_VARS.fd"
@@ -1049,23 +1075,26 @@ def main() -> None:
     )
     console_thread.start()
 
-    log("Starting sushy-emulator")
+    log("Starting recording Redfish fixture")
     run_quiet([
         "openssl", "req", "-x509", "-newkey", "rsa:2048",
-        "-keyout", str(TMPDIR / "sushy.key"),
-        "-out", str(TMPDIR / "sushy.crt"),
+        "-keyout", str(TMPDIR / "redfish.key"),
+        "-out", str(TMPDIR / "redfish.crt"),
         "-days", "1", "-nodes",
-        "-subj", "/CN=sushy-emulator",
+        "-subj", "/CN=metalman-redfish-fixture",
         "-addext", "subjectAltName=IP:127.0.0.1",
     ], check=True)
-    sushy_url = f"https://127.0.0.1:{SUSHY_PORT}"
+    redfish_url = f"https://127.0.0.1:{REDFISH_PORT}"
     proc = spawn([
-        "sushy-emulator", "--libvirt-uri", "qemu:///system",
-        "-i", "127.0.0.1", "-p", str(SUSHY_PORT),
-        "--ssl-certificate", str(TMPDIR / "sushy.crt"),
-        "--ssl-key", str(TMPDIR / "sushy.key"),
-    ], TMPDIR / "sushy.log")
-    log(f"  sushy-emulator PID={proc.pid}")
+        sys.executable, str(REPO_ROOT / "hack" / "metalman-redfish-fixture.py"),
+        "--domain", VM_NAME, "--mac", MAC_ADDRESS,
+        "--bind", "127.0.0.1", "--port", str(REDFISH_PORT),
+        "--cert", str(TMPDIR / "redfish.crt"),
+        "--key", str(TMPDIR / "redfish.key"),
+        "--record", str(TMPDIR / "redfish.jsonl"),
+        "--manage-boot-order",
+    ], TMPDIR / "redfish.log")
+    log(f"  Redfish fixture PID={proc.pid}")
     time.sleep(2)
     check_procs()
 
@@ -1191,7 +1220,7 @@ def main() -> None:
             "pxe": {
                 "image": IMAGE_NAME,
                 "redfish": {
-                    "url": sushy_url,
+                    "url": redfish_url,
                     "username": "",
                     "deviceID": VM_NAME,
                     "passwordRef": {"name": "bmc-pass", "key": "password", "namespace": NODE_NS},

--- a/hack/smoke-metalman.py
+++ b/hack/smoke-metalman.py
@@ -1092,6 +1092,7 @@ def main() -> None:
         "--cert", str(TMPDIR / "redfish.crt"),
         "--key", str(TMPDIR / "redfish.key"),
         "--record", str(TMPDIR / "redfish.jsonl"),
+        "--username", "", "--password", "smoke",
         "--manage-boot-order",
     ], TMPDIR / "redfish.log")
     log(f"  Redfish fixture PID={proc.pid}")

--- a/images/netboot/Containerfile
+++ b/images/netboot/Containerfile
@@ -77,7 +77,7 @@ RUN mkdir -p /disk/grub /disk/cloud-init && \
     cp /artifacts/vmlinuz /artifacts/initrd /artifacts/init.cpio /disk/ && \
 	if [ "${TARGETARCH}" = "amd64" ]; then \
 		cp /artifacts/shimx64.efi /artifacts/grubx64.efi /disk/ && \
-		printf '%s\n' "dhcpBootImageName: shimx64.efi" "httpBootPath: shimx64.efi" > /disk/metadata.yaml; \
+		printf '%s\n' "dhcpBootImageName: shimx64.efi" "httpBootPath: grubx64.efi" > /disk/metadata.yaml; \
 	elif [ "${TARGETARCH}" = "arm64" ]; then \
 		cp /artifacts/shimaa64.efi /artifacts/grubaa64.efi /disk/ && \
 		printf '%s\n' "dhcpBootImageName: shimaa64.efi" "httpBootPath: shimaa64.efi" > /disk/metadata.yaml; \

--- a/images/netboot/Containerfile
+++ b/images/netboot/Containerfile
@@ -77,7 +77,8 @@ RUN mkdir -p /disk/grub /disk/cloud-init && \
     cp /artifacts/vmlinuz /artifacts/initrd /artifacts/init.cpio /disk/ && \
 	if [ "${TARGETARCH}" = "amd64" ]; then \
 		cp /artifacts/shimx64.efi /artifacts/grubx64.efi /disk/ && \
-		printf '%s\n' "dhcpBootImageName: shimx64.efi" "httpBootPath: grubx64.efi" > /disk/metadata.yaml; \
+		cp /artifacts/shimx64.efi /disk/bootx64.efi && \
+		printf '%s\n' "dhcpBootImageName: shimx64.efi" "httpBootPath: bootx64.efi" > /disk/metadata.yaml; \
 	elif [ "${TARGETARCH}" = "arm64" ]; then \
 		cp /artifacts/shimaa64.efi /artifacts/grubaa64.efi /disk/ && \
 		printf '%s\n' "dhcpBootImageName: shimaa64.efi" "httpBootPath: shimaa64.efi" > /disk/metadata.yaml; \

--- a/images/netboot/Containerfile
+++ b/images/netboot/Containerfile
@@ -85,6 +85,7 @@ RUN mkdir -p /disk/grub /disk/cloud-init && \
 
 COPY images/netboot/assets/grub.cfg.tmpl /disk/grub/grub.cfg.tmpl
 COPY images/netboot/assets/meta-data.tmpl /disk/cloud-init/meta-data.tmpl
+COPY images/netboot/assets/network-config.tmpl /disk/cloud-init/network-config.tmpl
 COPY images/netboot/assets/vendor-data.tmpl /disk/cloud-init/vendor-data.tmpl
 
 FROM scratch

--- a/images/netboot/assets/grub.cfg.tmpl
+++ b/images/netboot/assets/grub.cfg.tmpl
@@ -36,6 +36,9 @@ menuentry "Unbounded Metal Install" {
     unbounded.apiserver_url={{ .ApiserverURL }} \
     {{- if .BootLease }}
     unbounded.boot_mac={{ .BootLease.MAC }} \
+    {{- if .BootLease.DNS }}
+    unbounded.dns={{ join (ipAddresses .BootLease.DNS) "," }} \
+    {{- end }}
     ip={{ .BootLease.IPv4 }}::{{ .BootLease.Gateway }}:{{ .BootLease.SubnetMask }}:::none \
     {{- end }}
     {{- if .Machine.Spec.PXE.TargetDisk }}

--- a/images/netboot/assets/grub.cfg.tmpl
+++ b/images/netboot/assets/grub.cfg.tmpl
@@ -36,7 +36,7 @@ menuentry "Unbounded Metal Install" {
     unbounded.apiserver_url={{ .ApiserverURL }} \
     {{- if .BootLease }}
     unbounded.boot_mac={{ .BootLease.MAC }} \
-    {{- if .BootLease.DNS }}
+    {{- if (ipAddresses .BootLease.DNS) }}
     unbounded.dns={{ join (ipAddresses .BootLease.DNS) "," }} \
     {{- end }}
     ip={{ .BootLease.IPv4 }}::{{ .BootLease.Gateway }}:{{ .BootLease.SubnetMask }}:::none \

--- a/images/netboot/assets/init
+++ b/images/netboot/assets/init
@@ -128,6 +128,7 @@ DS_URL=$(get_param unbounded.ds_url || true)
 NODE_NAME=$(get_param unbounded.node_name || true)
 NODE_NAMESPACE=$(get_param unbounded.node_namespace || true)
 APISERVER_URL=$(get_param unbounded.apiserver_url || true)
+DNS_SERVERS=$(get_param unbounded.dns || true)
 BOOT_MAC=$(normalize_mac "$BOOT_MAC")
 if [ -z "$BOOT_MAC" ] && [ -n "$BOOTIF" ]; then
     BOOT_MAC=$(bootif_to_mac "$BOOTIF")
@@ -165,7 +166,7 @@ find_first_iface() {
 
 if [ -n "$BOOT_MAC" ]; then
     retry 30 1 "find network interface with MAC $BOOT_MAC" find_iface_by_mac \
-        || log "WARNING: no network interface found with MAC $BOOT_MAC"
+        || fatal "no network interface found with MAC $BOOT_MAC"
 fi
 
 if [ -z "$IFACE" ]; then
@@ -176,15 +177,28 @@ else
 fi
 
 mask2cidr() {
-    local cidr=0
+    local cidr=0 octets=0 suffix=0
     for octet in $(echo "$1" | tr '.' ' '); do
+        octets=$((octets + 1))
+        [ "$octets" -le 4 ] || return 1
+        if [ "$suffix" -eq 1 ]; then
+            [ "$octet" = 0 ] || return 1
+            continue
+        fi
         case "$octet" in
-            255) cidr=$((cidr + 8)) ;; 254) cidr=$((cidr + 7)) ;;
-            252) cidr=$((cidr + 6)) ;; 248) cidr=$((cidr + 5)) ;;
-            240) cidr=$((cidr + 4)) ;; 224) cidr=$((cidr + 3)) ;;
-            192) cidr=$((cidr + 2)) ;; 128) cidr=$((cidr + 1)) ;;
+            255) cidr=$((cidr + 8)) ;;
+            254) cidr=$((cidr + 7)); suffix=1 ;;
+            252) cidr=$((cidr + 6)); suffix=1 ;;
+            248) cidr=$((cidr + 5)); suffix=1 ;;
+            240) cidr=$((cidr + 4)); suffix=1 ;;
+            224) cidr=$((cidr + 3)); suffix=1 ;;
+            192) cidr=$((cidr + 2)); suffix=1 ;;
+            128) cidr=$((cidr + 1)); suffix=1 ;;
+            0) suffix=1 ;;
+            *) return 1 ;;
         esac
     done
+    [ "$octets" -eq 4 ] || return 1
     echo "$cidr"
 }
 
@@ -196,9 +210,16 @@ if [ -n "$IP_PARAM" ]; then
     IFACE_PARAM=$(echo "$IP_PARAM" | cut -d: -f6)
 
     case "$MASK" in
-        *.*.*.*) PREFIX=$(mask2cidr "$MASK") ;;
+        *.*.*.*) PREFIX=$(mask2cidr "$MASK") || fatal "invalid or non-contiguous subnet mask $MASK" ;;
         *) PREFIX="$MASK" ;;
     esac
+    case "$PREFIX" in
+        ''|*[!0-9]*) fatal "invalid IPv4 prefix $PREFIX" ;;
+    esac
+    [ "$PREFIX" -le 32 ] || fatal "invalid IPv4 prefix $PREFIX"
+    [ -n "$CLIENT_IP" ] || fatal "static client IP is empty"
+    [ -n "$GW" ] || fatal "static gateway is empty"
+    [ -n "$BOOT_MAC" ] || fatal "unbounded.boot_mac is required for persistent static networking"
 
     if [ -n "$IFACE_PARAM" ] && [ -e "/sys/class/net/$IFACE_PARAM" ]; then
         IFACE="$IFACE_PARAM"
@@ -206,8 +227,24 @@ if [ -n "$IP_PARAM" ]; then
 
     log "configuring $IFACE with $CLIENT_IP/$PREFIX gw $GW"
     retry 5 2 "link up $IFACE" ip link set "$IFACE" up || fatal "failed to bring up $IFACE"
-    retry 3 1 "add address" ip addr add "$CLIENT_IP/$PREFIX" dev "$IFACE" || true
-    retry 3 1 "add default route" ip route add default via "$GW" dev "$IFACE" || true
+    retry 3 1 "set address" ip addr replace "$CLIENT_IP/$PREFIX" dev "$IFACE" \
+        || fatal "failed to configure $CLIENT_IP/$PREFIX on $IFACE"
+    retry 3 1 "set default route" ip route replace default via "$GW" dev "$IFACE" \
+        || fatal "failed to configure default route through $GW"
+
+    if [ -n "$DNS_SERVERS" ]; then
+        : > /etc/resolv.conf
+        old_ifs=$IFS
+        IFS=,
+        for dns in $DNS_SERVERS; do
+            IFS=$old_ifs
+            [ -n "$dns" ] || fatal "empty DNS server in unbounded.dns"
+            case "$dns" in *[!0-9a-fA-F:.]*) fatal "invalid DNS server $dns" ;; esac
+            echo "nameserver $dns" >> /etc/resolv.conf
+            IFS=,
+        done
+        IFS=$old_ifs
+    fi
 fi
 
 if [ -z "$TARGET_DISK" ]; then
@@ -275,28 +312,68 @@ find_root_part() {
     return 1
 }
 
-if [ -n "$DS_URL" ]; then
-    log "injecting cloud-init datasource: $DS_URL"
+if [ -n "$DS_URL" ] || [ -n "$IP_PARAM" ]; then
     retry 20 2 "find root partition" find_root_part || fatal "no root partition found on $TARGET_DISK"
     retry 5 2 "mount $ROOT_PART" mount "$ROOT_PART" /mnt || fatal "failed to mount $ROOT_PART"
 
-    mkdir -p /mnt/etc/cloud/cloud.cfg.d /mnt/etc/unbounded-metal
-    cat > /mnt/etc/cloud/cloud.cfg.d/99-unbounded-metal.cfg <<CLOUDINIT
+    if [ -n "$IP_PARAM" ]; then
+        log "persisting static network configuration"
+        mkdir -p /mnt/etc/netplan
+        rm -f /mnt/etc/netplan/50-cloud-init.yaml
+        cat > /mnt/etc/netplan/99-unbounded-metal.yaml <<NETPLAN
+network:
+  version: 2
+  ethernets:
+    provisioning:
+      match:
+        macaddress: "${BOOT_MAC}"
+      dhcp4: false
+      dhcp6: false
+      addresses:
+        - "${CLIENT_IP}/${PREFIX}"
+      routes:
+        - to: default
+          via: "${GW}"
+NETPLAN
+        if [ -n "$DNS_SERVERS" ]; then
+            cat >> /mnt/etc/netplan/99-unbounded-metal.yaml <<NETPLANDNS
+      nameservers:
+        addresses:
+NETPLANDNS
+            old_ifs=$IFS
+            IFS=,
+            for dns in $DNS_SERVERS; do
+                IFS=$old_ifs
+                echo "          - \"${dns}\"" >> /mnt/etc/netplan/99-unbounded-metal.yaml
+                IFS=,
+            done
+            IFS=$old_ifs
+        fi
+        chmod 600 /mnt/etc/netplan/99-unbounded-metal.yaml
+    fi
+
+    if [ -n "$DS_URL" ]; then
+        log "injecting cloud-init datasource: $DS_URL"
+        mkdir -p /mnt/etc/cloud/cloud.cfg.d /mnt/etc/unbounded-metal
+        cat > /mnt/etc/cloud/cloud.cfg.d/99-unbounded-metal.cfg <<CLOUDINIT
 datasource_list: [NoCloud]
 datasource:
   NoCloud:
     seedfrom: ${DS_URL}
+network:
+  config: disabled
 CLOUDINIT
-    rm -f /mnt/etc/cloud/cloud-init.disabled
-    cat > /mnt/etc/unbounded-metal/config <<UMCONFIG
+        rm -f /mnt/etc/cloud/cloud-init.disabled
+        cat > /mnt/etc/unbounded-metal/config <<UMCONFIG
 SERVE_URL=${SERVE_URL}
 NODE_NAME=${NODE_NAME}
 NODE_NAMESPACE=${NODE_NAMESPACE}
 APISERVER_URL=${APISERVER_URL}
 UMCONFIG
+    fi
     sync
     umount /mnt
-    log "cloud-init configured on $ROOT_PART"
+    log "installed system configured on $ROOT_PART"
 fi
 
 if [ -d /sys/firmware/efi ]; then

--- a/images/netboot/assets/init
+++ b/images/netboot/assets/init
@@ -218,19 +218,20 @@ if [ -n "$IP_PARAM" ]; then
     esac
     [ "$PREFIX" -le 32 ] || fatal "invalid IPv4 prefix $PREFIX"
     [ -n "$CLIENT_IP" ] || fatal "static client IP is empty"
-    [ -n "$GW" ] || fatal "static gateway is empty"
     [ -n "$BOOT_MAC" ] || fatal "unbounded.boot_mac is required for persistent static networking"
 
     if [ -n "$IFACE_PARAM" ] && [ -e "/sys/class/net/$IFACE_PARAM" ]; then
         IFACE="$IFACE_PARAM"
     fi
 
-    log "configuring $IFACE with $CLIENT_IP/$PREFIX gw $GW"
+    log "configuring $IFACE with $CLIENT_IP/$PREFIX"
     retry 5 2 "link up $IFACE" ip link set "$IFACE" up || fatal "failed to bring up $IFACE"
     retry 3 1 "set address" ip addr replace "$CLIENT_IP/$PREFIX" dev "$IFACE" \
         || fatal "failed to configure $CLIENT_IP/$PREFIX on $IFACE"
-    retry 3 1 "set default route" ip route replace default via "$GW" dev "$IFACE" \
-        || fatal "failed to configure default route through $GW"
+    if [ -n "$GW" ]; then
+        retry 3 1 "set default route" ip route replace default via "$GW" dev "$IFACE" \
+            || fatal "failed to configure default route through $GW"
+    fi
 
     if [ -n "$DNS_SERVERS" ]; then
         : > /etc/resolv.conf
@@ -331,10 +332,14 @@ network:
       dhcp6: false
       addresses:
         - "${CLIENT_IP}/${PREFIX}"
+NETPLAN
+        if [ -n "$GW" ]; then
+            cat >> /mnt/etc/netplan/99-unbounded-metal.yaml <<NETPLANROUTE
       routes:
         - to: default
           via: "${GW}"
-NETPLAN
+NETPLANROUTE
+        fi
         if [ -n "$DNS_SERVERS" ]; then
             cat >> /mnt/etc/netplan/99-unbounded-metal.yaml <<NETPLANDNS
       nameservers:

--- a/images/netboot/assets/network-config.tmpl
+++ b/images/netboot/assets/network-config.tmpl
@@ -8,10 +8,12 @@ ethernets:
     dhcp6: false
     addresses:
       - {{ yamlQuote (printf "%s/%d" .BootLease.IPv4 (subnetPrefix .BootLease.SubnetMask)) }}
+{{- if .BootLease.Gateway }}
     routes:
       - to: default
         via: {{ yamlQuote .BootLease.Gateway }}
-{{- if .BootLease.DNS }}
+{{- end }}
+{{- if (ipAddresses .BootLease.DNS) }}
     nameservers:
       addresses:
 {{- range (ipAddresses .BootLease.DNS) }}

--- a/images/netboot/assets/network-config.tmpl
+++ b/images/netboot/assets/network-config.tmpl
@@ -1,0 +1,24 @@
+{{- if .BootLease }}
+version: 2
+ethernets:
+  provisioning:
+    match:
+      macaddress: {{ yamlQuote .BootLease.MAC }}
+    dhcp4: false
+    dhcp6: false
+    addresses:
+      - {{ yamlQuote (printf "%s/%d" .BootLease.IPv4 (subnetPrefix .BootLease.SubnetMask)) }}
+    routes:
+      - to: default
+        via: {{ yamlQuote .BootLease.Gateway }}
+{{- if .BootLease.DNS }}
+    nameservers:
+      addresses:
+{{- range (ipAddresses .BootLease.DNS) }}
+        - {{ yamlQuote . }}
+{{- end }}
+{{- end }}
+{{- else }}
+version: 2
+ethernets: {}
+{{- end }}

--- a/internal/metalman/netboot/netboot.go
+++ b/internal/metalman/netboot/netboot.go
@@ -404,14 +404,15 @@ var (
 	}
 )
 
-func ipAddresses(values []string) ([]string, error) {
+func ipAddresses(values []string) []string {
+	result := make([]string, 0, len(values))
 	for _, value := range values {
-		if net.ParseIP(value) == nil {
-			return nil, fmt.Errorf("invalid IP address %q", value)
+		if net.ParseIP(value) != nil {
+			result = append(result, value)
 		}
 	}
 
-	return values, nil
+	return result
 }
 
 func subnetPrefix(mask string) (int, error) {

--- a/internal/metalman/netboot/netboot.go
+++ b/internal/metalman/netboot/netboot.go
@@ -8,9 +8,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	pathpkg "path"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -389,7 +391,11 @@ func operationRequestsInstall(op *v1alpha3.MachineOperation, machineName string)
 
 var (
 	templateFuncMap = template.FuncMap{
-		"indent": indentTemplateBlock,
+		"indent":       indentTemplateBlock,
+		"ipAddresses":  ipAddresses,
+		"join":         strings.Join,
+		"subnetPrefix": subnetPrefix,
+		"yamlQuote":    strconv.Quote,
 	}
 	templatePool = sync.Pool{
 		New: func() any {
@@ -397,6 +403,30 @@ var (
 		},
 	}
 )
+
+func ipAddresses(values []string) ([]string, error) {
+	for _, value := range values {
+		if net.ParseIP(value) == nil {
+			return nil, fmt.Errorf("invalid IP address %q", value)
+		}
+	}
+
+	return values, nil
+}
+
+func subnetPrefix(mask string) (int, error) {
+	ip := net.ParseIP(mask)
+	if ip == nil || ip.To4() == nil {
+		return 0, fmt.Errorf("invalid IPv4 subnet mask %q", mask)
+	}
+
+	ones, bits := net.IPMask(ip.To4()).Size()
+	if bits != net.IPv4len*8 || ones < 0 {
+		return 0, fmt.Errorf("non-contiguous IPv4 subnet mask %q", mask)
+	}
+
+	return ones, nil
+}
 
 func indentTemplateBlock(spaces int, value string) string {
 	if value == "" {

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1134,17 +1135,62 @@ func TestNetworkConfigTemplate_InvalidSubnetMask(t *testing.T) {
 	require.ErrorContains(t, err, "non-contiguous IPv4 subnet mask")
 }
 
-func TestNetworkConfigTemplate_InvalidDNS(t *testing.T) {
+func TestHTTPServer_NetworkConfigOmitsGatewayAndInvalidDNS(t *testing.T) {
 	networkTmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "images", "netboot", "assets", "network-config.tmpl"))
 	require.NoError(t, err)
 
-	node := &v1alpha3.Machine{Spec: v1alpha3.MachineSpec{PXE: &v1alpha3.PXESpec{DHCPLeases: []v1alpha3.DHCPLease{{
-		IPv4: "10.0.1.20", MAC: "aa:bb:cc:dd:ee:20", Gateway: "10.0.1.1", SubnetMask: "255.255.255.0",
-		DNS: []string{"not-an-address"},
-	}}}}}
+	const imageRef = "ghcr.io/test/netboot:v1"
 
-	_, err = renderTemplate(string(networkTmpl), newTemplateData(node, ClusterInfo{}, "", "", "10.0.1.20", true))
-	require.ErrorContains(t, err, `invalid IP address "not-an-address"`)
+	cache := setupOCICache(t, imageRef, "network-config", map[string][]byte{
+		"cloud-init/network-config.tmpl": networkTmpl,
+	})
+	node := &v1alpha3.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-on-link"},
+		Spec: v1alpha3.MachineSpec{PXE: &v1alpha3.PXESpec{DHCPLeases: []v1alpha3.DHCPLease{{
+			IPv4: "10.0.1.20", MAC: "aa:bb:cc:dd:ee:20", SubnetMask: "255.255.255.0",
+			DNS: []string{"not-an-address", "10.0.1.53"},
+		}}}},
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(node).
+		WithIndex(&v1alpha3.Machine{}, indexing.IndexNodeByIP, indexing.IndexNodeByIPFunc).
+		Build()
+	server := &HTTPServer{FileResolver: FileResolver{
+		Cache: cache, Reader: fc, Cluster: &StaticClusterInfo{}, DefaultNetbootRef: imageRef,
+	}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", server.handleFile)
+
+	httpServer := httptest.NewServer(mux)
+	defer httpServer.Close()
+
+	request, err := http.NewRequest(http.MethodGet, httpServer.URL+"/cloud-init/network-config", nil)
+	require.NoError(t, err)
+	request.Header.Set("X-Forwarded-For", "10.0.1.20")
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	var config struct {
+		Ethernets map[string]struct {
+			Addresses   []string `yaml:"addresses"`
+			Routes      []any    `yaml:"routes"`
+			Nameservers struct {
+				Addresses []string `yaml:"addresses"`
+			} `yaml:"nameservers"`
+		} `yaml:"ethernets"`
+	}
+	require.NoError(t, yaml.Unmarshal(body, &config), "rendered network configuration:\n%s", body)
+	provisioning := config.Ethernets["provisioning"]
+	require.Equal(t, []string{"10.0.1.20/24"}, provisioning.Addresses)
+	require.Empty(t, provisioning.Routes)
+	require.Equal(t, []string{"10.0.1.53"}, provisioning.Nameservers.Addresses)
 }
 
 func TestGrubTemplate_SelectsBootLeaseByRequestIP(t *testing.T) {

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -1039,6 +1039,7 @@ func TestGrubTemplate_NoInstallRequested(t *testing.T) {
 					MAC:        "aa:bb:cc:dd:ee:20",
 					Gateway:    "10.0.1.1",
 					SubnetMask: "255.255.255.0",
+					DNS:        []string{"10.0.1.53", "10.0.1.54"},
 				}},
 			},
 		},
@@ -1064,6 +1065,7 @@ func TestGrubTemplate_NoInstallRequested(t *testing.T) {
 		"unbounded.image_url=http://10.0.1.1:8080/disk.img.gz",
 		"unbounded.node_name=node-no-operations",
 		"unbounded.boot_mac=aa:bb:cc:dd:ee:20",
+		"unbounded.dns=10.0.1.53,10.0.1.54",
 		"unbounded.disk=/dev/disk/by-id/test-os-disk",
 		"ip=10.0.1.20::10.0.1.1:255.255.255.0:::none",
 	} {
@@ -1073,6 +1075,76 @@ func TestGrubTemplate_NoInstallRequested(t *testing.T) {
 	}
 
 	require.NotContains(t, body, "eth0")
+}
+
+func TestNetworkConfigTemplate_SelectsBootLease(t *testing.T) {
+	networkTmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "images", "netboot", "assets", "network-config.tmpl"))
+	require.NoError(t, err)
+
+	node := &v1alpha3.Machine{
+		Spec: v1alpha3.MachineSpec{
+			PXE: &v1alpha3.PXESpec{
+				DHCPLeases: []v1alpha3.DHCPLease{
+					{IPv4: "10.0.1.20", MAC: "aa:bb:cc:dd:ee:20", Gateway: "10.0.1.1", SubnetMask: "255.255.255.0"},
+					{
+						IPv4:       "10.0.2.21",
+						MAC:        "aa:bb:cc:dd:ee:21",
+						Gateway:    "10.0.2.1",
+						SubnetMask: "255.255.254.0",
+						DNS:        []string{"10.0.2.53", "2001:db8::53"},
+					},
+				},
+			},
+		},
+	}
+
+	data := newTemplateData(node, ClusterInfo{}, "", "", "10.0.2.21", true)
+	result, err := renderTemplate(string(networkTmpl), data)
+	require.NoError(t, err)
+
+	body := string(result)
+	require.Contains(t, body, `macaddress: "aa:bb:cc:dd:ee:21"`)
+	require.Contains(t, body, `- "10.0.2.21/23"`)
+	require.Contains(t, body, `via: "10.0.2.1"`)
+	require.Contains(t, body, `- "10.0.2.53"`)
+	require.Contains(t, body, `- "2001:db8::53"`)
+	require.Contains(t, body, "dhcp4: false")
+	require.Contains(t, body, "dhcp6: false")
+	require.NotContains(t, body, "10.0.1.20")
+}
+
+func TestNetworkConfigTemplate_NoLeaseDisablesDynamicConfiguration(t *testing.T) {
+	networkTmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "images", "netboot", "assets", "network-config.tmpl"))
+	require.NoError(t, err)
+
+	result, err := renderTemplate(string(networkTmpl), newTemplateData(&v1alpha3.Machine{}, ClusterInfo{}, "", "", "", false))
+	require.NoError(t, err)
+	require.Equal(t, "\nversion: 2\nethernets: {}\n", string(result))
+}
+
+func TestNetworkConfigTemplate_InvalidSubnetMask(t *testing.T) {
+	networkTmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "images", "netboot", "assets", "network-config.tmpl"))
+	require.NoError(t, err)
+
+	node := &v1alpha3.Machine{Spec: v1alpha3.MachineSpec{PXE: &v1alpha3.PXESpec{DHCPLeases: []v1alpha3.DHCPLease{{
+		IPv4: "10.0.1.20", MAC: "aa:bb:cc:dd:ee:20", Gateway: "10.0.1.1", SubnetMask: "255.0.255.0",
+	}}}}}
+
+	_, err = renderTemplate(string(networkTmpl), newTemplateData(node, ClusterInfo{}, "", "", "10.0.1.20", true))
+	require.ErrorContains(t, err, "non-contiguous IPv4 subnet mask")
+}
+
+func TestNetworkConfigTemplate_InvalidDNS(t *testing.T) {
+	networkTmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "images", "netboot", "assets", "network-config.tmpl"))
+	require.NoError(t, err)
+
+	node := &v1alpha3.Machine{Spec: v1alpha3.MachineSpec{PXE: &v1alpha3.PXESpec{DHCPLeases: []v1alpha3.DHCPLease{{
+		IPv4: "10.0.1.20", MAC: "aa:bb:cc:dd:ee:20", Gateway: "10.0.1.1", SubnetMask: "255.255.255.0",
+		DNS: []string{"not-an-address"},
+	}}}}}
+
+	_, err = renderTemplate(string(networkTmpl), newTemplateData(node, ClusterInfo{}, "", "", "10.0.1.20", true))
+	require.ErrorContains(t, err, `invalid IP address "not-an-address"`)
 }
 
 func TestGrubTemplate_SelectsBootLeaseByRequestIP(t *testing.T) {


### PR DESCRIPTION
Passes the configured IP address(s) through UEFI firmware into the netboot image and copies them into the host image. New smoke test proves that no DHCP packets are needed to successfully image a machine.