### PR TITLE
[unbounded-system] Operator owns CRD lifecycle and config; harden migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ UNBOUNDED_OPERATOR_BIN=bin/unbounded-operator
 UNBOUNDED_OPERATOR_CMD=./cmd/unbounded-operator
 UNBOUNDED_OPERATOR_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-operator:$(VERSION)
 UNBOUNDED_OPERATOR_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
-UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT ?=
 UNBOUNDED_OPERATOR_MANIFEST_TEMPLATES_DIR := deploy/unbounded-operator
 UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR  := deploy/unbounded-operator/rendered
 
@@ -1016,8 +1015,7 @@ unbounded-operator-manifests: ## Render unbounded-operator manifests into deploy
 		--output-dir $(UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR) \
 		--set Namespace=$(UNBOUNDED_OPERATOR_NAMESPACE) \
 		--set OperatorImage=$(UNBOUNDED_OPERATOR_IMAGE) \
-		--set MetalmanImage=$(METALMAN_IMAGE) \
-		--set APIServerEndpoint=$(UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT)
+		--set MetalmanImage=$(METALMAN_IMAGE)
 	@echo "Rendered unbounded-operator manifests into $(UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR) (image: $(UNBOUNDED_OPERATOR_IMAGE))"
 
 machine-ops-manifests: ## Render machine-ops-controller manifests into deploy/machine-ops/rendered

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ UNBOUNDED_OPERATOR_CMD=./cmd/unbounded-operator
 UNBOUNDED_OPERATOR_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-operator:$(VERSION)
 UNBOUNDED_OPERATOR_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
 UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT ?=
+export UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT
 UNBOUNDED_OPERATOR_MANIFEST_TEMPLATES_DIR := deploy/unbounded-operator
 UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR  := deploy/unbounded-operator/rendered
 
@@ -1017,7 +1018,7 @@ unbounded-operator-manifests: ## Render unbounded-operator manifests into deploy
 		--set Namespace=$(UNBOUNDED_OPERATOR_NAMESPACE) \
 		--set OperatorImage=$(UNBOUNDED_OPERATOR_IMAGE) \
 		--set MetalmanImage=$(METALMAN_IMAGE) \
-		--set APIServerEndpoint=$(UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT)
+		--set "APIServerEndpoint=$${UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT}"
 	@echo "Rendered unbounded-operator manifests into $(UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR) (image: $(UNBOUNDED_OPERATOR_IMAGE))"
 
 machine-ops-manifests: ## Render machine-ops-controller manifests into deploy/machine-ops/rendered

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ UNBOUNDED_OPERATOR_BIN=bin/unbounded-operator
 UNBOUNDED_OPERATOR_CMD=./cmd/unbounded-operator
 UNBOUNDED_OPERATOR_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-operator:$(VERSION)
 UNBOUNDED_OPERATOR_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
+UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT ?=
 UNBOUNDED_OPERATOR_MANIFEST_TEMPLATES_DIR := deploy/unbounded-operator
 UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR  := deploy/unbounded-operator/rendered
 
@@ -1015,7 +1016,8 @@ unbounded-operator-manifests: ## Render unbounded-operator manifests into deploy
 		--output-dir $(UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR) \
 		--set Namespace=$(UNBOUNDED_OPERATOR_NAMESPACE) \
 		--set OperatorImage=$(UNBOUNDED_OPERATOR_IMAGE) \
-		--set MetalmanImage=$(METALMAN_IMAGE)
+		--set MetalmanImage=$(METALMAN_IMAGE) \
+		--set APIServerEndpoint=$(UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT)
 	@echo "Rendered unbounded-operator manifests into $(UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR) (image: $(UNBOUNDED_OPERATOR_IMAGE))"
 
 machine-ops-manifests: ## Render machine-ops-controller manifests into deploy/machine-ops/rendered

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -24,8 +24,6 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	machinamanifests "github.com/Azure/unbounded/deploy/machina"
-	netmanifests "github.com/Azure/unbounded/deploy/net"
 	operatormanifests "github.com/Azure/unbounded/deploy/unbounded-operator"
 	"github.com/Azure/unbounded/internal/kube"
 	"github.com/Azure/unbounded/internal/unbounded"
@@ -41,9 +39,8 @@ type installHandler struct {
 	metalmanImage     string
 	apiServerEndpoint string
 
-	skipCRDs bool
-	wait     bool
-	timeout  time.Duration
+	wait    bool
+	timeout time.Duration
 
 	kubeCli          kubernetes.Interface
 	kubeResourcesCli client.Client
@@ -77,7 +74,6 @@ func addInstallFlags(cmd *cobra.Command, handler *installHandler) {
 	cmd.Flags().StringVar(&handler.operatorImage, "operator-image", "", "unbounded-operator image override")
 	cmd.Flags().StringVar(&handler.metalmanImage, "metalman-image", "", "metalman image override")
 	cmd.Flags().StringVar(&handler.apiServerEndpoint, "api-server-endpoint", "", "Kubernetes API server endpoint advertised to provisioned machines; defaults to the kubeconfig server")
-	cmd.Flags().BoolVar(&handler.skipCRDs, "skip-crds", false, "Skip applying CRDs")
 	cmd.Flags().BoolVar(&handler.wait, "wait", true, "Wait for unbounded-operator rollout")
 	cmd.Flags().DurationVar(&handler.timeout, "timeout", defaultInstallTimeout, "Timeout for rollout waits")
 }
@@ -115,28 +111,20 @@ func (h *installHandler) execute(ctx context.Context) error {
 		h.apiServerEndpoint = h.restConfig.Host
 	}
 
-	if !h.skipCRDs {
-		if err := applyManifestFS(ctx, h.logger, h.kubeResourcesCli, machinamanifests.Manifests, fieldManagerID, mutateCRDOnly); err != nil {
-			return fmt.Errorf("applying machina CRDs: %w", err)
-		}
-
-		if err := applyManifestFS(ctx, h.logger, h.kubeResourcesCli, netmanifests.Manifests, fieldManagerID, mutateCRDOnly); err != nil {
-			return fmt.Errorf("applying net CRDs: %w", err)
-		}
-
-		if h.wait {
-			if err := h.waitForCRDs(ctx); err != nil {
-				return err
-			}
-		}
-	}
-
+	// CRDs are installed and upgraded by the operator itself at startup
+	// (operator.BootstrapCRDs). install only bootstraps the operator; applying
+	// the operator manifests and waiting for its rollout is enough, because the
+	// operator becomes Ready only after it has established the CRDs.
 	if err := applyManifestFS(ctx, h.logger, h.kubeResourcesCli, operatormanifests.Manifests, fieldManagerID, h.mutateOperatorObject); err != nil {
 		return fmt.Errorf("applying unbounded-operator manifests: %w", err)
 	}
 
 	if h.wait {
 		if err := h.waitForOperator(ctx); err != nil {
+			return err
+		}
+
+		if err := h.waitForCRDs(ctx); err != nil {
 			return err
 		}
 	}
@@ -176,6 +164,15 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 	rewriteNamespace(obj, unbounded.SystemNamespace(), h.namespace)
 	setNamespace(obj, h.namespace)
 
+	// The api-server-endpoint is delivered to the operator via the
+	// unbounded-operator-config ConfigMap (envFrom), not a Deployment arg, so
+	// install and the apply-only path share one config surface.
+	if obj.GetKind() == "ConfigMap" && obj.GetName() == "unbounded-operator-config" && h.apiServerEndpoint != "" {
+		if err := unstructured.SetNestedField(obj.Object, h.apiServerEndpoint, "data", "UNBOUNDED_API_SERVER_ENDPOINT"); err != nil {
+			return fmt.Errorf("set operator config api-server-endpoint: %w", err)
+		}
+	}
+
 	if obj.GetKind() == "Deployment" && obj.GetName() == "unbounded-operator" {
 		if err := setContainerImage(obj, "controller", h.operatorImage); err != nil {
 			return err
@@ -188,7 +185,6 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 			{prefix: "--leader-elect-namespace=", value: h.namespace},
 			{prefix: "--namespace=", value: h.namespace},
 			{prefix: "--metalman-image=", value: h.metalmanImage},
-			{prefix: "--api-server-endpoint=", value: h.apiServerEndpoint},
 		} {
 			if err := replaceContainerArg(obj, "controller", replacement.prefix, replacement.value); err != nil {
 				return err
@@ -385,14 +381,6 @@ func yamlFiles(fsys fs.FS) ([]string, error) {
 	sort.Strings(files)
 
 	return files, nil
-}
-
-func mutateCRDOnly(obj *unstructured.Unstructured) error {
-	if obj.GetKind() != "CustomResourceDefinition" {
-		obj.Object = nil
-	}
-
-	return nil
 }
 
 func setNamespace(obj *unstructured.Unstructured, namespace string) {

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -202,7 +202,7 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 		}
 
 		// Stamp the config hash so a changed endpoint rolls the pod (see #3);
-		// this mirrors the render-time hash in 03-deployment.yaml.tmpl.
+		// this mirrors the render-time hash in 04-deployment.yaml.tmpl.
 		if err := unstructured.SetNestedField(obj.Object, operatorConfigHash(h.apiServerEndpoint), "spec", "template", "metadata", "annotations", operatorConfigHashAnnotation); err != nil {
 			return fmt.Errorf("set operator config hash annotation: %w", err)
 		}
@@ -212,7 +212,7 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 }
 
 // operatorConfigHash returns a stable hash of the environment-specific operator
-// config. It mirrors the render-time hash in 03-deployment.yaml.tmpl (sprig's
+// config. It mirrors the render-time hash in 04-deployment.yaml.tmpl (sprig's
 // sha256sum of the endpoint) so both the install path and make-rendered
 // manifests roll the operator when the advertised api-server-endpoint changes.
 func operatorConfigHash(apiServerEndpoint string) string {

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -6,6 +6,8 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
@@ -30,6 +32,14 @@ import (
 )
 
 const defaultInstallTimeout = 5 * time.Minute
+
+// operatorConfigHashAnnotation is stamped onto the operator Deployment pod
+// template so a change to the environment-specific operator config (currently the
+// advertised api-server-endpoint) changes the pod template and triggers a
+// rollout. Without it a re-install that only edits the unbounded-operator-config
+// ConfigMap would not restart the operator, and envFrom is read once at pod
+// start, so the running operator would keep advertising the old endpoint.
+const operatorConfigHashAnnotation = "unbounded-cloud.io/operator-config-hash"
 
 type installHandler struct {
 	kubeconfigPath string
@@ -190,9 +200,25 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 				return err
 			}
 		}
+
+		// Stamp the config hash so a changed endpoint rolls the pod (see #3);
+		// this mirrors the render-time hash in 03-deployment.yaml.tmpl.
+		if err := unstructured.SetNestedField(obj.Object, operatorConfigHash(h.apiServerEndpoint), "spec", "template", "metadata", "annotations", operatorConfigHashAnnotation); err != nil {
+			return fmt.Errorf("set operator config hash annotation: %w", err)
+		}
 	}
 
 	return nil
+}
+
+// operatorConfigHash returns a stable hash of the environment-specific operator
+// config. It mirrors the render-time hash in 03-deployment.yaml.tmpl (sprig's
+// sha256sum of the endpoint) so both the install path and make-rendered
+// manifests roll the operator when the advertised api-server-endpoint changes.
+func operatorConfigHash(apiServerEndpoint string) string {
+	sum := sha256.Sum256([]byte(apiServerEndpoint))
+
+	return hex.EncodeToString(sum[:])
 }
 
 func (h *installHandler) waitForOperator(ctx context.Context) error {
@@ -207,7 +233,7 @@ func (h *installHandler) waitForOperator(ctx context.Context) error {
 			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("get unbounded-operator deployment: %w", err)
 			}
-		} else if deploymentAvailable(deploy) {
+		} else if deploymentRolloutComplete(deploy) {
 			return nil
 		}
 
@@ -289,13 +315,27 @@ func crdEstablished(obj *unstructured.Unstructured) bool {
 	return false
 }
 
-func deploymentAvailable(deploy *appsv1.Deployment) bool {
+// deploymentRolloutComplete reports whether a Deployment rollout has fully
+// completed: the controller has observed the current generation and every
+// replica is updated, present, and available. This is the same condition
+// `kubectl rollout status` waits on.
+//
+// A weaker "available" check (AvailableReplicas >= desired) is not enough during
+// an upgrade: with the default RollingUpdate strategy at replicas: 1 the old
+// ReplicaSet stays Available while a new, possibly crash-looping, pod surges in,
+// so install would report success against the old operator. Requiring
+// Replicas == UpdatedReplicas == AvailableReplicas == desired rejects that case
+// (old replicas gone, the new pod is the only one and is available).
+func deploymentRolloutComplete(deploy *appsv1.Deployment) bool {
 	desired := int32(1)
 	if deploy.Spec.Replicas != nil {
 		desired = *deploy.Spec.Replicas
 	}
 
-	return deploy.Status.ObservedGeneration >= deploy.Generation && deploy.Status.AvailableReplicas >= desired
+	return deploy.Status.ObservedGeneration >= deploy.Generation &&
+		deploy.Status.UpdatedReplicas == desired &&
+		deploy.Status.Replicas == desired &&
+		deploy.Status.AvailableReplicas == desired
 }
 
 func applyManifestFS(ctx context.Context, logger *slog.Logger, k8sClient client.Client, manifests fs.FS, fieldManager string, mutate func(*unstructured.Unstructured) error) error {

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -7,8 +7,11 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -174,4 +177,154 @@ func TestCRDEstablished(t *testing.T) {
 	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	require.NoError(t, err)
 	require.True(t, crdEstablished(&unstructured.Unstructured{Object: unstructuredObj}))
+}
+
+// operatorDeployment builds an unbounded-operator Deployment with the given
+// replica count and rollout status, for the rollout-gate tests.
+func operatorDeployment(status appsv1.DeploymentStatus) *appsv1.Deployment {
+	replicas := int32(1)
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "unbounded-system",
+			Name:       "unbounded-operator",
+			Generation: 2,
+		},
+		Spec:   appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: status,
+	}
+}
+
+func TestDeploymentRolloutComplete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status appsv1.DeploymentStatus
+		want   bool
+	}{
+		{
+			name:   "complete: single updated replica available, no old replicas",
+			status: appsv1.DeploymentStatus{ObservedGeneration: 2, Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+			want:   true,
+		},
+		{
+			// The finding #1 case: the old ReplicaSet is still Available while the
+			// new, crash-looping pod surges in. A weaker AvailableReplicas>=1 check
+			// would wrongly report success here.
+			name:   "upgrade in progress: old available, new surging",
+			status: appsv1.DeploymentStatus{ObservedGeneration: 2, Replicas: 2, UpdatedReplicas: 1, AvailableReplicas: 1},
+			want:   false,
+		},
+		{
+			name:   "new generation not yet observed",
+			status: appsv1.DeploymentStatus{ObservedGeneration: 1, Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+			want:   false,
+		},
+		{
+			name:   "updated but not yet available",
+			status: appsv1.DeploymentStatus{ObservedGeneration: 2, Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 0},
+			want:   false,
+		},
+		{
+			name:   "fresh install not yet rolled out",
+			status: appsv1.DeploymentStatus{},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, deploymentRolloutComplete(operatorDeployment(tt.status)))
+		})
+	}
+}
+
+func TestWaitForOperatorRejectsIncompleteRollout(t *testing.T) {
+	t.Parallel()
+
+	// Old pod Available while the new pod surges in and never becomes ready.
+	deploy := operatorDeployment(appsv1.DeploymentStatus{
+		ObservedGeneration: 2,
+		Replicas:           2,
+		UpdatedReplicas:    1,
+		AvailableReplicas:  1,
+	})
+
+	cli := fakeclient.NewClientBuilder().WithObjects(deploy).Build()
+
+	h := installHandler{
+		namespace:        "unbounded-system",
+		timeout:          200 * time.Millisecond,
+		kubeResourcesCli: cli,
+		logger:           discardLogger(),
+	}
+
+	err := h.waitForOperator(context.Background())
+	require.Error(t, err, "waitForOperator must not report success while the new operator pod is unavailable")
+	require.Contains(t, err.Error(), "unbounded-operator rollout")
+}
+
+func TestWaitForOperatorSucceedsOnCompleteRollout(t *testing.T) {
+	t.Parallel()
+
+	deploy := operatorDeployment(appsv1.DeploymentStatus{
+		ObservedGeneration: 2,
+		Replicas:           1,
+		UpdatedReplicas:    1,
+		AvailableReplicas:  1,
+	})
+
+	cli := fakeclient.NewClientBuilder().WithObjects(deploy).Build()
+
+	h := installHandler{
+		namespace:        "unbounded-system",
+		timeout:          5 * time.Second,
+		kubeResourcesCli: cli,
+		logger:           discardLogger(),
+	}
+
+	require.NoError(t, h.waitForOperator(context.Background()))
+}
+
+func TestMutateOperatorObjectStampsConfigHash(t *testing.T) {
+	t.Parallel()
+
+	newDeploy := func() *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]any{"name": "unbounded-operator", "namespace": "unbounded-system"},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{map[string]any{"name": "controller"}},
+					},
+				},
+			},
+		}}
+	}
+
+	hashOf := func(endpoint string) string {
+		h := &installHandler{namespace: "unbounded-system", apiServerEndpoint: endpoint}
+		obj := newDeploy()
+		require.NoError(t, h.mutateOperatorObject(obj))
+
+		got, found, err := unstructured.NestedString(obj.Object, "spec", "template", "metadata", "annotations", operatorConfigHashAnnotation)
+		require.NoError(t, err)
+		require.True(t, found, "operator config-hash annotation must be stamped on the pod template")
+
+		return got
+	}
+
+	// The stamp is a stable hash of the resolved endpoint, matching the
+	// render-time hash so both install and make-rendered manifests agree.
+	endpoint := "https://api.example.test:6443"
+	require.Equal(t, operatorConfigHash(endpoint), hashOf(endpoint))
+
+	// A changed endpoint changes the hash, which changes the pod template and
+	// therefore triggers a rollout (finding #3).
+	require.NotEqual(t, hashOf(endpoint), hashOf("https://other.example.test:6443"))
 }

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -27,7 +27,6 @@ func TestInstallCommandFlags(t *testing.T) {
 		"operator-image",
 		"metalman-image",
 		"api-server-endpoint",
-		"skip-crds",
 		"wait",
 		"timeout",
 	} {
@@ -40,6 +39,9 @@ func TestInstallCommandFlags(t *testing.T) {
 		"net-node-image",
 		"machina-image",
 		"storage-supervisor-image",
+		// CRDs are now owned by the operator (BootstrapCRDs); install no longer
+		// applies them, so --skip-crds is gone.
+		"skip-crds",
 	} {
 		require.Nil(t, cmd.Flags().Lookup(name), "flag %s should be removed", name)
 	}
@@ -88,9 +90,31 @@ func TestInstallHandlerApplyBootstrapManifests(t *testing.T) {
 	}
 
 	require.NoError(t, h.execute(context.Background()))
-	require.Contains(t, applied, "sites.unbounded-cloud.io")
-	require.Contains(t, applied, "gatewaypools.net.unbounded-cloud.io")
+	// install applies only the operator manifests; CRDs are installed by the
+	// operator at startup (BootstrapCRDs), so install must NOT apply them.
 	require.Contains(t, applied, "unbounded-operator")
+	require.Contains(t, applied, "unbounded-operator-config")
+	require.NotContains(t, applied, "sites.unbounded-cloud.io")
+	require.NotContains(t, applied, "gatewaypools.net.unbounded-cloud.io")
+}
+
+func TestMutateOperatorObjectWritesConfigEndpoint(t *testing.T) {
+	t.Parallel()
+
+	h := &installHandler{namespace: "unbounded-system", apiServerEndpoint: "https://api.example.test:6443"}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "unbounded-operator-config", "namespace": "unbounded-system"},
+		"data":       map[string]any{"UNBOUNDED_API_SERVER_ENDPOINT": ""},
+	}}
+
+	require.NoError(t, h.mutateOperatorObject(obj))
+
+	got, _, err := unstructured.NestedString(obj.Object, "data", "UNBOUNDED_API_SERVER_ENDPOINT")
+	require.NoError(t, err)
+	require.Equal(t, "https://api.example.test:6443", got)
 }
 
 func TestMutateOperatorObjectRetargetsNamespace(t *testing.T) {

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -70,11 +70,14 @@ func TestInstallHandlerApplyBootstrapManifests(t *testing.T) {
 	cli := fakeclient.NewClientBuilder().
 		WithInterceptorFuncs(interceptor.Funcs{
 			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
-				named, ok := obj.(interface{ GetName() string })
+				named, ok := obj.(interface {
+					GetKind() string
+					GetName() string
+				})
 				if ok {
 					mu.Lock()
 
-					applied = append(applied, named.GetName())
+					applied = append(applied, named.GetKind()+"/"+named.GetName())
 					mu.Unlock()
 				}
 
@@ -95,10 +98,25 @@ func TestInstallHandlerApplyBootstrapManifests(t *testing.T) {
 	require.NoError(t, h.execute(context.Background()))
 	// install applies only the operator manifests; CRDs are installed by the
 	// operator at startup (BootstrapCRDs), so install must NOT apply them.
-	require.Contains(t, applied, "unbounded-operator")
-	require.Contains(t, applied, "unbounded-operator-config")
-	require.NotContains(t, applied, "sites.unbounded-cloud.io")
-	require.NotContains(t, applied, "gatewaypools.net.unbounded-cloud.io")
+	require.Contains(t, applied, "Deployment/unbounded-operator")
+	require.Contains(t, applied, "ConfigMap/unbounded-operator-config")
+	require.NotContains(t, applied, "CustomResourceDefinition/sites.unbounded-cloud.io")
+	require.NotContains(t, applied, "CustomResourceDefinition/gatewaypools.net.unbounded-cloud.io")
+	require.Less(t,
+		indexOf(applied, "ConfigMap/unbounded-operator-config"),
+		indexOf(applied, "Deployment/unbounded-operator"),
+		"operator ConfigMap must be applied before its Deployment",
+	)
+}
+
+func indexOf(values []string, want string) int {
+	for i, value := range values {
+		if value == want {
+			return i
+		}
+	}
+
+	return -1
 }
 
 func TestMutateOperatorObjectWritesConfigEndpoint(t *testing.T) {

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -35,16 +35,33 @@ import (
 )
 
 func main() {
+	cmd := newCommand(run)
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newCommand(runFn func(context.Context, config) error) *cobra.Command {
 	var cfg config
 
 	cmd := &cobra.Command{
 		Use:   "unbounded-operator",
 		Short: "Controller for top-level Unbounded Site configuration",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !cmd.Flags().Changed("reap-legacy-resources") {
+				reapLegacyResources, err := envBoolDefault("UNBOUNDED_REAP_LEGACY_RESOURCES", true)
+				if err != nil {
+					return err
+				}
+
+				cfg.reapLegacyResources = reapLegacyResources
+			}
+
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer cancel()
 
-			return run(ctx, cfg)
+			return runFn(ctx, cfg)
 		},
 		Version: version.Version + " (commit: " + version.GitCommit + ")",
 	}
@@ -56,14 +73,11 @@ func main() {
 	cmd.Flags().StringVar(&cfg.namespace, "namespace", unbounded.SystemNamespace(), "Namespace the operator reconciles components into and migrates legacy state to")
 	cmd.Flags().StringVar(&cfg.metalmanImage, "metalman-image", "", "Default metalman image")
 	cmd.Flags().StringVar(&cfg.apiServerEndpoint, "api-server-endpoint", os.Getenv("UNBOUNDED_API_SERVER_ENDPOINT"), "Kubernetes API server endpoint advertised by machina (defaults to $UNBOUNDED_API_SERVER_ENDPOINT)")
-	cmd.Flags().BoolVar(&cfg.reapLegacyResources, "reap-legacy-resources", envBoolDefault("UNBOUNDED_REAP_LEGACY_RESOURCES", true), "Translate legacy net-group Sites, migrate state into unbounded-system, and reap the pre-consolidation namespaces (defaults to $UNBOUNDED_REAP_LEGACY_RESOURCES or true)")
+	cmd.Flags().BoolVar(&cfg.reapLegacyResources, "reap-legacy-resources", true, "Translate legacy net-group Sites, migrate state into unbounded-system, and reap the pre-consolidation namespaces (defaults to $UNBOUNDED_REAP_LEGACY_RESOURCES or true)")
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
 
-	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
+	return cmd
 }
 
 type config struct {
@@ -78,21 +92,19 @@ type config struct {
 }
 
 // envBoolDefault returns the boolean value of the named environment variable, or
-// fallback when it is unset or not parseable. It lets operator flags default from
-// the unbounded-operator-config ConfigMap (surfaced via envFrom) while keeping an
-// explicit flag as an override.
-func envBoolDefault(name string, fallback bool) bool {
+// fallback when it is unset. Set values must be valid booleans.
+func envBoolDefault(name string, fallback bool) (bool, error) {
 	raw, ok := os.LookupEnv(name)
-	if !ok || raw == "" {
-		return fallback
+	if !ok {
+		return fallback, nil
 	}
 
 	value, err := strconv.ParseBool(raw)
 	if err != nil {
-		return fallback
+		return false, fmt.Errorf("parse %s: %w", name, err)
 	}
 
-	return value
+	return value, nil
 }
 
 func run(ctx context.Context, cfg config) error {
@@ -147,12 +159,13 @@ func run(ctx context.Context, cfg config) error {
 
 	if cfg.reapLegacyResources {
 		reaper := &operator.LegacyReaper{
-			Client:           mgr.GetClient(),
-			TargetNamespace:  namespace,
-			LegacyNamespaces: operator.LegacyNamespaces,
-			SkipSecretNames:  map[string]struct{}{"unbounded-net-serving-cert": {}},
-			CopyConfigMaps:   []string{"machina-config"},
-			Recorder:         mgr.GetEventRecorderFor("unbounded-operator-reaper"),
+			Client:            mgr.GetClient(),
+			TargetNamespace:   namespace,
+			LegacyNamespaces:  operator.LegacyNamespaces,
+			SkipSecretNames:   map[string]struct{}{"unbounded-net-serving-cert": {}},
+			CopyConfigMaps:    []string{"machina-config"},
+			APIServerEndpoint: cfg.apiServerEndpoint,
+			Recorder:          mgr.GetEventRecorder("unbounded-operator-reaper"),
 		}
 		if err := reaper.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("setup legacy reaper: %w", err)

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -21,6 +22,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -53,8 +55,8 @@ func main() {
 	cmd.Flags().StringVar(&cfg.leaderElectionNamespace, "leader-elect-namespace", unbounded.SystemNamespace(), "Namespace for the leader election lease")
 	cmd.Flags().StringVar(&cfg.namespace, "namespace", unbounded.SystemNamespace(), "Namespace the operator reconciles components into and migrates legacy state to")
 	cmd.Flags().StringVar(&cfg.metalmanImage, "metalman-image", "", "Default metalman image")
-	cmd.Flags().StringVar(&cfg.apiServerEndpoint, "api-server-endpoint", "", "Kubernetes API server endpoint advertised by machina")
-	cmd.Flags().BoolVar(&cfg.reapLegacyResources, "reap-legacy-resources", true, "Translate legacy net-group Sites, migrate state into unbounded-system, and reap the pre-consolidation namespaces")
+	cmd.Flags().StringVar(&cfg.apiServerEndpoint, "api-server-endpoint", os.Getenv("UNBOUNDED_API_SERVER_ENDPOINT"), "Kubernetes API server endpoint advertised by machina (defaults to $UNBOUNDED_API_SERVER_ENDPOINT)")
+	cmd.Flags().BoolVar(&cfg.reapLegacyResources, "reap-legacy-resources", envBoolDefault("UNBOUNDED_REAP_LEGACY_RESOURCES", true), "Translate legacy net-group Sites, migrate state into unbounded-system, and reap the pre-consolidation namespaces (defaults to $UNBOUNDED_REAP_LEGACY_RESOURCES or true)")
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
 
@@ -75,6 +77,24 @@ type config struct {
 	reapLegacyResources     bool
 }
 
+// envBoolDefault returns the boolean value of the named environment variable, or
+// fallback when it is unset or not parseable. It lets operator flags default from
+// the unbounded-operator-config ConfigMap (surfaced via envFrom) while keeping an
+// explicit flag as an override.
+func envBoolDefault(name string, fallback bool) bool {
+	raw, ok := os.LookupEnv(name)
+	if !ok || raw == "" {
+		return fallback
+	}
+
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return fallback
+	}
+
+	return value
+}
+
 func run(ctx context.Context, cfg config) error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -85,7 +105,22 @@ func run(ctx context.Context, cfg config) error {
 		namespace = unbounded.SystemNamespace()
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+
+	// Install/upgrade the CRDs before starting the manager: the typed Site
+	// informer cannot sync until the Site CRD is served, and the operator owns
+	// CRD lifecycle so a cluster can be maintained by applying the operator
+	// manifests alone. This runs on every start and is idempotent.
+	bootstrapClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("create bootstrap client: %w", err)
+	}
+
+	if err := operator.BootstrapCRDs(ctx, bootstrapClient); err != nil {
+		return fmt.Errorf("bootstrap CRDs: %w", err)
+	}
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                        scheme,
 		Metrics:                       metricsserver.Options{BindAddress: cfg.metricsAddr},
 		HealthProbeBindAddress:        cfg.probeAddr,
@@ -117,6 +152,7 @@ func run(ctx context.Context, cfg config) error {
 			LegacyNamespaces: operator.LegacyNamespaces,
 			SkipSecretNames:  map[string]struct{}{"unbounded-net-serving-cert": {}},
 			CopyConfigMaps:   []string{"machina-config"},
+			Recorder:         mgr.GetEventRecorderFor("unbounded-operator-reaper"),
 		}
 		if err := reaper.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("setup legacy reaper: %w", err)

--- a/cmd/unbounded-operator/main_test.go
+++ b/cmd/unbounded-operator/main_test.go
@@ -3,35 +3,107 @@
 
 package main
 
-import "testing"
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
 
-func TestEnvBoolDefault(t *testing.T) {
+func TestReapLegacyResourcesConfiguration(t *testing.T) {
 	cases := []struct {
-		name     string
-		set      bool
-		value    string
-		fallback bool
-		want     bool
+		name    string
+		setEnv  bool
+		env     string
+		args    []string
+		want    bool
+		wantErr bool
 	}{
-		{name: "unset uses fallback true", set: false, fallback: true, want: true},
-		{name: "unset uses fallback false", set: false, fallback: false, want: false},
-		{name: "empty uses fallback", set: true, value: "", fallback: true, want: true},
-		{name: "explicit false overrides", set: true, value: "false", fallback: true, want: false},
-		{name: "explicit true overrides", set: true, value: "true", fallback: false, want: true},
-		{name: "unparseable uses fallback", set: true, value: "notabool", fallback: true, want: true},
+		{name: "unset defaults true", want: true},
+		{name: "valid false environment", setEnv: true, env: "false", want: false},
+		{name: "valid true environment", setEnv: true, env: "true", want: true},
+		{name: "empty environment errors", setEnv: true, env: "", wantErr: true},
+		{name: "invalid environment errors", setEnv: true, env: "notabool", wantErr: true},
+		{
+			name:   "explicit flag overrides malformed environment",
+			setEnv: true,
+			env:    "notabool",
+			args:   []string{"--reap-legacy-resources=false"},
+			want:   false,
+		},
 	}
 
-	const key = "UNBOUNDED_TEST_BOOL"
+	const key = "UNBOUNDED_REAP_LEGACY_RESOURCES"
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.set {
-				t.Setenv(key, tc.value)
+			if tc.setEnv {
+				t.Setenv(key, tc.env)
+			} else {
+				unsetenv(t, key)
 			}
 
-			if got := envBoolDefault(key, tc.fallback); got != tc.want {
-				t.Fatalf("envBoolDefault = %v, want %v", got, tc.want)
+			called := false
+
+			var got config
+
+			cmd := newCommand(func(_ context.Context, cfg config) error {
+				called = true
+				got = cfg
+
+				return nil
+			})
+			cmd.SetArgs(tc.args)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+
+			err := cmd.Execute()
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), key) {
+					t.Fatalf("Execute error = %v, want error naming %s", err, key)
+				}
+
+				if called {
+					t.Fatal("runner called after environment parsing error")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+
+			if !called {
+				t.Fatal("runner was not called")
+			}
+
+			if got.reapLegacyResources != tc.want {
+				t.Fatalf("reapLegacyResources = %v, want %v", got.reapLegacyResources, tc.want)
 			}
 		})
 	}
+}
+
+func unsetenv(t *testing.T, key string) {
+	t.Helper()
+
+	value, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+
+	t.Cleanup(func() {
+		if ok {
+			if err := os.Setenv(key, value); err != nil {
+				t.Errorf("restore %s: %v", key, err)
+			}
+
+			return
+		}
+
+		if err := os.Unsetenv(key); err != nil {
+			t.Errorf("unset %s during cleanup: %v", key, err)
+		}
+	})
 }

--- a/cmd/unbounded-operator/main_test.go
+++ b/cmd/unbounded-operator/main_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import "testing"
+
+func TestEnvBoolDefault(t *testing.T) {
+	cases := []struct {
+		name     string
+		set      bool
+		value    string
+		fallback bool
+		want     bool
+	}{
+		{name: "unset uses fallback true", set: false, fallback: true, want: true},
+		{name: "unset uses fallback false", set: false, fallback: false, want: false},
+		{name: "empty uses fallback", set: true, value: "", fallback: true, want: true},
+		{name: "explicit false overrides", set: true, value: "false", fallback: true, want: false},
+		{name: "explicit true overrides", set: true, value: "true", fallback: false, want: true},
+		{name: "unparseable uses fallback", set: true, value: "notabool", fallback: true, want: true},
+	}
+
+	const key = "UNBOUNDED_TEST_BOOL"
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(key, tc.value)
+			}
+
+			if got := envBoolDefault(key, tc.fallback); got != tc.want {
+				t.Fatalf("envBoolDefault = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/deploy/unbounded-operator/02-rbac.yaml.tmpl
+++ b/deploy/unbounded-operator/02-rbac.yaml.tmpl
@@ -22,6 +22,9 @@ rules:
   - apiGroups: ["net.unbounded-cloud.io"]
     resources: ["sites"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["net.unbounded-cloud.io"]
+    resources: ["sitenodeslices"]
+    verbs: ["get", "list", "watch"]
   # Cluster-scoped custom resources whose embedded secret references are
   # repointed from the legacy namespaces to unbounded-system.
   - apiGroups: ["unbounded-cloud.io"]
@@ -33,9 +36,15 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces", "serviceaccounts", "configmaps", "services", "secrets"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete", "deletecollection"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "daemonsets"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete", "deletecollection"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
     # escalate + bind let the operator install the component RBAC (net,
@@ -56,6 +65,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/unbounded-operator/03-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/03-configmap.yaml.tmpl
@@ -25,7 +25,7 @@ data:
   # cannot be derived in-cluster. Set this before enabling machina provisioning.
   # Rendered from .APIServerEndpoint so make/GitOps deploys can set it via
   # --set APIServerEndpoint=; `kubectl unbounded install` overrides it in place.
-  UNBOUNDED_API_SERVER_ENDPOINT: "{{ default "" .APIServerEndpoint }}"
+  UNBOUNDED_API_SERVER_ENDPOINT: {{ default "" .APIServerEndpoint | quote }}
   # Whether the operator translates legacy net-group Sites, migrates state into
   # this namespace, and reaps the pre-consolidation namespaces.
   UNBOUNDED_REAP_LEGACY_RESOURCES: "true"

--- a/deploy/unbounded-operator/03-deployment.yaml.tmpl
+++ b/deploy/unbounded-operator/03-deployment.yaml.tmpl
@@ -20,6 +20,13 @@ spec:
       labels:
         app.kubernetes.io/name: unbounded-operator
         app.kubernetes.io/component: controller
+      annotations:
+        # Rolls the operator when the advertised api-server-endpoint changes at
+        # render time. envFrom is read once at pod start, so without a pod-template
+        # change a re-render with a new endpoint would not restart the operator.
+        # The `kubectl unbounded install` path stamps the same annotation. See
+        # deploy/unbounded-operator/04-configmap.yaml.tmpl.
+        unbounded-cloud.io/operator-config-hash: {{ default "" .APIServerEndpoint | sha256sum }}
     spec:
       serviceAccountName: unbounded-operator
       containers:
@@ -52,6 +59,18 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+          startupProbe:
+            # The operator installs/establishes CRDs at startup
+            # (operator.BootstrapCRDs, crdEstablishedTimeout ~= 2m) before the
+            # manager starts and binds the health server, so /healthz is not
+            # served during bootstrap. Give startup up to 150s (30 x 5s), which
+            # exceeds the bootstrap timeout, before liveness takes over; otherwise
+            # liveness would restart the container mid-bootstrap.
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/unbounded-operator/03-deployment.yaml.tmpl
+++ b/deploy/unbounded-operator/03-deployment.yaml.tmpl
@@ -31,7 +31,11 @@ spec:
             - --leader-elect-namespace={{ default "unbounded-system" .Namespace }}
             - --namespace={{ default "unbounded-system" .Namespace }}
             - --metalman-image={{ .MetalmanImage }}
-            - --api-server-endpoint={{ default "" .APIServerEndpoint }}
+          envFrom:
+            # Environment-specific operator settings (api-server-endpoint, reaper
+            # toggle). See deploy/unbounded-operator/04-configmap.yaml.tmpl.
+            - configMapRef:
+                name: unbounded-operator-config
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deploy/unbounded-operator/04-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/04-configmap.yaml.tmpl
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+# unbounded-operator-config holds the environment-specific operator settings that
+# used to be passed as `kubectl unbounded install` flags. It is surfaced to the
+# operator Deployment via envFrom, and each operator flag defaults from the
+# matching env var (an explicit flag still overrides). Edit this ConfigMap and
+# then `kubectl rollout restart deployment/unbounded-operator` to apply changes:
+# env is read once at pod start.
+#
+# Release-baked settings (operator image, component images, metalman image) are
+# NOT here; they are version-matched into the manifests at build time.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbounded-operator-config
+  namespace: {{ default "unbounded-system" .Namespace }}
+  labels:
+    app.kubernetes.io/name: unbounded-operator
+    app.kubernetes.io/component: controller
+data:
+  # External Kubernetes API endpoint advertised to provisioned machines. Remote
+  # nodes dial this to join, so it must be reachable from outside the cluster and
+  # cannot be derived in-cluster. Set this before enabling machina provisioning.
+  UNBOUNDED_API_SERVER_ENDPOINT: ""
+  # Whether the operator translates legacy net-group Sites, migrates state into
+  # this namespace, and reaps the pre-consolidation namespaces.
+  UNBOUNDED_REAP_LEGACY_RESOURCES: "true"

--- a/deploy/unbounded-operator/04-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/04-configmap.yaml.tmpl
@@ -23,7 +23,9 @@ data:
   # External Kubernetes API endpoint advertised to provisioned machines. Remote
   # nodes dial this to join, so it must be reachable from outside the cluster and
   # cannot be derived in-cluster. Set this before enabling machina provisioning.
-  UNBOUNDED_API_SERVER_ENDPOINT: ""
+  # Rendered from .APIServerEndpoint so make/GitOps deploys can set it via
+  # --set APIServerEndpoint=; `kubectl unbounded install` overrides it in place.
+  UNBOUNDED_API_SERVER_ENDPOINT: "{{ default "" .APIServerEndpoint }}"
   # Whether the operator translates legacy net-group Sites, migrates state into
   # this namespace, and reaps the pre-consolidation namespaces.
   UNBOUNDED_REAP_LEGACY_RESOURCES: "true"

--- a/deploy/unbounded-operator/04-deployment.yaml.tmpl
+++ b/deploy/unbounded-operator/04-deployment.yaml.tmpl
@@ -25,8 +25,8 @@ spec:
         # render time. envFrom is read once at pod start, so without a pod-template
         # change a re-render with a new endpoint would not restart the operator.
         # The `kubectl unbounded install` path stamps the same annotation. See
-        # deploy/unbounded-operator/04-configmap.yaml.tmpl.
-        unbounded-cloud.io/operator-config-hash: {{ default "" .APIServerEndpoint | sha256sum }}
+        # deploy/unbounded-operator/03-configmap.yaml.tmpl.
+        unbounded-cloud.io/operator-config-hash: {{ default "" .APIServerEndpoint | sha256sum | quote }}
     spec:
       serviceAccountName: unbounded-operator
       containers:
@@ -40,7 +40,7 @@ spec:
             - --metalman-image={{ .MetalmanImage }}
           envFrom:
             # Environment-specific operator settings (api-server-endpoint, reaper
-            # toggle). See deploy/unbounded-operator/04-configmap.yaml.tmpl.
+            # toggle). See deploy/unbounded-operator/03-configmap.yaml.tmpl.
             - configMapRef:
                 name: unbounded-operator-config
           env:
@@ -60,17 +60,16 @@ spec:
               cpu: 50m
               memory: 64Mi
           startupProbe:
-            # The operator installs/establishes CRDs at startup
-            # (operator.BootstrapCRDs, crdEstablishedTimeout ~= 2m) before the
+            # The operator applies and establishes CRDs at startup
+            # (operator.BootstrapCRDs, CRDBootstrapTimeout = 4m) before the
             # manager starts and binds the health server, so /healthz is not
-            # served during bootstrap. Give startup up to 150s (30 x 5s), which
-            # exceeds the bootstrap timeout, before liveness takes over; otherwise
-            # liveness would restart the container mid-bootstrap.
+            # served during bootstrap. Give startup up to 270s (54 x 5s), which
+            # exceeds the full bootstrap timeout, before liveness takes over.
             httpGet:
               path: /healthz
               port: health
             periodSeconds: 5
-            failureThreshold: 30
+            failureThreshold: 54
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/unbounded-operator/render_test.go
+++ b/deploy/unbounded-operator/render_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package unboundedoperator
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Azure/unbounded/hack/cmd/render-manifests/render"
+)
+
+// TestOperatorConfigEndpointAndHashRender asserts the make/GitOps render path
+// (`--set APIServerEndpoint=`) both populates the operator-config ConfigMap
+// endpoint and stamps a matching config-hash annotation on the Deployment pod
+// template. Together these make a re-render with a changed endpoint roll the
+// operator (envFrom is read once at pod start), and the shared hash keeps the
+// two templates from drifting apart (findings #3/#4).
+func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
+	t.Parallel()
+
+	const endpoint = "https://api.example.test:6443"
+
+	templatesDir := filepath.Join(repoRoot(t), "deploy", "unbounded-operator")
+	outputDir := t.TempDir()
+
+	data := map[string]string{
+		"Namespace":         "unbounded-system",
+		"OperatorImage":     "operator:test",
+		"MetalmanImage":     "metalman:test",
+		"APIServerEndpoint": endpoint,
+	}
+	if err := render.Render(templatesDir, outputDir, data); err != nil {
+		t.Fatalf("render.Render: %v", err)
+	}
+
+	// The ConfigMap carries the endpoint that the operator reads via envFrom.
+	var cm struct {
+		Data map[string]string `yaml:"data"`
+	}
+
+	readYAML(t, filepath.Join(outputDir, "04-configmap.yaml"), &cm)
+
+	if got := cm.Data["UNBOUNDED_API_SERVER_ENDPOINT"]; got != endpoint {
+		t.Fatalf("configmap UNBOUNDED_API_SERVER_ENDPOINT = %q, want %q", got, endpoint)
+	}
+
+	// The Deployment pod template carries the matching hash annotation.
+	var deploy struct {
+		Spec struct {
+			Template struct {
+				Metadata struct {
+					Annotations map[string]string `yaml:"annotations"`
+				} `yaml:"metadata"`
+			} `yaml:"template"`
+		} `yaml:"spec"`
+	}
+
+	readYAML(t, filepath.Join(outputDir, "03-deployment.yaml"), &deploy)
+
+	sum := sha256.Sum256([]byte(endpoint))
+	want := hex.EncodeToString(sum[:])
+
+	if got := deploy.Spec.Template.Metadata.Annotations["unbounded-cloud.io/operator-config-hash"]; got != want {
+		t.Fatalf("deployment operator-config-hash annotation = %q, want %q (sha256 of endpoint)", got, want)
+	}
+}
+
+func readYAML(t *testing.T, path string, out any) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	if err := yaml.Unmarshal(raw, out); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("reached filesystem root without finding go.mod (started at %s)", filepath.Dir(file))
+		}
+
+		dir = parent
+	}
+}

--- a/deploy/unbounded-operator/render_test.go
+++ b/deploy/unbounded-operator/render_test.go
@@ -10,10 +10,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/Azure/unbounded/hack/cmd/render-manifests/render"
+	"github.com/Azure/unbounded/internal/operator"
 )
 
 // TestOperatorConfigEndpointAndHashRender asserts the make/GitOps render path
@@ -25,7 +27,7 @@ import (
 func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 	t.Parallel()
 
-	const endpoint = "https://api.example.test:6443"
+	const endpoint = `https://api.example.test:6443/path?mode="strict"&ready=true`
 
 	templatesDir := filepath.Join(repoRoot(t), "deploy", "unbounded-operator")
 	outputDir := t.TempDir()
@@ -45,7 +47,7 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 		Data map[string]string `yaml:"data"`
 	}
 
-	readYAML(t, filepath.Join(outputDir, "04-configmap.yaml"), &cm)
+	readYAML(t, filepath.Join(outputDir, "03-configmap.yaml"), &cm)
 
 	if got := cm.Data["UNBOUNDED_API_SERVER_ENDPOINT"]; got != endpoint {
 		t.Fatalf("configmap UNBOUNDED_API_SERVER_ENDPOINT = %q, want %q", got, endpoint)
@@ -58,11 +60,20 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 				Metadata struct {
 					Annotations map[string]string `yaml:"annotations"`
 				} `yaml:"metadata"`
+				Spec struct {
+					Containers []struct {
+						Name         string `yaml:"name"`
+						StartupProbe *struct {
+							PeriodSeconds    int32 `yaml:"periodSeconds"`
+							FailureThreshold int32 `yaml:"failureThreshold"`
+						} `yaml:"startupProbe"`
+					} `yaml:"containers"`
+				} `yaml:"spec"`
 			} `yaml:"template"`
 		} `yaml:"spec"`
 	}
 
-	readYAML(t, filepath.Join(outputDir, "03-deployment.yaml"), &deploy)
+	readYAML(t, filepath.Join(outputDir, "04-deployment.yaml"), &deploy)
 
 	sum := sha256.Sum256([]byte(endpoint))
 	want := hex.EncodeToString(sum[:])
@@ -70,6 +81,76 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 	if got := deploy.Spec.Template.Metadata.Annotations["unbounded-cloud.io/operator-config-hash"]; got != want {
 		t.Fatalf("deployment operator-config-hash annotation = %q, want %q (sha256 of endpoint)", got, want)
 	}
+
+	for _, container := range deploy.Spec.Template.Spec.Containers {
+		if container.Name != "controller" || container.StartupProbe == nil {
+			continue
+		}
+
+		budget := time.Duration(container.StartupProbe.FailureThreshold) *
+			time.Duration(container.StartupProbe.PeriodSeconds) * time.Second
+		if budget <= operator.CRDBootstrapTimeout {
+			t.Fatalf("startup probe budget = %s, must exceed CRD bootstrap timeout %s", budget, operator.CRDBootstrapTimeout)
+		}
+
+		return
+	}
+
+	t.Fatal("controller startup probe not found")
+}
+
+func TestOperatorRBACIncludesCachedReadKinds(t *testing.T) {
+	t.Parallel()
+
+	outputDir := t.TempDir()
+	if err := render.Render(filepath.Join(repoRoot(t), "deploy", "unbounded-operator"), outputDir, map[string]string{
+		"Namespace":     "unbounded-system",
+		"OperatorImage": "operator:test",
+		"MetalmanImage": "metalman:test",
+	}); err != nil {
+		t.Fatalf("render.Render: %v", err)
+	}
+
+	var role struct {
+		Rules []struct {
+			APIGroups []string `yaml:"apiGroups"`
+			Resources []string `yaml:"resources"`
+			Verbs     []string `yaml:"verbs"`
+		} `yaml:"rules"`
+	}
+	readYAML(t, filepath.Join(outputDir, "02-rbac.yaml"), &role)
+
+	assertReadOnlyRule := func(group, resource string) {
+		t.Helper()
+
+		for _, rule := range role.Rules {
+			if len(rule.APIGroups) != 1 || rule.APIGroups[0] != group || len(rule.Resources) != 1 || rule.Resources[0] != resource {
+				continue
+			}
+
+			if len(rule.Verbs) != 3 || rule.Verbs[0] != "get" || rule.Verbs[1] != "list" || rule.Verbs[2] != "watch" {
+				t.Fatalf("%s/%s verbs = %v, want [get list watch]", group, resource, rule.Verbs)
+			}
+
+			return
+		}
+
+		t.Fatalf("read-only RBAC rule for %s/%s not found", group, resource)
+	}
+
+	assertReadOnlyRule("apps", "statefulsets")
+	assertReadOnlyRule("", "nodes")
+	assertReadOnlyRule("net.unbounded-cloud.io", "sitenodeslices")
+
+	for _, rule := range role.Rules {
+		if len(rule.APIGroups) == 1 && rule.APIGroups[0] == "events.k8s.io" &&
+			len(rule.Resources) == 1 && rule.Resources[0] == "events" &&
+			len(rule.Verbs) == 3 && rule.Verbs[0] == "create" && rule.Verbs[1] == "patch" && rule.Verbs[2] == "update" {
+			return
+		}
+	}
+
+	t.Fatal("events.k8s.io Event writer RBAC rule not found")
 }
 
 func readYAML(t *testing.T, path string, out any) {

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -50,9 +50,11 @@ below.
 ### `kubectl unbounded install`
 
 Bootstrap a cluster with the Unbounded CRDs and `unbounded-operator`. This
-command applies the machina CRDs, the net CRDs, and the operator manifests. It
-does not deploy component workloads directly; the operator reconciles those from
-`Site.spec.components` after Sites are created or updated.
+command applies the operator manifests and waits for the operator to roll out.
+The operator itself installs and upgrades the machina and net CRDs at startup, so
+`install` no longer applies CRDs directly. It does not deploy component workloads
+directly; the operator reconciles those from `Site.spec.components` after Sites
+are created or updated.
 
 ```bash
 kubectl unbounded install
@@ -64,10 +66,13 @@ Optional flags:
 |------|------|---------|-------------|
 | `--kubeconfig` | `string` | `$KUBECONFIG` or default | Path to kubeconfig file |
 | `--namespace` | `string` | `unbounded-system` | Namespace for the operator and default components |
-| `--skip-crds` | `bool` | `false` | Skip applying CRDs |
-| `--wait` | `bool` | `true` | Wait for the operator rollout |
+| `--wait` | `bool` | `true` | Wait for the operator rollout and CRD establishment |
 | `--timeout` | `duration` | `5m0s` | Timeout for rollout waits |
 | `--api-server-endpoint` | `string` | kubeconfig server | API server endpoint advertised to provisioned machines |
+
+> **Breaking change:** the `--skip-crds` flag has been removed. CRDs are now owned
+> and installed by the operator at startup (`operator.BootstrapCRDs`), so there is
+> nothing for `install` to skip. Automation passing `--skip-crds` must drop it.
 
 The image flags (`--operator-image` and `--metalman-image`) override the images
 embedded in the release manifests.

--- a/e2e/operator/reaper_e2e_test.go
+++ b/e2e/operator/reaper_e2e_test.go
@@ -18,6 +18,8 @@ package operatore2e
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -148,7 +150,9 @@ func stageLegacyWorkloads(ctx context.Context, t *testing.T, cli client.Client) 
 	// Legacy workloads only need to EXIST to have a footprint; keep them inert
 	// (0 replicas / unschedulable DaemonSets) so kind stays light.
 	mustCreate(ctx, t, cli, inertDeployment(legacyKube, "machina-controller", map[string]string{"app": "machina-controller"}))
-	mustCreate(ctx, t, cli, inertDeployment(legacyKube, "metalman-controller-edge", map[string]string{"app": "unbounded-pxe", unboundedv1alpha3.MachineSiteLabelKey: "edge"}))
+	metalman := inertDeployment(legacyKube, "metalman-controller-edge", map[string]string{"app": "unbounded-pxe", unboundedv1alpha3.MachineSiteLabelKey: "edge"})
+	metalman.Spec.Template.Spec.Containers[0].Args = []string{"serve-pxe", "--site=edge", "--dhcp-auto-interface"}
+	mustCreate(ctx, t, cli, metalman)
 	mustCreate(ctx, t, cli, unschedulableDaemonSet(legacyKube, "unbounded-storage-supervisor", map[string]string{"app.kubernetes.io/name": "unbounded-storage-supervisor"}))
 	mustCreate(ctx, t, cli, inertDeployment(legacyNet, "unbounded-net-controller", map[string]string{"app.kubernetes.io/name": "unbounded-net-controller"}))
 	mustCreate(ctx, t, cli, unschedulableDaemonSet(legacyNet, "unbounded-net-node", map[string]string{"app.kubernetes.io/name": "unbounded-net-node"}))
@@ -211,7 +215,12 @@ func stageTargetWorkloads(ctx context.Context, t *testing.T, cli client.Client) 
 
 	// New target workloads run as pause pods so they actually become Ready in
 	// kind, satisfying the reaper's per-component health gate.
-	mustCreate(ctx, t, cli, readyDeployment(targetNS, "machina-controller"))
+	config := "apiServerEndpoint: https://api.example:6443"
+	machina := readyDeployment(targetNS, "machina-controller")
+	machina.Spec.Template.Annotations = map[string]string{
+		"unbounded-cloud.io/machina-config-hash": configHash(config),
+	}
+	mustCreate(ctx, t, cli, machina)
 	mustCreate(ctx, t, cli, readyDeployment(targetNS, "unbounded-net-controller"))
 	mustCreate(ctx, t, cli, readyDaemonSet(targetNS, "unbounded-net-node"))
 	mustCreate(ctx, t, cli, readyDaemonSet(targetNS, "unbounded-storage-supervisor-cluster"))
@@ -253,6 +262,10 @@ func assertTranslatedSites(ctx context.Context, t *testing.T, cli client.Client)
 
 	if !nestedBool(edge, "spec", "components", "metalman", "enabled") {
 		t.Fatalf("expected metalman enabled on edge site")
+	}
+
+	if !nestedBool(edge, "spec", "components", "metalman", "dhcpAutoInterface") {
+		t.Fatalf("expected Metalman DHCP auto-interface mode preserved")
 	}
 }
 
@@ -436,6 +449,10 @@ func nestedBool(obj *unstructured.Unstructured, path ...string) bool {
 	v, _, _ := unstructured.NestedBool(obj.Object, path...)
 
 	return v
+}
+
+func configHash(config string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(config)))
 }
 
 // ---------------------------------------------------------------------------

--- a/e2e/operator/reaper_e2e_test.go
+++ b/e2e/operator/reaper_e2e_test.go
@@ -216,6 +216,10 @@ func stageTargetWorkloads(ctx context.Context, t *testing.T, cli client.Client) 
 	mustCreate(ctx, t, cli, readyDaemonSet(targetNS, "unbounded-net-node"))
 	mustCreate(ctx, t, cli, readyDaemonSet(targetNS, "unbounded-storage-supervisor-cluster"))
 	mustCreate(ctx, t, cli, readyDaemonSet(targetNS, "unbounded-storage-supervisor-edge"))
+	// The per-site metalman replacement must exist before the legacy metalman is
+	// reaped (presence gate; metalman is hostNetwork like net and cannot become
+	// Ready until the legacy one frees the host ports).
+	mustCreate(ctx, t, cli, readyDeployment(targetNS, "metalman-controller-edge"))
 }
 
 // ---------------------------------------------------------------------------

--- a/hack/operator-upgrade-e2e/e2e.py
+++ b/hack/operator-upgrade-e2e/e2e.py
@@ -26,6 +26,10 @@ everything onto the unified `unbounded-system` namespace:
   * the legacy `unbounded-kube`/`unbounded-net` namespaces and the old
     `sites.net.unbounded-cloud.io` CRD are reaped.
 
+`kubectl unbounded install` no longer applies CRDs: the operator installs and
+upgrades them itself at startup (operator.BootstrapCRDs), so verify asserts the
+Site CRD is Established and owned by the unbounded-operator field manager.
+
 Scope: net + machina run for real in kind. Storage (RDMA) and metalman (PXE)
 cannot run in vanilla kind, so they are intentionally NOT installed in the old
 cluster (their reaping is covered by the in-process simulation test in
@@ -537,7 +541,38 @@ def _migration_complete() -> tuple[bool, str]:
         return False, (f"site-label dual-write mismatch: "
                        f"canonical={sorted(canonical)} deprecated={sorted(deprecated)}")
 
+    # 8. The operator owns CRD lifecycle: `kubectl unbounded install` no longer
+    # applies CRDs, the operator installs them at startup. Verify the Site CRD is
+    # Established and was server-side-applied by the operator field manager
+    # (proving the operator, not install, installed it).
+    if not _crd_established("sites.unbounded-cloud.io"):
+        return False, "sites.unbounded-cloud.io CRD not established yet"
+    if not _crd_managed_by("sites.unbounded-cloud.io", "unbounded-operator"):
+        return False, "sites.unbounded-cloud.io not yet owned by the unbounded-operator field manager"
+
+    # 9. Operator config is delivered via the ConfigMap install populated.
+    if not resource_exists(["-n", TARGET_NS, "configmap", "unbounded-operator-config"]):
+        return False, "unbounded-operator-config ConfigMap not present"
+
     return True, "migration complete"
+
+
+def _crd_established(name: str) -> bool:
+    out = kubectl_out(["get", "crd", name, "-o", "json"], check=False)
+    try:
+        conds = json.loads(out).get("status", {}).get("conditions", [])
+    except json.JSONDecodeError:
+        return False
+    return any(c.get("type") == "Established" and c.get("status") == "True" for c in conds)
+
+
+def _crd_managed_by(name: str, manager: str) -> bool:
+    out = kubectl_out(["get", "crd", name, "-o", "json"], check=False)
+    try:
+        managed = json.loads(out).get("metadata", {}).get("managedFields", [])
+    except json.JSONDecodeError:
+        return False
+    return any(f.get("manager") == manager for f in managed)
 
 
 def _nodes_with_label(key: str, value: str) -> set[str]:

--- a/hack/test-goreleaser-hook.sh
+++ b/hack/test-goreleaser-hook.sh
@@ -16,7 +16,7 @@ MANIFEST="deploy/machina/rendered/04-deployment.yaml"
 EXPECTED_IMAGE="ghcr.io/azure/machina:${TAG}"
 NET_MANIFEST="deploy/net/rendered/controller/03-deployment.yaml"
 EXPECTED_NET_IMAGE="ghcr.io/azure/unbounded-net-controller:${TAG}"
-OPERATOR_MANIFEST="deploy/unbounded-operator/rendered/03-deployment.yaml"
+OPERATOR_MANIFEST="deploy/unbounded-operator/rendered/04-deployment.yaml"
 EXPECTED_OPERATOR_IMAGE="ghcr.io/azure/unbounded-operator:${TAG}"
 
 # Save the original manifest so we can restore it on exit.

--- a/internal/net/controller/site_controller.go
+++ b/internal/net/controller/site_controller.go
@@ -1164,7 +1164,9 @@ func (sc *SiteController) createOrUpdateSlice(ctx context.Context, site unbounde
 		existingNodes, _, _ := unstructured.NestedSlice(existing.Object, "nodes") //nolint:errcheck
 
 		existingNodeCount, foundNodeCount, _ := unstructured.NestedInt64(existing.Object, "nodeCount") //nolint:errcheck
-		if sc.sliceNodesEqual(existingNodes, nodesData) && foundNodeCount && existingNodeCount == int64(len(nodesData)) {
+		if sc.sliceNodesEqual(existingNodes, nodesData) &&
+			foundNodeCount && existingNodeCount == int64(len(nodesData)) &&
+			hasExactSiteOwnerReference(existing.GetOwnerReferences(), site) {
 			return
 		}
 
@@ -1222,6 +1224,21 @@ func (sc *SiteController) buildSliceObject(site unboundedv1alpha3.Site, sliceNam
 			"nodeCount":  int64(len(nodesData)),
 		},
 	}
+}
+
+func hasExactSiteOwnerReference(refs []metav1.OwnerReference, site unboundedv1alpha3.Site) bool {
+	if len(refs) != 1 {
+		return false
+	}
+
+	ref := refs[0]
+
+	return ref.APIVersion == unboundedv1alpha3.GroupVersion.String() &&
+		ref.Kind == "Site" &&
+		ref.Name == site.Name &&
+		ref.UID == site.UID &&
+		ref.Controller != nil && *ref.Controller &&
+		ref.BlockOwnerDeletion != nil && *ref.BlockOwnerDeletion
 }
 
 // sliceNodesEqual compares two node lists for equality

--- a/internal/net/controller/site_controller_helpers_test.go
+++ b/internal/net/controller/site_controller_helpers_test.go
@@ -4,12 +4,17 @@
 package controller
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/tools/cache"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
@@ -415,5 +420,44 @@ func TestBuildSliceObjectOwnerRefUsesMachinaSiteGVK(t *testing.T) {
 
 	if got := owner["uid"]; got != "uid-123" {
 		t.Fatalf("owner uid = %v, want uid-123", got)
+	}
+}
+
+func TestCreateOrUpdateSliceRepairsOwnerReferenceWithoutNodeChanges(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "current-uid"}}
+	nodes := []interface{}{map[string]interface{}{"name": "node-a"}}
+	desired := (&SiteController{}).buildSliceObject(site, "site-a-0", 0, nodes)
+	stale := desired.DeepCopy()
+	stale.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: "net.unbounded-cloud.io/v1alpha1",
+		Kind:       "Site",
+		Name:       site.Name,
+		UID:        "legacy-uid",
+	}})
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(stale.DeepCopy()); err != nil {
+		t.Fatalf("add stale slice to cache: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{siteNodeSliceGVR: "SiteNodeSliceList"},
+		stale.DeepCopy(),
+	)
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+
+	sc.createOrUpdateSlice(context.Background(), site, 0, []unboundednetv1alpha1.NodeInfo{{Name: "node-a"}})
+
+	got, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), "site-a-0", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated SiteNodeSlice: %v", err)
+	}
+
+	if !hasExactSiteOwnerReference(got.GetOwnerReferences(), site) {
+		t.Fatalf("owner reference was not repaired: %#v", got.GetOwnerReferences())
 	}
 }

--- a/internal/operator/bootstrap.go
+++ b/internal/operator/bootstrap.go
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"time"
+
+	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	machinamanifests "github.com/Azure/unbounded/deploy/machina"
+	netmanifests "github.com/Azure/unbounded/deploy/net"
+)
+
+const (
+	// crdKind is the Kind of a CustomResourceDefinition object in the embedded
+	// manifests.
+	crdKind = "CustomResourceDefinition"
+
+	// crdEstablishedTimeout bounds how long BootstrapCRDs waits for every applied
+	// CRD to be served by the apiserver before giving up.
+	crdEstablishedTimeout = 2 * time.Minute
+
+	// crdEstablishedPoll is the poll interval while waiting for CRDs to become
+	// Established.
+	crdEstablishedPoll = time.Second
+)
+
+// bootstrapManifestSets returns the embedded manifest filesystems whose CRDs the
+// operator installs at startup. The operator owns CRD lifecycle so a cluster can
+// be maintained by applying the operator manifests alone; the reconcile loop no
+// longer applies CRDs.
+func bootstrapManifestSets() []fs.FS {
+	return []fs.FS{machinamanifests.Manifests, netmanifests.Manifests}
+}
+
+// BootstrapCRDs server-side applies every CustomResourceDefinition embedded in
+// the machina and net manifests and waits for each to become Established. It is
+// idempotent (safe to run on every operator start) and must run before the
+// manager starts, because the typed Site informer cannot sync until the Site CRD
+// is served.
+func BootstrapCRDs(ctx context.Context, c client.Client) error {
+	logger := log.FromContext(ctx).WithName("crd-bootstrap")
+
+	var names []string
+
+	for _, manifests := range bootstrapManifestSets() {
+		applied, err := applyCRDsFromFS(ctx, logger, c, manifests)
+		if err != nil {
+			return err
+		}
+
+		names = append(names, applied...)
+	}
+
+	if len(names) == 0 {
+		return nil
+	}
+
+	if err := waitForCRDsEstablished(ctx, c, names); err != nil {
+		return err
+	}
+
+	logger.Info("CRDs installed and established", "count", len(names))
+
+	return nil
+}
+
+// applyCRDsFromFS applies every CRD found in the given manifest filesystem and
+// returns the names it applied.
+func applyCRDsFromFS(ctx context.Context, logger logr.Logger, c client.Client, manifests fs.FS) ([]string, error) {
+	files, err := yamlFiles(manifests)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+
+	for _, file := range files {
+		data, err := fs.ReadFile(manifests, file)
+		if err != nil {
+			return nil, fmt.Errorf("read manifest %s: %w", file, err)
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+		for {
+			obj := &unstructured.Unstructured{}
+			if err := decoder.Decode(obj); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, fmt.Errorf("decode %s: %w", file, err)
+			}
+
+			if obj.Object == nil || obj.GetKind() != crdKind {
+				continue
+			}
+
+			applyCfg := client.ApplyConfigurationFromUnstructured(obj)
+			if err := c.Apply(ctx, applyCfg, client.FieldOwner(FieldOwner), client.ForceOwnership); err != nil {
+				return nil, fmt.Errorf("apply CRD %s: %w", obj.GetName(), err)
+			}
+
+			logger.Info("applied CRD", "name", obj.GetName())
+			names = append(names, obj.GetName())
+		}
+	}
+
+	return names, nil
+}
+
+// waitForCRDsEstablished blocks until every named CRD reports the Established
+// condition or the timeout elapses.
+func waitForCRDsEstablished(ctx context.Context, c client.Client, names []string) error {
+	waitCtx, cancel := context.WithTimeout(ctx, crdEstablishedTimeout)
+	defer cancel()
+
+	return wait.PollUntilContextCancel(waitCtx, crdEstablishedPoll, true, func(ctx context.Context) (bool, error) {
+		for _, name := range names {
+			crd := &apiextensionsv1.CustomResourceDefinition{}
+			if err := c.Get(ctx, client.ObjectKey{Name: name}, crd); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+
+				return false, err
+			}
+
+			if !crdEstablished(crd) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}
+
+// crdEstablished reports whether a CRD has the Established=True condition.
+func crdEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	for _, cond := range crd.Status.Conditions {
+		if cond.Type == apiextensionsv1.Established && cond.Status == apiextensionsv1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/operator/bootstrap.go
+++ b/internal/operator/bootstrap.go
@@ -31,7 +31,11 @@ const (
 	crdKind = "CustomResourceDefinition"
 
 	// crdEstablishedTimeout bounds how long BootstrapCRDs waits for every applied
-	// CRD to be served by the apiserver before giving up.
+	// CRD to be served by the apiserver before giving up. The operator health
+	// server only binds after bootstrap (mgr.Start), so the Deployment's
+	// startupProbe budget in deploy/unbounded-operator/03-deployment.yaml.tmpl
+	// must exceed this timeout, otherwise liveness restarts the container
+	// mid-bootstrap.
 	crdEstablishedTimeout = 2 * time.Minute
 
 	// crdEstablishedPoll is the poll interval while waiting for CRDs to become

--- a/internal/operator/bootstrap.go
+++ b/internal/operator/bootstrap.go
@@ -30,18 +30,20 @@ const (
 	// manifests.
 	crdKind = "CustomResourceDefinition"
 
-	// crdEstablishedTimeout bounds how long BootstrapCRDs waits for every applied
-	// CRD to be served by the apiserver before giving up. The operator health
-	// server only binds after bootstrap (mgr.Start), so the Deployment's
-	// startupProbe budget in deploy/unbounded-operator/03-deployment.yaml.tmpl
-	// must exceed this timeout, otherwise liveness restarts the container
-	// mid-bootstrap.
-	crdEstablishedTimeout = 2 * time.Minute
-
 	// crdEstablishedPoll is the poll interval while waiting for CRDs to become
 	// Established.
 	crdEstablishedPoll = time.Second
+
+	// crdEstablishedTimeout preserves the full establishment window after the
+	// apply phase while CRDBootstrapTimeout bounds the complete operation.
+	crdEstablishedTimeout = 2 * time.Minute
 )
+
+// CRDBootstrapTimeout bounds the complete CRD bootstrap, including manifest
+// applies and waiting for every CRD to be served by the apiserver. The operator
+// health server only binds after bootstrap, so the startupProbe budget in
+// deploy/unbounded-operator/04-deployment.yaml.tmpl must exceed this timeout.
+const CRDBootstrapTimeout = 4 * time.Minute
 
 // bootstrapManifestSets returns the embedded manifest filesystems whose CRDs the
 // operator installs at startup. The operator owns CRD lifecycle so a cluster can
@@ -57,6 +59,14 @@ func bootstrapManifestSets() []fs.FS {
 // manager starts, because the typed Site informer cannot sync until the Site CRD
 // is served.
 func BootstrapCRDs(ctx context.Context, c client.Client) error {
+	return bootstrapCRDs(ctx, c, CRDBootstrapTimeout)
+}
+
+func bootstrapCRDs(ctx context.Context, c client.Client, timeout time.Duration) error {
+	bootstrapCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ctx = bootstrapCtx
 	logger := log.FromContext(ctx).WithName("crd-bootstrap")
 
 	var names []string
@@ -129,7 +139,7 @@ func applyCRDsFromFS(ctx context.Context, logger logr.Logger, c client.Client, m
 }
 
 // waitForCRDsEstablished blocks until every named CRD reports the Established
-// condition or the timeout elapses.
+// condition or its context ends.
 func waitForCRDsEstablished(ctx context.Context, c client.Client, names []string) error {
 	waitCtx, cancel := context.WithTimeout(ctx, crdEstablishedTimeout)
 	defer cancel()

--- a/internal/operator/bootstrap_test.go
+++ b/internal/operator/bootstrap_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"context"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// TestBootstrapCRDsAppliesEmbeddedCRDs exercises the real startup CRD bootstrap
+// against the embedded machina + net manifests (rendered by `make test`). A fake
+// client records the applied CRDs and reports them Established so the wait
+// completes. It guards that the operator installs the Site and net CRDs itself,
+// which is what lets a cluster be maintained by applying the operator manifests
+// alone.
+func TestBootstrapCRDsAppliesEmbeddedCRDs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apiextensions: %v", err)
+	}
+
+	applied := map[string]bool{}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				if named, ok := obj.(interface{ GetName() string }); ok {
+					applied[named.GetName()] = true
+				}
+
+				return nil
+			},
+			// Report every CRD Established so waitForCRDsEstablished returns
+			// promptly.
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+				if !ok {
+					return apierrorsNotImplemented(key)
+				}
+
+				crd.Name = key.Name
+				crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{
+					Type:   apiextensionsv1.Established,
+					Status: apiextensionsv1.ConditionTrue,
+				}}
+
+				return nil
+			},
+		}).
+		Build()
+
+	if err := BootstrapCRDs(context.Background(), cli); err != nil {
+		t.Fatalf("BootstrapCRDs: %v", err)
+	}
+
+	for _, name := range []string{
+		"sites.unbounded-cloud.io",
+		"machines.unbounded-cloud.io",
+		"gatewaypools.net.unbounded-cloud.io",
+		"sitenodeslices.net.unbounded-cloud.io",
+	} {
+		if !applied[name] {
+			t.Fatalf("expected CRD %q to be installed by BootstrapCRDs (applied=%v)", name, applied)
+		}
+	}
+}
+
+// apierrorsNotImplemented is a small helper so a non-CRD Get in the test fails
+// loudly rather than silently.
+func apierrorsNotImplemented(key client.ObjectKey) error {
+	return &notImplementedError{key: key}
+}
+
+type notImplementedError struct{ key client.ObjectKey }
+
+func (e *notImplementedError) Error() string {
+	return "unexpected Get for non-CRD object: " + e.key.String()
+}

--- a/internal/operator/bootstrap_test.go
+++ b/internal/operator/bootstrap_test.go
@@ -5,6 +5,7 @@ package operator
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -14,12 +15,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
+// embeddedCRDNames are every CustomResourceDefinition the operator installs at
+// startup: the six machina-group and six net-group CRDs embedded in the machina
+// and net manifests. BootstrapCRDs must apply all of them so a cluster can be
+// maintained by applying the operator manifests alone.
+var embeddedCRDNames = []string{
+	"machines.unbounded-cloud.io",
+	"machineoperations.unbounded-cloud.io",
+	"sites.unbounded-cloud.io",
+	"machineconfigurations.unbounded-cloud.io",
+	"machineoperationcredentials.unbounded-cloud.io",
+	"machineconfigurationversions.unbounded-cloud.io",
+	"sitenodeslices.net.unbounded-cloud.io",
+	"gatewaypools.net.unbounded-cloud.io",
+	"gatewaypoolnodes.net.unbounded-cloud.io",
+	"sitegatewaypoolassignments.net.unbounded-cloud.io",
+	"sitepeerings.net.unbounded-cloud.io",
+	"gatewaypoolpeerings.net.unbounded-cloud.io",
+}
+
 // TestBootstrapCRDsAppliesEmbeddedCRDs exercises the real startup CRD bootstrap
 // against the embedded machina + net manifests (rendered by `make test`). A fake
 // client records the applied CRDs and reports them Established so the wait
-// completes. It guards that the operator installs the Site and net CRDs itself,
-// which is what lets a cluster be maintained by applying the operator manifests
-// alone.
+// completes. It guards that the operator installs every machina and net CRD
+// itself, which is what lets a cluster be maintained by applying the operator
+// manifests alone.
 func TestBootstrapCRDsAppliesEmbeddedCRDs(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
@@ -61,15 +81,77 @@ func TestBootstrapCRDsAppliesEmbeddedCRDs(t *testing.T) {
 		t.Fatalf("BootstrapCRDs: %v", err)
 	}
 
-	for _, name := range []string{
-		"sites.unbounded-cloud.io",
-		"machines.unbounded-cloud.io",
-		"gatewaypools.net.unbounded-cloud.io",
-		"sitenodeslices.net.unbounded-cloud.io",
-	} {
+	for _, name := range embeddedCRDNames {
 		if !applied[name] {
 			t.Fatalf("expected CRD %q to be installed by BootstrapCRDs (applied=%v)", name, applied)
 		}
+	}
+
+	if len(applied) != len(embeddedCRDNames) {
+		t.Fatalf("BootstrapCRDs applied %d CRDs, want %d (applied=%v)", len(applied), len(embeddedCRDNames), applied)
+	}
+}
+
+// TestBootstrapCRDsWaitsForEstablished proves BootstrapCRDs blocks on the
+// Established condition rather than returning as soon as a CRD exists: the fake
+// client reports the CRDs not-Established on the first observation and
+// Established thereafter, so BootstrapCRDs can only succeed by re-polling.
+func TestBootstrapCRDsWaitsForEstablished(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apiextensions: %v", err)
+	}
+
+	var (
+		mu        sync.Mutex
+		gets      int
+		firstSeen bool
+	)
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(context.Context, client.WithWatch, runtime.ApplyConfiguration, ...client.ApplyOption) error {
+				return nil
+			},
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+				if !ok {
+					return apierrorsNotImplemented(key)
+				}
+
+				crd.Name = key.Name
+
+				mu.Lock()
+				gets++
+				established := firstSeen
+				firstSeen = true
+				mu.Unlock()
+
+				// First observation reports not-Established (no condition); every
+				// later poll reports Established.
+				if established {
+					crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{
+						Type:   apiextensionsv1.Established,
+						Status: apiextensionsv1.ConditionTrue,
+					}}
+				}
+
+				return nil
+			},
+		}).
+		Build()
+
+	if err := BootstrapCRDs(context.Background(), cli); err != nil {
+		t.Fatalf("BootstrapCRDs: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// A single pass (one Get) would mean it never waited for establishment.
+	if gets <= len(embeddedCRDNames) {
+		t.Fatalf("expected BootstrapCRDs to re-poll for establishment; got %d Gets for %d CRDs", gets, len(embeddedCRDNames))
 	}
 }
 

--- a/internal/operator/bootstrap_test.go
+++ b/internal/operator/bootstrap_test.go
@@ -5,8 +5,10 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +34,32 @@ var embeddedCRDNames = []string{
 	"sitegatewaypoolassignments.net.unbounded-cloud.io",
 	"sitepeerings.net.unbounded-cloud.io",
 	"gatewaypoolpeerings.net.unbounded-cloud.io",
+}
+
+func TestBootstrapCRDsTimeoutCancelsBlockedApply(t *testing.T) {
+	applyStarted := make(chan struct{})
+
+	cli := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				close(applyStarted)
+				<-ctx.Done()
+
+				return ctx.Err()
+			},
+		}).
+		Build()
+
+	err := bootstrapCRDs(context.Background(), cli, 20*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("bootstrapCRDs error = %v, want context deadline exceeded", err)
+	}
+
+	select {
+	case <-applyStarted:
+	default:
+		t.Fatal("BootstrapCRDs did not attempt an apply")
+	}
 }
 
 // TestBootstrapCRDsAppliesEmbeddedCRDs exercises the real startup CRD bootstrap

--- a/internal/operator/machina_config.go
+++ b/internal/operator/machina_config.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+const machinaConfigHashAnnotation = "unbounded-cloud.io/machina-config-hash"
+
+func machinaConfigHash(config string) string {
+	sum := sha256.Sum256([]byte(config))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// setMachinaAPIServerEndpoint updates only the top-level apiServerEndpoint
+// field. Using a YAML node preserves all other migrated or user-managed fields.
+func setMachinaAPIServerEndpoint(config, endpoint string) (string, error) {
+	if endpoint == "" {
+		return config, nil
+	}
+
+	var document yaml.Node
+	if config == "" {
+		document = yaml.Node{
+			Kind: yaml.DocumentNode,
+			Content: []*yaml.Node{{
+				Kind: yaml.MappingNode,
+				Tag:  "!!map",
+			}},
+		}
+	} else if err := yaml.Unmarshal([]byte(config), &document); err != nil {
+		return "", fmt.Errorf("parse machina config: %w", err)
+	}
+
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return "", fmt.Errorf("parse machina config: expected a top-level mapping")
+	}
+
+	mapping := document.Content[0]
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value != "apiServerEndpoint" {
+			continue
+		}
+
+		mapping.Content[i+1].Kind = yaml.ScalarNode
+		mapping.Content[i+1].Tag = "!!str"
+		mapping.Content[i+1].Value = endpoint
+		mapping.Content[i+1].Style = yaml.DoubleQuotedStyle
+
+		encoded, err := yaml.Marshal(&document)
+		if err != nil {
+			return "", fmt.Errorf("encode machina config: %w", err)
+		}
+
+		return string(encoded), nil
+	}
+
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "apiServerEndpoint"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: endpoint, Style: yaml.DoubleQuotedStyle},
+	)
+
+	encoded, err := yaml.Marshal(&document)
+	if err != nil {
+		return "", fmt.Errorf("encode machina config: %w", err)
+	}
+
+	return string(encoded), nil
+}

--- a/internal/operator/migrate.go
+++ b/internal/operator/migrate.go
@@ -6,6 +6,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -18,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -68,6 +69,12 @@ var legacySiteGVK = schema.GroupVersionKind{
 	Group:   "net.unbounded-cloud.io",
 	Version: "v1alpha1",
 	Kind:    "Site",
+}
+
+var siteNodeSliceGVK = schema.GroupVersionKind{
+	Group:   "net.unbounded-cloud.io",
+	Version: "v1alpha1",
+	Kind:    "SiteNodeSlice",
 }
 
 // legacySiteCRDName is the CustomResourceDefinition name for the pre-redesign
@@ -195,6 +202,10 @@ type LegacyReaper struct {
 	// CopyConfigMaps are operator-owned ConfigMaps to carry across by name.
 	CopyConfigMaps []string
 
+	// APIServerEndpoint overrides the endpoint in migrated Machina config while
+	// preserving every other legacy setting.
+	APIServerEndpoint string
+
 	// Interval is the requeue period while waiting for target workloads to
 	// become healthy.
 	Interval time.Duration
@@ -202,7 +213,7 @@ type LegacyReaper struct {
 	// Recorder, when set, receives Events for notable migration actions (for
 	// example a legacy namespace that still holds non-operator workloads at
 	// delete time). Optional; nil disables Event emission.
-	Recorder record.EventRecorder
+	Recorder events.EventRecorder
 }
 
 // NeedLeaderElection ensures the reaper only runs on the elected leader.
@@ -493,13 +504,18 @@ func (r *LegacyReaper) detectComponents(ctx context.Context, siteName string) (m
 		}
 	}
 
-	metalman, err := r.legacyMetalmanExistsForSite(ctx, siteName)
+	metalman, dhcpAutoInterface, err := r.legacyMetalmanConfigForSite(ctx, siteName)
 	if err != nil {
 		return nil, err
 	}
 
 	if metalman {
-		components["metalman"] = map[string]any{"enabled": true}
+		config := map[string]any{"enabled": true}
+		if dhcpAutoInterface != nil {
+			config["dhcpAutoInterface"] = *dhcpAutoInterface
+		}
+
+		components["metalman"] = config
 	}
 
 	return components, nil
@@ -513,25 +529,97 @@ func (r *LegacyReaper) detectComponents(ctx context.Context, siteName string) (m
 // and the operator use) guards against the site label being carried under the
 // deprecated key on older clusters.
 func (r *LegacyReaper) legacyMetalmanExistsForSite(ctx context.Context, siteName string) (bool, error) {
+	found, _, err := r.legacyMetalmanConfigForSite(ctx, siteName)
+
+	return found, err
+}
+
+// legacyMetalmanConfigForSite finds the legacy per-site Metalman Deployment and
+// preserves its --dhcp-auto-interface setting. Malformed or contradictory flag
+// values block translation rather than silently changing DHCP behavior.
+func (r *LegacyReaper) legacyMetalmanConfigForSite(ctx context.Context, siteName string) (bool, *bool, error) {
+	var (
+		dhcpAutoInterface *bool
+		effectiveValue    *bool
+	)
+
+	found := false
+
 	for _, legacyNs := range r.LegacyNamespaces {
 		var list appsv1.DeploymentList
 		if err := r.List(ctx, &list, client.InNamespace(legacyNs), client.MatchingLabels{"app": "unbounded-pxe"}); err != nil {
-			return false, err
+			return false, nil, err
 		}
 
 		for i := range list.Items {
 			d := &list.Items[i]
-			if d.Name == metalmanDeploymentName(siteName) {
-				return true, nil
+			if d.Name != metalmanDeploymentName(siteName) &&
+				d.Labels[unboundedv1alpha3.MachineSiteLabelKey] != siteName &&
+				d.Labels[deprecatedSiteLabelKey] != siteName {
+				continue
 			}
 
-			if d.Labels[unboundedv1alpha3.MachineSiteLabelKey] == siteName || d.Labels[deprecatedSiteLabelKey] == siteName {
-				return true, nil
+			found = true
+
+			value, err := metalmanDHCPAutoInterface(d)
+			if err != nil {
+				return false, nil, err
+			}
+
+			effective := false
+			if value != nil {
+				effective = *value
+			}
+
+			if effectiveValue != nil && *effectiveValue != effective {
+				return false, nil, fmt.Errorf("legacy Metalman Deployments for Site %s have conflicting --dhcp-auto-interface values", siteName)
+			}
+
+			matchedEffective := effective
+			effectiveValue = &matchedEffective
+
+			if value != nil {
+				dhcpAutoInterface = value
 			}
 		}
 	}
 
-	return false, nil
+	return found, dhcpAutoInterface, nil
+}
+
+func metalmanDHCPAutoInterface(deploy *appsv1.Deployment) (*bool, error) {
+	var found *bool
+
+	for _, container := range deploy.Spec.Template.Spec.Containers {
+		for _, arg := range container.Args {
+			var value bool
+
+			switch {
+			case arg == "--dhcp-auto-interface":
+				value = true
+			case strings.HasPrefix(arg, "--dhcp-auto-interface="):
+				switch strings.TrimPrefix(arg, "--dhcp-auto-interface=") {
+				case "true":
+					value = true
+				case "false":
+					value = false
+				default:
+					return nil, fmt.Errorf("legacy Metalman Deployment %s/%s has invalid argument %q", deploy.Namespace, deploy.Name, arg)
+				}
+			default:
+				continue
+			}
+
+			if found != nil && *found != value {
+				return nil, fmt.Errorf("legacy Metalman Deployment %s/%s has conflicting --dhcp-auto-interface arguments", deploy.Namespace, deploy.Name)
+			}
+
+			matched := value
+			found = &matched
+		}
+	}
+
+	return found, nil
 }
 
 // legacyWorkloadExists reports whether a Deployment or DaemonSet matching the
@@ -616,7 +704,22 @@ func (r *LegacyReaper) migrateConfigMaps(ctx context.Context, logger logr.Logger
 			return err
 		}
 
-		if err := r.upsertConfigMap(ctx, copyObjectMeta(src.ObjectMeta, target), src.Data, src.BinaryData); err != nil {
+		data := src.Data
+		if name == "machina-config" && r.APIServerEndpoint != "" {
+			data = make(map[string]string, len(src.Data))
+			for key, value := range src.Data {
+				data[key] = value
+			}
+
+			config, err := setMachinaAPIServerEndpoint(data["config.yaml"], r.APIServerEndpoint)
+			if err != nil {
+				return fmt.Errorf("update migrated machina config endpoint: %w", err)
+			}
+
+			data["config.yaml"] = config
+		}
+
+		if err := r.upsertConfigMap(ctx, copyObjectMeta(src.ObjectMeta, target), data, src.BinaryData); err != nil {
 			return fmt.Errorf("copy configmap %s/%s: %w", legacyNs, name, err)
 		}
 
@@ -902,6 +1005,8 @@ func (r *LegacyReaper) componentResourcesRemain(ctx context.Context, component l
 // other component uses its static gating workloads.
 func (r *LegacyReaper) componentReady(ctx context.Context, target string, component legacyComponent) (bool, error) {
 	switch component.name {
+	case ComponentMachina:
+		return r.machinaTargetReady(ctx, target)
 	case ComponentStorage:
 		return r.storageTargetsReady(ctx, target)
 	case ComponentNet:
@@ -911,6 +1016,32 @@ func (r *LegacyReaper) componentReady(ctx context.Context, target string, compon
 	default:
 		return r.targetsReady(ctx, target, component.targets)
 	}
+}
+
+func (r *LegacyReaper) machinaTargetReady(ctx context.Context, target string) (bool, error) {
+	var config corev1.ConfigMap
+	if err := r.Get(ctx, client.ObjectKey{Namespace: target, Name: "machina-config"}, &config); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	var deploy appsv1.Deployment
+	if err := r.Get(ctx, client.ObjectKey{Namespace: target, Name: "machina-controller"}, &deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	if deploy.Spec.Template.Annotations[machinaConfigHashAnnotation] != machinaConfigHash(config.Data["config.yaml"]) {
+		return false, nil
+	}
+
+	return deploymentRolloutComplete(&deploy), nil
 }
 
 // metalmanTargetsPresent reports whether the operator has created the per-site
@@ -983,8 +1114,9 @@ func (r *LegacyReaper) netTargetsPresent(ctx context.Context, target string) (bo
 // conjunction of two invariants:
 //
 //   - Every per-site unbounded-storage-supervisor-<site> DaemonSet that exists
-//     in the target namespace must be Ready, and at least one must exist (do not
-//     reap before the operator has created a replacement).
+//     in the target namespace must be Ready. A zero-desired DaemonSet is safe
+//     only when no Node InternalIP matches that Site's node CIDRs. At least one
+//     DaemonSet must exist (do not reap before a replacement is created).
 //   - Every storage-enabled translated Site must have its per-site DaemonSet
 //     present, so a multi-site cluster never loses the legacy supervisor before
 //     every storage-enabled Site has its own replacement.
@@ -993,6 +1125,18 @@ func (r *LegacyReaper) storageTargetsReady(ctx context.Context, target string) (
 	if err := r.List(ctx, &list, client.InNamespace(target)); err != nil {
 		return false, err
 	}
+
+	var sites unboundedv1alpha3.SiteList
+	if err := r.List(ctx, &sites); err != nil {
+		return false, fmt.Errorf("list sites: %w", err)
+	}
+
+	sitesByName := make(map[string]*unboundedv1alpha3.Site, len(sites.Items))
+	for i := range sites.Items {
+		sitesByName[sites.Items[i].Name] = &sites.Items[i]
+	}
+
+	var nodes *corev1.NodeList
 
 	found := false
 
@@ -1004,6 +1148,37 @@ func (r *LegacyReaper) storageTargetsReady(ctx context.Context, target string) (
 
 		found = true
 
+		if ds.Status.ObservedGeneration < ds.Generation {
+			return false, nil
+		}
+
+		if ds.Status.DesiredNumberScheduled == 0 {
+			siteName := strings.TrimPrefix(ds.Name, "unbounded-storage-supervisor-")
+
+			site := sitesByName[siteName]
+			if site == nil {
+				return false, nil
+			}
+
+			if nodes == nil {
+				nodes = &corev1.NodeList{}
+				if err := r.List(ctx, nodes); err != nil {
+					return false, fmt.Errorf("list nodes: %w", err)
+				}
+			}
+
+			matched, err := siteHasMatchingNode(site, nodes.Items)
+			if err != nil {
+				return false, err
+			}
+
+			if matched {
+				return false, nil
+			}
+
+			continue
+		}
+
 		if !storageDaemonSetReady(ds) {
 			return false, nil
 		}
@@ -1011,11 +1186,6 @@ func (r *LegacyReaper) storageTargetsReady(ctx context.Context, target string) (
 
 	// Require every storage-enabled Site to have its per-site DaemonSet present
 	// before reaping the legacy supervisor.
-	var sites unboundedv1alpha3.SiteList
-	if err := r.List(ctx, &sites); err != nil {
-		return false, fmt.Errorf("list sites: %w", err)
-	}
-
 	for i := range sites.Items {
 		site := &sites.Items[i]
 		if !componentEnabled(site, ComponentStorage) {
@@ -1033,6 +1203,36 @@ func (r *LegacyReaper) storageTargetsReady(ctx context.Context, target string) (
 	}
 
 	return found, nil
+}
+
+func siteHasMatchingNode(site *unboundedv1alpha3.Site, nodes []corev1.Node) (bool, error) {
+	cidrs := make([]*net.IPNet, 0, len(site.Spec.NodeCidrs))
+
+	for _, raw := range site.Spec.NodeCidrs {
+		_, cidr, err := net.ParseCIDR(raw)
+		if err != nil {
+			return false, fmt.Errorf("site %s has invalid node CIDR %q: %w", site.Name, raw, err)
+		}
+
+		cidrs = append(cidrs, cidr)
+	}
+
+	for i := range nodes {
+		for _, address := range nodes[i].Status.Addresses {
+			if address.Type != corev1.NodeInternalIP {
+				continue
+			}
+
+			ip := net.ParseIP(address.Address)
+			for _, cidr := range cidrs {
+				if ip != nil && cidr.Contains(ip) {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
 }
 
 // targetsReady reports whether every gating workload is healthy in the target
@@ -1108,10 +1308,9 @@ func (r *LegacyReaper) cleanup(ctx context.Context, logger logr.Logger, target s
 
 // cleanupLegacySiteCRD deletes the legacy net-group Site CRD once it is safe to
 // do so. When the CRD still exists it is only deleted after the new net
-// controller is Available: the new controller re-owns the SiteNodeSlices under
-// the v1alpha3 Site GVK and recreates them, so deleting the legacy CRD (and its
-// Sites) beforehand would let the garbage collector transiently remove slices
-// still owned by the legacy Sites, widening the cutover gap. When the CRD is
+// controller is Available and every existing SiteNodeSlice has been re-owned by
+// its current v1alpha3 Site. Deleting the legacy CRD sooner could let garbage
+// collection remove slices that still reference legacy Sites. When the CRD is
 // already gone there is nothing to protect and it reports gone=true.
 func (r *LegacyReaper) cleanupLegacySiteCRD(ctx context.Context, logger logr.Logger, target string) (bool, error) {
 	exists, err := r.legacySiteCRDExists(ctx)
@@ -1134,7 +1333,74 @@ func (r *LegacyReaper) cleanupLegacySiteCRD(ctx context.Context, logger logr.Log
 		return false, nil
 	}
 
+	slicesCurrent, err := r.siteNodeSlicesOwnedByCurrentSites(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if !slicesCurrent {
+		logger.Info("waiting for SiteNodeSlices to be owned by their current v1alpha3 Sites")
+
+		return false, nil
+	}
+
 	return r.deleteLegacySiteCRD(ctx, logger)
+}
+
+func (r *LegacyReaper) siteNodeSlicesOwnedByCurrentSites(ctx context.Context) (bool, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   siteNodeSliceGVK.Group,
+		Version: siteNodeSliceGVK.Version,
+		Kind:    siteNodeSliceGVK.Kind + "List",
+	})
+
+	if err := r.List(ctx, list); err != nil {
+		if apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("list SiteNodeSlices: %w", err)
+	}
+
+	for i := range list.Items {
+		slice := &list.Items[i]
+
+		siteName, found, err := unstructured.NestedString(slice.Object, "siteName")
+		if err != nil || !found || siteName == "" {
+			return false, nil
+		}
+
+		site := &unboundedv1alpha3.Site{}
+		if err := r.Get(ctx, client.ObjectKey{Name: siteName}, site); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("get Site %s for SiteNodeSlice %s: %w", siteName, slice.GetName(), err)
+		}
+
+		if !hasExactSiteOwnerReference(slice.GetOwnerReferences(), site) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func hasExactSiteOwnerReference(refs []metav1.OwnerReference, site *unboundedv1alpha3.Site) bool {
+	if len(refs) != 1 {
+		return false
+	}
+
+	ref := refs[0]
+
+	return ref.APIVersion == unboundedv1alpha3.GroupVersion.String() &&
+		ref.Kind == "Site" &&
+		ref.Name == site.Name &&
+		ref.UID == site.UID &&
+		ref.Controller != nil && *ref.Controller &&
+		ref.BlockOwnerDeletion != nil && *ref.BlockOwnerDeletion
 }
 
 // legacySiteCRDExists reports whether the pre-redesign net-group Site CRD is
@@ -1194,7 +1460,7 @@ func (r *LegacyReaper) warnOnForeignWorkloads(ctx context.Context, logger logr.L
 
 	if r.Recorder != nil {
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
-		r.Recorder.Eventf(ns, corev1.EventTypeWarning, "ForeignWorkloadsDeleted",
+		r.Recorder.Eventf(ns, nil, corev1.EventTypeWarning, "ForeignWorkloadsDeleted", "DeleteLegacyNamespace",
 			"deleting drained legacy namespace %s which still holds non-operator workloads: %v", nsName, foreign)
 	}
 }
@@ -1396,6 +1662,18 @@ func deploymentAvailable(deploy *appsv1.Deployment) bool {
 	return deploy.Status.ObservedGeneration >= deploy.Generation && deploy.Status.AvailableReplicas >= desired
 }
 
+func deploymentRolloutComplete(deploy *appsv1.Deployment) bool {
+	desired := int32(1)
+	if deploy.Spec.Replicas != nil {
+		desired = *deploy.Spec.Replicas
+	}
+
+	return deploy.Status.ObservedGeneration >= deploy.Generation &&
+		deploy.Status.UpdatedReplicas == desired &&
+		deploy.Status.Replicas == desired &&
+		deploy.Status.AvailableReplicas == desired
+}
+
 func daemonSetReady(ds *appsv1.DaemonSet) bool {
 	if ds.Status.ObservedGeneration < ds.Generation {
 		return false
@@ -1408,12 +1686,9 @@ func daemonSetReady(ds *appsv1.DaemonSet) bool {
 	return ds.Status.NumberReady >= ds.Status.DesiredNumberScheduled
 }
 
-// storageDaemonSetReady is stricter than daemonSetReady: a per-site storage
-// DaemonSet must actually schedule at least one pod (DesiredNumberScheduled >= 1)
-// and have all of them Ready before the legacy supervisor is reaped. This
-// prevents dropping storage while the replacement has zero pods (for example
-// before the node site labels have converged), where a DesiredNumberScheduled of
-// 0 would otherwise read as "ready".
+// storageDaemonSetReady is stricter than daemonSetReady: absent the explicit
+// node-CIDR exception in storageTargetsReady, a per-site storage DaemonSet must
+// schedule at least one pod and have all scheduled pods Ready.
 func storageDaemonSetReady(ds *appsv1.DaemonSet) bool {
 	if ds.Status.ObservedGeneration < ds.Generation {
 		return false

--- a/internal/operator/migrate.go
+++ b/internal/operator/migrate.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -197,6 +198,11 @@ type LegacyReaper struct {
 	// Interval is the requeue period while waiting for target workloads to
 	// become healthy.
 	Interval time.Duration
+
+	// Recorder, when set, receives Events for notable migration actions (for
+	// example a legacy namespace that still holds non-operator workloads at
+	// delete time). Optional; nil disables Event emission.
+	Recorder record.EventRecorder
 }
 
 // NeedLeaderElection ensures the reaper only runs on the elected leader.
@@ -369,7 +375,7 @@ func (r *LegacyReaper) reapOnce(ctx context.Context, logger logr.Logger) (bool, 
 
 	// 6: everything is migrated and reaped; remove the legacy Site CRD and the
 	// now-drained legacy namespaces.
-	return r.cleanup(ctx, logger)
+	return r.cleanup(ctx, logger, target)
 }
 
 // translateSites lists the pre-redesign net-group Sites and creates an
@@ -487,10 +493,7 @@ func (r *LegacyReaper) detectComponents(ctx context.Context, siteName string) (m
 		}
 	}
 
-	metalman, err := r.legacyWorkloadExists(ctx, "Deployment", map[string]string{
-		"app":                                 "unbounded-pxe",
-		unboundedv1alpha3.MachineSiteLabelKey: siteName,
-	})
+	metalman, err := r.legacyMetalmanExistsForSite(ctx, siteName)
 	if err != nil {
 		return nil, err
 	}
@@ -500,6 +503,35 @@ func (r *LegacyReaper) detectComponents(ctx context.Context, siteName string) (m
 	}
 
 	return components, nil
+}
+
+// legacyMetalmanExistsForSite reports whether a legacy per-site metalman
+// Deployment for siteName exists in any legacy namespace. It matches the
+// released deploy-pxe Deployment robustly: any `app: unbounded-pxe` Deployment
+// whose name is metalman-controller-<site> OR whose canonical/deprecated site
+// label equals siteName. Matching the name (which both the released installer
+// and the operator use) guards against the site label being carried under the
+// deprecated key on older clusters.
+func (r *LegacyReaper) legacyMetalmanExistsForSite(ctx context.Context, siteName string) (bool, error) {
+	for _, legacyNs := range r.LegacyNamespaces {
+		var list appsv1.DeploymentList
+		if err := r.List(ctx, &list, client.InNamespace(legacyNs), client.MatchingLabels{"app": "unbounded-pxe"}); err != nil {
+			return false, err
+		}
+
+		for i := range list.Items {
+			d := &list.Items[i]
+			if d.Name == metalmanDeploymentName(siteName) {
+				return true, nil
+			}
+
+			if d.Labels[unboundedv1alpha3.MachineSiteLabelKey] == siteName || d.Labels[deprecatedSiteLabelKey] == siteName {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }
 
 // legacyWorkloadExists reports whether a Deployment or DaemonSet matching the
@@ -874,9 +906,48 @@ func (r *LegacyReaper) componentReady(ctx context.Context, target string, compon
 		return r.storageTargetsReady(ctx, target)
 	case ComponentNet:
 		return r.netTargetsPresent(ctx, target)
+	case ComponentMetalman:
+		return r.metalmanTargetsPresent(ctx, target)
 	default:
 		return r.targetsReady(ctx, target, component.targets)
 	}
+}
+
+// metalmanTargetsPresent reports whether the operator has created the per-site
+// metalman Deployment for every metalman-enabled Site. Like net, metalman is
+// hostNetwork and binds host ports (DHCP/TFTP/HTTP), so the new per-site pod
+// cannot become Ready while the legacy metalman on the same node still holds
+// those ports; gating on creation (not readiness) frees the ports without
+// deadlocking. If a legacy metalman footprint reached this gate but no Site
+// enables metalman (for example a detection miss), reaping is refused so the
+// workload is not silently dropped.
+func (r *LegacyReaper) metalmanTargetsPresent(ctx context.Context, target string) (bool, error) {
+	var sites unboundedv1alpha3.SiteList
+	if err := r.List(ctx, &sites); err != nil {
+		return false, fmt.Errorf("list sites: %w", err)
+	}
+
+	enabled := 0
+
+	for i := range sites.Items {
+		site := &sites.Items[i]
+		if !componentEnabled(site, ComponentMetalman) {
+			continue
+		}
+
+		enabled++
+
+		var deploy appsv1.Deployment
+		if err := r.Get(ctx, client.ObjectKey{Namespace: target, Name: metalmanDeploymentName(site.Name)}, &deploy); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+	}
+
+	return enabled > 0, nil
 }
 
 // netTargetsPresent reports whether the operator has created the new net
@@ -933,7 +1004,7 @@ func (r *LegacyReaper) storageTargetsReady(ctx context.Context, target string) (
 
 		found = true
 
-		if !daemonSetReady(ds) {
+		if !storageDaemonSetReady(ds) {
 			return false, nil
 		}
 	}
@@ -1004,10 +1075,10 @@ func (r *LegacyReaper) targetsReady(ctx context.Context, target string, refs []w
 // cleanup removes the legacy Site CRD and the drained legacy namespaces. It
 // returns done=true only once the CRD and every legacy namespace are gone
 // (namespace deletion is asynchronous, so a later pass observes completion).
-func (r *LegacyReaper) cleanup(ctx context.Context, logger logr.Logger) (bool, error) {
+func (r *LegacyReaper) cleanup(ctx context.Context, logger logr.Logger, target string) (bool, error) {
 	done := true
 
-	crdGone, err := r.deleteLegacySiteCRD(ctx, logger)
+	crdGone, err := r.cleanupLegacySiteCRD(ctx, logger, target)
 	if err != nil {
 		return false, err
 	}
@@ -1021,6 +1092,8 @@ func (r *LegacyReaper) cleanup(ctx context.Context, logger logr.Logger) (bool, e
 			continue
 		}
 
+		r.warnOnForeignWorkloads(ctx, logger, nsName)
+
 		if err := r.deleteNamespace(ctx, nsName); err != nil {
 			return false, fmt.Errorf("delete legacy namespace %s: %w", nsName, err)
 		}
@@ -1031,6 +1104,136 @@ func (r *LegacyReaper) cleanup(ctx context.Context, logger logr.Logger) (bool, e
 	}
 
 	return done, nil
+}
+
+// cleanupLegacySiteCRD deletes the legacy net-group Site CRD once it is safe to
+// do so. When the CRD still exists it is only deleted after the new net
+// controller is Available: the new controller re-owns the SiteNodeSlices under
+// the v1alpha3 Site GVK and recreates them, so deleting the legacy CRD (and its
+// Sites) beforehand would let the garbage collector transiently remove slices
+// still owned by the legacy Sites, widening the cutover gap. When the CRD is
+// already gone there is nothing to protect and it reports gone=true.
+func (r *LegacyReaper) cleanupLegacySiteCRD(ctx context.Context, logger logr.Logger, target string) (bool, error) {
+	exists, err := r.legacySiteCRDExists(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if !exists {
+		return true, nil
+	}
+
+	netReady, err := r.netControllerAvailable(ctx, target)
+	if err != nil {
+		return false, err
+	}
+
+	if !netReady {
+		logger.Info("waiting for the new net controller to be Available before deleting the legacy Site CRD", "namespace", target)
+
+		return false, nil
+	}
+
+	return r.deleteLegacySiteCRD(ctx, logger)
+}
+
+// legacySiteCRDExists reports whether the pre-redesign net-group Site CRD is
+// still installed.
+func (r *LegacyReaper) legacySiteCRDExists(ctx context.Context) (bool, error) {
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+
+	err := r.Get(ctx, client.ObjectKey{Name: legacySiteCRDName}, crd)
+	switch {
+	case err == nil:
+		return true, nil
+	case apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err):
+		return false, nil
+	default:
+		return false, fmt.Errorf("get legacy site crd: %w", err)
+	}
+}
+
+// netControllerAvailable reports whether the new net controller Deployment in the
+// target namespace is Available.
+func (r *LegacyReaper) netControllerAvailable(ctx context.Context, target string) (bool, error) {
+	var deploy appsv1.Deployment
+	if err := r.Get(ctx, client.ObjectKey{Namespace: target, Name: "unbounded-net-controller"}, &deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return deploymentAvailable(&deploy), nil
+}
+
+// warnOnForeignWorkloads logs a warning and emits an Event when a legacy
+// namespace still holds workloads the reaper did not create, so operators are
+// alerted before the whole-namespace delete removes them too. Deletion still
+// proceeds (the namespace is the migration target); the warning surfaces
+// unexpected residents rather than blocking the migration.
+func (r *LegacyReaper) warnOnForeignWorkloads(ctx context.Context, logger logr.Logger, nsName string) {
+	foreign, err := r.foreignWorkloads(ctx, nsName)
+	if err != nil {
+		logger.Error(err, "failed to check for foreign workloads before deleting legacy namespace", "namespace", nsName)
+		return
+	}
+
+	if len(foreign) == 0 {
+		return
+	}
+
+	logger.Info("legacy namespace still holds non-operator workloads; they will be deleted with the namespace",
+		"namespace", nsName, "workloads", foreign)
+
+	if r.Recorder != nil {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+		r.Recorder.Eventf(ns, corev1.EventTypeWarning, "ForeignWorkloadsDeleted",
+			"deleting drained legacy namespace %s which still holds non-operator workloads: %v", nsName, foreign)
+	}
+}
+
+// foreignWorkloads returns the "Kind/name" of workload controllers in the
+// namespace that the reaper did not create. cleanup runs only after every
+// operator-owned Deployment/DaemonSet has been reaped, so any remaining
+// Deployment/DaemonSet/StatefulSet here is foreign.
+func (r *LegacyReaper) foreignWorkloads(ctx context.Context, nsName string) ([]string, error) {
+	var names []string
+
+	var deployments appsv1.DeploymentList
+	if err := r.List(ctx, &deployments, client.InNamespace(nsName)); err != nil {
+		return nil, err
+	}
+
+	for i := range deployments.Items {
+		names = append(names, "Deployment/"+deployments.Items[i].Name)
+	}
+
+	var daemonsets appsv1.DaemonSetList
+	if err := r.List(ctx, &daemonsets, client.InNamespace(nsName)); err != nil {
+		return nil, err
+	}
+
+	for i := range daemonsets.Items {
+		names = append(names, "DaemonSet/"+daemonsets.Items[i].Name)
+	}
+
+	var statefulsets appsv1.StatefulSetList
+	if err := r.List(ctx, &statefulsets, client.InNamespace(nsName)); err != nil {
+		return nil, err
+	}
+
+	for i := range statefulsets.Items {
+		names = append(names, "StatefulSet/"+statefulsets.Items[i].Name)
+	}
+
+	return names, nil
 }
 
 // deleteLegacySiteCRD deletes the pre-redesign net-group Site CRD. It reports
@@ -1200,6 +1403,24 @@ func daemonSetReady(ds *appsv1.DaemonSet) bool {
 
 	if ds.Status.DesiredNumberScheduled == 0 {
 		return true
+	}
+
+	return ds.Status.NumberReady >= ds.Status.DesiredNumberScheduled
+}
+
+// storageDaemonSetReady is stricter than daemonSetReady: a per-site storage
+// DaemonSet must actually schedule at least one pod (DesiredNumberScheduled >= 1)
+// and have all of them Ready before the legacy supervisor is reaped. This
+// prevents dropping storage while the replacement has zero pods (for example
+// before the node site labels have converged), where a DesiredNumberScheduled of
+// 0 would otherwise read as "ready".
+func storageDaemonSetReady(ds *appsv1.DaemonSet) bool {
+	if ds.Status.ObservedGeneration < ds.Generation {
+		return false
+	}
+
+	if ds.Status.DesiredNumberScheduled < 1 {
+		return false
 	}
 
 	return ds.Status.NumberReady >= ds.Status.DesiredNumberScheduled

--- a/internal/operator/migrate_gates_test.go
+++ b/internal/operator/migrate_gates_test.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 )
@@ -81,6 +84,62 @@ func TestMetalmanTargetsPresent(t *testing.T) {
 	})
 }
 
+func TestMachinaTargetReadyRequiresCurrentConfigAndRollout(t *testing.T) {
+	const target = "unbounded-system"
+
+	config := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: "machina-config"},
+		Data:       map[string]string{"config.yaml": "apiServerEndpoint: https://api.example:6443\n"},
+	}
+	replicas := int32(1)
+	ready := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: "machina-controller", Generation: 2},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				machinaConfigHashAnnotation: machinaConfigHash(config.Data["config.yaml"]),
+			}}},
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+		},
+	}
+
+	t.Run("current config and complete rollout pass", func(t *testing.T) {
+		r := newReaper(t, config.DeepCopy(), ready.DeepCopy())
+
+		got, err := r.machinaTargetReady(t.Context(), target)
+		if err != nil || !got {
+			t.Fatalf("machinaTargetReady = %t, err=%v, want true", got, err)
+		}
+	})
+
+	t.Run("stale hash blocks", func(t *testing.T) {
+		deploy := ready.DeepCopy()
+		deploy.Spec.Template.Annotations[machinaConfigHashAnnotation] = "stale"
+		r := newReaper(t, config.DeepCopy(), deploy)
+
+		got, err := r.machinaTargetReady(t.Context(), target)
+		if err != nil || got {
+			t.Fatalf("machinaTargetReady = %t, err=%v, want false", got, err)
+		}
+	})
+
+	t.Run("incomplete rollout blocks", func(t *testing.T) {
+		deploy := ready.DeepCopy()
+		deploy.Status.AvailableReplicas = 0
+		r := newReaper(t, config.DeepCopy(), deploy)
+
+		got, err := r.machinaTargetReady(t.Context(), target)
+		if err != nil || got {
+			t.Fatalf("machinaTargetReady = %t, err=%v, want false", got, err)
+		}
+	})
+}
+
 // Finding 2: metalman detection tolerates the deprecated site-label key and
 // matches by the deterministic Deployment name, so a real v0.1.19 cluster (which
 // happens to use the canonical key) and older shapes both migrate.
@@ -138,11 +197,32 @@ func TestLegacyMetalmanDetectionHardening(t *testing.T) {
 			t.Fatal("did not expect a different site's metalman to match")
 		}
 	})
+
+	t.Run("conflicting matching Deployments fail closed", func(t *testing.T) {
+		byName := metalmanDeploymentForSiteWithArgs(legacyKubeNamespace, "edge", "--dhcp-auto-interface")
+		byLabel := metalmanDeploymentForSiteWithArgs(legacyNetNamespace, "edge", "--dhcp-auto-interface=false")
+		byLabel.Name = "older-metalman-name"
+		r := newReaper(t, byName, byLabel)
+
+		if _, _, err := r.legacyMetalmanConfigForSite(t.Context(), "edge"); err == nil {
+			t.Fatal("expected conflicting matching Metalman Deployments to fail closed")
+		}
+	})
+
+	t.Run("absent and enabled arguments conflict", func(t *testing.T) {
+		withoutFlag := metalmanDeploymentForSiteWithArgs(legacyKubeNamespace, "edge", "serve-pxe")
+		withFlag := metalmanDeploymentForSiteWithArgs(legacyNetNamespace, "edge", "--dhcp-auto-interface")
+		withFlag.Name = "older-metalman-name"
+		r := newReaper(t, withoutFlag, withFlag)
+
+		if _, _, err := r.legacyMetalmanConfigForSite(t.Context(), "edge"); err == nil {
+			t.Fatal("expected absent and enabled Metalman arguments to conflict")
+		}
+	})
 }
 
-// Finding 7: a per-site storage DaemonSet that has not scheduled any pod is not
-// "ready"; treating DesiredNumberScheduled==0 as ready would let the legacy
-// supervisor be reaped before the replacement runs anywhere.
+// The generic storage readiness predicate remains strict for zero desired; the
+// higher-level gate applies the narrow no-matching-Node exception.
 func TestStorageDaemonSetReadyRequiresScheduled(t *testing.T) {
 	cases := []struct {
 		name string
@@ -175,23 +255,85 @@ func TestStorageDaemonSetReadyRequiresScheduled(t *testing.T) {
 	}
 }
 
-func TestStorageTargetsReadyBlocksOnZeroDesired(t *testing.T) {
+func TestStorageTargetsReadyAllowsZeroDesiredWithoutMatchingNodes(t *testing.T) {
 	target := "unbounded-system"
 
 	zeroDesired := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: storageDaemonSetName("edge")},
 		Status:     appsv1.DaemonSetStatus{ObservedGeneration: 100, DesiredNumberScheduled: 0},
 	}
-	r := newReaper(t, storageEnabledSite("edge"), zeroDesired)
+	site := storageEnabledSite("edge")
+	site.Spec.NodeCidrs = []string{"10.20.0.0/16"}
+	r := newReaper(t, site, zeroDesired)
 
 	ready, err := r.storageTargetsReady(t.Context(), target)
 	if err != nil {
 		t.Fatalf("storageTargetsReady: %v", err)
 	}
 
-	if ready {
-		t.Fatal("expected storage not ready while the per-site DaemonSet has zero scheduled pods")
+	if !ready {
+		t.Fatal("expected zero-desired storage ready when no Node matches the Site CIDRs")
 	}
+}
+
+func TestStorageTargetsReadyZeroDesiredNodeCIDRGate(t *testing.T) {
+	target := "unbounded-system"
+	zeroDesired := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: storageDaemonSetName("edge")},
+		Status:     appsv1.DaemonSetStatus{ObservedGeneration: 100},
+	}
+
+	t.Run("matching unlabeled node blocks", func(t *testing.T) {
+		site := storageEnabledSite("edge")
+		site.Spec.NodeCidrs = []string{"10.20.0.0/16"}
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+			Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.20.1.2"},
+			}},
+		}
+		r := newReaper(t, site, zeroDesired.DeepCopy(), node)
+
+		ready, err := r.storageTargetsReady(t.Context(), target)
+		if err != nil {
+			t.Fatalf("storageTargetsReady: %v", err)
+		}
+
+		if ready {
+			t.Fatal("expected matching unlabeled Node to block zero-desired storage")
+		}
+	})
+
+	t.Run("nonmatching node allows", func(t *testing.T) {
+		site := storageEnabledSite("edge")
+		site.Spec.NodeCidrs = []string{"10.20.0.0/16"}
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+			Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.30.1.2"},
+			}},
+		}
+		r := newReaper(t, site, zeroDesired.DeepCopy(), node)
+
+		ready, err := r.storageTargetsReady(t.Context(), target)
+		if err != nil {
+			t.Fatalf("storageTargetsReady: %v", err)
+		}
+
+		if !ready {
+			t.Fatal("expected nonmatching Node to allow zero-desired storage")
+		}
+	})
+
+	t.Run("invalid Site CIDR errors", func(t *testing.T) {
+		site := storageEnabledSite("edge")
+		site.Spec.NodeCidrs = []string{"not-a-cidr"}
+		r := newReaper(t, site, zeroDesired.DeepCopy())
+
+		if _, err := r.storageTargetsReady(t.Context(), target); err == nil {
+			t.Fatal("expected invalid Site CIDR to fail the storage gate")
+		}
+	})
 }
 
 // Finding 6: the legacy net-group Site CRD is only deleted once the new net
@@ -236,15 +378,16 @@ func TestNetControllerAvailable(t *testing.T) {
 // reported (so the warning path fires) but deletion still proceeds.
 func TestForeignWorkloads(t *testing.T) {
 	foreign := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: legacyKubeNamespace, Name: "user-app"}}
-	r := newReaper(t, foreign)
+	stateful := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: legacyKubeNamespace, Name: "user-database"}}
+	r := newReaper(t, foreign, stateful)
 
 	got, err := r.foreignWorkloads(t.Context(), legacyKubeNamespace)
 	if err != nil {
 		t.Fatalf("foreignWorkloads: %v", err)
 	}
 
-	if len(got) != 1 || got[0] != "Deployment/user-app" {
-		t.Fatalf("foreignWorkloads = %v, want [Deployment/user-app]", got)
+	if len(got) != 2 || got[0] != "Deployment/user-app" || got[1] != "StatefulSet/user-database" {
+		t.Fatalf("foreignWorkloads = %v, want [Deployment/user-app StatefulSet/user-database]", got)
 	}
 
 	// warnOnForeignWorkloads must be nil-Recorder safe and not error.
@@ -306,6 +449,36 @@ func TestCleanupLegacySiteCRDGatesOnNetController(t *testing.T) {
 		}
 	})
 
+	t.Run("retained while a slice has stale ownership", func(t *testing.T) {
+		replicas := int32(1)
+		netCtrl := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: "unbounded-net-controller"},
+			Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+			Status:     appsv1.DeploymentStatus{ObservedGeneration: 100, AvailableReplicas: 1},
+		}
+		site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "current-uid"}}
+		slice := siteNodeSlice("edge-0", "edge", []metav1.OwnerReference{{
+			APIVersion: legacySiteGVK.GroupVersion().String(),
+			Kind:       legacySiteGVK.Kind,
+			Name:       "edge",
+			UID:        "legacy-uid",
+		}})
+		r := newReaper(t, crd.DeepCopy(), netCtrl, site, slice)
+
+		gone, err := r.cleanupLegacySiteCRD(t.Context(), logr.Discard(), target)
+		if err != nil {
+			t.Fatalf("cleanupLegacySiteCRD: %v", err)
+		}
+
+		if gone {
+			t.Fatal("expected legacy CRD retained while a SiteNodeSlice has stale ownership")
+		}
+
+		if exists, err := r.legacySiteCRDExists(t.Context()); err != nil || !exists {
+			t.Fatalf("legacy CRD should still exist: exists=%t err=%v", exists, err)
+		}
+	})
+
 	t.Run("absent CRD reports gone", func(t *testing.T) {
 		r := newReaper(t)
 
@@ -318,4 +491,49 @@ func TestCleanupLegacySiteCRDGatesOnNetController(t *testing.T) {
 			t.Fatal("expected gone when the legacy CRD does not exist")
 		}
 	})
+}
+
+func siteNodeSlice(name, siteName string, refs []metav1.OwnerReference) *unstructured.Unstructured {
+	slice := &unstructured.Unstructured{}
+	slice.SetGroupVersionKind(siteNodeSliceGVK)
+	slice.SetName(name)
+	slice.SetOwnerReferences(refs)
+	slice.Object["siteName"] = siteName
+
+	return slice
+}
+
+func TestSiteNodeSlicesOwnedByCurrentSites(t *testing.T) {
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "current-uid"}}
+	exact := *metav1.NewControllerRef(site, newSiteGVK())
+
+	tests := []struct {
+		name string
+		objs []client.Object
+		want bool
+	}{
+		{name: "zero slices pass", want: true},
+		{name: "exact sole owner passes", objs: []client.Object{siteNodeSlice("edge-0", "edge", []metav1.OwnerReference{exact})}, want: true},
+		{name: "wrong UID blocks", objs: []client.Object{siteNodeSlice("edge-0", "edge", []metav1.OwnerReference{{APIVersion: exact.APIVersion, Kind: exact.Kind, Name: exact.Name, UID: "old-uid", Controller: exact.Controller, BlockOwnerDeletion: exact.BlockOwnerDeletion}})}},
+		{name: "wrong GVK blocks", objs: []client.Object{siteNodeSlice("edge-0", "edge", []metav1.OwnerReference{{APIVersion: legacySiteGVK.GroupVersion().String(), Kind: "Site", Name: exact.Name, UID: exact.UID, Controller: exact.Controller, BlockOwnerDeletion: exact.BlockOwnerDeletion}})}},
+		{name: "additional owner blocks", objs: []client.Object{siteNodeSlice("edge-0", "edge", []metav1.OwnerReference{exact, {APIVersion: "v1", Kind: "Node", Name: "node", UID: "node-uid"}})}},
+		{name: "missing matching Site blocks", objs: []client.Object{siteNodeSlice("missing-0", "missing", nil)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []client.Object{site.DeepCopy()}
+			objs = append(objs, tt.objs...)
+			r := newReaper(t, objs...)
+
+			got, err := r.siteNodeSlicesOwnedByCurrentSites(t.Context())
+			if err != nil {
+				t.Fatalf("siteNodeSlicesOwnedByCurrentSites: %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("siteNodeSlicesOwnedByCurrentSites = %t, want %t", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/operator/migrate_gates_test.go
+++ b/internal/operator/migrate_gates_test.go
@@ -1,0 +1,321 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+func metalmanEnabledSite(name string) *unboundedv1alpha3.Site {
+	return &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: unboundedv1alpha3.SiteSpec{
+			Components: unboundedv1alpha3.SiteComponents{
+				Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
+					SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: boolPtr(true)},
+				},
+			},
+		},
+	}
+}
+
+func targetMetalmanDeployment(target, site string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: metalmanDeploymentName(site)},
+	}
+}
+
+// Finding 1: metalman legacy resources may only be reaped once the per-site
+// replacement Deployment exists (presence, not readiness - host-port contention
+// would deadlock a readiness gate). A footprint with no enabled Site blocks reap.
+func TestMetalmanTargetsPresent(t *testing.T) {
+	target := "unbounded-system"
+
+	t.Run("absent replacement blocks reap", func(t *testing.T) {
+		r := newReaper(t, metalmanEnabledSite("edge"))
+
+		present, err := r.metalmanTargetsPresent(t.Context(), target)
+		if err != nil {
+			t.Fatalf("metalmanTargetsPresent: %v", err)
+		}
+
+		if present {
+			t.Fatal("expected not present when the per-site metalman Deployment is missing")
+		}
+	})
+
+	t.Run("present replacement allows reap", func(t *testing.T) {
+		r := newReaper(t, metalmanEnabledSite("edge"), targetMetalmanDeployment(target, "edge"))
+
+		present, err := r.metalmanTargetsPresent(t.Context(), target)
+		if err != nil {
+			t.Fatalf("metalmanTargetsPresent: %v", err)
+		}
+
+		if !present {
+			t.Fatal("expected present when the per-site metalman Deployment exists")
+		}
+	})
+
+	t.Run("no enabled site blocks reap", func(t *testing.T) {
+		r := newReaper(t) // no Sites enable metalman
+
+		present, err := r.metalmanTargetsPresent(t.Context(), target)
+		if err != nil {
+			t.Fatalf("metalmanTargetsPresent: %v", err)
+		}
+
+		if present {
+			t.Fatal("expected not present when no Site enables metalman (detection miss guard)")
+		}
+	})
+}
+
+// Finding 2: metalman detection tolerates the deprecated site-label key and
+// matches by the deterministic Deployment name, so a real v0.1.19 cluster (which
+// happens to use the canonical key) and older shapes both migrate.
+func TestLegacyMetalmanDetectionHardening(t *testing.T) {
+	t.Run("deprecated label key", func(t *testing.T) {
+		deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Namespace: legacyKubeNamespace,
+			Name:      "metalman-controller-edge",
+			Labels:    map[string]string{"app": "unbounded-pxe", deprecatedSiteLabelKey: "edge"},
+		}}
+		r := newReaper(t, deploy)
+
+		got, err := r.legacyMetalmanExistsForSite(t.Context(), "edge")
+		if err != nil {
+			t.Fatalf("legacyMetalmanExistsForSite: %v", err)
+		}
+
+		if !got {
+			t.Fatal("expected metalman detected via deprecated site label")
+		}
+	})
+
+	t.Run("name-only (no site label)", func(t *testing.T) {
+		deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Namespace: legacyKubeNamespace,
+			Name:      "metalman-controller-edge",
+			Labels:    map[string]string{"app": "unbounded-pxe"},
+		}}
+		r := newReaper(t, deploy)
+
+		got, err := r.legacyMetalmanExistsForSite(t.Context(), "edge")
+		if err != nil {
+			t.Fatalf("legacyMetalmanExistsForSite: %v", err)
+		}
+
+		if !got {
+			t.Fatal("expected metalman detected via deterministic Deployment name")
+		}
+	})
+
+	t.Run("different site not matched", func(t *testing.T) {
+		deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Namespace: legacyKubeNamespace,
+			Name:      "metalman-controller-other",
+			Labels:    map[string]string{"app": "unbounded-pxe", unboundedv1alpha3.MachineSiteLabelKey: "other"},
+		}}
+		r := newReaper(t, deploy)
+
+		got, err := r.legacyMetalmanExistsForSite(t.Context(), "edge")
+		if err != nil {
+			t.Fatalf("legacyMetalmanExistsForSite: %v", err)
+		}
+
+		if got {
+			t.Fatal("did not expect a different site's metalman to match")
+		}
+	})
+}
+
+// Finding 7: a per-site storage DaemonSet that has not scheduled any pod is not
+// "ready"; treating DesiredNumberScheduled==0 as ready would let the legacy
+// supervisor be reaped before the replacement runs anywhere.
+func TestStorageDaemonSetReadyRequiresScheduled(t *testing.T) {
+	cases := []struct {
+		name string
+		ds   appsv1.DaemonSet
+		want bool
+	}{
+		{
+			name: "zero desired is not ready",
+			ds:   appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 0, NumberReady: 0}},
+			want: false,
+		},
+		{
+			name: "scheduled and ready",
+			ds:   appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 2, NumberReady: 2}},
+			want: true,
+		},
+		{
+			name: "scheduled but not all ready",
+			ds:   appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 2, NumberReady: 1}},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := storageDaemonSetReady(&tc.ds); got != tc.want {
+				t.Fatalf("storageDaemonSetReady = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStorageTargetsReadyBlocksOnZeroDesired(t *testing.T) {
+	target := "unbounded-system"
+
+	zeroDesired := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: storageDaemonSetName("edge")},
+		Status:     appsv1.DaemonSetStatus{ObservedGeneration: 100, DesiredNumberScheduled: 0},
+	}
+	r := newReaper(t, storageEnabledSite("edge"), zeroDesired)
+
+	ready, err := r.storageTargetsReady(t.Context(), target)
+	if err != nil {
+		t.Fatalf("storageTargetsReady: %v", err)
+	}
+
+	if ready {
+		t.Fatal("expected storage not ready while the per-site DaemonSet has zero scheduled pods")
+	}
+}
+
+// Finding 6: the legacy net-group Site CRD is only deleted once the new net
+// controller is Available (so it has re-owned/recreated the SiteNodeSlices).
+func TestNetControllerAvailable(t *testing.T) {
+	target := "unbounded-system"
+
+	t.Run("absent", func(t *testing.T) {
+		r := newReaper(t)
+
+		ok, err := r.netControllerAvailable(t.Context(), target)
+		if err != nil {
+			t.Fatalf("netControllerAvailable: %v", err)
+		}
+
+		if ok {
+			t.Fatal("expected not available when the Deployment is missing")
+		}
+	})
+
+	t.Run("available", func(t *testing.T) {
+		replicas := int32(1)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: "unbounded-net-controller"},
+			Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+			Status:     appsv1.DeploymentStatus{ObservedGeneration: 100, AvailableReplicas: 1},
+		}
+		r := newReaper(t, deploy)
+
+		ok, err := r.netControllerAvailable(t.Context(), target)
+		if err != nil {
+			t.Fatalf("netControllerAvailable: %v", err)
+		}
+
+		if !ok {
+			t.Fatal("expected available")
+		}
+	})
+}
+
+// Finding 5: a legacy namespace that still holds non-operator workloads is
+// reported (so the warning path fires) but deletion still proceeds.
+func TestForeignWorkloads(t *testing.T) {
+	foreign := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: legacyKubeNamespace, Name: "user-app"}}
+	r := newReaper(t, foreign)
+
+	got, err := r.foreignWorkloads(t.Context(), legacyKubeNamespace)
+	if err != nil {
+		t.Fatalf("foreignWorkloads: %v", err)
+	}
+
+	if len(got) != 1 || got[0] != "Deployment/user-app" {
+		t.Fatalf("foreignWorkloads = %v, want [Deployment/user-app]", got)
+	}
+
+	// warnOnForeignWorkloads must be nil-Recorder safe and not error.
+	r.warnOnForeignWorkloads(t.Context(), logr.Discard(), legacyKubeNamespace)
+
+	empty := newReaper(t)
+
+	names, err := empty.foreignWorkloads(t.Context(), legacyKubeNamespace)
+	if err != nil {
+		t.Fatalf("foreignWorkloads(empty): %v", err)
+	}
+
+	if len(names) != 0 {
+		t.Fatalf("expected no foreign workloads, got %v", names)
+	}
+}
+
+// Finding 6: cleanupLegacySiteCRD retains the legacy CRD while the new net
+// controller is not yet Available, then deletes it once it is.
+func TestCleanupLegacySiteCRDGatesOnNetController(t *testing.T) {
+	target := "unbounded-system"
+	crd := &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: legacySiteCRDName}}
+
+	t.Run("retained while net controller unavailable", func(t *testing.T) {
+		r := newReaper(t, crd.DeepCopy())
+
+		gone, err := r.cleanupLegacySiteCRD(t.Context(), logr.Discard(), target)
+		if err != nil {
+			t.Fatalf("cleanupLegacySiteCRD: %v", err)
+		}
+
+		if gone {
+			t.Fatal("expected legacy CRD retained while net controller is unavailable")
+		}
+	})
+
+	t.Run("deleted once net controller available", func(t *testing.T) {
+		replicas := int32(1)
+		netCtrl := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: target, Name: "unbounded-net-controller"},
+			Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+			Status:     appsv1.DeploymentStatus{ObservedGeneration: 100, AvailableReplicas: 1},
+		}
+		r := newReaper(t, crd.DeepCopy(), netCtrl)
+
+		// First pass issues the delete; deleteLegacySiteCRD reports not-gone
+		// until the object is observed absent.
+		if _, err := r.cleanupLegacySiteCRD(t.Context(), logr.Discard(), target); err != nil {
+			t.Fatalf("cleanupLegacySiteCRD (delete pass): %v", err)
+		}
+
+		gone, err := r.cleanupLegacySiteCRD(t.Context(), logr.Discard(), target)
+		if err != nil {
+			t.Fatalf("cleanupLegacySiteCRD (confirm pass): %v", err)
+		}
+
+		if !gone {
+			t.Fatal("expected legacy CRD deleted once net controller is Available")
+		}
+	})
+
+	t.Run("absent CRD reports gone", func(t *testing.T) {
+		r := newReaper(t)
+
+		gone, err := r.cleanupLegacySiteCRD(t.Context(), logr.Discard(), target)
+		if err != nil {
+			t.Fatalf("cleanupLegacySiteCRD: %v", err)
+		}
+
+		if !gone {
+			t.Fatal("expected gone when the legacy CRD does not exist")
+		}
+	})
+}

--- a/internal/operator/migrate_test.go
+++ b/internal/operator/migrate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -44,6 +45,10 @@ func reaperScheme(t *testing.T) *runtime.Scheme {
 	listGVK := legacySiteGVK
 	listGVK.Kind += "List"
 	scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(siteNodeSliceGVK, &unstructured.Unstructured{})
+	sliceListGVK := siteNodeSliceGVK
+	sliceListGVK.Kind += "List"
+	scheme.AddKnownTypeWithName(sliceListGVK, &unstructured.UnstructuredList{})
 
 	return scheme
 }
@@ -97,6 +102,13 @@ func metalmanDeploymentForSite(namespace, site string) *appsv1.Deployment {
 			Labels: map[string]string{"app": "unbounded-pxe", unboundedv1alpha3.MachineSiteLabelKey: site},
 		},
 	}
+}
+
+func metalmanDeploymentForSiteWithArgs(namespace, site string, args ...string) *appsv1.Deployment {
+	deploy := metalmanDeploymentForSite(namespace, site)
+	deploy.Spec.Template.Spec.Containers = []corev1.Container{{Name: "metalman", Args: args}}
+
+	return deploy
 }
 
 func TestDetectComponentsMatchesV019MetalmanLabels(t *testing.T) {
@@ -213,6 +225,87 @@ func TestTranslateSitesCreatesMachinaSite(t *testing.T) {
 	}
 }
 
+func TestTranslateSitesPreservesMetalmanDHCPAutoInterface(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want bool
+	}{
+		{name: "bare", arg: "--dhcp-auto-interface", want: true},
+		{name: "explicit true", arg: "--dhcp-auto-interface=true", want: true},
+		{name: "explicit false", arg: "--dhcp-auto-interface=false", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newReaper(t,
+				legacySite("edge", map[string]any{"nodeCidrs": []any{"10.0.0.0/16"}}),
+				metalmanDeploymentForSiteWithArgs(legacyKubeNamespace, "edge", "serve-pxe", tt.arg),
+			)
+
+			if err := r.translateSites(t.Context(), logr.Discard()); err != nil {
+				t.Fatalf("translateSites: %v", err)
+			}
+
+			got := &unstructured.Unstructured{}
+			got.SetGroupVersionKind(newSiteGVK())
+
+			if err := r.Get(t.Context(), client.ObjectKey{Name: "edge"}, got); err != nil {
+				t.Fatalf("get translated Site: %v", err)
+			}
+
+			value, found, err := unstructured.NestedBool(got.Object, "spec", "components", "metalman", "dhcpAutoInterface")
+			if err != nil || !found || value != tt.want {
+				t.Fatalf("dhcpAutoInterface = %t, found=%t, err=%v; want %t", value, found, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetalmanDHCPAutoInterface(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    *bool
+		wantErr bool
+	}{
+		{name: "absent", args: []string{"serve-pxe"}},
+		{name: "bare", args: []string{"--dhcp-auto-interface"}, want: boolPtr(true)},
+		{name: "explicit true", args: []string{"--dhcp-auto-interface=true"}, want: boolPtr(true)},
+		{name: "explicit false", args: []string{"--dhcp-auto-interface=false"}, want: boolPtr(false)},
+		{name: "repeated same value", args: []string{"--dhcp-auto-interface", "--dhcp-auto-interface=true"}, want: boolPtr(true)},
+		{name: "invalid", args: []string{"--dhcp-auto-interface=yes"}, wantErr: true},
+		{name: "conflicting", args: []string{"--dhcp-auto-interface", "--dhcp-auto-interface=false"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deploy := metalmanDeploymentForSiteWithArgs(legacyKubeNamespace, "edge", tt.args...)
+
+			got, err := metalmanDHCPAutoInterface(deploy)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("metalmanDHCPAutoInterface error = %v, wantErr %t", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if got == nil || tt.want == nil {
+				if got != nil || tt.want != nil {
+					t.Fatalf("metalmanDHCPAutoInterface = %v, want %v", got, tt.want)
+				}
+
+				return
+			}
+
+			if *got != *tt.want {
+				t.Fatalf("metalmanDHCPAutoInterface = %t, want %t", *got, *tt.want)
+			}
+		})
+	}
+}
+
 func TestTranslateSitesDoesNotClobberExisting(t *testing.T) {
 	existing := &unboundedv1alpha3.Site{
 		ObjectMeta: metav1.ObjectMeta{Name: clusterSiteName},
@@ -321,6 +414,38 @@ func TestMigrateConfigMapsCopiesNamedOnly(t *testing.T) {
 	}
 }
 
+func TestMigrateMachinaConfigUsesConfiguredEndpoint(t *testing.T) {
+	r := newReaper(t,
+		ns(legacyKubeNamespace),
+		ns("unbounded-system"),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "machina-config", Namespace: legacyKubeNamespace},
+			Data: map[string]string{
+				"config.yaml": "apiServerEndpoint: https://old.example:6443\ncustom: keep\n",
+			},
+		},
+	)
+	r.APIServerEndpoint = "https://new.example:6443"
+
+	if err := r.migrateConfigMaps(t.Context(), logr.Discard(), legacyKubeNamespace, "unbounded-system"); err != nil {
+		t.Fatalf("migrateConfigMaps: %v", err)
+	}
+
+	var cm corev1.ConfigMap
+	if err := r.Get(t.Context(), client.ObjectKey{Namespace: "unbounded-system", Name: "machina-config"}, &cm); err != nil {
+		t.Fatalf("get migrated machina config: %v", err)
+	}
+
+	var config map[string]any
+	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &config); err != nil {
+		t.Fatalf("unmarshal migrated config: %v", err)
+	}
+
+	if config["apiServerEndpoint"] != r.APIServerEndpoint || config["custom"] != "keep" {
+		t.Fatalf("migrated config = %#v", config)
+	}
+}
+
 func machineWithPasswordNS(name, namespace string) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "unbounded-cloud.io", Version: "v1alpha3", Kind: "Machine"})
@@ -384,6 +509,23 @@ func readyDeployment(namespace, name string) *appsv1.Deployment {
 		Spec:       appsv1.DeploymentSpec{Replicas: &one},
 		Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
 	}
+}
+
+func readyMachinaTarget(namespace, config string) (*corev1.ConfigMap, *appsv1.Deployment) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "machina-config"},
+		Data:       map[string]string{"config.yaml": config},
+	}
+	deploy := readyDeployment(namespace, "machina-controller")
+	deploy.Generation = 1
+	deploy.Spec.Template.Annotations = map[string]string{
+		machinaConfigHashAnnotation: machinaConfigHash(config),
+	}
+	deploy.Status.ObservedGeneration = 1
+	deploy.Status.Replicas = 1
+	deploy.Status.UpdatedReplicas = 1
+
+	return cm, deploy
 }
 
 func readyDaemonSet(namespace, name string) *appsv1.DaemonSet {
@@ -836,11 +978,13 @@ func TestReapOnceStorageGatedOnPerSiteDaemonSet(t *testing.T) {
 func TestReapOnceSkipsComponentsWithoutLegacyFootprint(t *testing.T) {
 	// The legacy unbounded-kube namespace contains only machina (no storage).
 	// The reaper must NOT block waiting for a storage target that never exists.
+	config, target := readyMachinaTarget("unbounded-system", "apiServerEndpoint: https://api.example:6443\n")
 	r := newReaper(t,
 		ns(legacyKubeNamespace),
 		ns("unbounded-system"),
 		labeledAppDeployment(legacyKubeNamespace, "machina-controller", map[string]string{"app": "machina-controller"}),
-		readyDeployment("unbounded-system", "machina-controller"),
+		config,
+		target,
 	)
 
 	done, err := r.reapOnce(t.Context(), logr.Discard())

--- a/internal/operator/migrate_test.go
+++ b/internal/operator/migrate_test.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,6 +30,7 @@ func reaperScheme(t *testing.T) *runtime.Scheme {
 		corev1.AddToScheme,
 		appsv1.AddToScheme,
 		rbacv1.AddToScheme,
+		apiextensionsv1.AddToScheme,
 		unboundedv1alpha3.AddToScheme,
 	} {
 		if err := add(scheme); err != nil {

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -24,7 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -141,10 +144,16 @@ func (r *SiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	patch := client.MergeFrom(site.DeepCopy())
 
+	var reconcileErrs []error
+
 	// Publish one condition per component in a stable order so the status patch
 	// is deterministic and callers can `kubectl wait --for=condition=NetReady`.
 	for _, name := range []string{ComponentNet, ComponentMachina, ComponentMetalman, ComponentStorage} {
 		res := results[name]
+		if res.err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("%s: %w", name, res.err))
+		}
+
 		if !res.ready {
 			logger.Info("component not ready", "site", site.Name, "component", name, "message", res.message)
 		}
@@ -164,10 +173,10 @@ func (r *SiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	if err := r.Status().Patch(ctx, &site, patch); err != nil {
-		return ctrl.Result{}, fmt.Errorf("patch site status: %w", err)
+		reconcileErrs = append(reconcileErrs, fmt.Errorf("patch site status: %w", err))
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, errors.Join(reconcileErrs...)
 }
 
 // componentResult is the internal outcome of reconciling a single component,
@@ -176,6 +185,7 @@ type componentResult struct {
 	ready   bool
 	reason  string
 	message string
+	err     error
 }
 
 // componentConditionType maps a component name to its Site status condition
@@ -197,14 +207,56 @@ func componentConditionType(component string) string {
 
 func (r *SiteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&unboundedv1alpha3.Site{}).
+		For(&unboundedv1alpha3.Site{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		// Site status is written by the net controller (nodeCount/sliceCount) on
 		// node churn; reconciling on those status-only updates would re-apply the
 		// full net + machina manifest sets on every event. Filter to spec/
 		// generation changes (Create/Delete still pass) so component reconcile is
 		// driven by intent, not status noise.
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForMachinaConfig),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(e event.CreateEvent) bool { return r.isMachinaConfig(e.Object) },
+				DeleteFunc: func(e event.DeleteEvent) bool { return r.isMachinaConfig(e.Object) },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					if !r.isMachinaConfig(e.ObjectNew) {
+						return false
+					}
+
+					oldConfig, oldOK := e.ObjectOld.(*corev1.ConfigMap)
+
+					newConfig, newOK := e.ObjectNew.(*corev1.ConfigMap)
+					if !oldOK || !newOK {
+						return false
+					}
+
+					return oldConfig.Data["config.yaml"] != newConfig.Data["config.yaml"]
+				},
+				GenericFunc: func(event.GenericEvent) bool { return false },
+			}),
+		).
 		Complete(r)
+}
+
+func (r *SiteReconciler) isMachinaConfig(obj client.Object) bool {
+	return obj.GetNamespace() == r.namespace() && obj.GetName() == "machina-config"
+}
+
+func (r *SiteReconciler) requestsForMachinaConfig(ctx context.Context, _ client.Object) []ctrl.Request {
+	sites, err := r.listSites(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "list Sites after machina config change")
+
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0, len(sites))
+	for i := range sites {
+		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKey{Name: sites[i].Name}})
+	}
+
+	return requests
 }
 
 // reconcilePerSiteComponent reconciles a per-site component when enabled and
@@ -212,14 +264,14 @@ func (r *SiteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *SiteReconciler) reconcilePerSiteComponent(enabled bool, reconcile, cleanup func() error) componentResult {
 	if !enabled {
 		if err := cleanup(); err != nil {
-			return componentResult{ready: false, reason: reasonReconcileError, message: err.Error()}
+			return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
 		}
 
 		return componentResult{ready: true, reason: reasonDisabled, message: "component disabled"}
 	}
 
 	if err := reconcile(); err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error()}
+		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
 	}
 
 	return componentResult{ready: true, reason: reasonReconciled, message: "component reconciled"}
@@ -245,7 +297,7 @@ func (r *SiteReconciler) reconcileSingletons(ctx context.Context) error {
 func (r *SiteReconciler) reconcileNet(ctx context.Context) componentResult {
 	sites, err := r.listSites(ctx)
 	if err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error()}
+		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
 	}
 
 	if len(sites) == 0 {
@@ -256,7 +308,7 @@ func (r *SiteReconciler) reconcileNet(ctx context.Context) componentResult {
 	}
 
 	if err := r.applyManifestFS(ctx, netmanifests.Manifests, skipCRDObjects); err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error()}
+		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
 	}
 
 	return componentResult{ready: true, reason: reasonReconciled, message: "component reconciled"}
@@ -267,7 +319,7 @@ func (r *SiteReconciler) reconcileNet(ctx context.Context) componentResult {
 func (r *SiteReconciler) reconcileMachina(ctx context.Context) componentResult {
 	sites, err := r.listSites(ctx)
 	if err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error()}
+		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
 	}
 
 	enabled := false
@@ -286,19 +338,21 @@ func (r *SiteReconciler) reconcileMachina(ctx context.Context) componentResult {
 		return componentResult{ready: true, reason: reasonDisabled, message: "no site enables machina; retained"}
 	}
 
-	if err := r.applyManifestFS(ctx, machinamanifests.Manifests, r.machinaApplyMutator(ctx)); err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error()}
+	configHash, err := r.ensureMachinaConfig(ctx)
+	if err != nil {
+		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
+	}
+
+	if err := r.applyManifestFS(ctx, machinamanifests.Manifests, r.machinaApplyMutator(configHash)); err != nil {
+		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
 	}
 
 	return componentResult{ready: true, reason: reasonReconciled, message: "component reconciled"}
 }
 
-// machinaApplyMutator returns the mutate used when applying the machina
-// singleton. It layers migrated-config preservation on top of mutateMachinaObject:
-// the machina-config ConfigMap is created with embedded defaults only when it is
-// absent, so config migrated by the reaper (or later edited by an operator) is
-// never clobbered by a force-apply of the embedded defaults.
-func (r *SiteReconciler) machinaApplyMutator(ctx context.Context) func(*unstructured.Unstructured) error {
+// machinaApplyMutator skips the separately reconciled ConfigMap and stamps its
+// exact content hash on the Deployment so every config change rolls Machina.
+func (r *SiteReconciler) machinaApplyMutator(configHash string) func(*unstructured.Unstructured) error {
 	return func(obj *unstructured.Unstructured) error {
 		if err := r.mutateMachinaObject(obj); err != nil {
 			return err
@@ -309,14 +363,15 @@ func (r *SiteReconciler) machinaApplyMutator(ctx context.Context) func(*unstruct
 		}
 
 		if obj.GetKind() == "ConfigMap" && obj.GetName() == "machina-config" {
-			exists, err := r.objectExists(ctx, r.namespace(), "machina-config", &corev1.ConfigMap{})
-			if err != nil {
-				return err
-			}
+			obj.Object = nil
 
-			if exists {
-				// Preserve the existing (migrated/edited) config.
-				obj.Object = nil
+			return nil
+		}
+
+		if obj.GetKind() == "Deployment" && obj.GetName() == "machina-controller" {
+			if err := unstructured.SetNestedField(obj.Object, configHash,
+				"spec", "template", "metadata", "annotations", machinaConfigHashAnnotation); err != nil {
+				return fmt.Errorf("set machina config hash annotation: %w", err)
 			}
 		}
 
@@ -324,18 +379,96 @@ func (r *SiteReconciler) machinaApplyMutator(ctx context.Context) func(*unstruct
 	}
 }
 
-// objectExists reports whether a namespaced object of the given empty type
-// exists.
-func (r *SiteReconciler) objectExists(ctx context.Context, namespace, name string, obj client.Object) (bool, error) {
-	err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj)
-	switch {
-	case err == nil:
-		return true, nil
-	case apierrors.IsNotFound(err):
-		return false, nil
-	default:
-		return false, fmt.Errorf("get %s/%s: %w", namespace, name, err)
+func (r *SiteReconciler) ensureMachinaConfig(ctx context.Context) (string, error) {
+	desired, err := defaultMachinaConfigMap(r.namespace())
+	if err != nil {
+		return "", err
 	}
+
+	key := client.ObjectKeyFromObject(desired)
+	existing := &corev1.ConfigMap{}
+
+	err = r.Get(ctx, key, existing)
+	if apierrors.IsNotFound(err) {
+		config, mergeErr := setMachinaAPIServerEndpoint(desired.Data["config.yaml"], r.Config.APIServerEndpoint)
+		if mergeErr != nil {
+			return "", mergeErr
+		}
+
+		desired.Data["config.yaml"] = config
+		if createErr := r.Create(ctx, desired); createErr != nil {
+			return "", fmt.Errorf("create machina config %s/%s: %w", key.Namespace, key.Name, createErr)
+		}
+
+		return machinaConfigHash(config), nil
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("get machina config %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	config := existing.Data["config.yaml"]
+
+	merged, err := setMachinaAPIServerEndpoint(config, r.Config.APIServerEndpoint)
+	if err != nil {
+		return "", err
+	}
+
+	if merged != config {
+		before := existing.DeepCopy()
+		if existing.Data == nil {
+			existing.Data = map[string]string{}
+		}
+
+		existing.Data["config.yaml"] = merged
+		if err := r.Patch(ctx, existing, client.MergeFrom(before)); err != nil {
+			return "", fmt.Errorf("update machina config %s/%s: %w", key.Namespace, key.Name, err)
+		}
+	}
+
+	return machinaConfigHash(merged), nil
+}
+
+func defaultMachinaConfigMap(namespace string) (*corev1.ConfigMap, error) {
+	files, err := yamlFiles(machinamanifests.Manifests)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		data, err := fs.ReadFile(machinamanifests.Manifests, file)
+		if err != nil {
+			return nil, fmt.Errorf("read machina manifest %s: %w", file, err)
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+		for {
+			obj := &unstructured.Unstructured{}
+			if err := decoder.Decode(obj); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, fmt.Errorf("decode machina manifest %s: %w", file, err)
+			}
+
+			if obj.Object == nil || obj.GetKind() != "ConfigMap" || obj.GetName() != "machina-config" {
+				continue
+			}
+
+			cm := &corev1.ConfigMap{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, cm); err != nil {
+				return nil, fmt.Errorf("convert machina config template: %w", err)
+			}
+
+			cm.Namespace = namespace
+
+			return cm, nil
+		}
+	}
+
+	return nil, errors.New("machina config template not found")
 }
 
 // reconcileMetalman deploys the per-site metalman PXE controller and its RBAC.
@@ -663,18 +796,6 @@ func (r *SiteReconciler) mutateMachinaObject(obj *unstructured.Unstructured) err
 	if isMetalmanSupportObject(obj) {
 		obj.Object = nil
 		return nil
-	}
-
-	if obj.GetKind() == "ConfigMap" && obj.GetName() == "machina-config" && r.Config.APIServerEndpoint != "" {
-		current, _, err := unstructured.NestedString(obj.Object, "data", "config.yaml")
-		if err != nil {
-			return fmt.Errorf("get machina config data: %w", err)
-		}
-
-		updated := strings.ReplaceAll(current, `apiServerEndpoint: ""`, fmt.Sprintf(`apiServerEndpoint: %q`, r.Config.APIServerEndpoint))
-		if err := unstructured.SetNestedField(obj.Object, updated, "data", "config.yaml"); err != nil {
-			return fmt.Errorf("set machina config data: %w", err)
-		}
 	}
 
 	return nil

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	machinamanifests "github.com/Azure/unbounded/deploy/machina"
@@ -197,6 +198,12 @@ func componentConditionType(component string) string {
 func (r *SiteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&unboundedv1alpha3.Site{}).
+		// Site status is written by the net controller (nodeCount/sliceCount) on
+		// node churn; reconciling on those status-only updates would re-apply the
+		// full net + machina manifest sets on every event. Filter to spec/
+		// generation changes (Create/Delete still pass) so component reconcile is
+		// driven by intent, not status noise.
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 
@@ -248,7 +255,7 @@ func (r *SiteReconciler) reconcileNet(ctx context.Context) componentResult {
 		return componentResult{ready: true, reason: reasonNoSites, message: "no sites; net retained"}
 	}
 
-	if err := r.applyManifestFS(ctx, netmanifests.Manifests, nil); err != nil {
+	if err := r.applyManifestFS(ctx, netmanifests.Manifests, skipCRDObjects); err != nil {
 		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error()}
 	}
 
@@ -587,36 +594,70 @@ func (r *SiteReconciler) retargetNamespace(obj *unstructured.Unstructured) {
 		obj.SetNamespace(ns)
 	}
 
-	rewriteStringValues(obj.Object, buildDefaultNamespace, ns)
+	rewriteNamespaceValues(obj.Object, buildDefaultNamespace, ns)
 }
 
-// rewriteStringValues recursively replaces every string value equal to oldValue
-// with newValue, so embedded cross-references (RBAC subjects, webhook client
-// configs, config-map references) follow a retargeted namespace.
-func rewriteStringValues(value any, oldValue, newValue string) {
+// rewriteNamespaceValues recursively retargets every string value that embeds the
+// old namespace to the new one. Unlike a naive equality swap it also handles the
+// namespace appearing as a substring, which the rendered manifests rely on:
+//   - service-account usernames in ValidatingAdmissionPolicy CEL
+//     ("system:serviceaccount:<ns>:<sa>"), and
+//   - flag values ("--leader-elect-resource-namespace=<ns>").
+//
+// Runtime re-rendering of the templates is not an option here because the
+// component image references are baked into the rendered manifests at build time
+// and are not available to the operator process.
+func rewriteNamespaceValues(value any, oldNS, newNS string) {
 	switch typed := value.(type) {
 	case map[string]any:
 		for key, v := range typed {
-			if str, ok := v.(string); ok && str == oldValue {
-				typed[key] = newValue
+			if str, ok := v.(string); ok {
+				typed[key] = retargetNamespaceInString(str, oldNS, newNS)
 				continue
 			}
 
-			rewriteStringValues(v, oldValue, newValue)
+			rewriteNamespaceValues(v, oldNS, newNS)
 		}
 	case []any:
 		for i, v := range typed {
-			if str, ok := v.(string); ok && str == oldValue {
-				typed[i] = newValue
+			if str, ok := v.(string); ok {
+				typed[i] = retargetNamespaceInString(str, oldNS, newNS)
 				continue
 			}
 
-			rewriteStringValues(v, oldValue, newValue)
+			rewriteNamespaceValues(v, oldNS, newNS)
 		}
 	}
 }
 
+// retargetNamespaceInString rewrites the old namespace to the new one within a
+// single string value, covering exact matches, service-account usernames, and
+// flag values, while leaving unrelated strings (for example image references)
+// untouched.
+func retargetNamespaceInString(s, oldNS, newNS string) string {
+	if s == oldNS {
+		return newNS
+	}
+
+	if strings.Contains(s, "system:serviceaccount:"+oldNS+":") {
+		s = strings.ReplaceAll(s, "system:serviceaccount:"+oldNS+":", "system:serviceaccount:"+newNS+":")
+	}
+
+	if strings.HasPrefix(s, "--") && strings.HasSuffix(s, "="+oldNS) {
+		s = strings.TrimSuffix(s, "="+oldNS) + "=" + newNS
+	}
+
+	return s
+}
+
 func (r *SiteReconciler) mutateMachinaObject(obj *unstructured.Unstructured) error {
+	// CRDs are installed once at operator startup (BootstrapCRDs), not from the
+	// reconcile loop; skip them here so a Site event does not re-apply schemas.
+	if obj.GetKind() == crdKind {
+		obj.Object = nil
+		return nil
+	}
+
 	// Metalman RBAC ships in the machina manifests but is applied per-site by
 	// reconcileMetalman; skip it here so the singleton apply does not create it.
 	if isMetalmanSupportObject(obj) {
@@ -634,6 +675,17 @@ func (r *SiteReconciler) mutateMachinaObject(obj *unstructured.Unstructured) err
 		if err := unstructured.SetNestedField(obj.Object, updated, "data", "config.yaml"); err != nil {
 			return fmt.Errorf("set machina config data: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// skipCRDObjects nils out CustomResourceDefinition objects so the reconcile
+// loop never applies CRDs; the operator installs them once at startup via
+// BootstrapCRDs.
+func skipCRDObjects(obj *unstructured.Unstructured) error {
+	if obj.GetKind() == crdKind {
+		obj.Object = nil
 	}
 
 	return nil

--- a/internal/operator/reconciler_test.go
+++ b/internal/operator/reconciler_test.go
@@ -390,6 +390,92 @@ func TestRetargetNamespaceRewritesToCustomNamespace(t *testing.T) {
 	}
 }
 
+// Finding 4: retargeting a custom namespace must also rewrite the namespace
+// where it appears as a substring - service-account usernames in VAP CEL and
+// flag values - while leaving unrelated strings (image refs) untouched.
+func TestRetargetNamespaceRewritesServiceAccountAndArgs(t *testing.T) {
+	r := &SiteReconciler{Namespace: "custom-ns"}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "admissionregistration.k8s.io/v1",
+		"kind":       "ValidatingAdmissionPolicy",
+		"metadata":   map[string]any{"name": "p"},
+		"spec": map[string]any{
+			"matchConditions": []any{
+				map[string]any{"expression": "request.userInfo.username == 'system:serviceaccount:unbounded-system:unbounded-net-controller'"},
+			},
+			"args":  []any{"--leader-elect-resource-namespace=unbounded-system"},
+			"image": "ghcr.io/azure/unbounded-system:v1",
+		},
+	}}
+
+	r.retargetNamespace(obj)
+
+	conds, _, _ := unstructured.NestedSlice(obj.Object, "spec", "matchConditions")
+	gotExpr := conds[0].(map[string]any)["expression"].(string)
+
+	if gotExpr != "request.userInfo.username == 'system:serviceaccount:custom-ns:unbounded-net-controller'" {
+		t.Fatalf("SA username not rewritten: %q", gotExpr)
+	}
+
+	args, _, _ := unstructured.NestedStringSlice(obj.Object, "spec", "args")
+	if len(args) != 1 || args[0] != "--leader-elect-resource-namespace=custom-ns" {
+		t.Fatalf("flag value not rewritten: %v", args)
+	}
+
+	if img, _, _ := unstructured.NestedString(obj.Object, "spec", "image"); img != "ghcr.io/azure/unbounded-system:v1" {
+		t.Fatalf("image ref must not be rewritten, got %q", img)
+	}
+}
+
+func TestRetargetNamespaceInString(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"unbounded-system", "custom-ns"},
+		{"system:serviceaccount:unbounded-system:sa", "system:serviceaccount:custom-ns:sa"},
+		{"--leader-elect-resource-namespace=unbounded-system", "--leader-elect-resource-namespace=custom-ns"},
+		{"ghcr.io/azure/unbounded-system:v1", "ghcr.io/azure/unbounded-system:v1"},
+		{"unbounded-system-other", "unbounded-system-other"},
+	}
+
+	for _, tc := range cases {
+		if got := retargetNamespaceInString(tc.in, "unbounded-system", "custom-ns"); got != tc.want {
+			t.Fatalf("retargetNamespaceInString(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Finding 3: the reconcile loop never applies CRDs (the operator installs them
+// once at startup via BootstrapCRDs).
+func TestSkipCRDObjects(t *testing.T) {
+	crd := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata":   map[string]any{"name": "sites.unbounded-cloud.io"},
+	}}
+
+	if err := skipCRDObjects(crd); err != nil {
+		t.Fatalf("skipCRDObjects: %v", err)
+	}
+
+	if crd.Object != nil {
+		t.Fatal("expected CRD object nilled out")
+	}
+
+	other := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "x"},
+	}}
+
+	if err := skipCRDObjects(other); err != nil {
+		t.Fatalf("skipCRDObjects: %v", err)
+	}
+
+	if other.Object == nil {
+		t.Fatal("non-CRD object must be preserved")
+	}
+}
+
 func assertSiteOwnerRef(t *testing.T, refs []metav1.OwnerReference, siteName, uid string) {
 	t.Helper()
 

--- a/internal/operator/reconciler_test.go
+++ b/internal/operator/reconciler_test.go
@@ -4,19 +4,156 @@
 package operator
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 )
+
+func TestReconcilePatchesAllConditionsAndReturnsComponentErrors(t *testing.T) {
+	scheme := newReconcilerTestScheme(t)
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "rack-a", Generation: 7},
+	}
+	netErr := errors.New("net reconcile failed")
+	machinaErr := errors.New("machina reconcile failed")
+	listErrs := []error{netErr, machinaErr}
+	listCalls := 0
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(site).
+		WithStatusSubresource(site).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*unboundedv1alpha3.SiteList); !ok {
+					t.Fatalf("unexpected list type %T", list)
+				}
+
+				err := listErrs[listCalls]
+				listCalls++
+
+				return err
+			},
+		}).
+		Build()
+
+	r := &SiteReconciler{Client: cl, Scheme: scheme}
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(site)})
+	if !errors.Is(err, netErr) || !errors.Is(err, machinaErr) {
+		t.Fatalf("Reconcile error = %v, want joined net and machina errors", err)
+	}
+
+	var got unboundedv1alpha3.Site
+	if err := cl.Get(t.Context(), client.ObjectKeyFromObject(site), &got); err != nil {
+		t.Fatalf("get reconciled Site: %v", err)
+	}
+
+	want := map[string]struct {
+		status metav1.ConditionStatus
+		reason string
+	}{
+		"NetReady":      {status: metav1.ConditionFalse, reason: reasonReconcileError},
+		"MachinaReady":  {status: metav1.ConditionFalse, reason: reasonReconcileError},
+		"MetalmanReady": {status: metav1.ConditionTrue, reason: reasonDisabled},
+		"StorageReady":  {status: metav1.ConditionTrue, reason: reasonDisabled},
+	}
+
+	if len(got.Status.Conditions) != len(want) {
+		t.Fatalf("conditions len = %d, want %d: %#v", len(got.Status.Conditions), len(want), got.Status.Conditions)
+	}
+
+	for conditionType, expected := range want {
+		condition := apimeta.FindStatusCondition(got.Status.Conditions, conditionType)
+		if condition == nil {
+			t.Fatalf("condition %q not found", conditionType)
+		}
+
+		if condition.Status != expected.status || condition.Reason != expected.reason || condition.ObservedGeneration != site.Generation {
+			t.Fatalf("condition %q = %#v, want status=%s reason=%s generation=%d", conditionType, condition, expected.status, expected.reason, site.Generation)
+		}
+	}
+}
+
+func TestReconcileJoinsStatusPatchError(t *testing.T) {
+	scheme := newReconcilerTestScheme(t)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}
+	componentErr := errors.New("component reconcile failed")
+	patchErr := errors.New("status patch failed")
+
+	var patched *unboundedv1alpha3.Site
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(site).
+		WithStatusSubresource(site).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return componentErr
+			},
+			SubResourcePatch: func(
+				_ context.Context,
+				_ client.Client,
+				subResourceName string,
+				obj client.Object,
+				_ client.Patch,
+				_ ...client.SubResourcePatchOption,
+			) error {
+				if subResourceName != "status" {
+					t.Fatalf("subresource = %q, want status", subResourceName)
+				}
+
+				patched = obj.(*unboundedv1alpha3.Site).DeepCopy()
+
+				return patchErr
+			},
+		}).
+		Build()
+
+	r := &SiteReconciler{Client: cl, Scheme: scheme}
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(site)})
+	if !errors.Is(err, componentErr) || !errors.Is(err, patchErr) {
+		t.Fatalf("Reconcile error = %v, want joined component and status patch errors", err)
+	}
+
+	if patched == nil || len(patched.Status.Conditions) != 4 {
+		t.Fatalf("status patch received conditions %#v, want all four", patched)
+	}
+}
+
+func newReconcilerTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for name, add := range map[string]func(*runtime.Scheme) error{
+		"apps/v1":     appsv1.AddToScheme,
+		"core/v1":     corev1.AddToScheme,
+		"machina API": unboundedv1alpha3.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add %s to scheme: %v", name, err)
+		}
+	}
+
+	return scheme
+}
 
 func TestMutateStorageScopesDaemonSetToSite(t *testing.T) {
 	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
@@ -86,26 +223,93 @@ func TestMutateMachinaSkipsMetalmanSupport(t *testing.T) {
 	}
 }
 
-func TestMutateMachinaInjectsAPIServerEndpoint(t *testing.T) {
+func TestSetMachinaAPIServerEndpointPreservesConfig(t *testing.T) {
+	input := `# retained comment
+apiServerEndpoint: "https://old.example:6443"
+maxConcurrentReconciles: 17
+customField: keep-me
+`
+	endpoint := "https://api.example:6443/path?mode=\"strict\"&ready=true"
+
+	got, err := setMachinaAPIServerEndpoint(input, endpoint)
+	if err != nil {
+		t.Fatalf("setMachinaAPIServerEndpoint: %v", err)
+	}
+
+	var config map[string]any
+	if err := yaml.Unmarshal([]byte(got), &config); err != nil {
+		t.Fatalf("unmarshal merged config: %v", err)
+	}
+
+	if config["apiServerEndpoint"] != endpoint {
+		t.Fatalf("apiServerEndpoint = %q, want %q", config["apiServerEndpoint"], endpoint)
+	}
+
+	if config["maxConcurrentReconciles"] != 17 || config["customField"] != "keep-me" {
+		t.Fatalf("custom config was not preserved: %#v", config)
+	}
+
+	if !strings.Contains(got, "# retained comment") {
+		t.Fatalf("config comment was not preserved: %q", got)
+	}
+}
+
+func TestEnsureMachinaConfigUpdatesEndpointAndPreservesData(t *testing.T) {
+	scheme := newReconcilerTestScheme(t)
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "machina-config", Namespace: DefaultNamespace},
+		Data: map[string]string{
+			"config.yaml": "apiServerEndpoint: https://old.example:6443\ncustom: true\n",
+		},
+	}
+	r := &SiteReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build(),
+		Config: Config{APIServerEndpoint: "https://new.example:6443"},
+	}
+
+	hash, err := r.ensureMachinaConfig(t.Context())
+	if err != nil {
+		t.Fatalf("ensureMachinaConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := r.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
+		t.Fatalf("get machina config: %v", err)
+	}
+
+	var config map[string]any
+	if err := yaml.Unmarshal([]byte(got.Data["config.yaml"]), &config); err != nil {
+		t.Fatalf("unmarshal updated config: %v", err)
+	}
+
+	if config["apiServerEndpoint"] != "https://new.example:6443" || config["custom"] != true {
+		t.Fatalf("updated config = %#v", config)
+	}
+
+	if hash != machinaConfigHash(got.Data["config.yaml"]) {
+		t.Fatalf("hash = %q, want hash of exact stored config", hash)
+	}
+}
+
+func TestMachinaApplyMutatorStampsConfigHash(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "v1",
-		"kind":       "ConfigMap",
-		"metadata":   map[string]any{"name": "machina-config"},
-		"data":       map[string]any{"config.yaml": `apiServerEndpoint: ""`},
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "machina-controller"},
+		"spec": map[string]any{
+			"template": map[string]any{"metadata": map[string]any{}},
+		},
 	}}
 
-	r := &SiteReconciler{Config: Config{APIServerEndpoint: "https://api.example:6443"}}
-	if err := r.mutateMachinaObject(obj); err != nil {
-		t.Fatalf("mutateMachinaObject returned error: %v", err)
+	const hash = "config-hash"
+	if err := (&SiteReconciler{}).machinaApplyMutator(hash)(obj); err != nil {
+		t.Fatalf("machinaApplyMutator: %v", err)
 	}
 
-	got, ok, err := unstructured.NestedString(obj.Object, "data", "config.yaml")
-	if err != nil || !ok {
-		t.Fatalf("missing data.config.yaml: ok=%t err=%v", ok, err)
-	}
-
-	if got != `apiServerEndpoint: "https://api.example:6443"` {
-		t.Fatalf("config.yaml = %q", got)
+	got, found, err := unstructured.NestedString(obj.Object,
+		"spec", "template", "metadata", "annotations", machinaConfigHashAnnotation)
+	if err != nil || !found || got != hash {
+		t.Fatalf("config hash = %q found=%t err=%v, want %q", got, found, err, hash)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #386 that was meant to land there. Targets the `feature/unbounded-system` integration branch as part of umbrella #388.

Makes `unbounded-operator` self-sufficient for CRD lifecycle, moves environment-specific settings into a ConfigMap, and hardens reconciliation and legacy migration against rollout, ownership, readiness, and configuration races.

## Operator owns CRDs

- Add `operator.BootstrapCRDs`: at startup the operator server-side applies all 12 CRDs embedded in the machina and net manifests before starting the manager.
- Bound the complete bootstrap operation, including CRD applies and establishment, with a four-minute timeout.
- Add a startup probe whose budget exceeds the complete bootstrap timeout so liveness cannot restart the operator mid-bootstrap.
- `kubectl unbounded install` no longer applies CRDs or exposes `--skip-crds`; the breaking CLI change is documented.
- `install` waits for a complete operator rollout, rejecting the old-ReplicaSet-available/new-pod-failing upgrade case, and then waits for CRD establishment.
- The Site reconcile loop skips CRD objects because CRDs are owned exclusively by startup bootstrap.

## Config via ConfigMap

- Add `unbounded-operator-config`, surfaced to the Deployment through `envFrom`.
- `--api-server-endpoint` and `--reap-legacy-resources` default from `UNBOUNDED_API_SERVER_ENDPOINT` and `UNBOUNDED_REAP_LEGACY_RESOURCES`; explicit flags retain precedence.
- Invalid `UNBOUNDED_REAP_LEGACY_RESOURCES` values now fail startup rather than silently enabling destructive migration.
- Apply the operator ConfigMap before the Deployment to prevent a new pod from starting with stale environment values.
- Stamp the resolved config hash on the operator pod template so endpoint changes trigger a rollout in both `install` and rendered-manifest workflows.
- Restore `UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT` to the Make/render path and make endpoint forwarding and YAML rendering safe for shell- and YAML-sensitive values.

## Machina config propagation

- Merge the configured API endpoint into existing or migrated `machina-config` while preserving all other custom settings and comments.
- Hash the exact stored `config.yaml` and stamp it on the Machina Deployment so configuration changes roll Machina, which reads its subPath-mounted config only at startup.
- Watch `machina-config` changes and enqueue Sites without re-enabling status-only Site reconciliation.
- During migration, apply the configured endpoint to copied legacy Machina config.
- Reap legacy Machina only after the replacement Deployment has the current config hash and a completed rollout.

## Reconciliation reliability

- Preserve per-component reconciliation errors while still publishing all Site status conditions.
- Return joined component and status-patch errors so controller-runtime rate-limits and retries transient failures even with `GenerationChangedPredicate` filtering status-only updates.

## Migration hardening

- Detect legacy per-site Metalman by deterministic Deployment name or canonical/deprecated Site label.
- Preserve the legacy `--dhcp-auto-interface` setting in the translated Site; malformed or conflicting values fail closed.
- Gate Metalman reaping on creation of every corresponding replacement Deployment without requiring readiness, avoiding host-port cutover deadlock.
- Require storage replacements to be current and ready. A zero-desired per-Site DaemonSet is accepted only when no Node InternalIP matches that Site node CIDRs; matching but not-yet-labeled Nodes continue to block reaping.
- Make the net controller update SiteNodeSlice ownership even when slice contents are unchanged.
- Delete the legacy net-group Site CRD only after the new net controller is Available and every existing SiteNodeSlice has the exact current v1alpha3 Site UID/GVK owner reference.
- Warn and emit an Event when a drained legacy namespace still contains non-operator workloads before namespace deletion.
- Add the missing read-only RBAC for StatefulSets, Nodes, and SiteNodeSlices, plus `events.k8s.io` write access for the modern event recorder.
- Reconcile Sites on generation changes only, avoiding full net/machina re-application on status-only updates.
- Retarget embedded namespace references in service-account usernames and flag values, not only exact-value matches.

## Tests

Added or extended coverage for:

- all embedded CRDs, establishment polling, and apply-phase timeout cancellation;
- startup probe budget and operator ConfigMap-before-Deployment ordering;
- complete Deployment rollout detection and endpoint-driven rollout hashes;
- shell/YAML-sensitive endpoint rendering;
- strict environment parsing and explicit flag precedence;
- reconciliation error retries and joined status-patch errors;
- Machina config preservation, endpoint updates, hashes, and rollout gates;
- Metalman detection and DHCP mode preservation;
- zero-node storage readiness and unconverged-node blocking;
- SiteNodeSlice owner migration and legacy CRD deletion gates;
- StatefulSet foreign-workload detection and rendered RBAC.

The kind-based operator reaper e2e now validates the migration against a real Kubernetes API server, including preserved Metalman mode and the Machina config rollout gate.

## Verification

- `make fmt`
- `make build`
- `make lint`
- `make test`
- race tests for all modified Go packages
- `go test -tags=e2e ./e2e/operator/... -run TestOperatorReaperMigration -count=1 -v`
