### PR TITLE
operator: own CRD lifecycle with periodic maintenance and idempotent install repair

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ UNBOUNDED_OPERATOR_CMD=./cmd/unbounded-operator
 UNBOUNDED_OPERATOR_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-operator:$(VERSION)
 UNBOUNDED_OPERATOR_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
 UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT ?=
+UNBOUNDED_OPERATOR_REAP_LEGACY_RESOURCES ?= true
 export UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT
 UNBOUNDED_OPERATOR_MANIFEST_TEMPLATES_DIR := deploy/unbounded-operator
 UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR  := deploy/unbounded-operator/rendered
@@ -1018,7 +1019,8 @@ unbounded-operator-manifests: ## Render unbounded-operator manifests into deploy
 		--set Namespace=$(UNBOUNDED_OPERATOR_NAMESPACE) \
 		--set OperatorImage=$(UNBOUNDED_OPERATOR_IMAGE) \
 		--set MetalmanImage=$(METALMAN_IMAGE) \
-		--set "APIServerEndpoint=$${UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT}"
+		--set "APIServerEndpoint=$${UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT}" \
+		--set ReapLegacyResources=$(UNBOUNDED_OPERATOR_REAP_LEGACY_RESOURCES)
 	@echo "Rendered unbounded-operator manifests into $(UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR) (image: $(UNBOUNDED_OPERATOR_IMAGE))"
 
 machine-ops-manifests: ## Render machine-ops-controller manifests into deploy/machine-ops/rendered

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -6,14 +6,17 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
 	"log/slog"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -28,18 +32,21 @@ import (
 
 	operatormanifests "github.com/Azure/unbounded/deploy/unbounded-operator"
 	"github.com/Azure/unbounded/internal/kube"
+	"github.com/Azure/unbounded/internal/operator"
 	"github.com/Azure/unbounded/internal/unbounded"
 )
 
 const defaultInstallTimeout = 5 * time.Minute
 
-// operatorConfigHashAnnotation is stamped onto the operator Deployment pod
-// template so a change to the environment-specific operator config (currently the
-// advertised api-server-endpoint) changes the pod template and triggers a
-// rollout. Without it a re-install that only edits the unbounded-operator-config
-// ConfigMap would not restart the operator, and envFrom is read once at pod
-// start, so the running operator would keep advertising the old endpoint.
-const operatorConfigHashAnnotation = "unbounded-cloud.io/operator-config-hash"
+const (
+	// operatorConfigHashAnnotation is stamped onto the operator Deployment pod
+	// template so a change to the operator ConfigMap data triggers a rollout.
+	operatorConfigHashAnnotation = "unbounded-cloud.io/operator-config-hash"
+
+	// operatorCRDRepairAnnotation restarts an existing operator when its startup
+	// CRD bootstrap needs to repair a missing or unestablished CRD.
+	operatorCRDRepairAnnotation = "unbounded-cloud.io/operator-crd-repair-token"
+)
 
 type installHandler struct {
 	kubeconfigPath string
@@ -56,6 +63,10 @@ type installHandler struct {
 	kubeResourcesCli client.Client
 	restConfig       *rest.Config
 	logger           *slog.Logger
+
+	operatorConfigData  map[string]string
+	operatorRepairToken string
+	newRepairToken      func() (string, error)
 }
 
 func installCommand() *cobra.Command {
@@ -89,6 +100,11 @@ func addInstallFlags(cmd *cobra.Command, handler *installHandler) {
 }
 
 func (h *installHandler) execute(ctx context.Context) error {
+	// execute can be called repeatedly in tests and by command embedders. Do not
+	// carry values derived from the previous cluster state into this run.
+	h.operatorConfigData = nil
+	h.operatorRepairToken = ""
+
 	if h.logger == nil {
 		h.logger = slog.Default()
 	}
@@ -117,14 +133,18 @@ func (h *installHandler) execute(ctx context.Context) error {
 		}
 	}
 
-	if h.apiServerEndpoint == "" && h.restConfig != nil {
-		h.apiServerEndpoint = h.restConfig.Host
+	if err := h.prepareOperatorConfig(ctx); err != nil {
+		return err
 	}
 
 	// CRDs are installed and upgraded by the operator itself at startup
 	// (operator.BootstrapCRDs). install only bootstraps the operator; applying
 	// the operator manifests and waiting for its rollout is enough, because the
 	// operator becomes Ready only after it has established the CRDs.
+	if err := h.prepareOperatorRepair(ctx); err != nil {
+		return err
+	}
+
 	if err := applyManifestFS(ctx, h.logger, h.kubeResourcesCli, operatormanifests.Manifests, fieldManagerID, h.mutateOperatorObject); err != nil {
 		return fmt.Errorf("applying unbounded-operator manifests: %w", err)
 	}
@@ -177,10 +197,29 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 	// The api-server-endpoint is delivered to the operator via the
 	// unbounded-operator-config ConfigMap (envFrom), not a Deployment arg, so
 	// install and the apply-only path share one config surface.
-	if obj.GetKind() == "ConfigMap" && obj.GetName() == "unbounded-operator-config" && h.apiServerEndpoint != "" {
-		if err := unstructured.SetNestedField(obj.Object, h.apiServerEndpoint, "data", "UNBOUNDED_API_SERVER_ENDPOINT"); err != nil {
-			return fmt.Errorf("set operator config api-server-endpoint: %w", err)
+	if obj.GetKind() == "ConfigMap" && obj.GetName() == "unbounded-operator-config" {
+		if h.operatorConfigData == nil {
+			return fmt.Errorf("operator config must be prepared before manifest mutation")
 		}
+
+		data, found, err := unstructured.NestedStringMap(obj.Object, "data")
+		if err != nil {
+			return fmt.Errorf("get operator config data: %w", err)
+		}
+
+		if !found {
+			return fmt.Errorf("operator config data not found")
+		}
+
+		for key, value := range h.operatorConfigData {
+			data[key] = value
+		}
+
+		if err := unstructured.SetNestedStringMap(obj.Object, data, "data"); err != nil {
+			return fmt.Errorf("set operator config data: %w", err)
+		}
+
+		h.operatorConfigData = data
 	}
 
 	if obj.GetKind() == "Deployment" && obj.GetName() == "unbounded-operator" {
@@ -201,24 +240,159 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 			}
 		}
 
-		// Stamp the config hash so a changed endpoint rolls the pod (see #3);
-		// this mirrors the render-time hash in 04-deployment.yaml.tmpl.
-		if err := unstructured.SetNestedField(obj.Object, operatorConfigHash(h.apiServerEndpoint), "spec", "template", "metadata", "annotations", operatorConfigHashAnnotation); err != nil {
+		if h.operatorConfigData == nil {
+			return fmt.Errorf("operator ConfigMap must be processed before Deployment")
+		}
+
+		// Hash the complete final ConfigMap data. Canonical JSON matches sprig's
+		// toJson in the deployment template and is independent of map order.
+		if err := unstructured.SetNestedField(obj.Object, operatorConfigHash(h.operatorConfigData), "spec", "template", "metadata", "annotations", operatorConfigHashAnnotation); err != nil {
 			return fmt.Errorf("set operator config hash annotation: %w", err)
+		}
+
+		if h.operatorRepairToken != "" {
+			if err := unstructured.SetNestedField(obj.Object, h.operatorRepairToken, "spec", "template", "metadata", "annotations", operatorCRDRepairAnnotation); err != nil {
+				return fmt.Errorf("set operator CRD repair annotation: %w", err)
+			}
 		}
 	}
 
 	return nil
 }
 
-// operatorConfigHash returns a stable hash of the environment-specific operator
-// config. It mirrors the render-time hash in 04-deployment.yaml.tmpl (sprig's
-// sha256sum of the endpoint) so both the install path and make-rendered
-// manifests roll the operator when the advertised api-server-endpoint changes.
-func operatorConfigHash(apiServerEndpoint string) string {
-	sum := sha256.Sum256([]byte(apiServerEndpoint))
+// operatorConfigHash returns the SHA-256 hash of the config data's canonical
+// JSON representation. encoding/json sorts map keys, matching sprig's toJson.
+func operatorConfigHash(data map[string]string) string {
+	canonical, err := json.Marshal(data)
+	if err != nil {
+		panic(fmt.Sprintf("marshal operator config data: %v", err))
+	}
+
+	sum := sha256.Sum256(canonical)
 
 	return hex.EncodeToString(sum[:])
+}
+
+func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
+	endpoint := h.apiServerEndpoint
+	if endpoint == "" && h.restConfig != nil {
+		endpoint = h.restConfig.Host
+	}
+
+	reapLegacyResources := true
+	configMap := &unstructured.Unstructured{}
+	configMap.SetAPIVersion("v1")
+	configMap.SetKind("ConfigMap")
+
+	key := client.ObjectKey{Namespace: h.namespace, Name: "unbounded-operator-config"}
+	if err := h.kubeResourcesCli.Get(ctx, key, configMap); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("inspect unbounded-operator-config ConfigMap: %w", err)
+		}
+	} else {
+		data, _, err := unstructured.NestedStringMap(configMap.Object, "data")
+		if err != nil {
+			return fmt.Errorf("get existing unbounded-operator-config data: %w", err)
+		}
+
+		if value, found := data["UNBOUNDED_REAP_LEGACY_RESOURCES"]; found {
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("parse existing UNBOUNDED_REAP_LEGACY_RESOURCES value %q: %w", value, err)
+			}
+
+			reapLegacyResources = parsed
+		}
+	}
+
+	h.operatorConfigData = map[string]string{
+		"UNBOUNDED_API_SERVER_ENDPOINT":   endpoint,
+		"UNBOUNDED_REAP_LEGACY_RESOURCES": strconv.FormatBool(reapLegacyResources),
+	}
+
+	return nil
+}
+
+func (h *installHandler) prepareOperatorRepair(ctx context.Context) error {
+	allEstablished := true
+
+	for _, name := range operator.RequiredCRDNames {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion("apiextensions.k8s.io/v1")
+		obj.SetKind("CustomResourceDefinition")
+
+		if err := h.kubeResourcesCli.Get(ctx, client.ObjectKey{Name: name}, obj); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("inspect customresourcedefinition %s: %w", name, err)
+			}
+
+			allEstablished = false
+
+			continue
+		}
+
+		if !crdEstablished(obj) {
+			allEstablished = false
+		}
+	}
+
+	deploy := &unstructured.Unstructured{}
+	deploy.SetAPIVersion("apps/v1")
+	deploy.SetKind("Deployment")
+
+	key := client.ObjectKey{Namespace: h.namespace, Name: "unbounded-operator"}
+	if err := h.kubeResourcesCli.Get(ctx, key, deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("inspect unbounded-operator deployment: %w", err)
+	}
+
+	token, _, err := unstructured.NestedString(deploy.Object, "spec", "template", "metadata", "annotations", operatorCRDRepairAnnotation)
+	if err != nil {
+		return fmt.Errorf("get operator CRD repair annotation: %w", err)
+	}
+
+	if allEstablished {
+		h.operatorRepairToken = token
+
+		return nil
+	}
+
+	typedDeploy := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(deploy.Object, typedDeploy); err != nil {
+		return fmt.Errorf("convert unbounded-operator deployment: %w", err)
+	}
+
+	if !deploymentRolloutComplete(typedDeploy) {
+		h.operatorRepairToken = token
+
+		return nil
+	}
+
+	newRepairToken := h.newRepairToken
+	if newRepairToken == nil {
+		newRepairToken = randomRepairToken
+	}
+
+	token, err = newRepairToken()
+	if err != nil {
+		return fmt.Errorf("generate operator CRD repair token: %w", err)
+	}
+
+	h.operatorRepairToken = token
+
+	return nil
+}
+
+func randomRepairToken() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(value), nil
 }
 
 func (h *installHandler) waitForOperator(ctx context.Context) error {
@@ -249,20 +423,10 @@ func (h *installHandler) waitForCRDs(ctx context.Context) error {
 	deadlineCtx, cancel := context.WithTimeout(ctx, h.timeout)
 	defer cancel()
 
-	crds := []string{
-		"sites.unbounded-cloud.io",
-		"gatewaypools.net.unbounded-cloud.io",
-		"gatewaypoolnodes.net.unbounded-cloud.io",
-		"gatewaypoolpeerings.net.unbounded-cloud.io",
-		"sitegatewaypoolassignments.net.unbounded-cloud.io",
-		"sitenodeslices.net.unbounded-cloud.io",
-		"sitepeerings.net.unbounded-cloud.io",
-	}
-
 	for {
 		ready := true
 
-		for _, name := range crds {
+		for _, name := range operator.RequiredCRDNames {
 			obj := &unstructured.Unstructured{}
 			obj.SetAPIVersion("apiextensions.k8s.io/v1")
 			obj.SetKind("CustomResourceDefinition")
@@ -296,6 +460,10 @@ func (h *installHandler) waitForCRDs(ctx context.Context) error {
 }
 
 func crdEstablished(obj *unstructured.Unstructured) bool {
+	if obj.GetDeletionTimestamp() != nil {
+		return false
+	}
+
 	conditions, ok, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
 	if err != nil || !ok {
 		return false

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -5,6 +5,8 @@ package app
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -14,11 +16,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/unbounded/internal/operator"
 )
 
 func TestInstallCommandFlags(t *testing.T) {
@@ -100,8 +105,11 @@ func TestInstallHandlerApplyBootstrapManifests(t *testing.T) {
 	// operator at startup (BootstrapCRDs), so install must NOT apply them.
 	require.Contains(t, applied, "Deployment/unbounded-operator")
 	require.Contains(t, applied, "ConfigMap/unbounded-operator-config")
-	require.NotContains(t, applied, "CustomResourceDefinition/sites.unbounded-cloud.io")
-	require.NotContains(t, applied, "CustomResourceDefinition/gatewaypools.net.unbounded-cloud.io")
+
+	for _, resource := range applied {
+		require.NotContains(t, resource, "CustomResourceDefinition/", "install must leave CRD field ownership with unbounded-operator")
+	}
+
 	require.Less(t,
 		indexOf(applied, "ConfigMap/unbounded-operator-config"),
 		indexOf(applied, "Deployment/unbounded-operator"),
@@ -119,10 +127,54 @@ func indexOf(values []string, want string) int {
 	return -1
 }
 
+type capturedOperatorApply struct {
+	configMap  *unstructured.Unstructured
+	deployment *unstructured.Unstructured
+	applyCount int
+}
+
+func newCapturingInstallClient(objects ...client.Object) (client.Client, *capturedOperatorApply) {
+	captured := &capturedOperatorApply{}
+	cli := fakeclient.NewClientBuilder().
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				named, ok := obj.(interface {
+					GetKind() string
+					GetName() string
+					DeepCopy() *unstructured.Unstructured
+				})
+				if !ok {
+					return fmt.Errorf("unexpected apply configuration %T", obj)
+				}
+
+				captured.applyCount++
+
+				switch {
+				case named.GetKind() == "ConfigMap" && named.GetName() == "unbounded-operator-config":
+					captured.configMap = named.DeepCopy()
+				case named.GetKind() == "Deployment" && named.GetName() == "unbounded-operator":
+					captured.deployment = named.DeepCopy()
+				}
+
+				return nil
+			},
+		}).
+		Build()
+
+	return cli, captured
+}
+
 func TestMutateOperatorObjectWritesConfigEndpoint(t *testing.T) {
 	t.Parallel()
 
-	h := &installHandler{namespace: "unbounded-system", apiServerEndpoint: "https://api.example.test:6443"}
+	h := &installHandler{
+		namespace: "unbounded-system",
+		operatorConfigData: map[string]string{
+			"UNBOUNDED_API_SERVER_ENDPOINT":   "https://api.example.test:6443",
+			"UNBOUNDED_REAP_LEGACY_RESOURCES": "true",
+		},
+	}
 
 	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
@@ -136,12 +188,181 @@ func TestMutateOperatorObjectWritesConfigEndpoint(t *testing.T) {
 	got, _, err := unstructured.NestedString(obj.Object, "data", "UNBOUNDED_API_SERVER_ENDPOINT")
 	require.NoError(t, err)
 	require.Equal(t, "https://api.example.test:6443", got)
+
+	got, _, err = unstructured.NestedString(obj.Object, "data", "UNBOUNDED_REAP_LEGACY_RESOURCES")
+	require.NoError(t, err)
+	require.Equal(t, "true", got)
+}
+
+func TestInstallMergesLiveReaperConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		existingConfig *unstructured.Unstructured
+		wantReaper     string
+	}{
+		{
+			name: "existing false remains false",
+			existingConfig: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "unbounded-operator-config",
+					"namespace": "unbounded-system",
+				},
+				"data": map[string]any{
+					"UNBOUNDED_API_SERVER_ENDPOINT":   "https://old.example.test:6443",
+					"UNBOUNDED_REAP_LEGACY_RESOURCES": "FALSE",
+				},
+			}},
+			wantReaper: "false",
+		},
+		{
+			name: "existing config without reaper defaults true",
+			existingConfig: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "unbounded-operator-config",
+					"namespace": "unbounded-system",
+				},
+				"data": map[string]any{"UNBOUNDED_API_SERVER_ENDPOINT": "https://old.example.test:6443"},
+			}},
+			wantReaper: "true",
+		},
+		{
+			name:       "missing config defaults true",
+			wantReaper: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var objects []client.Object
+			if tt.existingConfig != nil {
+				objects = append(objects, tt.existingConfig)
+			}
+
+			cli, captured := newCapturingInstallClient(objects...)
+			h := installHandler{
+				namespace:         "unbounded-system",
+				apiServerEndpoint: "https://api.example.test:6443",
+				kubeResourcesCli:  cli,
+				logger:            discardLogger(),
+			}
+
+			require.NoError(t, h.execute(context.Background()))
+			require.NotNil(t, captured.configMap)
+			require.NotNil(t, captured.deployment)
+
+			data, found, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, map[string]string{
+				"UNBOUNDED_API_SERVER_ENDPOINT":   "https://api.example.test:6443",
+				"UNBOUNDED_REAP_LEGACY_RESOURCES": tt.wantReaper,
+			}, data)
+
+			gotHash, found, err := unstructured.NestedString(captured.deployment.Object, "spec", "template", "metadata", "annotations", operatorConfigHashAnnotation)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, operatorConfigHash(data), gotHash)
+
+			strategyType, found, err := unstructured.NestedString(captured.deployment.Object, "spec", "strategy", "type")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, "Recreate", strategyType)
+
+			rollingUpdate, found, err := unstructured.NestedFieldNoCopy(captured.deployment.Object, "spec", "strategy", "rollingUpdate")
+			require.NoError(t, err)
+			require.True(t, found, "rollingUpdate must remain explicit through manifest apply conversion")
+			require.Nil(t, rollingUpdate)
+		})
+	}
+}
+
+func TestInstallRejectsInvalidLiveReaperConfigBeforeApply(t *testing.T) {
+	t.Parallel()
+
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      "unbounded-operator-config",
+			"namespace": "unbounded-system",
+		},
+		"data": map[string]any{"UNBOUNDED_REAP_LEGACY_RESOURCES": "not-a-bool"},
+	}}
+	cli, captured := newCapturingInstallClient(existing)
+	h := installHandler{
+		namespace:        "unbounded-system",
+		kubeResourcesCli: cli,
+		logger:           discardLogger(),
+	}
+
+	err := h.execute(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "UNBOUNDED_REAP_LEGACY_RESOURCES")
+	require.Zero(t, captured.applyCount)
+}
+
+func TestInstallExecuteReinitializesDerivedConfig(t *testing.T) {
+	t.Parallel()
+
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      "unbounded-operator-config",
+			"namespace": "unbounded-system",
+		},
+		"data": map[string]any{"UNBOUNDED_REAP_LEGACY_RESOURCES": "false"},
+	}}
+	firstClient, first := newCapturingInstallClient(existing)
+	h := installHandler{
+		namespace:        "unbounded-system",
+		kubeResourcesCli: firstClient,
+		restConfig:       &rest.Config{Host: "https://first.example.test:6443"},
+		logger:           discardLogger(),
+	}
+
+	require.NoError(t, h.execute(context.Background()))
+
+	firstData, _, err := unstructured.NestedStringMap(first.configMap.Object, "data")
+	require.NoError(t, err)
+	require.Equal(t, "false", firstData["UNBOUNDED_REAP_LEGACY_RESOURCES"])
+	require.Equal(t, "https://first.example.test:6443", firstData["UNBOUNDED_API_SERVER_ENDPOINT"])
+
+	secondClient, second := newCapturingInstallClient()
+	h.kubeResourcesCli = secondClient
+	h.restConfig.Host = "https://second.example.test:6443"
+	h.operatorRepairToken = "stale-repair-token"
+
+	require.NoError(t, h.execute(context.Background()))
+
+	secondData, _, err := unstructured.NestedStringMap(second.configMap.Object, "data")
+	require.NoError(t, err)
+	require.Equal(t, "true", secondData["UNBOUNDED_REAP_LEGACY_RESOURCES"])
+	require.Equal(t, "https://second.example.test:6443", secondData["UNBOUNDED_API_SERVER_ENDPOINT"])
+
+	_, found, err := unstructured.NestedString(second.deployment.Object, "spec", "template", "metadata", "annotations", operatorCRDRepairAnnotation)
+	require.NoError(t, err)
+	require.False(t, found)
 }
 
 func TestMutateOperatorObjectRetargetsNamespace(t *testing.T) {
 	t.Parallel()
 
-	h := &installHandler{namespace: "custom-system"}
+	h := &installHandler{
+		namespace: "custom-system",
+		operatorConfigData: map[string]string{
+			"UNBOUNDED_API_SERVER_ENDPOINT":   "",
+			"UNBOUNDED_REAP_LEGACY_RESOURCES": "true",
+		},
+	}
 
 	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
@@ -181,7 +402,7 @@ func TestMutateOperatorObjectRetargetsNamespace(t *testing.T) {
 func TestCRDEstablished(t *testing.T) {
 	t.Parallel()
 
-	obj := &apiextensionsv1.CustomResourceDefinition{
+	established := &apiextensionsv1.CustomResourceDefinition{
 		Status: apiextensionsv1.CustomResourceDefinitionStatus{
 			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
 				{
@@ -192,9 +413,15 @@ func TestCRDEstablished(t *testing.T) {
 		},
 	}
 
-	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(established)
 	require.NoError(t, err)
-	require.True(t, crdEstablished(&unstructured.Unstructured{Object: unstructuredObj}))
+
+	obj := &unstructured.Unstructured{Object: unstructuredObj}
+	require.True(t, crdEstablished(obj))
+
+	now := metav1.Now()
+	obj.SetDeletionTimestamp(&now)
+	require.False(t, crdEstablished(obj), "a terminating CRD must not be treated as established")
 }
 
 // operatorDeployment builds an unbounded-operator Deployment with the given
@@ -203,6 +430,10 @@ func operatorDeployment(status appsv1.DeploymentStatus) *appsv1.Deployment {
 	replicas := int32(1)
 
 	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "unbounded-system",
 			Name:       "unbounded-operator",
@@ -310,7 +541,16 @@ func TestWaitForOperatorSucceedsOnCompleteRollout(t *testing.T) {
 func TestMutateOperatorObjectStampsConfigHash(t *testing.T) {
 	t.Parallel()
 
-	newDeploy := func() *unstructured.Unstructured {
+	newConfigMap := func(data map[string]any) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "unbounded-operator-config", "namespace": "unbounded-system"},
+			"data":       data,
+		}}
+	}
+
+	newDeployment := func() *unstructured.Unstructured {
 		return &unstructured.Unstructured{Object: map[string]any{
 			"apiVersion": "apps/v1",
 			"kind":       "Deployment",
@@ -325,9 +565,16 @@ func TestMutateOperatorObjectStampsConfigHash(t *testing.T) {
 		}}
 	}
 
-	hashOf := func(endpoint string) string {
-		h := &installHandler{namespace: "unbounded-system", apiServerEndpoint: endpoint}
-		obj := newDeploy()
+	hashOf := func(data map[string]any) string {
+		configData := make(map[string]string, len(data))
+		for key, value := range data {
+			configData[key] = value.(string)
+		}
+
+		h := &installHandler{namespace: "unbounded-system", operatorConfigData: configData}
+		require.NoError(t, h.mutateOperatorObject(newConfigMap(data)))
+
+		obj := newDeployment()
 		require.NoError(t, h.mutateOperatorObject(obj))
 
 		got, found, err := unstructured.NestedString(obj.Object, "spec", "template", "metadata", "annotations", operatorConfigHashAnnotation)
@@ -337,12 +584,337 @@ func TestMutateOperatorObjectStampsConfigHash(t *testing.T) {
 		return got
 	}
 
-	// The stamp is a stable hash of the resolved endpoint, matching the
-	// render-time hash so both install and make-rendered manifests agree.
-	endpoint := "https://api.example.test:6443"
-	require.Equal(t, operatorConfigHash(endpoint), hashOf(endpoint))
+	first := map[string]any{
+		"UNBOUNDED_API_SERVER_ENDPOINT":   "https://api.example.test:6443",
+		"UNBOUNDED_REAP_LEGACY_RESOURCES": "true",
+	}
+	second := map[string]any{
+		"UNBOUNDED_REAP_LEGACY_RESOURCES": "true",
+		"UNBOUNDED_API_SERVER_ENDPOINT":   "https://api.example.test:6443",
+	}
 
-	// A changed endpoint changes the hash, which changes the pod template and
-	// therefore triggers a rollout (finding #3).
-	require.NotEqual(t, hashOf(endpoint), hashOf("https://other.example.test:6443"))
+	wantData := map[string]string{
+		"UNBOUNDED_API_SERVER_ENDPOINT":   "https://api.example.test:6443",
+		"UNBOUNDED_REAP_LEGACY_RESOURCES": "true",
+	}
+	require.Equal(t, operatorConfigHash(wantData), hashOf(first))
+	require.Equal(t, hashOf(first), hashOf(second), "hash must be independent of ConfigMap map order")
+
+	changedEndpoint := map[string]any{
+		"UNBOUNDED_API_SERVER_ENDPOINT":   "https://other.example.test:6443",
+		"UNBOUNDED_REAP_LEGACY_RESOURCES": "true",
+	}
+	changedReaper := map[string]any{
+		"UNBOUNDED_API_SERVER_ENDPOINT":   "https://api.example.test:6443",
+		"UNBOUNDED_REAP_LEGACY_RESOURCES": "false",
+	}
+
+	require.NotEqual(t, hashOf(first), hashOf(changedEndpoint))
+	require.NotEqual(t, hashOf(first), hashOf(changedReaper))
+}
+
+func TestWaitForCRDsChecksCompleteOperatorContract(t *testing.T) {
+	t.Parallel()
+
+	var names []string
+
+	cli := fakeclient.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				crd, ok := obj.(*unstructured.Unstructured)
+				if !ok || crd.GetKind() != "CustomResourceDefinition" {
+					return fmt.Errorf("unexpected get %s into %T", key, obj)
+				}
+
+				names = append(names, key.Name)
+				crd.SetName(key.Name)
+				crd.Object["status"] = map[string]any{
+					"conditions": []any{map[string]any{"type": "Established", "status": "True"}},
+				}
+
+				return nil
+			},
+		}).
+		Build()
+
+	h := installHandler{
+		timeout:          5 * time.Second,
+		kubeResourcesCli: cli,
+	}
+	require.NoError(t, h.waitForCRDs(context.Background()))
+
+	want := append([]string(nil), operator.RequiredCRDNames[:]...)
+
+	sort.Strings(names)
+	sort.Strings(want)
+	require.Equal(t, want, names)
+}
+
+func TestWaitForCRDsRejectsTerminatingEstablishedCRD(t *testing.T) {
+	t.Parallel()
+
+	terminatingName := operator.RequiredCRDNames[0]
+	now := metav1.Now()
+	cli := fakeclient.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				crd, ok := obj.(*unstructured.Unstructured)
+				if !ok || crd.GetKind() != "CustomResourceDefinition" {
+					return fmt.Errorf("unexpected get %s into %T", key, obj)
+				}
+
+				crd.SetName(key.Name)
+
+				crd.Object["status"] = map[string]any{
+					"conditions": []any{map[string]any{"type": "Established", "status": "True"}},
+				}
+				if key.Name == terminatingName {
+					crd.SetDeletionTimestamp(&now)
+				}
+
+				return nil
+			},
+		}).
+		Build()
+
+	h := installHandler{timeout: 100 * time.Millisecond, kubeResourcesCli: cli}
+	err := h.waitForCRDs(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "waiting for CRDs to be established")
+}
+
+func TestInstallRepairsCRDsOnlyByRestartingExistingOperator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		existingDeploy    bool
+		unhealthyCRDName  string
+		unhealthyExists   bool
+		unhealthyDeleting bool
+		oldRepairToken    string
+		rolloutComplete   bool
+		wantRepairToken   string
+		wantTokenCalls    int
+	}{
+		{
+			name:             "missing CRD restarts existing operator",
+			existingDeploy:   true,
+			unhealthyCRDName: operator.RequiredCRDNames[0],
+			rolloutComplete:  true,
+			wantRepairToken:  "fresh-repair-token",
+			wantTokenCalls:   1,
+		},
+		{
+			name:             "unestablished CRD restarts existing operator",
+			existingDeploy:   true,
+			unhealthyCRDName: operator.RequiredCRDNames[1],
+			unhealthyExists:  true,
+			rolloutComplete:  true,
+			wantRepairToken:  "fresh-repair-token",
+			wantTokenCalls:   1,
+		},
+		{
+			name:              "terminating established CRD restarts existing operator",
+			existingDeploy:    true,
+			unhealthyCRDName:  operator.RequiredCRDNames[2],
+			unhealthyExists:   true,
+			unhealthyDeleting: true,
+			rolloutComplete:   true,
+			wantRepairToken:   "fresh-repair-token",
+			wantTokenCalls:    1,
+		},
+		{
+			name:             "fresh install needs no repair token",
+			unhealthyCRDName: operator.RequiredCRDNames[0],
+		},
+		{
+			name:            "healthy reinstall preserves existing token",
+			existingDeploy:  true,
+			oldRepairToken:  "existing-repair-token",
+			wantRepairToken: "existing-repair-token",
+		},
+		{
+			name:             "in-progress repair preserves existing token",
+			existingDeploy:   true,
+			unhealthyCRDName: operator.RequiredCRDNames[0],
+			oldRepairToken:   "existing-repair-token",
+			wantRepairToken:  "existing-repair-token",
+		},
+		{
+			name:             "in-progress repair preserves empty token",
+			existingDeploy:   true,
+			unhealthyCRDName: operator.RequiredCRDNames[0],
+		},
+		{
+			name:           "healthy reinstall adds no token",
+			existingDeploy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			objects := make([]client.Object, 0, len(operator.RequiredCRDNames)+1)
+			for _, name := range operator.RequiredCRDNames {
+				if name == tt.unhealthyCRDName && !tt.unhealthyExists {
+					continue
+				}
+
+				crd := establishedCRD(name)
+				if name == tt.unhealthyCRDName {
+					if tt.unhealthyDeleting {
+						now := metav1.Now()
+						crd.SetDeletionTimestamp(&now)
+						crd.SetFinalizers([]string{"test.unbounded-cloud.io/hold"})
+					} else {
+						delete(crd.Object, "status")
+					}
+				}
+
+				objects = append(objects, crd)
+			}
+
+			if tt.existingDeploy {
+				annotations := map[string]string{}
+				if tt.oldRepairToken != "" {
+					annotations[operatorCRDRepairAnnotation] = tt.oldRepairToken
+				}
+
+				status := appsv1.DeploymentStatus{}
+				if tt.rolloutComplete {
+					status = appsv1.DeploymentStatus{ObservedGeneration: 2, Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1}
+				}
+
+				deploy := operatorDeployment(status)
+				deploy.Spec.Template.Annotations = annotations
+				deployObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+				require.NoError(t, err)
+
+				objects = append(objects, &unstructured.Unstructured{Object: deployObject})
+			}
+
+			var (
+				appliedDeployment *unstructured.Unstructured
+				appliedKinds      []string
+				tokenCalls        int
+			)
+
+			cli := fakeclient.NewClientBuilder().
+				WithObjects(objects...).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+						named, ok := obj.(interface {
+							GetKind() string
+							GetName() string
+							DeepCopy() *unstructured.Unstructured
+						})
+						if !ok {
+							return fmt.Errorf("unexpected apply configuration %T", obj)
+						}
+
+						appliedKinds = append(appliedKinds, named.GetKind())
+						if named.GetKind() == "Deployment" && named.GetName() == "unbounded-operator" {
+							appliedDeployment = named.DeepCopy()
+						}
+
+						return nil
+					},
+				}).
+				Build()
+
+			h := installHandler{
+				namespace:        "unbounded-system",
+				wait:             false,
+				kubeResourcesCli: cli,
+				logger:           discardLogger(),
+				newRepairToken: func() (string, error) {
+					tokenCalls++
+
+					return "fresh-repair-token", nil
+				},
+			}
+
+			require.NoError(t, h.execute(context.Background()))
+			require.NotNil(t, appliedDeployment)
+			require.Equal(t, tt.wantTokenCalls, tokenCalls)
+
+			gotToken, _, err := unstructured.NestedString(appliedDeployment.Object, "spec", "template", "metadata", "annotations", operatorCRDRepairAnnotation)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantRepairToken, gotToken)
+
+			configHash, found, err := unstructured.NestedString(appliedDeployment.Object, "spec", "template", "metadata", "annotations", operatorConfigHashAnnotation)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.NotEmpty(t, configHash)
+			require.NotContains(t, appliedKinds, "CustomResourceDefinition")
+		})
+	}
+}
+
+func TestPrepareOperatorRepairRapidRetryPreservesNewToken(t *testing.T) {
+	t.Parallel()
+
+	objects := make([]client.Object, 0, len(operator.RequiredCRDNames))
+	for _, name := range operator.RequiredCRDNames[1:] {
+		objects = append(objects, establishedCRD(name))
+	}
+
+	deploy := operatorDeployment(appsv1.DeploymentStatus{
+		ObservedGeneration: 2,
+		Replicas:           1,
+		UpdatedReplicas:    1,
+		AvailableReplicas:  1,
+	})
+	deployObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+	require.NoError(t, err)
+
+	objects = append(objects, &unstructured.Unstructured{Object: deployObject})
+	cli := fakeclient.NewClientBuilder().WithObjects(objects...).Build()
+
+	tokenCalls := 0
+	h := installHandler{
+		namespace:        "unbounded-system",
+		kubeResourcesCli: cli,
+		newRepairToken: func() (string, error) {
+			tokenCalls++
+
+			return "first-repair-token", nil
+		},
+	}
+
+	require.NoError(t, h.prepareOperatorRepair(context.Background()))
+	require.Equal(t, "first-repair-token", h.operatorRepairToken)
+	require.Equal(t, 1, tokenCalls)
+
+	inProgressDeploy := operatorDeployment(appsv1.DeploymentStatus{
+		ObservedGeneration: 2,
+		Replicas:           1,
+		UpdatedReplicas:    1,
+	})
+	inProgressDeploy.Spec.Template.Annotations = map[string]string{
+		operatorCRDRepairAnnotation: "first-repair-token",
+	}
+	inProgressObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(inProgressDeploy)
+	require.NoError(t, err)
+
+	objects[len(objects)-1] = &unstructured.Unstructured{Object: inProgressObject}
+	h.kubeResourcesCli = fakeclient.NewClientBuilder().WithObjects(objects...).Build()
+
+	h.operatorRepairToken = ""
+	require.NoError(t, h.prepareOperatorRepair(context.Background()))
+	require.Equal(t, "first-repair-token", h.operatorRepairToken)
+	require.Equal(t, 1, tokenCalls, "rapid retry must not generate another rollout token")
+}
+
+func establishedCRD(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata":   map[string]any{"name": name},
+		"status": map[string]any{
+			"conditions": []any{map[string]any{"type": "Established", "status": "True"}},
+		},
+	}}
 }

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -145,6 +145,10 @@ func run(ctx context.Context, cfg config) error {
 		return fmt.Errorf("create manager: %w", err)
 	}
 
+	if err := mgr.Add(&operator.CRDMaintainer{Client: bootstrapClient}); err != nil {
+		return fmt.Errorf("add CRD maintainer: %w", err)
+	}
+
 	if err := (&operator.SiteReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    scheme,

--- a/deploy/unbounded-operator/03-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/03-configmap.yaml.tmpl
@@ -28,4 +28,4 @@ data:
   UNBOUNDED_API_SERVER_ENDPOINT: {{ default "" .APIServerEndpoint | quote }}
   # Whether the operator translates legacy net-group Sites, migrates state into
   # this namespace, and reaps the pre-consolidation namespaces.
-  UNBOUNDED_REAP_LEGACY_RESOURCES: "true"
+  UNBOUNDED_REAP_LEGACY_RESOURCES: {{ default "true" .ReapLegacyResources | quote }}

--- a/deploy/unbounded-operator/04-deployment.yaml.tmpl
+++ b/deploy/unbounded-operator/04-deployment.yaml.tmpl
@@ -12,6 +12,9 @@ metadata:
     app.kubernetes.io/component: controller
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/name: unbounded-operator
@@ -21,12 +24,9 @@ spec:
         app.kubernetes.io/name: unbounded-operator
         app.kubernetes.io/component: controller
       annotations:
-        # Rolls the operator when the advertised api-server-endpoint changes at
-        # render time. envFrom is read once at pod start, so without a pod-template
-        # change a re-render with a new endpoint would not restart the operator.
-        # The `kubectl unbounded install` path stamps the same annotation. See
-        # deploy/unbounded-operator/03-configmap.yaml.tmpl.
-        unbounded-cloud.io/operator-config-hash: {{ default "" .APIServerEndpoint | sha256sum | quote }}
+        # Rolls the operator when any ConfigMap data changes at render time.
+        # Canonical JSON matches the `kubectl unbounded install` hash.
+        unbounded-cloud.io/operator-config-hash: {{ dict "UNBOUNDED_API_SERVER_ENDPOINT" (default "" .APIServerEndpoint) "UNBOUNDED_REAP_LEGACY_RESOURCES" (default "true" .ReapLegacyResources) | toJson | sha256sum | quote }}
     spec:
       serviceAccountName: unbounded-operator
       containers:

--- a/deploy/unbounded-operator/render_test.go
+++ b/deploy/unbounded-operator/render_test.go
@@ -6,6 +6,7 @@ package unboundedoperator
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -56,13 +57,16 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 	// The Deployment pod template carries the matching hash annotation.
 	var deploy struct {
 		Spec struct {
+			Replicas int32          `yaml:"replicas"`
+			Strategy map[string]any `yaml:"strategy"`
 			Template struct {
 				Metadata struct {
 					Annotations map[string]string `yaml:"annotations"`
 				} `yaml:"metadata"`
 				Spec struct {
 					Containers []struct {
-						Name         string `yaml:"name"`
+						Name         string   `yaml:"name"`
+						Args         []string `yaml:"args"`
 						StartupProbe *struct {
 							PeriodSeconds    int32 `yaml:"periodSeconds"`
 							FailureThreshold int32 `yaml:"failureThreshold"`
@@ -75,16 +79,38 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 
 	readYAML(t, filepath.Join(outputDir, "04-deployment.yaml"), &deploy)
 
-	sum := sha256.Sum256([]byte(endpoint))
+	canonical, err := json.Marshal(cm.Data)
+	if err != nil {
+		t.Fatalf("marshal configmap data: %v", err)
+	}
+
+	sum := sha256.Sum256(canonical)
 	want := hex.EncodeToString(sum[:])
 
 	if got := deploy.Spec.Template.Metadata.Annotations["unbounded-cloud.io/operator-config-hash"]; got != want {
-		t.Fatalf("deployment operator-config-hash annotation = %q, want %q (sha256 of endpoint)", got, want)
+		t.Fatalf("deployment operator-config-hash annotation = %q, want %q (sha256 of complete ConfigMap data)", got, want)
+	}
+
+	if deploy.Spec.Replicas != 1 {
+		t.Fatalf("deployment replicas = %d, want 1", deploy.Spec.Replicas)
+	}
+
+	if got := deploy.Spec.Strategy["type"]; got != "Recreate" {
+		t.Fatalf("deployment strategy = %q, want Recreate", got)
+	}
+
+	rollingUpdate, found := deploy.Spec.Strategy["rollingUpdate"]
+	if !found || rollingUpdate != nil {
+		t.Fatalf("deployment strategy rollingUpdate = %#v (present: %t), want explicit null", rollingUpdate, found)
 	}
 
 	for _, container := range deploy.Spec.Template.Spec.Containers {
 		if container.Name != "controller" || container.StartupProbe == nil {
 			continue
+		}
+
+		if !contains(container.Args, "--leader-elect=true") {
+			t.Fatalf("controller args = %v, want --leader-elect=true", container.Args)
 		}
 
 		budget := time.Duration(container.StartupProbe.FailureThreshold) *
@@ -107,6 +133,73 @@ func contains(values []string, want string) bool {
 	}
 
 	return false
+}
+
+func TestOperatorConfigHashChangesWithEachConfigValue(t *testing.T) {
+	t.Parallel()
+
+	renderHash := func(endpoint, reapLegacyResources string) string {
+		t.Helper()
+
+		outputDir := t.TempDir()
+		if err := render.Render(filepath.Join(repoRoot(t), "deploy", "unbounded-operator"), outputDir, map[string]string{
+			"Namespace":           "unbounded-system",
+			"OperatorImage":       "operator:test",
+			"MetalmanImage":       "metalman:test",
+			"APIServerEndpoint":   endpoint,
+			"ReapLegacyResources": reapLegacyResources,
+		}); err != nil {
+			t.Fatalf("render.Render: %v", err)
+		}
+
+		var cm struct {
+			Data map[string]string `yaml:"data"`
+		}
+		readYAML(t, filepath.Join(outputDir, "03-configmap.yaml"), &cm)
+
+		if got := cm.Data["UNBOUNDED_API_SERVER_ENDPOINT"]; got != endpoint {
+			t.Fatalf("configmap endpoint = %q, want %q", got, endpoint)
+		}
+
+		if got := cm.Data["UNBOUNDED_REAP_LEGACY_RESOURCES"]; got != reapLegacyResources {
+			t.Fatalf("configmap reap legacy resources = %q, want %q", got, reapLegacyResources)
+		}
+
+		var deploy struct {
+			Spec struct {
+				Template struct {
+					Metadata struct {
+						Annotations map[string]string `yaml:"annotations"`
+					} `yaml:"metadata"`
+				} `yaml:"template"`
+			} `yaml:"spec"`
+		}
+		readYAML(t, filepath.Join(outputDir, "04-deployment.yaml"), &deploy)
+
+		canonical, err := json.Marshal(cm.Data)
+		if err != nil {
+			t.Fatalf("marshal configmap data: %v", err)
+		}
+
+		sum := sha256.Sum256(canonical)
+		wantHash := hex.EncodeToString(sum[:])
+
+		gotHash := deploy.Spec.Template.Metadata.Annotations["unbounded-cloud.io/operator-config-hash"]
+		if gotHash != wantHash {
+			t.Fatalf("deployment config hash = %q, want %q", gotHash, wantHash)
+		}
+
+		return gotHash
+	}
+
+	baseline := renderHash("https://api.example.test:6443", "true")
+	if got := renderHash("https://other.example.test:6443", "true"); got == baseline {
+		t.Fatal("changing UNBOUNDED_API_SERVER_ENDPOINT did not change the rendered config hash")
+	}
+
+	if got := renderHash("https://api.example.test:6443", "false"); got == baseline {
+		t.Fatal("changing UNBOUNDED_REAP_LEGACY_RESOURCES did not change the rendered config hash")
+	}
 }
 
 func TestOperatorRBACIncludesCachedReadKinds(t *testing.T) {

--- a/internal/operator/bootstrap.go
+++ b/internal/operator/bootstrap.go
@@ -37,6 +37,13 @@ const (
 	// crdEstablishedTimeout preserves the full establishment window after the
 	// apply phase while CRDBootstrapTimeout bounds the complete operation.
 	crdEstablishedTimeout = 2 * time.Minute
+
+	defaultCRDMaintenanceInterval = time.Minute
+
+	// defaultCRDMaintenanceFailures is the number of consecutive CRD maintenance
+	// failures tolerated before the maintainer stops the manager and lets the
+	// pod restart.
+	defaultCRDMaintenanceFailures = 3
 )
 
 // CRDBootstrapTimeout bounds the complete CRD bootstrap, including manifest
@@ -44,6 +51,23 @@ const (
 // health server only binds after bootstrap, so the startupProbe budget in
 // deploy/unbounded-operator/04-deployment.yaml.tmpl must exceed this timeout.
 const CRDBootstrapTimeout = 4 * time.Minute
+
+// RequiredCRDNames is the complete set of CRDs owned and bootstrapped by the
+// unbounded-operator.
+var RequiredCRDNames = [...]string{
+	"machines.unbounded-cloud.io",
+	"machineoperations.unbounded-cloud.io",
+	"sites.unbounded-cloud.io",
+	"machineconfigurations.unbounded-cloud.io",
+	"machineoperationcredentials.unbounded-cloud.io",
+	"machineconfigurationversions.unbounded-cloud.io",
+	"sitenodeslices.net.unbounded-cloud.io",
+	"gatewaypools.net.unbounded-cloud.io",
+	"gatewaypoolnodes.net.unbounded-cloud.io",
+	"sitegatewaypoolassignments.net.unbounded-cloud.io",
+	"sitepeerings.net.unbounded-cloud.io",
+	"gatewaypoolpeerings.net.unbounded-cloud.io",
+}
 
 // bootstrapManifestSets returns the embedded manifest filesystems whose CRDs the
 // operator installs at startup. The operator owns CRD lifecycle so a cluster can
@@ -62,6 +86,74 @@ func BootstrapCRDs(ctx context.Context, c client.Client) error {
 	return bootstrapCRDs(ctx, c, CRDBootstrapTimeout)
 }
 
+// CRDMaintainer periodically reapplies the operator-owned CRDs using an
+// uncached client. Transient maintenance failures are retried on the next
+// interval; only a run of MaxFailures consecutive failures stops the manager,
+// so the pod is restarted and retries after any terminating CRD has finished
+// deleting.
+type CRDMaintainer struct {
+	Client   client.Client
+	Interval time.Duration
+	// MaxFailures is the number of consecutive maintenance failures tolerated
+	// before Start returns an error and stops the manager. Defaults to
+	// defaultCRDMaintenanceFailures.
+	MaxFailures int
+	Bootstrap   func(context.Context, client.Client) error
+}
+
+// NeedLeaderElection ensures only the elected operator replica maintains CRDs.
+func (*CRDMaintainer) NeedLeaderElection() bool { return true }
+
+// Start runs CRD maintenance until the manager stops or maintenance fails
+// MaxFailures times in a row.
+func (m *CRDMaintainer) Start(ctx context.Context) error {
+	interval := m.Interval
+	if interval <= 0 {
+		interval = defaultCRDMaintenanceInterval
+	}
+
+	maxFailures := m.MaxFailures
+	if maxFailures <= 0 {
+		maxFailures = defaultCRDMaintenanceFailures
+	}
+
+	bootstrap := m.Bootstrap
+	if bootstrap == nil {
+		bootstrap = BootstrapCRDs
+	}
+
+	logger := log.FromContext(ctx).WithName("crd-maintainer")
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	failures := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := bootstrap(ctx, m.Client); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+
+				failures++
+				if failures >= maxFailures {
+					return fmt.Errorf("maintain CRDs after %d consecutive failures: %w", failures, err)
+				}
+
+				logger.Error(err, "CRD maintenance failed; will retry", "failures", failures, "maxFailures", maxFailures)
+
+				continue
+			}
+
+			failures = 0
+		}
+	}
+}
+
 func bootstrapCRDs(ctx context.Context, c client.Client, timeout time.Duration) error {
 	bootstrapCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -69,7 +161,7 @@ func bootstrapCRDs(ctx context.Context, c client.Client, timeout time.Duration) 
 	ctx = bootstrapCtx
 	logger := log.FromContext(ctx).WithName("crd-bootstrap")
 
-	var names []string
+	appliedCount := 0
 
 	for _, manifests := range bootstrapManifestSets() {
 		applied, err := applyCRDsFromFS(ctx, logger, c, manifests)
@@ -77,18 +169,18 @@ func bootstrapCRDs(ctx context.Context, c client.Client, timeout time.Duration) 
 			return err
 		}
 
-		names = append(names, applied...)
+		appliedCount += len(applied)
 	}
 
-	if len(names) == 0 {
+	if appliedCount == 0 {
 		return nil
 	}
 
-	if err := waitForCRDsEstablished(ctx, c, names); err != nil {
+	if err := waitForCRDsEstablished(ctx, c, RequiredCRDNames[:]); err != nil {
 		return err
 	}
 
-	logger.Info("CRDs installed and established", "count", len(names))
+	logger.Info("CRDs installed and established", "count", appliedCount)
 
 	return nil
 }
@@ -155,6 +247,10 @@ func waitForCRDsEstablished(ctx context.Context, c client.Client, names []string
 				return false, err
 			}
 
+			if crd.DeletionTimestamp != nil {
+				return false, fmt.Errorf("customresourcedefinition %s is being deleted", name)
+			}
+
 			if !crdEstablished(crd) {
 				return false, nil
 			}
@@ -166,6 +262,10 @@ func waitForCRDsEstablished(ctx context.Context, c client.Client, names []string
 
 // crdEstablished reports whether a CRD has the Established=True condition.
 func crdEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	if crd.DeletionTimestamp != nil {
+		return false
+	}
+
 	for _, cond := range crd.Status.Conditions {
 		if cond.Type == apiextensionsv1.Established && cond.Status == apiextensionsv1.ConditionTrue {
 			return true

--- a/internal/operator/bootstrap_test.go
+++ b/internal/operator/bootstrap_test.go
@@ -6,34 +6,144 @@ package operator
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
-// embeddedCRDNames are every CustomResourceDefinition the operator installs at
-// startup: the six machina-group and six net-group CRDs embedded in the machina
-// and net manifests. BootstrapCRDs must apply all of them so a cluster can be
-// maintained by applying the operator manifests alone.
-var embeddedCRDNames = []string{
-	"machines.unbounded-cloud.io",
-	"machineoperations.unbounded-cloud.io",
-	"sites.unbounded-cloud.io",
-	"machineconfigurations.unbounded-cloud.io",
-	"machineoperationcredentials.unbounded-cloud.io",
-	"machineconfigurationversions.unbounded-cloud.io",
-	"sitenodeslices.net.unbounded-cloud.io",
-	"gatewaypools.net.unbounded-cloud.io",
-	"gatewaypoolnodes.net.unbounded-cloud.io",
-	"sitegatewaypoolassignments.net.unbounded-cloud.io",
-	"sitepeerings.net.unbounded-cloud.io",
-	"gatewaypoolpeerings.net.unbounded-cloud.io",
+func TestCRDMaintainerNeedsLeaderElection(t *testing.T) {
+	if !(&CRDMaintainer{}).NeedLeaderElection() {
+		t.Fatal("CRDMaintainer must require leader election")
+	}
+}
+
+func TestCRDMaintainerInvokesBootstrap(t *testing.T) {
+	cli := fake.NewClientBuilder().Build()
+	ctx, cancel := context.WithCancel(context.Background())
+	called := make(chan struct{})
+
+	maintainer := &CRDMaintainer{
+		Client:   cli,
+		Interval: time.Millisecond,
+		Bootstrap: func(_ context.Context, got client.Client) error {
+			if got != cli {
+				t.Errorf("bootstrap client = %v, want direct client %v", got, cli)
+			}
+
+			close(called)
+			cancel()
+
+			return nil
+		},
+	}
+
+	if err := maintainer.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	select {
+	case <-called:
+	default:
+		t.Fatal("CRDMaintainer did not invoke Bootstrap")
+	}
+}
+
+func TestCRDMaintainerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	maintainer := &CRDMaintainer{
+		Interval: time.Hour,
+		Bootstrap: func(context.Context, client.Client) error {
+			called = true
+
+			return nil
+		},
+	}
+
+	if err := maintainer.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if called {
+		t.Fatal("Bootstrap called after cancellation")
+	}
+}
+
+func TestCRDMaintainerReturnsBootstrapError(t *testing.T) {
+	wantErr := errors.New("apply failed")
+	calls := 0
+	maintainer := &CRDMaintainer{
+		Interval:    time.Millisecond,
+		MaxFailures: 3,
+		Bootstrap: func(context.Context, client.Client) error {
+			calls++
+
+			return wantErr
+		},
+	}
+
+	err := maintainer.Start(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Start error = %v, want %v", err, wantErr)
+	}
+
+	if calls != 3 {
+		t.Fatalf("Bootstrap called %d times, want 3 consecutive failures before crashing", calls)
+	}
+}
+
+func TestCRDMaintainerRetriesTransientFailureWithoutCrashing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	transient := errors.New("transient apply failure")
+	recovered := make(chan struct{})
+	calls := 0
+
+	maintainer := &CRDMaintainer{
+		Interval:    time.Millisecond,
+		MaxFailures: 3,
+		Bootstrap: func(context.Context, client.Client) error {
+			calls++
+
+			switch calls {
+			case 1:
+				return transient
+			case 2:
+				close(recovered)
+
+				return nil
+			default:
+				return nil
+			}
+		},
+	}
+
+	done := make(chan error, 1)
+
+	go func() { done <- maintainer.Start(ctx) }()
+
+	select {
+	case <-recovered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("maintainer did not recover from a transient failure")
+	}
+
+	cancel()
+
+	if err := <-done; err != nil {
+		t.Fatalf("Start after transient failure = %v, want nil", err)
+	}
 }
 
 func TestBootstrapCRDsTimeoutCancelsBlockedApply(t *testing.T) {
@@ -109,21 +219,19 @@ func TestBootstrapCRDsAppliesEmbeddedCRDs(t *testing.T) {
 		t.Fatalf("BootstrapCRDs: %v", err)
 	}
 
-	for _, name := range embeddedCRDNames {
+	for _, name := range RequiredCRDNames {
 		if !applied[name] {
 			t.Fatalf("expected CRD %q to be installed by BootstrapCRDs (applied=%v)", name, applied)
 		}
 	}
 
-	if len(applied) != len(embeddedCRDNames) {
-		t.Fatalf("BootstrapCRDs applied %d CRDs, want %d (applied=%v)", len(applied), len(embeddedCRDNames), applied)
+	if len(applied) != len(RequiredCRDNames) {
+		t.Fatalf("BootstrapCRDs applied %d CRDs, want %d (applied=%v)", len(applied), len(RequiredCRDNames), applied)
 	}
 }
 
 // TestBootstrapCRDsWaitsForEstablished proves BootstrapCRDs blocks on the
-// Established condition rather than returning as soon as a CRD exists: the fake
-// client reports the CRDs not-Established on the first observation and
-// Established thereafter, so BootstrapCRDs can only succeed by re-polling.
+// Established condition rather than returning as soon as a CRD exists.
 func TestBootstrapCRDsWaitsForEstablished(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
@@ -156,8 +264,6 @@ func TestBootstrapCRDsWaitsForEstablished(t *testing.T) {
 				firstSeen = true
 				mu.Unlock()
 
-				// First observation reports not-Established (no condition); every
-				// later poll reports Established.
 				if established {
 					crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{
 						Type:   apiextensionsv1.Established,
@@ -178,8 +284,80 @@ func TestBootstrapCRDsWaitsForEstablished(t *testing.T) {
 	defer mu.Unlock()
 
 	// A single pass (one Get) would mean it never waited for establishment.
-	if gets <= len(embeddedCRDNames) {
-		t.Fatalf("expected BootstrapCRDs to re-poll for establishment; got %d Gets for %d CRDs", gets, len(embeddedCRDNames))
+	if gets <= len(RequiredCRDNames) {
+		t.Fatalf("expected BootstrapCRDs to re-poll for establishment; got %d Gets for %d CRDs", gets, len(RequiredCRDNames))
+	}
+}
+
+func TestWaitForCRDsEstablishedRejectsDeletingCRDImmediately(t *testing.T) {
+	now := metav1.Now()
+	cli := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				crd := obj.(*apiextensionsv1.CustomResourceDefinition)
+				crd.Name = key.Name
+				crd.DeletionTimestamp = &now
+				crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{
+					Type:   apiextensionsv1.Established,
+					Status: apiextensionsv1.ConditionTrue,
+				}}
+
+				return nil
+			},
+		}).
+		Build()
+
+	started := time.Now()
+
+	err := waitForCRDsEstablished(context.Background(), cli, []string{"deleting.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "deleting.example.com is being deleted") {
+		t.Fatalf("waitForCRDsEstablished error = %v, want deleting CRD error", err)
+	}
+
+	if elapsed := time.Since(started); elapsed >= crdEstablishedPoll {
+		t.Fatalf("waitForCRDsEstablished polled for %v instead of failing immediately", elapsed)
+	}
+}
+
+func TestCRDEstablishedRejectsDeletingCRD(t *testing.T) {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{{
+				Type:   apiextensionsv1.Established,
+				Status: apiextensionsv1.ConditionTrue,
+			}},
+		},
+	}
+	if !crdEstablished(crd) {
+		t.Fatal("live Established CRD was rejected")
+	}
+
+	now := metav1.Now()
+
+	crd.DeletionTimestamp = &now
+	if crdEstablished(crd) {
+		t.Fatal("terminating CRD was treated as established")
+	}
+}
+
+func TestRequiredCRDNames(t *testing.T) {
+	want := [...]string{
+		"machines.unbounded-cloud.io",
+		"machineoperations.unbounded-cloud.io",
+		"sites.unbounded-cloud.io",
+		"machineconfigurations.unbounded-cloud.io",
+		"machineoperationcredentials.unbounded-cloud.io",
+		"machineconfigurationversions.unbounded-cloud.io",
+		"sitenodeslices.net.unbounded-cloud.io",
+		"gatewaypools.net.unbounded-cloud.io",
+		"gatewaypoolnodes.net.unbounded-cloud.io",
+		"sitegatewaypoolassignments.net.unbounded-cloud.io",
+		"sitepeerings.net.unbounded-cloud.io",
+		"gatewaypoolpeerings.net.unbounded-cloud.io",
+	}
+
+	if RequiredCRDNames != want {
+		t.Fatalf("RequiredCRDNames = %v, want %v", RequiredCRDNames, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
Gives the operator ongoing ownership of its CRD set and makes `kubectl unbounded install` correctly repair CRDs and roll config.

## Findings addressed
- **No ongoing CRD repair:** leader-elected `CRDMaintainer` re-applies/re-establishes the full owned CRD set on an interval.
- **Incomplete CRD contract:** exported `RequiredCRDNames` (all 12) is the single source of truth; bootstrap waits on the full set; terminating CRDs are rejected as established (operator + install client).
- **Install waited on only 7 CRDs; config hash covered only the endpoint:** now waits on all 12 and hashes the **full** operator ConfigMap payload so a change to `UNBOUNDED_REAP_LEGACY_RESOURCES` rolls the operator.
- **Reinstall silently re-enabled the reaper:** preserve the live value via `strconv.ParseBool`, fail closed on invalid before applying.
- **No CRD repair against a healthy operator:** idempotent repair token that only rolls when CRDs are unhealthy and the prior rollout is complete.
- **Rolling update could false-succeed:** operator Deployment pinned to `Recreate` with `rollingUpdate: null`; reap flag templated and threaded through the Makefile + render tests.

## Verification
`make fmt` / `make lint` / `make build` / `make test` green; `go test -race` on operator/install/cmd-operator/deploy green.

## Merge notes
Compile-independent of the operator config/migration PR. Touches `cmd/unbounded-operator/main.go` and `deploy/unbounded-operator/render_test.go`; the second of this/the config-migration PR to merge will need a trivial `render_test.go` conflict resolution (keep both PRs' assertions).
