### PR TITLE
net: harden SiteNodeSlice ownership and reconcile against delete/recreate races

### DIFF
--- a/internal/net/controller/site_controller.go
+++ b/internal/net/controller/site_controller.go
@@ -138,9 +138,8 @@ type SiteController struct {
 	// Mutex to prevent concurrent slice updates
 	sliceUpdateLock sync.Mutex
 
-	// slicesDirty is set when syncNode changes node state and cleared when
-	// updateAllSiteSlices runs. The periodic loop checks this to coalesce
-	// slice updates instead of rebuilding after every single node sync.
+	// slicesDirty is set when node or slice state changes. The periodic loop
+	// atomically consumes it to coalesce updates and restores it after failures.
 	slicesDirty atomic.Bool
 
 	// hasSynced indicates whether the informer caches have completed initial sync
@@ -249,6 +248,22 @@ func NewSiteController(
 		},
 	}); err != nil {
 		return nil, fmt.Errorf("failed to add site event handler: %w", err)
+	}
+
+	// Reconcile externally modified slices. Events caused by this controller's
+	// own writes may trigger one redundant pass, which is harmless.
+	if _, err := sliceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			sc.markSlicesDirty()
+		},
+		UpdateFunc: func(old, new interface{}) {
+			sc.markSlicesDirty()
+		},
+		DeleteFunc: func(obj interface{}) {
+			sc.markSlicesDirty()
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add site node slice event handler: %w", err)
 	}
 
 	// Set up event handlers for gateway pools
@@ -777,12 +792,12 @@ func (sc *SiteController) Run(ctx context.Context, workers int) error {
 		go wait.UntilWithContext(ctx, sc.runWorker, time.Second)
 	}
 
-	// Periodically update site statuses and slices when dirty or every 30s
+	// Periodically update site statuses and slices when dirty.
 	go wait.UntilWithContext(ctx, func(ctx context.Context) {
 		sc.reportDuplicateNodePodCIDRs()
 
-		if sc.slicesDirty.CompareAndSwap(true, false) {
-			sc.updateAllSiteSlices(ctx)
+		if err := sc.updateSiteSlicesIfDirty(ctx); err != nil {
+			klog.Errorf("Failed to update SiteNodeSlices: %v", err)
 		}
 	}, 5*time.Second)
 
@@ -934,24 +949,65 @@ func (sc *SiteController) reconcileAllNodes(_ context.Context) {
 	}
 }
 
+// updateSiteSlicesIfDirty updates slices after atomically consuming the dirty
+// flag. A failed pass restores the flag so the periodic loop retries it.
+func (sc *SiteController) updateSiteSlicesIfDirty(ctx context.Context) error {
+	if !sc.slicesDirty.CompareAndSwap(true, false) {
+		return nil
+	}
+
+	if err := sc.updateAllSiteSlices(ctx); err != nil {
+		sc.markSlicesDirty()
+
+		return err
+	}
+
+	return nil
+}
+
 // updateAllSiteSlices updates the SiteNodeSlice objects for all sites
-func (sc *SiteController) updateAllSiteSlices(ctx context.Context) {
+func (sc *SiteController) updateAllSiteSlices(ctx context.Context) error {
 	// Ensure only one slice update runs at a time to prevent conflicts
 	sc.sliceUpdateLock.Lock()
 	defer sc.sliceUpdateLock.Unlock()
 
 	sc.sitesCacheLock.RLock()
-	sites := sc.sitesCache
+	cachedSites := append([]unboundedv1alpha3.Site(nil), sc.sitesCache...)
 	sc.sitesCacheLock.RUnlock()
 
+	// Continue converging independent resources, but return every error so the
+	// periodic loop schedules another pass.
+	var updateErrors []error
+
+	if err := sc.cleanupOrphanSiteNodeSlices(ctx); err != nil {
+		updateErrors = append(updateErrors, fmt.Errorf("clean up orphan site node slices: %w", err))
+	}
+
+	// Never use an informer-cached Site as a mutation input. Besides protecting
+	// against stale fields, the UID check prevents a delete/recreate with the
+	// same name from receiving writes intended for the deleted Site.
+	sites := make([]unboundedv1alpha3.Site, 0, len(cachedSites))
+
+	for _, cachedSite := range cachedSites {
+		liveSite, err := sc.getLiveSiteWithUID(ctx, cachedSite.Name, cachedSite.UID)
+		if err != nil {
+			updateErrors = append(updateErrors, fmt.Errorf("site %s: %w", cachedSite.Name, err))
+
+			continue
+		}
+
+		sites = append(sites, liveSite)
+	}
+
 	if len(sites) == 0 {
-		return
+		return errors.Join(updateErrors...)
 	}
 
 	nodes, err := sc.nodeLister.List(labels.Everything())
 	if err != nil {
-		klog.Errorf("Failed to list nodes for slice update: %v", err)
-		return
+		updateErrors = append(updateErrors, fmt.Errorf("failed to list nodes for slice update: %w", err))
+
+		return errors.Join(updateErrors...)
 	}
 
 	// Track which nodes belong to each site
@@ -983,7 +1039,6 @@ func (sc *SiteController) updateAllSiteSlices(ctx context.Context) {
 		}
 	}
 
-	// Update slices for each site
 	for _, site := range sites {
 		nodesInfo := siteNodesInfo[site.Name]
 		// Sort by node name for consistent ordering
@@ -991,33 +1046,43 @@ func (sc *SiteController) updateAllSiteSlices(ctx context.Context) {
 			return nodesInfo[i].Name < nodesInfo[j].Name
 		})
 
-		sc.updateSiteSlices(ctx, site, nodesInfo)
+		if err := sc.updateSiteSlices(ctx, site, nodesInfo, allSiteNodeCounts[site.Name]); err != nil {
+			updateErrors = append(updateErrors, fmt.Errorf("site %s: %w", site.Name, err))
+		}
 	}
 
 	// Manage protection finalizers: add when nodes are assigned, remove when
 	// no nodes remain so the site can be deleted.
 	for _, site := range sites {
 		nodeCount := allSiteNodeCounts[site.Name]
-		hasFinalizer := containsFinalizer(site.Finalizers, ProtectionFinalizer)
-
-		if nodeCount > 0 && !hasFinalizer {
-			if err := ensureFinalizer(ctx, sc.dynamicClient, siteGVR, site.Name, site.Finalizers); err != nil {
-				klog.Warningf("Failed to add protection finalizer to site %s: %v", site.Name, err)
-			} else {
-				klog.V(2).Infof("Added protection finalizer to site %s (%d nodes)", site.Name, nodeCount)
+		if nodeCount > 0 {
+			if err := ensureFinalizer(ctx, sc.dynamicClient, siteGVR, site.Name, site.Finalizers, site.UID); err != nil {
+				updateErrors = append(updateErrors, fmt.Errorf("site %s protection finalizer: %w", site.Name, err))
 			}
-		} else if nodeCount == 0 && hasFinalizer {
-			if err := removeFinalizer(ctx, sc.dynamicClient, siteGVR, site.Name, site.Finalizers); err != nil {
-				klog.Warningf("Failed to remove protection finalizer from site %s: %v", site.Name, err)
-			} else {
-				klog.V(2).Infof("Removed protection finalizer from site %s (no nodes)", site.Name)
+		} else {
+			if err := removeFinalizer(ctx, sc.dynamicClient, siteGVR, site.Name, site.Finalizers, site.UID); err != nil {
+				updateErrors = append(updateErrors, fmt.Errorf("site %s protection finalizer: %w", site.Name, err))
 			}
 		}
 	}
+
+	return errors.Join(updateErrors...)
 }
 
 // updateSiteSlices creates/updates/deletes SiteNodeSlice objects for a site
-func (sc *SiteController) updateSiteSlices(ctx context.Context, site unboundedv1alpha3.Site, nodesInfo []unboundednetv1alpha1.NodeInfo) {
+func (sc *SiteController) updateSiteSlices(
+	ctx context.Context,
+	site unboundedv1alpha3.Site,
+	nodesInfo []unboundednetv1alpha1.NodeInfo,
+	allNodeCount int,
+) error {
+	var err error
+
+	site, err = sc.getLiveSiteWithUID(ctx, site.Name, site.UID)
+	if err != nil {
+		return err
+	}
+
 	// Calculate how many slices we need
 	numSlices := (len(nodesInfo) + unboundednetv1alpha1.MaxNodesPerSlice - 1) / unboundednetv1alpha1.MaxNodesPerSlice
 	if numSlices == 0 {
@@ -1026,9 +1091,12 @@ func (sc *SiteController) updateSiteSlices(ctx context.Context, site unboundedv1
 
 	// Get existing slices for this site
 	existingSlices := sc.getExistingSlices(site.Name)
+	desiredSliceNames := make(map[string]struct{}, numSlices)
 
 	// Create or update slices
 	for i := 0; i < numSlices; i++ {
+		desiredSliceNames[fmt.Sprintf("%s-%d", site.Name, i)] = struct{}{}
+
 		start := i * unboundednetv1alpha1.MaxNodesPerSlice
 
 		end := start + unboundednetv1alpha1.MaxNodesPerSlice
@@ -1038,23 +1106,64 @@ func (sc *SiteController) updateSiteSlices(ctx context.Context, site unboundedv1
 
 		sliceNodes := nodesInfo[start:end]
 
-		sc.createOrUpdateSlice(ctx, site, i, sliceNodes)
+		if err := sc.createOrUpdateSlice(ctx, site, i, sliceNodes); err != nil {
+			return err
+		}
 	}
 
-	// Delete extra slices
-	for i := numSlices; i < len(existingSlices); i++ {
-		sliceName := fmt.Sprintf("%s-%d", site.Name, i)
+	resource := sc.dynamicClient.Resource(siteNodeSliceGVR)
 
-		err := sc.dynamicClient.Resource(siteNodeSliceGVR).Delete(ctx, sliceName, metav1.DeleteOptions{})
+	// Delete any slice whose index is no longer desired. Re-read and revalidate
+	// each object so a stale informer entry cannot delete a reassigned slice.
+	for _, existingSlice := range existingSlices {
+		if _, desired := desiredSliceNames[existingSlice.Name]; desired {
+			continue
+		}
+
+		sliceName := existingSlice.Name
+
+		liveSlice, err := resource.Get(ctx, sliceName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to get extra slice %s: %w", sliceName, err)
+		}
+
+		liveSiteName, found, err := unstructured.NestedString(liveSlice.Object, "siteName")
+		if err != nil {
+			return fmt.Errorf("failed to read siteName from extra slice %s: %w", sliceName, err)
+		}
+
+		if !found || liveSiteName != site.Name {
+			continue
+		}
+
+		if _, desired := desiredSliceNames[liveSlice.GetName()]; desired {
+			continue
+		}
+
+		if _, err := sc.getLiveSiteWithUID(ctx, site.Name, site.UID); err != nil {
+			return err
+		}
+
+		err = deleteLiveSiteNodeSlice(ctx, resource, liveSlice)
 		if err != nil && !apierrors.IsNotFound(err) {
-			klog.Errorf("Failed to delete extra slice %s: %v", sliceName, err)
-		} else {
+			return fmt.Errorf("failed to delete extra slice %s: %w", sliceName, err)
+		}
+
+		if err == nil {
 			klog.V(2).Infof("Deleted extra slice %s", sliceName)
 		}
 	}
 
 	// Update site status only if it changed
-	sc.updateSiteStatusIfChanged(ctx, site, len(nodesInfo), numSlices)
+	if err := sc.updateSiteStatusIfChanged(ctx, site, allNodeCount, numSlices); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // getExistingSlices returns the existing slices for a site
@@ -1096,8 +1205,101 @@ func (sc *SiteController) getExistingSlices(siteName string) []unboundednetv1alp
 	return slices
 }
 
+func (sc *SiteController) getLiveSiteWithUID(ctx context.Context, name string, expectedUID types.UID) (unboundedv1alpha3.Site, error) {
+	live, err := sc.dynamicClient.Resource(siteGVR).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return unboundedv1alpha3.Site{}, fmt.Errorf("expected site %s with UID %q no longer exists: %w", name, expectedUID, err)
+	}
+
+	if err != nil {
+		return unboundedv1alpha3.Site{}, fmt.Errorf("failed to get site %s: %w", name, err)
+	}
+
+	if live.GetUID() != expectedUID {
+		return unboundedv1alpha3.Site{}, fmt.Errorf("site %s UID changed from %q to %q", name, expectedUID, live.GetUID())
+	}
+
+	site := unboundedv1alpha3.Site{}
+
+	data, err := live.MarshalJSON()
+	if err != nil {
+		return unboundedv1alpha3.Site{}, fmt.Errorf("failed to marshal live site %s: %w", name, err)
+	}
+
+	if err := json.Unmarshal(data, &site); err != nil {
+		return unboundedv1alpha3.Site{}, fmt.Errorf("failed to unmarshal live site %s: %w", name, err)
+	}
+
+	return site, nil
+}
+
+func (sc *SiteController) cleanupOrphanSiteNodeSlices(ctx context.Context) error {
+	resource := sc.dynamicClient.Resource(siteNodeSliceGVR)
+	siteResource := sc.dynamicClient.Resource(siteGVR)
+
+	var cleanupErrors []error
+
+	for _, item := range sc.sliceInformer.GetStore().List() {
+		cachedSlice, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+
+		name := cachedSlice.GetName()
+
+		liveSlice, err := resource.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("get slice %s: %w", name, err))
+
+			continue
+		}
+
+		siteName, found, err := unstructured.NestedString(liveSlice.Object, "siteName")
+		if err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("read siteName from slice %s: %w", name, err))
+
+			continue
+		}
+
+		if found && siteName != "" {
+			_, err = siteResource.Get(ctx, siteName, metav1.GetOptions{})
+			if err == nil {
+				continue
+			}
+
+			if !apierrors.IsNotFound(err) {
+				cleanupErrors = append(cleanupErrors, fmt.Errorf("check site %s for slice %s: %w", siteName, name, err))
+
+				continue
+			}
+		}
+
+		if err := deleteLiveSiteNodeSlice(ctx, resource, liveSlice); err != nil && !apierrors.IsNotFound(err) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("delete orphan slice %s: %w", name, err))
+		}
+	}
+
+	return errors.Join(cleanupErrors...)
+}
+
+func deleteLiveSiteNodeSlice(ctx context.Context, resource dynamic.ResourceInterface, liveSlice *unstructured.Unstructured) error {
+	uid := liveSlice.GetUID()
+	resourceVersion := liveSlice.GetResourceVersion()
+
+	return resource.Delete(ctx, liveSlice.GetName(), metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID:             &uid,
+			ResourceVersion: &resourceVersion,
+		},
+	})
+}
+
 // createOrUpdateSlice creates or updates a SiteNodeSlice with retry logic for conflicts
-func (sc *SiteController) createOrUpdateSlice(ctx context.Context, site unboundedv1alpha3.Site, sliceIndex int, nodes []unboundednetv1alpha1.NodeInfo) {
+func (sc *SiteController) createOrUpdateSlice(ctx context.Context, site unboundedv1alpha3.Site, sliceIndex int, nodes []unboundednetv1alpha1.NodeInfo) error {
 	sliceName := fmt.Sprintf("%s-%d", site.Name, sliceIndex)
 
 	// Convert nodes to unstructured format
@@ -1111,88 +1313,119 @@ func (sc *SiteController) createOrUpdateSlice(ctx context.Context, site unbounde
 		}
 
 		if len(ni.InternalIPs) > 0 {
-			nodeData["internalIPs"] = ni.InternalIPs
+			nodeData["internalIPs"] = stringSliceToInterfaceSlice(ni.InternalIPs)
 		}
 
 		if len(ni.PodCIDRs) > 0 {
-			nodeData["podCIDRs"] = ni.PodCIDRs
+			nodeData["podCIDRs"] = stringSliceToInterfaceSlice(ni.PodCIDRs)
 		}
 
 		nodesData[i] = nodeData
 	}
 
-	// Retry logic for conflicts
-	maxRetries := 5
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		if attempt > 0 {
-			// Exponential backoff: 100ms, 200ms, 400ms, 800ms
-			backoff := time.Duration(100<<uint(attempt-1)) * time.Millisecond
-			klog.V(2).Infof("Retrying slice %s update (attempt %d/%d) after %v", sliceName, attempt+1, maxRetries, backoff)
-			time.Sleep(backoff)
-		}
+	resource := sc.dynamicClient.Resource(siteNodeSliceGVR)
+	backoff := wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   2,
+		Steps:    5,
+	}
 
-		// Check if slice exists using informer cache
-		existingObj, exists, err := sc.sliceInformer.GetStore().GetByKey(sliceName)
-		if err != nil {
-			klog.Errorf("Failed to get slice %s from cache: %v", sliceName, err)
-			return
-		}
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		// Always read directly from the API. The informer may remain stale after
+		// an AlreadyExists or Conflict response.
+		existing, err := resource.Get(ctx, sliceName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			liveSite, siteErr := sc.getLiveSiteWithUID(ctx, site.Name, site.UID)
+			if siteErr != nil {
+				return false, siteErr
+			}
 
-		if !exists {
 			// Create new slice
-			sliceObj := sc.buildSliceObject(site, sliceName, sliceIndex, nodesData)
+			desired := sc.buildSliceObject(liveSite, sliceName, sliceIndex, nodesData)
 
-			_, err = sc.dynamicClient.Resource(siteNodeSliceGVR).Create(ctx, sliceObj, metav1.CreateOptions{})
+			_, err = resource.Create(ctx, desired, metav1.CreateOptions{})
 			if err != nil {
 				if apierrors.IsAlreadyExists(err) {
-					// Race condition: slice was created by another process, retry to update it
 					klog.V(2).Infof("Slice %s was created by another process, retrying", sliceName)
-					continue
+
+					return false, nil
 				}
 
-				klog.Errorf("Failed to create slice %s: %v", sliceName, err)
-			} else {
-				klog.V(2).Infof("Created slice %s with %d nodes", sliceName, len(nodes))
+				return false, fmt.Errorf("failed to create slice %s: %w", sliceName, err)
 			}
 
-			return
+			klog.V(2).Infof("Created slice %s with %d nodes", sliceName, len(nodes))
+
+			return true, nil
 		}
 
-		existing := existingObj.(*unstructured.Unstructured) //nolint:errcheck
+		if err != nil {
+			return false, fmt.Errorf("failed to get slice %s: %w", sliceName, err)
+		}
+
+		liveSite, err := sc.getLiveSiteWithUID(ctx, site.Name, site.UID)
+		if err != nil {
+			return false, err
+		}
+
+		desired := sc.buildSliceObject(liveSite, sliceName, sliceIndex, nodesData)
 
 		// Check if update is needed
-		existingNodes, _, _ := unstructured.NestedSlice(existing.Object, "nodes") //nolint:errcheck
+		existingNodes, _, _ := unstructured.NestedSlice(existing.Object, "nodes")                         //nolint:errcheck
+		existingNodeCount, foundNodeCount, _ := unstructured.NestedInt64(existing.Object, "nodeCount")    //nolint:errcheck
+		existingSiteName, foundSiteName, _ := unstructured.NestedString(existing.Object, "siteName")      //nolint:errcheck
+		existingSliceIndex, foundSliceIndex, _ := unstructured.NestedInt64(existing.Object, "sliceIndex") //nolint:errcheck
 
-		existingNodeCount, foundNodeCount, _ := unstructured.NestedInt64(existing.Object, "nodeCount") //nolint:errcheck
 		if sc.sliceNodesEqual(existingNodes, nodesData) &&
 			foundNodeCount && existingNodeCount == int64(len(nodesData)) &&
-			hasExactSiteOwnerReference(existing.GetOwnerReferences(), site) {
-			return
+			foundSiteName && existingSiteName == liveSite.Name &&
+			foundSliceIndex && existingSliceIndex == int64(sliceIndex) &&
+			hasExactSiteOwnerReference(existing.GetOwnerReferences(), liveSite) {
+			return true, nil
 		}
 
-		// Update existing slice
-		sliceObj := sc.buildSliceObject(site, sliceName, sliceIndex, nodesData)
-		sliceObj.SetResourceVersion(existing.GetResourceVersion())
+		// Mutate a copy of the live object so labels, annotations, finalizers,
+		// and metadata owned by other actors survive this update.
+		sliceObj := existing.DeepCopy()
+		sliceObj.SetOwnerReferences(desired.GetOwnerReferences())
+		sliceObj.Object["siteName"] = liveSite.Name
+		sliceObj.Object["sliceIndex"] = int64(sliceIndex)
+		sliceObj.Object["nodes"] = nodesData
+		sliceObj.Object["nodeCount"] = int64(len(nodesData))
 
-		_, err = sc.dynamicClient.Resource(siteNodeSliceGVR).Update(ctx, sliceObj, metav1.UpdateOptions{})
+		_, err = resource.Update(ctx, sliceObj, metav1.UpdateOptions{})
 		if err != nil {
-			if apierrors.IsConflict(err) {
-				// Conflict: resource was modified, retry with fresh version
-				klog.V(2).Infof("Conflict updating slice %s, will retry", sliceName)
-				continue
+			if apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
+				klog.V(2).Infof("Slice %s changed during update, will retry", sliceName)
+
+				return false, nil
 			}
 
-			klog.Errorf("Failed to update slice %s: %v", sliceName, err)
-
-			return
+			return false, fmt.Errorf("failed to update slice %s: %w", sliceName, err)
 		}
 
 		klog.V(2).Infof("Updated slice %s with %d nodes", sliceName, len(nodes))
 
-		return
+		return true, nil
+	})
+	if err != nil {
+		if wait.Interrupted(err) {
+			return fmt.Errorf("failed to converge slice %s after %d attempts: %w", sliceName, backoff.Steps, err)
+		}
+
+		return err
 	}
 
-	klog.Errorf("Failed to update slice %s after %d retries", sliceName, maxRetries)
+	return nil
+}
+
+func stringSliceToInterfaceSlice(values []string) []interface{} {
+	result := make([]interface{}, len(values))
+	for i, value := range values {
+		result[i] = value
+	}
+
+	return result
 }
 
 // buildSliceObject constructs the unstructured SiteNodeSlice object
@@ -1214,7 +1447,7 @@ func (sc *SiteController) buildSliceObject(site unboundedv1alpha3.Site, sliceNam
 						"name":               site.Name,
 						"uid":                string(site.UID),
 						"controller":         true,
-						"blockOwnerDeletion": true,
+						"blockOwnerDeletion": false,
 					},
 				},
 			},
@@ -1238,7 +1471,7 @@ func hasExactSiteOwnerReference(refs []metav1.OwnerReference, site unboundedv1al
 		ref.Name == site.Name &&
 		ref.UID == site.UID &&
 		ref.Controller != nil && *ref.Controller &&
-		ref.BlockOwnerDeletion != nil && *ref.BlockOwnerDeletion
+		(ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion)
 }
 
 // sliceNodesEqual compares two node lists for equality
@@ -1334,61 +1567,73 @@ func (sc *SiteController) buildNodeInfo(node *corev1.Node) unboundednetv1alpha1.
 	return info
 }
 
-// updateSiteStatusIfChanged updates the status of a site only if it has changed
-func (sc *SiteController) updateSiteStatusIfChanged(ctx context.Context, site unboundedv1alpha3.Site, nodeCount, sliceCount int) {
+// updateSiteStatusIfChanged updates the status of a site only if it has changed.
+func (sc *SiteController) updateSiteStatusIfChanged(ctx context.Context, site unboundedv1alpha3.Site, nodeCount, sliceCount int) error {
 	// Always update gauges so they reflect the latest state.
 	SiteNodesGauge.WithLabelValues(site.Name).Set(float64(nodeCount))
 	SiteNodeSlicesGauge.WithLabelValues(site.Name).Set(float64(sliceCount))
 
-	// Check if status actually changed
-	if site.Status.NodeCount == nodeCount && site.Status.SliceCount == sliceCount {
-		klog.V(4).Infof("Site %s status unchanged (%d nodes, %d slices), skipping update", site.Name, nodeCount, sliceCount)
-		return
+	backoff := wait.Backoff{
+		Duration: 50 * time.Millisecond,
+		Factor:   2,
+		Steps:    3,
 	}
 
-	statusPatch := map[string]interface{}{
-		"status": map[string]interface{}{
-			"nodeCount":  nodeCount,
-			"sliceCount": sliceCount,
-		},
-	}
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		liveSite, err := sc.getLiveSiteWithUID(ctx, site.Name, site.UID)
+		if err != nil {
+			return false, err
+		}
 
-	patchData, err := json.Marshal(statusPatch)
-	if err != nil {
-		klog.Errorf("Failed to marshal status patch for site %s: %v", site.Name, err)
-		return
-	}
+		if liveSite.Status.NodeCount == nodeCount && liveSite.Status.SliceCount == sliceCount {
+			klog.V(4).Infof("Site %s status unchanged (%d nodes, %d slices), skipping update", site.Name, nodeCount, sliceCount)
 
-	// Retry logic for conflicts
-	maxRetries := 3
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		if attempt > 0 {
-			backoff := time.Duration(50<<uint(attempt-1)) * time.Millisecond
-			time.Sleep(backoff)
+			return true, nil
+		}
+
+		patchData, err := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"resourceVersion": liveSite.ResourceVersion,
+			},
+			"status": map[string]interface{}{
+				"nodeCount":  nodeCount,
+				"sliceCount": sliceCount,
+			},
+		})
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal status patch for site %s: %w", site.Name, err)
 		}
 
 		_, err = sc.dynamicClient.Resource(siteGVR).Patch(ctx, site.Name, types.MergePatchType, patchData, metav1.PatchOptions{}, "status")
 		if err == nil {
 			klog.Infof("Updated site %s status: %d nodes, %d slices", site.Name, nodeCount, sliceCount)
-			return
+
+			return true, nil
 		}
 
 		if apierrors.IsConflict(err) {
 			klog.V(2).Infof("Conflict updating site %s status, retrying", site.Name)
-			continue
+
+			return false, nil
 		}
 
 		if apierrors.IsNotFound(err) {
-			klog.V(2).Infof("Site %s no longer exists, skipping status update", site.Name)
-			return
+			klog.V(2).Infof("Site %s changed during status update, retrying", site.Name)
+
+			return false, nil
 		}
 
-		klog.Errorf("Failed to update status for site %s: %v", site.Name, err)
+		return false, fmt.Errorf("failed to update status for site %s: %w", site.Name, err)
+	})
+	if err != nil {
+		if wait.Interrupted(err) {
+			return fmt.Errorf("failed to update site %s status after %d attempts: %w", site.Name, backoff.Steps, err)
+		}
 
-		return
+		return err
 	}
 
-	klog.Errorf("Failed to update site %s status after %d retries", site.Name, maxRetries)
+	return nil
 }
 
 func (sc *SiteController) logNoSiteMatchOnce(nodeName string, internalIPs []string) {
@@ -2271,59 +2516,90 @@ func containsFinalizer(finalizers []string, finalizer string) bool {
 	return false
 }
 
-// ensureFinalizer adds the protection finalizer to a resource if not already
-// present. It uses a merge patch to set the full finalizers list.
-func ensureFinalizer(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, name string, finalizers []string) error {
-	if containsFinalizer(finalizers, ProtectionFinalizer) {
-		return nil
-	}
-
-	newFinalizers := make([]string, len(finalizers), len(finalizers)+1)
-	copy(newFinalizers, finalizers)
-	newFinalizers = append(newFinalizers, ProtectionFinalizer)
-
-	patch := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"finalizers": newFinalizers,
-		},
-	}
-
-	patchData, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("failed to marshal finalizer patch: %w", err)
-	}
-
-	_, err = client.Resource(gvr).Patch(ctx, name, types.MergePatchType, patchData, metav1.PatchOptions{})
-
-	return err
+// ensureFinalizer adds the protection finalizer using the live resource state.
+func ensureFinalizer(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, name string, _ []string, expectedUID ...types.UID) error {
+	return updateProtectionFinalizer(ctx, client, gvr, name, true, expectedUID...)
 }
 
-// removeFinalizer removes the protection finalizer from a resource if present.
-// It uses a merge patch to replace the finalizers list with the filtered list.
-func removeFinalizer(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, name string, finalizers []string) error {
-	if !containsFinalizer(finalizers, ProtectionFinalizer) {
-		return nil
+// removeFinalizer removes the protection finalizer using the live resource state.
+func removeFinalizer(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, name string, _ []string, expectedUID ...types.UID) error {
+	return updateProtectionFinalizer(ctx, client, gvr, name, false, expectedUID...)
+}
+
+func updateProtectionFinalizer(
+	ctx context.Context,
+	client dynamic.Interface,
+	gvr schema.GroupVersionResource,
+	name string,
+	wantFinalizer bool,
+	expectedUID ...types.UID,
+) error {
+	if gvr == siteGVR && len(expectedUID) != 1 {
+		return fmt.Errorf("expected exactly one Site UID for finalizer update of %s", name)
 	}
 
-	newFinalizers := make([]string, 0, len(finalizers))
-	for _, f := range finalizers {
-		if f != ProtectionFinalizer {
-			newFinalizers = append(newFinalizers, f)
+	resource := client.Resource(gvr)
+	backoff := wait.Backoff{
+		Duration: 50 * time.Millisecond,
+		Factor:   2,
+		Steps:    3,
+	}
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		live, err := resource.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			if len(expectedUID) == 1 {
+				return false, fmt.Errorf("expected %s %s with UID %q no longer exists: %w", gvr.Resource, name, expectedUID[0], err)
+			}
+
+			return true, nil
 		}
-	}
 
-	patch := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"finalizers": newFinalizers,
-		},
-	}
+		if err != nil {
+			return false, fmt.Errorf("failed to get %s %s for finalizer update: %w", gvr.Resource, name, err)
+		}
 
-	patchData, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("failed to marshal finalizer patch: %w", err)
-	}
+		if len(expectedUID) == 1 && live.GetUID() != expectedUID[0] {
+			return false, fmt.Errorf("%s %s UID changed from %q to %q", gvr.Resource, name, expectedUID[0], live.GetUID())
+		}
 
-	_, err = client.Resource(gvr).Patch(ctx, name, types.MergePatchType, patchData, metav1.PatchOptions{})
+		finalizers := live.GetFinalizers()
+
+		hasFinalizer := containsFinalizer(finalizers, ProtectionFinalizer)
+		if hasFinalizer == wantFinalizer {
+			return true, nil
+		}
+
+		updated := live.DeepCopy()
+
+		if wantFinalizer {
+			newFinalizers := append([]string(nil), finalizers...)
+			updated.SetFinalizers(append(newFinalizers, ProtectionFinalizer))
+		} else {
+			newFinalizers := make([]string, 0, len(finalizers)-1)
+			for _, finalizer := range finalizers {
+				if finalizer != ProtectionFinalizer {
+					newFinalizers = append(newFinalizers, finalizer)
+				}
+			}
+
+			updated.SetFinalizers(newFinalizers)
+		}
+
+		_, err = resource.Update(ctx, updated, metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		if err != nil {
+			return false, fmt.Errorf("failed to update %s %s finalizers: %w", gvr.Resource, name, err)
+		}
+
+		return true, nil
+	})
+	if err != nil && wait.Interrupted(err) {
+		return fmt.Errorf("failed to update %s %s finalizers after %d attempts: %w", gvr.Resource, name, backoff.Steps, err)
+	}
 
 	return err
 }

--- a/internal/net/controller/site_controller_helpers_test.go
+++ b/internal/net/controller/site_controller_helpers_test.go
@@ -5,15 +5,26 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
@@ -317,6 +328,28 @@ func ptrInt32(v int32) *int32 {
 	return &v
 }
 
+func ptrString(v string) *string {
+	return &v
+}
+
+func ptrUID(v types.UID) *types.UID {
+	return &v
+}
+
+func siteUnstructured(t *testing.T, site unboundedv1alpha3.Site) *unstructured.Unstructured {
+	t.Helper()
+
+	site.APIVersion = unboundedv1alpha3.GroupVersion.String()
+	site.Kind = "Site"
+
+	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&site)
+	if err != nil {
+		t.Fatalf("convert site: %v", err)
+	}
+
+	return &unstructured.Unstructured{Object: object}
+}
+
 // TestNodeSiteLabelFallback verifies the canonical-first, deprecated-fallback
 // read of a Node's site membership.
 func TestNodeSiteLabelFallback(t *testing.T) {
@@ -421,6 +454,29 @@ func TestBuildSliceObjectOwnerRefUsesMachinaSiteGVK(t *testing.T) {
 	if got := owner["uid"]; got != "uid-123" {
 		t.Fatalf("owner uid = %v, want uid-123", got)
 	}
+
+	refs := obj.GetOwnerReferences()
+	if len(refs) != 1 || refs[0].Controller == nil || !*refs[0].Controller {
+		t.Fatalf("owner reference is not controlling: %#v", refs)
+	}
+
+	if refs[0].BlockOwnerDeletion == nil || *refs[0].BlockOwnerDeletion {
+		t.Fatalf("blockOwnerDeletion must be explicitly false: %#v", refs[0].BlockOwnerDeletion)
+	}
+
+	if !hasExactSiteOwnerReference(refs, site) {
+		t.Fatalf("desired owner reference was not accepted: %#v", refs)
+	}
+
+	refs[0].BlockOwnerDeletion = nil
+	if !hasExactSiteOwnerReference(refs, site) {
+		t.Fatalf("nil blockOwnerDeletion must be equivalent to false")
+	}
+
+	refs[0].BlockOwnerDeletion = ptrBool(true)
+	if hasExactSiteOwnerReference(refs, site) {
+		t.Fatalf("true blockOwnerDeletion must be repaired")
+	}
 }
 
 func TestCreateOrUpdateSliceRepairsOwnerReferenceWithoutNodeChanges(t *testing.T) {
@@ -442,7 +498,11 @@ func TestCreateOrUpdateSliceRepairsOwnerReferenceWithoutNodeChanges(t *testing.T
 
 	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
 		runtime.NewScheme(),
-		map[schema.GroupVersionResource]string{siteNodeSliceGVR: "SiteNodeSliceList"},
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, site),
 		stale.DeepCopy(),
 	)
 	sc := &SiteController{
@@ -450,7 +510,9 @@ func TestCreateOrUpdateSliceRepairsOwnerReferenceWithoutNodeChanges(t *testing.T
 		sliceInformer: &fakeInformer{store: store},
 	}
 
-	sc.createOrUpdateSlice(context.Background(), site, 0, []unboundednetv1alpha1.NodeInfo{{Name: "node-a"}})
+	if err := sc.createOrUpdateSlice(context.Background(), site, 0, []unboundednetv1alpha1.NodeInfo{{Name: "node-a"}}); err != nil {
+		t.Fatalf("createOrUpdateSlice: %v", err)
+	}
 
 	got, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), "site-a-0", metav1.GetOptions{})
 	if err != nil {
@@ -459,5 +521,1096 @@ func TestCreateOrUpdateSliceRepairsOwnerReferenceWithoutNodeChanges(t *testing.T
 
 	if !hasExactSiteOwnerReference(got.GetOwnerReferences(), site) {
 		t.Fatalf("owner reference was not repaired: %#v", got.GetOwnerReferences())
+	}
+}
+
+func TestCreateOrUpdateSliceGetsLiveObjectAfterConflict(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "current-uid"}}
+	desired := (&SiteController{}).buildSliceObject(site, "site-a-0", 0, []interface{}{map[string]interface{}{"name": "node-a"}})
+	stale := desired.DeepCopy()
+	stale.SetResourceVersion("1")
+	stale.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: "net.unbounded-cloud.io/v1alpha1",
+		Kind:       "Site",
+		Name:       site.Name,
+		UID:        "legacy-uid",
+	}})
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(stale.DeepCopy()); err != nil {
+		t.Fatalf("add stale slice to cache: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, site),
+		stale.DeepCopy(),
+	)
+
+	getCalls := 0
+
+	dynamicClient.PrependReactor("get", "sitenodeslices", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+
+		return false, nil, nil
+	})
+
+	updateCalls := 0
+
+	dynamicClient.PrependReactor("update", "sitenodeslices", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		updated := action.(clienttesting.UpdateAction).GetObject().(*unstructured.Unstructured) //nolint:errcheck
+
+		if updateCalls == 1 {
+			fresh := stale.DeepCopy()
+			fresh.SetResourceVersion("2")
+
+			if err := dynamicClient.Tracker().Update(siteNodeSliceGVR, fresh, ""); err != nil {
+				t.Fatalf("update live object after conflict: %v", err)
+			}
+
+			return true, nil, apierrors.NewConflict(siteNodeSliceGVR.GroupResource(), stale.GetName(), errors.New("test conflict"))
+		}
+
+		if got := updated.GetResourceVersion(); got != "2" {
+			t.Errorf("retry resourceVersion = %q, want live version 2", got)
+		}
+
+		return false, nil, nil
+	})
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+	if err := sc.createOrUpdateSlice(context.Background(), site, 0, []unboundednetv1alpha1.NodeInfo{{Name: "node-a"}}); err != nil {
+		t.Fatalf("createOrUpdateSlice: %v", err)
+	}
+
+	if getCalls < 2 {
+		t.Fatalf("live GET calls = %d, want at least 2", getCalls)
+	}
+
+	if updateCalls != 2 {
+		t.Fatalf("update calls = %d, want 2", updateCalls)
+	}
+}
+
+func TestCreateOrUpdateSliceGetsLiveObjectAfterAlreadyExists(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "current-uid"}}
+	existing := (&SiteController{}).buildSliceObject(site, "site-a-0", 0, []interface{}{map[string]interface{}{"name": "old-node"}})
+	existing.SetResourceVersion("1")
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, site),
+		existing.DeepCopy(),
+	)
+
+	getCalls := 0
+
+	dynamicClient.PrependReactor("get", "sitenodeslices", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls == 1 {
+			return true, nil, apierrors.NewNotFound(siteNodeSliceGVR.GroupResource(), existing.GetName())
+		}
+
+		return false, nil, nil
+	})
+
+	sc := &SiteController{dynamicClient: dynamicClient}
+	if err := sc.createOrUpdateSlice(context.Background(), site, 0, []unboundednetv1alpha1.NodeInfo{{Name: "node-a"}}); err != nil {
+		t.Fatalf("createOrUpdateSlice: %v", err)
+	}
+
+	if getCalls < 2 {
+		t.Fatalf("live GET calls = %d, want at least 2", getCalls)
+	}
+
+	got, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), existing.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated SiteNodeSlice: %v", err)
+	}
+
+	nodes, _, err := unstructured.NestedSlice(got.Object, "nodes")
+	if err != nil {
+		t.Fatalf("get updated nodes: %v", err)
+	}
+
+	if len(nodes) != 1 || nodes[0].(map[string]interface{})["name"] != "node-a" { //nolint:errcheck
+		t.Fatalf("slice was not updated after AlreadyExists: %#v", nodes)
+	}
+}
+
+func TestCreateOrUpdateSlicePreservesLiveMetadata(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"}}
+	existing := (&SiteController{}).buildSliceObject(site, "site-a-0", 0, []interface{}{map[string]interface{}{"name": "old-node"}})
+	existing.SetLabels(map[string]string{"concurrent-label": "keep"})
+	existing.SetAnnotations(map[string]string{"concurrent-annotation": "keep"})
+	existing.SetFinalizers([]string{"example.com/concurrent-finalizer"})
+	existing.Object["concurrentField"] = map[string]interface{}{"value": "keep"}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, site),
+		existing.DeepCopy(),
+	)
+
+	sc := &SiteController{dynamicClient: dynamicClient}
+	if err := sc.createOrUpdateSlice(context.Background(), site, 0, []unboundednetv1alpha1.NodeInfo{{Name: "node-a"}}); err != nil {
+		t.Fatalf("createOrUpdateSlice: %v", err)
+	}
+
+	got, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), existing.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated SiteNodeSlice: %v", err)
+	}
+
+	if got.GetLabels()["concurrent-label"] != "keep" {
+		t.Fatalf("labels were not preserved: %#v", got.GetLabels())
+	}
+
+	if got.GetAnnotations()["concurrent-annotation"] != "keep" {
+		t.Fatalf("annotations were not preserved: %#v", got.GetAnnotations())
+	}
+
+	if len(got.GetFinalizers()) != 1 || got.GetFinalizers()[0] != "example.com/concurrent-finalizer" {
+		t.Fatalf("finalizers were not preserved: %#v", got.GetFinalizers())
+	}
+
+	if value, found, _ := unstructured.NestedString(got.Object, "concurrentField", "value"); !found || value != "keep" { //nolint:errcheck
+		t.Fatalf("uncontrolled field was not preserved: %#v", got.Object["concurrentField"])
+	}
+
+	if !hasExactSiteOwnerReference(got.GetOwnerReferences(), site) {
+		t.Fatalf("owner reference was not converged: %#v", got.GetOwnerReferences())
+	}
+}
+
+func TestCreateOrUpdateSliceRetriesUpdateNotFound(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"}}
+	existing := (&SiteController{}).buildSliceObject(site, "site-a-0", 0, []interface{}{map[string]interface{}{"name": "old-node"}})
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, site),
+		existing.DeepCopy(),
+	)
+
+	updateCalls := 0
+
+	dynamicClient.PrependReactor("update", "sitenodeslices", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls != 1 {
+			return false, nil, nil
+		}
+
+		if err := dynamicClient.Tracker().Delete(siteNodeSliceGVR, "", existing.GetName()); err != nil {
+			t.Fatalf("delete slice before NotFound response: %v", err)
+		}
+
+		return true, nil, apierrors.NewNotFound(siteNodeSliceGVR.GroupResource(), existing.GetName())
+	})
+
+	sc := &SiteController{dynamicClient: dynamicClient}
+	if err := sc.createOrUpdateSlice(context.Background(), site, 0, []unboundednetv1alpha1.NodeInfo{{Name: "node-a"}}); err != nil {
+		t.Fatalf("createOrUpdateSlice: %v", err)
+	}
+
+	got, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), existing.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get recreated SiteNodeSlice: %v", err)
+	}
+
+	nodes, _, err := unstructured.NestedSlice(got.Object, "nodes")
+	if err != nil {
+		t.Fatalf("get recreated nodes: %v", err)
+	}
+
+	if updateCalls != 1 || len(nodes) != 1 || nodes[0].(map[string]interface{})["name"] != "node-a" { //nolint:errcheck
+		t.Fatalf("slice was not recreated after update NotFound: updates=%d nodes=%#v", updateCalls, nodes)
+	}
+}
+
+func TestUpdateSiteSlicesRevalidatesExtraSlicesAndUsesDeletePreconditions(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"}}
+	reassignedCached := (&SiteController{}).buildSliceObject(site, "site-a-reassigned", 5, nil)
+	reassignedCached.SetUID("cached-uid")
+	reassignedLive := reassignedCached.DeepCopy()
+	reassignedLive.Object["siteName"] = "site-b"
+	reassignedLive.SetUID("replacement-uid")
+
+	extraCached := (&SiteController{}).buildSliceObject(site, "site-a-extra", 6, nil)
+	extraCached.SetUID("cached-extra-uid")
+	extraLive := extraCached.DeepCopy()
+	extraLive.SetUID("live-extra-uid")
+	extraLive.SetResourceVersion("live-extra-version")
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(reassignedCached); err != nil {
+		t.Fatalf("add reassigned slice to cache: %v", err)
+	}
+
+	if err := store.Add(extraCached); err != nil {
+		t.Fatalf("add extra slice to cache: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, site),
+		reassignedLive,
+		extraLive,
+	)
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+	if err := sc.updateSiteSlices(context.Background(), site, nil, 0); err != nil {
+		t.Fatalf("updateSiteSlices: %v", err)
+	}
+
+	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), reassignedLive.GetName(), metav1.GetOptions{}); err != nil {
+		t.Fatalf("reassigned replacement was deleted: %v", err)
+	}
+
+	deleteActions := 0
+
+	for _, action := range dynamicClient.Actions() {
+		deleteAction, ok := action.(clienttesting.DeleteAction)
+		if !ok {
+			continue
+		}
+
+		deleteActions++
+
+		if deleteAction.GetName() != extraLive.GetName() {
+			t.Fatalf("deleted unexpected slice %q", deleteAction.GetName())
+		}
+
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		if preconditions == nil || preconditions.UID == nil || *preconditions.UID != extraLive.GetUID() {
+			t.Fatalf("delete UID precondition = %#v, want %q", preconditions, extraLive.GetUID())
+		}
+
+		if preconditions.ResourceVersion == nil || *preconditions.ResourceVersion != extraLive.GetResourceVersion() {
+			t.Fatalf("delete resourceVersion precondition = %#v, want %q", preconditions, extraLive.GetResourceVersion())
+		}
+	}
+
+	if deleteActions != 1 {
+		t.Fatalf("delete actions = %d, want 1", deleteActions)
+	}
+}
+
+func TestUpdateSiteSlicesDoesNotDeleteSameUIDConcurrentUpdate(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"}}
+	extra := (&SiteController{}).buildSliceObject(site, "site-a-extra", 1, nil)
+	extra.SetUID("extra-uid")
+	extra.SetResourceVersion("1")
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(extra.DeepCopy()); err != nil {
+		t.Fatalf("add extra slice to cache: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, site),
+		extra.DeepCopy(),
+	)
+
+	deleteCalls := 0
+
+	dynamicClient.PrependReactor("delete", "sitenodeslices", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		deleteCalls++
+		deleteAction := action.(clienttesting.DeleteAction) //nolint:errcheck
+
+		concurrent := extra.DeepCopy()
+		concurrent.SetResourceVersion("2")
+		concurrent.SetAnnotations(map[string]string{"concurrent-update": "preserve"})
+
+		if err := dynamicClient.Tracker().Update(siteNodeSliceGVR, concurrent, ""); err != nil {
+			t.Fatalf("store concurrent slice update: %v", err)
+		}
+
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		if preconditions == nil || preconditions.UID == nil || *preconditions.UID != concurrent.GetUID() {
+			t.Errorf("delete UID precondition = %#v, want %q", preconditions, concurrent.GetUID())
+		}
+
+		if preconditions == nil || preconditions.ResourceVersion == nil {
+			t.Errorf("delete resourceVersion precondition = %#v, want %q", preconditions, extra.GetResourceVersion())
+
+			return false, nil, nil
+		}
+
+		if *preconditions.ResourceVersion != extra.GetResourceVersion() {
+			t.Errorf("delete resourceVersion precondition = %q, want %q", *preconditions.ResourceVersion, extra.GetResourceVersion())
+		}
+
+		if *preconditions.ResourceVersion != concurrent.GetResourceVersion() {
+			return true, nil, apierrors.NewConflict(
+				siteNodeSliceGVR.GroupResource(),
+				concurrent.GetName(),
+				errors.New("resourceVersion precondition failed"),
+			)
+		}
+
+		return false, nil, nil
+	})
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+
+	err := sc.updateSiteSlices(context.Background(), site, nil, 0)
+	if err == nil || !apierrors.IsConflict(err) {
+		t.Fatalf("updateSiteSlices error = %v, want conflict", err)
+	}
+
+	if deleteCalls != 1 {
+		t.Fatalf("delete calls = %d, want 1", deleteCalls)
+	}
+
+	got, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), extra.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get concurrently updated slice: %v", err)
+	}
+
+	if got.GetUID() != extra.GetUID() || got.GetResourceVersion() != "2" || got.GetAnnotations()["concurrent-update"] != "preserve" {
+		t.Fatalf("concurrently updated slice was not preserved: %#v", got.Object["metadata"])
+	}
+}
+
+func TestCreateOrUpdateSliceDoesNotUseSameNameReplacementSite(t *testing.T) {
+	oldSite := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "old-site-uid"}}
+	replacement := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: oldSite.Name, UID: "replacement-site-uid"}}
+	existing := (&SiteController{}).buildSliceObject(oldSite, "site-a-0", 0, []interface{}{map[string]interface{}{"name": "old-node"}})
+	existing.SetUID("slice-uid")
+	existing.SetResourceVersion("1")
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, oldSite),
+		existing.DeepCopy(),
+	)
+
+	replaced := false
+
+	dynamicClient.PrependReactor("get", "sitenodeslices", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if replaced {
+			return false, nil, nil
+		}
+
+		replaced = true
+
+		if err := dynamicClient.Tracker().Delete(siteGVR, "", oldSite.Name); err != nil {
+			t.Fatalf("delete old site: %v", err)
+		}
+
+		if err := dynamicClient.Tracker().Add(siteUnstructured(t, replacement)); err != nil {
+			t.Fatalf("add replacement site: %v", err)
+		}
+
+		return false, nil, nil
+	})
+
+	sc := &SiteController{dynamicClient: dynamicClient}
+
+	err := sc.createOrUpdateSlice(context.Background(), oldSite, 0, []unboundednetv1alpha1.NodeInfo{{Name: "new-node"}})
+	if err == nil || !strings.Contains(err.Error(), "UID changed") {
+		t.Fatalf("createOrUpdateSlice error = %v, want Site UID change", err)
+	}
+
+	for _, action := range dynamicClient.Actions() {
+		if action.GetResource() == siteNodeSliceGVR && (action.GetVerb() == "create" || action.GetVerb() == "update") {
+			t.Fatalf("slice was mutated after Site replacement: %#v", action)
+		}
+	}
+
+	got, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), existing.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get preserved slice: %v", err)
+	}
+
+	if !hasExactSiteOwnerReference(got.GetOwnerReferences(), oldSite) {
+		t.Fatalf("slice owner was changed to the replacement Site: %#v", got.GetOwnerReferences())
+	}
+}
+
+func TestCleanupOrphanSiteNodeSlicesRevalidatesSitesAndDeletePreconditions(t *testing.T) {
+	oldSite := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "old-site-uid"}}
+	replacement := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: oldSite.Name, UID: "replacement-site-uid"}}
+
+	emptySiteName := (&SiteController{}).buildSliceObject(oldSite, "empty-site-name", 0, nil)
+	emptySiteName.Object["siteName"] = ""
+	emptySiteName.SetUID("empty-uid")
+	emptySiteName.SetResourceVersion("empty-rv")
+
+	missingSite := (&SiteController{}).buildSliceObject(oldSite, "missing-site", 0, nil)
+	missingSite.Object["siteName"] = "missing"
+	missingSite.SetUID("missing-uid")
+	missingSite.SetResourceVersion("missing-rv")
+
+	recreatedSite := (&SiteController{}).buildSliceObject(oldSite, "recreated-site", 0, nil)
+	recreatedSite.SetUID("recreated-slice-uid")
+	recreatedSite.SetResourceVersion("recreated-slice-rv")
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, slice := range []*unstructured.Unstructured{emptySiteName, missingSite, recreatedSite} {
+		if err := store.Add(slice.DeepCopy()); err != nil {
+			t.Fatalf("add slice %s to cache: %v", slice.GetName(), err)
+		}
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, oldSite),
+		emptySiteName.DeepCopy(),
+		missingSite.DeepCopy(),
+		recreatedSite.DeepCopy(),
+	)
+
+	dynamicClient.PrependReactor("get", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		getAction := action.(clienttesting.GetAction) //nolint:errcheck
+		if getAction.GetName() != oldSite.Name {
+			return false, nil, nil
+		}
+
+		if err := dynamicClient.Tracker().Delete(siteGVR, "", oldSite.Name); err != nil {
+			t.Fatalf("delete old site: %v", err)
+		}
+
+		if err := dynamicClient.Tracker().Add(siteUnstructured(t, replacement)); err != nil {
+			t.Fatalf("add replacement site: %v", err)
+		}
+
+		return false, nil, nil
+	})
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+	if err := sc.cleanupOrphanSiteNodeSlices(context.Background()); err != nil {
+		t.Fatalf("cleanupOrphanSiteNodeSlices: %v", err)
+	}
+
+	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), recreatedSite.GetName(), metav1.GetOptions{}); err != nil {
+		t.Fatalf("slice for recreated same-name Site was deleted: %v", err)
+	}
+
+	wantPreconditions := map[string]metav1.Preconditions{
+		emptySiteName.GetName(): {
+			UID:             ptrUID(emptySiteName.GetUID()),
+			ResourceVersion: ptrString(emptySiteName.GetResourceVersion()),
+		},
+		missingSite.GetName(): {
+			UID:             ptrUID(missingSite.GetUID()),
+			ResourceVersion: ptrString(missingSite.GetResourceVersion()),
+		},
+	}
+
+	deleteActions := 0
+
+	for _, action := range dynamicClient.Actions() {
+		deleteAction, ok := action.(clienttesting.DeleteAction)
+		if !ok || action.GetResource() != siteNodeSliceGVR {
+			continue
+		}
+
+		deleteActions++
+		want, ok := wantPreconditions[deleteAction.GetName()]
+
+		if !ok {
+			t.Fatalf("deleted non-orphan slice %q", deleteAction.GetName())
+		}
+
+		got := deleteAction.GetDeleteOptions().Preconditions
+		if got == nil || got.UID == nil || *got.UID != *want.UID || got.ResourceVersion == nil || *got.ResourceVersion != *want.ResourceVersion {
+			t.Fatalf("delete preconditions for %s = %#v, want %#v", deleteAction.GetName(), got, want)
+		}
+	}
+
+	if deleteActions != len(wantPreconditions) {
+		t.Fatalf("delete actions = %d, want %d", deleteActions, len(wantPreconditions))
+	}
+}
+
+func TestCleanupOrphanSiteNodeSlicesPreservesSliceOnSiteLookupError(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"}}
+	slice := (&SiteController{}).buildSliceObject(site, "site-a-0", 0, nil)
+	slice.SetUID("slice-uid")
+	slice.SetResourceVersion("slice-rv")
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(slice.DeepCopy()); err != nil {
+		t.Fatalf("add slice to cache: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		slice.DeepCopy(),
+	)
+	dynamicClient.PrependReactor("get", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(siteGVR.GroupResource(), site.Name, errors.New("test denial"))
+	})
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+
+	err := sc.cleanupOrphanSiteNodeSlices(context.Background())
+	if err == nil || !apierrors.IsForbidden(err) {
+		t.Fatalf("cleanupOrphanSiteNodeSlices error = %v, want forbidden", err)
+	}
+
+	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), slice.GetName(), metav1.GetOptions{}); err != nil {
+		t.Fatalf("slice was deleted after conservative Site lookup failure: %v", err)
+	}
+}
+
+func TestSliceMutationFailurePropagatesRedirtiesAndSkipsStatus(t *testing.T) {
+	site := unboundedv1alpha3.Site{
+		TypeMeta: metav1.TypeMeta{APIVersion: unboundedv1alpha3.GroupVersion.String(), Kind: "Site"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "site-a",
+			UID:        "site-uid",
+			Finalizers: []string{ProtectionFinalizer},
+		},
+		Spec: unboundedv1alpha3.SiteSpec{NodeCidrs: []string{"10.0.0.0/24"}},
+	}
+
+	siteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&site)
+	if err != nil {
+		t.Fatalf("convert site: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		&unstructured.Unstructured{Object: siteObject},
+	)
+	dynamicClient.PrependReactor("create", "sitenodeslices", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(siteNodeSliceGVR.GroupResource(), "site-a-0", errors.New("test denial"))
+	})
+
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := nodeIndexer.Add(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{
+			Type:    corev1.NodeInternalIP,
+			Address: "10.0.0.10",
+		}}},
+	}); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		nodeLister:    corev1listers.NewNodeLister(nodeIndexer),
+		sliceInformer: &fakeInformer{store: cache.NewStore(cache.MetaNamespaceKeyFunc)},
+		sitesCache:    []unboundedv1alpha3.Site{site},
+	}
+	sc.markSlicesDirty()
+
+	err = sc.updateSiteSlicesIfDirty(context.Background())
+	if err == nil || !apierrors.IsForbidden(err) {
+		t.Fatalf("updateSiteSlicesIfDirty error = %v, want forbidden", err)
+	}
+
+	if !sc.slicesDirty.Load() {
+		t.Fatalf("failed slice pass did not restore dirty flag")
+	}
+
+	for _, action := range dynamicClient.Actions() {
+		if action.GetVerb() == "patch" && action.GetResource() == siteGVR && action.GetSubresource() == "status" {
+			t.Fatalf("site status was published after slice mutation failed: %#v", action)
+		}
+	}
+}
+
+func TestStatusFailurePropagatesAndRedirties(t *testing.T) {
+	site := unboundedv1alpha3.Site{
+		TypeMeta:   metav1.TypeMeta{APIVersion: unboundedv1alpha3.GroupVersion.String(), Kind: "Site"},
+		ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"},
+		Status:     unboundedv1alpha3.SiteStatus{NodeCount: 1},
+	}
+
+	siteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&site)
+	if err != nil {
+		t.Fatalf("convert site: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		&unstructured.Unstructured{Object: siteObject},
+	)
+	dynamicClient.PrependReactor("patch", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(siteGVR.GroupResource(), site.Name, errors.New("test status denial"))
+	})
+
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		nodeLister:    corev1listers.NewNodeLister(nodeIndexer),
+		sliceInformer: &fakeInformer{store: cache.NewStore(cache.MetaNamespaceKeyFunc)},
+		sitesCache:    []unboundedv1alpha3.Site{site},
+	}
+	sc.markSlicesDirty()
+
+	err = sc.updateSiteSlicesIfDirty(context.Background())
+	if err == nil || !apierrors.IsForbidden(err) {
+		t.Fatalf("updateSiteSlicesIfDirty error = %v, want forbidden", err)
+	}
+
+	if !sc.slicesDirty.Load() {
+		t.Fatalf("failed status update did not restore dirty flag")
+	}
+}
+
+func TestFinalizerFailurePropagatesAndRedirties(t *testing.T) {
+	site := unboundedv1alpha3.Site{
+		TypeMeta:   metav1.TypeMeta{APIVersion: unboundedv1alpha3.GroupVersion.String(), Kind: "Site"},
+		ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"},
+		Spec:       unboundedv1alpha3.SiteSpec{NodeCidrs: []string{"10.0.0.0/24"}},
+		Status:     unboundedv1alpha3.SiteStatus{NodeCount: 1},
+	}
+
+	siteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&site)
+	if err != nil {
+		t.Fatalf("convert site: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		&unstructured.Unstructured{Object: siteObject},
+	)
+	dynamicClient.PrependReactor("update", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(siteGVR.GroupResource(), site.Name, errors.New("test finalizer denial"))
+	})
+
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := nodeIndexer.Add(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway-a", Labels: map[string]string{"role": "gateway"}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{
+			Type:    corev1.NodeInternalIP,
+			Address: "10.0.0.10",
+		}}},
+	}); err != nil {
+		t.Fatalf("add gateway node: %v", err)
+	}
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		nodeLister:    corev1listers.NewNodeLister(nodeIndexer),
+		sliceInformer: &fakeInformer{store: cache.NewStore(cache.MetaNamespaceKeyFunc)},
+		sitesCache:    []unboundedv1alpha3.Site{site},
+		gatewayPoolsCache: []unboundednetv1alpha1.GatewayPool{{
+			Spec: unboundednetv1alpha1.GatewayPoolSpec{NodeSelector: map[string]string{"role": "gateway"}},
+		}},
+	}
+	sc.markSlicesDirty()
+
+	err = sc.updateSiteSlicesIfDirty(context.Background())
+	if err == nil || !apierrors.IsForbidden(err) {
+		t.Fatalf("updateSiteSlicesIfDirty error = %v, want forbidden", err)
+	}
+
+	if !sc.slicesDirty.Load() {
+		t.Fatalf("failed finalizer update did not restore dirty flag")
+	}
+}
+
+func TestFinalizerConflictRetryPreservesConcurrentFinalizers(t *testing.T) {
+	resource := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": unboundedv1alpha3.GroupVersion.String(),
+		"kind":       "Site",
+		"metadata": map[string]interface{}{
+			"name":       "site-a",
+			"uid":        "site-uid",
+			"finalizers": []interface{}{"example.com/existing"},
+		},
+	}}
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{siteGVR: "SiteList"},
+		resource,
+	)
+
+	updateCalls := 0
+
+	dynamicClient.PrependReactor("update", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls != 1 {
+			return false, nil, nil
+		}
+
+		concurrent := resource.DeepCopy()
+		concurrent.SetFinalizers([]string{"example.com/existing", "example.com/concurrent"})
+
+		if err := dynamicClient.Tracker().Update(siteGVR, concurrent, ""); err != nil {
+			t.Fatalf("store concurrent finalizer: %v", err)
+		}
+
+		return true, nil, apierrors.NewConflict(siteGVR.GroupResource(), resource.GetName(), errors.New("test conflict"))
+	})
+
+	if err := ensureFinalizer(context.Background(), dynamicClient, siteGVR, resource.GetName(), nil, resource.GetUID()); err != nil {
+		t.Fatalf("ensureFinalizer: %v", err)
+	}
+
+	got, err := dynamicClient.Resource(siteGVR).Get(context.Background(), resource.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated site: %v", err)
+	}
+
+	wantFinalizers := []string{"example.com/existing", "example.com/concurrent", ProtectionFinalizer}
+	if !stringSlicesEqual(got.GetFinalizers(), wantFinalizers) {
+		t.Fatalf("finalizers = %#v, want %#v", got.GetFinalizers(), wantFinalizers)
+	}
+
+	if err := removeFinalizer(context.Background(), dynamicClient, siteGVR, resource.GetName(), nil, resource.GetUID()); err != nil {
+		t.Fatalf("removeFinalizer: %v", err)
+	}
+
+	got, err = dynamicClient.Resource(siteGVR).Get(context.Background(), resource.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get site after remove: %v", err)
+	}
+
+	wantFinalizers = []string{"example.com/existing", "example.com/concurrent"}
+	if !stringSlicesEqual(got.GetFinalizers(), wantFinalizers) {
+		t.Fatalf("finalizers after remove = %#v, want %#v", got.GetFinalizers(), wantFinalizers)
+	}
+}
+
+func TestFinalizerRetryDoesNotMutateSameNameReplacement(t *testing.T) {
+	oldSite := unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "site-a",
+			UID:        "old-site-uid",
+			Finalizers: []string{"example.com/old"},
+		},
+	}
+	replacement := unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       oldSite.Name,
+			UID:        "replacement-site-uid",
+			Finalizers: []string{"example.com/replacement"},
+		},
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{siteGVR: "SiteList"},
+		siteUnstructured(t, oldSite),
+	)
+
+	updateCalls := 0
+
+	dynamicClient.PrependReactor("update", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+
+		if err := dynamicClient.Tracker().Delete(siteGVR, "", oldSite.Name); err != nil {
+			t.Fatalf("delete old site: %v", err)
+		}
+
+		if err := dynamicClient.Tracker().Add(siteUnstructured(t, replacement)); err != nil {
+			t.Fatalf("add replacement site: %v", err)
+		}
+
+		return true, nil, apierrors.NewConflict(siteGVR.GroupResource(), oldSite.Name, errors.New("test replacement"))
+	})
+
+	err := ensureFinalizer(context.Background(), dynamicClient, siteGVR, oldSite.Name, oldSite.Finalizers, oldSite.UID)
+	if err == nil || !strings.Contains(err.Error(), "UID changed") {
+		t.Fatalf("ensureFinalizer error = %v, want Site UID change", err)
+	}
+
+	if updateCalls != 1 {
+		t.Fatalf("update calls = %d, want 1", updateCalls)
+	}
+
+	got, err := dynamicClient.Resource(siteGVR).Get(context.Background(), replacement.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get replacement site: %v", err)
+	}
+
+	if got.GetUID() != replacement.UID || !stringSlicesEqual(got.GetFinalizers(), replacement.Finalizers) {
+		t.Fatalf("replacement Site was mutated: uid=%q finalizers=%#v", got.GetUID(), got.GetFinalizers())
+	}
+}
+
+func TestStatusRetryDoesNotPatchSameNameReplacement(t *testing.T) {
+	oldSite := unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "old-site-uid", ResourceVersion: "10"},
+	}
+	replacement := unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: oldSite.Name, UID: "replacement-site-uid", ResourceVersion: "11"},
+		Status:     unboundedv1alpha3.SiteStatus{NodeCount: 99, SliceCount: 99},
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{siteGVR: "SiteList"},
+		siteUnstructured(t, oldSite),
+	)
+
+	patchCalls := 0
+
+	dynamicClient.PrependReactor("patch", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchCalls++
+		patchAction := action.(clienttesting.PatchAction) //nolint:errcheck
+
+		var patch struct {
+			Metadata struct {
+				ResourceVersion string `json:"resourceVersion"`
+			} `json:"metadata"`
+		}
+		if err := json.Unmarshal(patchAction.GetPatch(), &patch); err != nil {
+			t.Fatalf("unmarshal status patch: %v", err)
+		}
+
+		if patch.Metadata.ResourceVersion != oldSite.ResourceVersion {
+			t.Fatalf("status patch resourceVersion = %q, want %q", patch.Metadata.ResourceVersion, oldSite.ResourceVersion)
+		}
+
+		if err := dynamicClient.Tracker().Delete(siteGVR, "", oldSite.Name); err != nil {
+			t.Fatalf("delete old site: %v", err)
+		}
+
+		if err := dynamicClient.Tracker().Add(siteUnstructured(t, replacement)); err != nil {
+			t.Fatalf("add replacement site: %v", err)
+		}
+
+		return true, nil, apierrors.NewConflict(siteGVR.GroupResource(), oldSite.Name, errors.New("resourceVersion precondition failed"))
+	})
+
+	sc := &SiteController{dynamicClient: dynamicClient}
+
+	err := sc.updateSiteStatusIfChanged(context.Background(), oldSite, 1, 1)
+	if err == nil || !strings.Contains(err.Error(), "UID changed") {
+		t.Fatalf("updateSiteStatusIfChanged error = %v, want Site UID change", err)
+	}
+
+	if patchCalls != 1 {
+		t.Fatalf("status patch calls = %d, want 1", patchCalls)
+	}
+
+	got, err := dynamicClient.Resource(siteGVR).Get(context.Background(), replacement.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get replacement site: %v", err)
+	}
+
+	nodeCount, _, err := unstructured.NestedInt64(got.Object, "status", "nodeCount")
+	if err != nil {
+		t.Fatalf("read replacement status: %v", err)
+	}
+
+	if got.GetUID() != replacement.UID || nodeCount != int64(replacement.Status.NodeCount) {
+		t.Fatalf("replacement Site was mutated: uid=%q status=%#v", got.GetUID(), got.Object["status"])
+	}
+}
+
+func TestGatewayNodesIncludedInSiteStatusCount(t *testing.T) {
+	site := unboundedv1alpha3.Site{
+		TypeMeta: metav1.TypeMeta{APIVersion: unboundedv1alpha3.GroupVersion.String(), Kind: "Site"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "site-a",
+			UID:        "site-uid",
+			Finalizers: []string{ProtectionFinalizer},
+		},
+		Spec: unboundedv1alpha3.SiteSpec{NodeCidrs: []string{"10.0.0.0/24"}},
+	}
+
+	siteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&site)
+	if err != nil {
+		t.Fatalf("convert site: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		&unstructured.Unstructured{Object: siteObject},
+	)
+
+	statusNodeCount := -1
+	statusSliceCount := -1
+
+	dynamicClient.PrependReactor("patch", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(clienttesting.PatchAction) //nolint:errcheck
+		if patchAction.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+
+		var patch struct {
+			Status struct {
+				NodeCount  int `json:"nodeCount"`
+				SliceCount int `json:"sliceCount"`
+			} `json:"status"`
+		}
+		if err := json.Unmarshal(patchAction.GetPatch(), &patch); err != nil {
+			t.Fatalf("unmarshal status patch: %v", err)
+		}
+
+		statusNodeCount = patch.Status.NodeCount
+		statusSliceCount = patch.Status.SliceCount
+
+		return false, nil, nil
+	})
+
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := nodeIndexer.Add(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway-a", Labels: map[string]string{"role": "gateway"}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{
+			Type:    corev1.NodeInternalIP,
+			Address: "10.0.0.10",
+		}}},
+	}); err != nil {
+		t.Fatalf("add gateway node: %v", err)
+	}
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		nodeLister:    corev1listers.NewNodeLister(nodeIndexer),
+		sliceInformer: &fakeInformer{store: cache.NewStore(cache.MetaNamespaceKeyFunc)},
+		sitesCache:    []unboundedv1alpha3.Site{site},
+		gatewayPoolsCache: []unboundednetv1alpha1.GatewayPool{{
+			Spec: unboundednetv1alpha1.GatewayPoolSpec{NodeSelector: map[string]string{"role": "gateway"}},
+		}},
+	}
+
+	if err := sc.updateAllSiteSlices(context.Background()); err != nil {
+		t.Fatalf("updateAllSiteSlices: %v", err)
+	}
+
+	if statusNodeCount != 1 || statusSliceCount != 0 {
+		t.Fatalf("site status counts = nodes %d, slices %d; want 1, 0", statusNodeCount, statusSliceCount)
+	}
+}
+
+func TestSiteNodeSliceInformerEventsMarkSlicesDirty(t *testing.T) {
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:            "SiteList",
+			siteNodeSliceGVR:   "SiteNodeSliceList",
+			gatewayPoolGVRSite: "GatewayPoolList",
+		},
+	)
+	dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+	nodeInformerFactory := informers.NewSharedInformerFactory(kubefake.NewSimpleClientset(), 0)
+
+	sc, err := NewSiteController(kubefake.NewSimpleClientset(), dynamicClient, dynamicInformerFactory, nodeInformerFactory)
+	if err != nil {
+		t.Fatalf("NewSiteController: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dynamicInformerFactory.Start(ctx.Done())
+	nodeInformerFactory.Start(ctx.Done())
+
+	if !cache.WaitForCacheSync(ctx.Done(), sc.nodeSynced, sc.siteSynced, sc.sliceSynced, sc.gatewayPoolSynced) {
+		t.Fatalf("informer caches did not sync")
+	}
+
+	resource := dynamicClient.Resource(siteNodeSliceGVR)
+	slice := (&SiteController{}).buildSliceObject(
+		unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"}},
+		"site-a-0",
+		0,
+		nil,
+	)
+
+	created, err := resource.Create(ctx, slice, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create SiteNodeSlice: %v", err)
+	}
+
+	waitForSlicesDirty(t, ctx, sc)
+
+	sc.slicesDirty.Store(false)
+	created.SetAnnotations(map[string]string{"test": "updated"})
+
+	created, err = resource.Update(ctx, created, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("update SiteNodeSlice: %v", err)
+	}
+
+	waitForSlicesDirty(t, ctx, sc)
+
+	sc.slicesDirty.Store(false)
+
+	if err := resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete SiteNodeSlice: %v", err)
+	}
+
+	waitForSlicesDirty(t, ctx, sc)
+}
+
+func waitForSlicesDirty(t *testing.T, ctx context.Context, sc *SiteController) {
+	t.Helper()
+
+	err := utilwait.PollUntilContextTimeout(ctx, 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
+		return sc.slicesDirty.Load(), nil
+	})
+	if err != nil {
+		t.Fatalf("SiteNodeSlice event did not mark slices dirty: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
Hardens the net Site controller's SiteNodeSlice ownership and reconcile loop against ownership-admission failures and delete/recreate races.

## Findings addressed
- **Owner ref requires `sites/finalizers` RBAC the controller lacks:** set `blockOwnerDeletion: false` (accept nil/false, repair true) so slice writes are no longer rejected by ownerRef admission.
- **No UID guard -> mutating a same-name replacement Site:** every slice/status/finalizer write now does a live GET + expected-UID check.
- **Unconditioned extra-slice deletion:** deletes now use UID + ResourceVersion preconditions and revalidate the live `siteName`.
- **Full-object Update clobbered foreign metadata:** mutate a deep copy of the live slice.
- **Dirty flag lost on error:** failures propagate and re-dirty so the next pass retries; per-site status/finalizer errors are aggregated.
- **Status under-counted gateway nodes**, `[]string` embedded in unstructured content, missing orphan-slice cleanup, and missing slice-informer wiring - all fixed.

## Verification
`make fmt` / `make lint` / `make build` / `make test` green; `go test -race ./internal/net/controller/...` green.

## Merge notes
Independent, compile-standalone. Runtime-coupled to the operator config/migration PR (reaper owner-ref predicate); recommend merging this **before** that PR. Non-destructive in either order.
