### PR TITLE
metalman: improve redfish logging

### DIFF
--- a/internal/metalman/redfish/client.go
+++ b/internal/metalman/redfish/client.go
@@ -156,6 +156,8 @@ func Dial(ctx context.Context, url, certSHA256, user, pass, deviceID string) (*C
 		return nil, err
 	}
 
+	slog.Info("Redfish dialed BMC", "url", url, "device", id)
+
 	return &Client{session: s, deviceID: id}, nil
 }
 
@@ -184,6 +186,8 @@ func (c *Client) PowerState(ctx context.Context) (PowerState, error) {
 		return "", fmt.Errorf("parsing power state: %w", err)
 	}
 
+	slog.Info("Redfish read power state", "device", c.deviceID, "powerState", result.PowerState)
+
 	return result.PowerState, nil
 }
 
@@ -200,6 +204,8 @@ func (c *Client) Reset(ctx context.Context, resetType ResetType) error {
 	if !isSuccessStatus(status) {
 		return fmt.Errorf("reset %s failed: %w", resetType, redfishResponseError(http.MethodPost, path, status, data, nil))
 	}
+
+	slog.Info("Redfish reset", "device", c.deviceID, "resetType", resetType)
 
 	return nil
 }
@@ -241,6 +247,8 @@ func (c *Client) GetBootConfig(ctx context.Context) (BootConfig, error) {
 		}
 	}
 
+	slog.Info("Redfish read boot config", "device", c.deviceID, "target", config.Target, "enabled", config.Enabled, "mode", config.Mode)
+
 	return config, nil
 }
 
@@ -268,6 +276,8 @@ func (c *Client) SetBootOverride(ctx context.Context, target BootTarget, enabled
 	if !isSuccessStatus(status) {
 		return redfishResponseError(http.MethodPatch, path, status, data, nil)
 	}
+
+	slog.Info("Redfish set boot override", "device", c.deviceID, "target", target, "enabled", enabled)
 
 	return nil
 }
@@ -299,6 +309,8 @@ func (c *Client) SetHTTPBootOverride(ctx context.Context, bootURL string) error 
 		return redfishResponseError(http.MethodPatch, path, status, data, nil)
 	}
 
+	slog.Info("Redfish set HTTP boot override", "device", c.deviceID, "bootURL", bootURL)
+
 	return nil
 }
 
@@ -329,6 +341,8 @@ func (c *Client) GetBIOSHTTPBootURI(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("parsing BIOS HTTP boot URI: %w", err)
 	}
 
+	slog.Info("Redfish read BIOS HTTP boot URI", "device", c.deviceID, "bootURI", result.Attributes.HTTPBootURI)
+
 	return result.Attributes.HTTPBootURI, nil
 }
 
@@ -354,6 +368,8 @@ func (c *Client) SetBIOSHTTPBootURI(ctx context.Context, bootURL string) error {
 	if !isSuccessStatus(status) {
 		return redfishResponseError(http.MethodPatch, path, status, data, nil)
 	}
+
+	slog.Info("Redfish set BIOS HTTP boot URI", "device", c.deviceID, "bootURL", bootURL)
 
 	return nil
 }
@@ -397,6 +413,8 @@ func (c *Client) SetBIOSStaticIPv4(ctx context.Context, config StaticIPv4Config)
 	if !isSuccessStatus(status) {
 		return redfishResponseError(http.MethodPatch, path, status, data, nil)
 	}
+
+	slog.Info("Redfish set BIOS static IPv4", "device", c.deviceID, "address", config.Address)
 
 	return nil
 }
@@ -450,6 +468,8 @@ func (c *Client) SetStaticIPv4(ctx context.Context, config StaticIPv4Config) err
 		return redfishResponseError(http.MethodPatch, path, status, data, nil)
 	}
 
+	slog.Info("Redfish set static IPv4", "device", c.deviceID, "mac", mac, "address", config.Address, "path", path)
+
 	return nil
 }
 
@@ -476,6 +496,8 @@ func (c *Client) DisableBootOverride(ctx context.Context) error {
 	if !isSuccessStatus(status) {
 		return redfishResponseError(http.MethodPatch, path, status, data, nil)
 	}
+
+	slog.Info("Redfish disabled boot override", "device", c.deviceID)
 
 	return nil
 }
@@ -681,7 +703,11 @@ func CaptureFingerprint(ctx context.Context, url string) (string, error) {
 		return "", fmt.Errorf("no TLS peer certificates")
 	}
 
-	return formatFingerprint(sha256Sum(resp.TLS.PeerCertificates[0].Raw)), nil
+	fingerprint := formatFingerprint(sha256Sum(resp.TLS.PeerCertificates[0].Raw))
+
+	slog.Info("Redfish captured TLS cert fingerprint", "url", url, "fingerprint", fingerprint)
+
+	return fingerprint, nil
 }
 
 // newHTTPClient returns an *http.Client with TLS cert pinning.

--- a/internal/metalman/redfish/session.go
+++ b/internal/metalman/redfish/session.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -157,4 +158,6 @@ func (s *bmcSession) close() {
 	}
 
 	resp.Body.Close() //nolint:errcheck // Best-effort close of session delete response.
+
+	slog.Info("Redfish deleted session", "url", s.baseURL)
 }


### PR DESCRIPTION
Refactoring to primarily drive Redfish with the MachineOperation API removed a bunch of good logs. This PR just adds them to the client.