### PR TITLE
metalman: normalize URL paths

### DIFF
--- a/internal/metalman/netboot/http.go
+++ b/internal/metalman/netboot/http.go
@@ -71,7 +71,7 @@ func (h *HTTPServer) Start(ctx context.Context) error {
 	mux.HandleFunc("GET /", h.handleFile)
 
 	addr := fmt.Sprintf("%s:%d", h.BindAddr, h.Port)
-	srv := &http.Server{Addr: addr, Handler: logRequests(mux)}
+	srv := &http.Server{Addr: addr, Handler: normalizePath(mux)}
 
 	go func() {
 		<-ctx.Done()
@@ -87,99 +87,28 @@ func (h *HTTPServer) Start(ctx context.Context) error {
 	return nil
 }
 
-// statusRecorderWriter wraps an http.ResponseWriter to capture the status code
-// and number of bytes written so request-logging middleware can report them.
-type statusRecorderWriter struct {
-	http.ResponseWriter
-	status int
-	bytes  int
-}
-
-func (w *statusRecorderWriter) WriteHeader(status int) {
-	w.status = status
-	w.ResponseWriter.WriteHeader(status)
-}
-
-func (w *statusRecorderWriter) Write(b []byte) (int, error) {
-	if w.status == 0 {
-		w.status = http.StatusOK
-	}
-
-	n, err := w.ResponseWriter.Write(b)
-	w.bytes += n
-
-	return n, err
-}
-
-// Unwrap exposes the underlying ResponseWriter so http.ResponseController and
-// http.ServeFile optimizations (e.g. sendfile, flushing) keep working.
-func (w *statusRecorderWriter) Unwrap() http.ResponseWriter {
-	return w.ResponseWriter
-}
-
-// logRequests wraps a handler to normalize unclean request paths and log every
-// request. It is important for UEFI HTTP boot: shim derives its second-stage URL
-// by appending its loader name to its own boot URL's directory, which for a
-// root-served shim yields a double slash (e.g. "//grubx64.efi"). Go's ServeMux
-// path-cleans that and returns a 307 redirect, but shim does not follow
-// redirects and treats the 3xx as EFI_HTTP_ERROR (0x23), aborting the boot.
-//
-// To keep shim booting, this middleware collapses the duplicate slashes in
-// place before dispatch so the mux serves the file directly with a 200 instead
-// of redirecting. The original request-target is preserved in the log for
-// diagnostics.
-func logRequests(next http.Handler) http.Handler {
+// normalizePath collapses redundant slashes in the request path before the
+// ServeMux routes it. When shim is HTTP-booted from the web root it requests
+// its second stage as "//grubx64.efi": it appends its absolute-path loader name
+// to its boot URL's directory. Go's ServeMux would answer that with a 307
+// redirect, which shim refuses to follow (it treats the 3xx as EFI_HTTP_ERROR
+// 0x23 and aborts the boot). Normalizing the path here makes the mux serve the
+// file directly with a 200.
+func normalizePath(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		originalTarget := r.RequestURI
-
-		normalized := false
-
 		if cleaned := cleanRequestPath(r.URL.Path); cleaned != r.URL.Path {
-			// Rewrite to the cleaned path so ServeMux dispatches to handleFile
-			// with a 200 rather than emitting a redirect that shim cannot follow.
 			r.URL.Path = cleaned
 			r.URL.RawPath = ""
-			normalized = true
 		}
 
-		rec := &statusRecorderWriter{ResponseWriter: w}
-
-		next.ServeHTTP(rec, r)
-
-		status := rec.status
-		if status == 0 {
-			status = http.StatusOK
-		}
-
-		log := slog.With(
-			"proto", "http",
-			"method", r.Method,
-			"target", originalTarget,
-			"path", r.URL.Path,
-			"ip", clientIP(r),
-			"status", status,
-			"bytes", rec.bytes,
-		)
-
-		if normalized {
-			log.Warn("normalized unclean request path so it is served directly instead of redirected (shim second-stage double-slash)")
-
-			return
-		}
-
-		if status >= 300 && status < 400 {
-			log.Warn("http request redirected", "location", rec.Header().Get("Location"))
-
-			return
-		}
-
-		log.Info("http request")
+		next.ServeHTTP(w, r)
 	})
 }
 
 // cleanRequestPath normalizes a URL path the same way path.Clean does, so the
-// middleware can detect unclean paths (e.g. "//grubx64.efi") that the ServeMux
-// would redirect. A trailing slash is preserved to mirror ServeMux behavior.
+// middleware can collapse unclean paths (e.g. "//grubx64.efi") that the
+// ServeMux would otherwise redirect. A trailing slash is preserved to mirror
+// ServeMux behavior.
 func cleanRequestPath(p string) string {
 	if p == "" {
 		return "/"

--- a/internal/metalman/netboot/http.go
+++ b/internal/metalman/netboot/http.go
@@ -117,16 +117,31 @@ func (w *statusRecorderWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }
 
-// logRequests wraps a handler and logs every incoming request, including ones
-// the ServeMux rewrites or redirects before dispatch. This is important for
-// diagnosing UEFI HTTP boot: shim derives its second-stage URL by appending its
-// loader name to its own boot URL's directory, which for a root-served shim
-// yields a double slash (e.g. "//grubx64.efi"). Go's ServeMux path-cleans that
-// and returns a 307 redirect BEFORE handleFile runs, so without this middleware
-// the request produces no log line at all. shim does not follow redirects and
-// treats the 3xx as EFI_HTTP_ERROR (0x23), aborting the boot.
+// logRequests wraps a handler to normalize unclean request paths and log every
+// request. It is important for UEFI HTTP boot: shim derives its second-stage URL
+// by appending its loader name to its own boot URL's directory, which for a
+// root-served shim yields a double slash (e.g. "//grubx64.efi"). Go's ServeMux
+// path-cleans that and returns a 307 redirect, but shim does not follow
+// redirects and treats the 3xx as EFI_HTTP_ERROR (0x23), aborting the boot.
+//
+// To keep shim booting, this middleware collapses the duplicate slashes in
+// place before dispatch so the mux serves the file directly with a 200 instead
+// of redirecting. The original request-target is preserved in the log for
+// diagnostics.
 func logRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originalTarget := r.RequestURI
+
+		normalized := false
+
+		if cleaned := cleanRequestPath(r.URL.Path); cleaned != r.URL.Path {
+			// Rewrite to the cleaned path so ServeMux dispatches to handleFile
+			// with a 200 rather than emitting a redirect that shim cannot follow.
+			r.URL.Path = cleaned
+			r.URL.RawPath = ""
+			normalized = true
+		}
+
 		rec := &statusRecorderWriter{ResponseWriter: w}
 
 		next.ServeHTTP(rec, r)
@@ -139,18 +154,15 @@ func logRequests(next http.Handler) http.Handler {
 		log := slog.With(
 			"proto", "http",
 			"method", r.Method,
-			"target", r.RequestURI,
+			"target", originalTarget,
 			"path", r.URL.Path,
 			"ip", clientIP(r),
 			"status", status,
 			"bytes", rec.bytes,
 		)
 
-		// A request-target that does not match its cleaned path (for example a
-		// leading double slash) is what triggers the ServeMux redirect. Flag it
-		// loudly because it is the signature of the shim second-stage failure.
-		if cleaned := cleanRequestPath(r.URL.Path); cleaned != r.URL.Path {
-			log.Warn("request path is not clean; ServeMux will redirect and shim will not follow it", "cleaned_path", cleaned)
+		if normalized {
+			log.Warn("normalized unclean request path so it is served directly instead of redirected (shim second-stage double-slash)")
 
 			return
 		}

--- a/internal/metalman/netboot/http.go
+++ b/internal/metalman/netboot/http.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"path"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,7 +71,7 @@ func (h *HTTPServer) Start(ctx context.Context) error {
 	mux.HandleFunc("GET /", h.handleFile)
 
 	addr := fmt.Sprintf("%s:%d", h.BindAddr, h.Port)
-	srv := &http.Server{Addr: addr, Handler: mux}
+	srv := &http.Server{Addr: addr, Handler: logRequests(mux)}
 
 	go func() {
 		<-ctx.Done()
@@ -84,6 +85,100 @@ func (h *HTTPServer) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// statusRecorderWriter wraps an http.ResponseWriter to capture the status code
+// and number of bytes written so request-logging middleware can report them.
+type statusRecorderWriter struct {
+	http.ResponseWriter
+	status int
+	bytes  int
+}
+
+func (w *statusRecorderWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *statusRecorderWriter) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+
+	n, err := w.ResponseWriter.Write(b)
+	w.bytes += n
+
+	return n, err
+}
+
+// Unwrap exposes the underlying ResponseWriter so http.ResponseController and
+// http.ServeFile optimizations (e.g. sendfile, flushing) keep working.
+func (w *statusRecorderWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+// logRequests wraps a handler and logs every incoming request, including ones
+// the ServeMux rewrites or redirects before dispatch. This is important for
+// diagnosing UEFI HTTP boot: shim derives its second-stage URL by appending its
+// loader name to its own boot URL's directory, which for a root-served shim
+// yields a double slash (e.g. "//grubx64.efi"). Go's ServeMux path-cleans that
+// and returns a 307 redirect BEFORE handleFile runs, so without this middleware
+// the request produces no log line at all. shim does not follow redirects and
+// treats the 3xx as EFI_HTTP_ERROR (0x23), aborting the boot.
+func logRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &statusRecorderWriter{ResponseWriter: w}
+
+		next.ServeHTTP(rec, r)
+
+		status := rec.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+
+		log := slog.With(
+			"proto", "http",
+			"method", r.Method,
+			"target", r.RequestURI,
+			"path", r.URL.Path,
+			"ip", clientIP(r),
+			"status", status,
+			"bytes", rec.bytes,
+		)
+
+		// A request-target that does not match its cleaned path (for example a
+		// leading double slash) is what triggers the ServeMux redirect. Flag it
+		// loudly because it is the signature of the shim second-stage failure.
+		if cleaned := cleanRequestPath(r.URL.Path); cleaned != r.URL.Path {
+			log.Warn("request path is not clean; ServeMux will redirect and shim will not follow it", "cleaned_path", cleaned)
+
+			return
+		}
+
+		if status >= 300 && status < 400 {
+			log.Warn("http request redirected", "location", rec.Header().Get("Location"))
+
+			return
+		}
+
+		log.Info("http request")
+	})
+}
+
+// cleanRequestPath normalizes a URL path the same way path.Clean does, so the
+// middleware can detect unclean paths (e.g. "//grubx64.efi") that the ServeMux
+// would redirect. A trailing slash is preserved to mirror ServeMux behavior.
+func cleanRequestPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+
+	cleaned := path.Clean(p)
+	if cleaned != "/" && strings.HasSuffix(p, "/") {
+		cleaned += "/"
+	}
+
+	return cleaned
 }
 
 func (h *HTTPServer) handleFile(w http.ResponseWriter, r *http.Request) {

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -3853,6 +3853,82 @@ func freePort(t *testing.T) int {
 	return port
 }
 
+func TestCleanRequestPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "/"},
+		{"/", "/"},
+		{"/bootx64.efi", "/bootx64.efi"},
+		{"//grubx64.efi", "/grubx64.efi"},
+		{"/a//b", "/a/b"},
+		{"/dir/", "/dir/"},
+		{"/dir//", "/dir/"},
+	}
+
+	for _, tc := range cases {
+		if got := cleanRequestPath(tc.in); got != tc.want {
+			t.Errorf("cleanRequestPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestLogRequestsRedirectsUncleanPath verifies that a request whose raw target
+// contains a double slash (as shim generates for its second-stage loader when
+// the shim is served from the web root, e.g. "//grubx64.efi") is redirected by
+// the ServeMux with a 307 and never reaches the wrapped handler. This is the
+// mechanism behind the UEFI HTTP boot failure: shim does not follow the
+// redirect and treats the 3xx as EFI_HTTP_ERROR (0x23).
+func TestLogRequestsRedirectsUncleanPath(t *testing.T) {
+	t.Parallel()
+
+	var handlerHits []string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		handlerHits = append(handlerHits, r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ts := httptest.NewServer(logRequests(mux))
+	defer ts.Close()
+
+	host := strings.TrimPrefix(ts.URL, "http://")
+
+	statusLine := func(target string) string {
+		t.Helper()
+
+		conn, err := net.Dial("tcp", host)
+		require.NoError(t, err)
+
+		defer conn.Close()
+
+		_, err = fmt.Fprintf(conn, "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", target, host)
+		require.NoError(t, err)
+
+		buf := make([]byte, 256)
+		n, _ := conn.Read(buf)
+
+		line := string(buf[:n])
+		if i := strings.Index(line, "\r\n"); i >= 0 {
+			line = line[:i]
+		}
+
+		return line
+	}
+
+	require.Contains(t, statusLine("/bootx64.efi"), "200")
+	require.Contains(t, statusLine("//grubx64.efi"), "307")
+
+	// The double-slash request must be redirected by the mux before dispatch, so
+	// the wrapped handler only ever saw the clean bootx64.efi request.
+	require.Equal(t, []string{"/bootx64.efi"}, handlerHits)
+}
+
 func waitForHTTP(t *testing.T, url string, timeout time.Duration) {
 	t.Helper()
 

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -3876,12 +3876,12 @@ func TestCleanRequestPath(t *testing.T) {
 	}
 }
 
-// TestLogRequestsNormalizesUncleanPath verifies that a request whose raw target
+// TestNormalizePathServesUncleanPath verifies that a request whose raw target
 // contains a double slash (as shim generates for its second-stage loader when
 // the shim is served from the web root, e.g. "//grubx64.efi") is normalized in
 // place and served directly with a 200, instead of the ServeMux emitting a 307
 // redirect that shim would refuse to follow (EFI_HTTP_ERROR / 0x23).
-func TestLogRequestsNormalizesUncleanPath(t *testing.T) {
+func TestNormalizePathServesUncleanPath(t *testing.T) {
 	t.Parallel()
 
 	var handlerHits []string
@@ -3893,7 +3893,7 @@ func TestLogRequestsNormalizesUncleanPath(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	ts := httptest.NewServer(logRequests(mux))
+	ts := httptest.NewServer(normalizePath(mux))
 	defer ts.Close()
 
 	host := strings.TrimPrefix(ts.URL, "http://")

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -3876,13 +3876,12 @@ func TestCleanRequestPath(t *testing.T) {
 	}
 }
 
-// TestLogRequestsRedirectsUncleanPath verifies that a request whose raw target
+// TestLogRequestsNormalizesUncleanPath verifies that a request whose raw target
 // contains a double slash (as shim generates for its second-stage loader when
-// the shim is served from the web root, e.g. "//grubx64.efi") is redirected by
-// the ServeMux with a 307 and never reaches the wrapped handler. This is the
-// mechanism behind the UEFI HTTP boot failure: shim does not follow the
-// redirect and treats the 3xx as EFI_HTTP_ERROR (0x23).
-func TestLogRequestsRedirectsUncleanPath(t *testing.T) {
+// the shim is served from the web root, e.g. "//grubx64.efi") is normalized in
+// place and served directly with a 200, instead of the ServeMux emitting a 307
+// redirect that shim would refuse to follow (EFI_HTTP_ERROR / 0x23).
+func TestLogRequestsNormalizesUncleanPath(t *testing.T) {
 	t.Parallel()
 
 	var handlerHits []string
@@ -3922,11 +3921,11 @@ func TestLogRequestsRedirectsUncleanPath(t *testing.T) {
 	}
 
 	require.Contains(t, statusLine("/bootx64.efi"), "200")
-	require.Contains(t, statusLine("//grubx64.efi"), "307")
+	// The double-slash request must be normalized and served (200), not redirected.
+	require.Contains(t, statusLine("//grubx64.efi"), "200")
 
-	// The double-slash request must be redirected by the mux before dispatch, so
-	// the wrapped handler only ever saw the clean bootx64.efi request.
-	require.Equal(t, []string{"/bootx64.efi"}, handlerHits)
+	// The handler must have seen both requests with clean, collapsed paths.
+	require.Equal(t, []string{"/bootx64.efi", "/grubx64.efi"}, handlerHits)
 }
 
 func waitForHTTP(t *testing.T, url string, timeout time.Duration) {


### PR DESCRIPTION
In some cases UEFI firmwares will send extra slashes without following redirects.