### PR TITLE
operator: auto-discover API server endpoint from kube-public/cluster-info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,25 +55,25 @@ AGENT_CMD=./cmd/agent
 
 MACHINA_BIN=bin/machina
 MACHINA_CMD=./cmd/machina
-MACHINA_IMAGE ?= $(CONTAINER_REGISTRY)/machina:$(VERSION)
+MACHINA_IMAGE ?= $(CONTAINER_REGISTRY)/machina:$(VERSION_TAG)
 
 MACHINE_OPS_CONTROLLER_BIN=bin/machine-ops-controller
 MACHINE_OPS_CONTROLLER_CMD=./cmd/machine-ops-controller
-MACHINE_OPS_CONTROLLER_IMAGE ?= $(CONTAINER_REGISTRY)/machine-ops-controller:$(VERSION)
+MACHINE_OPS_CONTROLLER_IMAGE ?= $(CONTAINER_REGISTRY)/machine-ops-controller:$(VERSION_TAG)
 MACHINE_OPS_CONTROLLER_NAME ?= machine-ops-controller
 MACHINE_OPS_PROVIDER ?=
 MACHINE_OPS_SITE ?=
 
 METALMAN_BIN=bin/metalman
 METALMAN_CMD=./cmd/metalman
-NETBOOT_IMAGE ?= $(CONTAINER_REGISTRY)/netboot:$(VERSION)
+NETBOOT_IMAGE ?= $(CONTAINER_REGISTRY)/netboot:$(VERSION_TAG)
 
-PLAYPEN_TAG ?= $(subst /,-,$(VERSION))
+PLAYPEN_TAG ?= $(VERSION_TAG)
 PLAYPEN_IMAGE ?= $(CONTAINER_REGISTRY)/playpen:$(PLAYPEN_TAG)
 
 UNBOUNDED_OPERATOR_BIN=bin/unbounded-operator
 UNBOUNDED_OPERATOR_CMD=./cmd/unbounded-operator
-UNBOUNDED_OPERATOR_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-operator:$(VERSION)
+UNBOUNDED_OPERATOR_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-operator:$(VERSION_TAG)
 UNBOUNDED_OPERATOR_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
 UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT ?=
 UNBOUNDED_OPERATOR_REAP_LEGACY_RESOURCES ?= true
@@ -103,7 +103,7 @@ UNROUTE_CMD=./cmd/unroute
 # Gantry (peer-to-peer OCI distribution)
 GANTRY_BIN=bin/gantry
 GANTRY_CMD=./cmd/gantry
-GANTRY_IMAGE ?= $(CONTAINER_REGISTRY)/gantry:$(VERSION)
+GANTRY_IMAGE ?= $(CONTAINER_REGISTRY)/gantry:$(VERSION_TAG)
 GANTRY_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
 GANTRY_MANIFEST_TEMPLATES_DIR := deploy/gantry
 GANTRY_MANIFEST_RENDERED_DIR  := deploy/gantry/rendered
@@ -113,7 +113,7 @@ UNBOUNDED_STORAGE_SUPERVISOR_BIN=bin/unbounded-storage-supervisor
 UNBOUNDED_STORAGE_SUPERVISOR_CMD=./cmd/unbounded-storage-supervisor
 # Default to the version-matched tag so operator-managed storage components stay
 # aligned with the release; override for local/e2e (e.g. TAG=dev).
-UNBOUNDED_STORAGE_SUPERVISOR_TAG ?= $(VERSION)
+UNBOUNDED_STORAGE_SUPERVISOR_TAG ?= $(VERSION_TAG)
 UNBOUNDED_STORAGE_SUPERVISOR_IMAGE=$(CONTAINER_REGISTRY)/unbounded-storage-supervisor:$(UNBOUNDED_STORAGE_SUPERVISOR_TAG)
 UNBOUNDED_STORAGE_SUPERVISOR_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
 UNBOUNDED_STORAGE_SUPERVISOR_MANIFEST_TEMPLATES_DIR := deploy/unbounded-storage-supervisor
@@ -174,6 +174,11 @@ STORAGE_TARBALL := $(STORAGE_DIST_DIR)/$(STORAGE_TARBALL_STEM).tar.gz
 
 # Version is derived from the latest git tag. Override with: make VERSION=v1.0.0
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+# VERSION_TAG is VERSION made safe for use as a Docker image tag: git describe can
+# surface a nearest tag containing a slash (e.g. agent-artifacts/v20260710), which
+# is invalid in an image reference. VERSION itself is kept intact for the embedded
+# version string (ldflags) and release artifact paths.
+VERSION_TAG ?= $(subst /,-,$(VERSION))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -183,12 +188,12 @@ STAMP_LDFLAGS=-X github.com/Azure/unbounded/internal/version.Version=$(VERSION) 
               -X github.com/Azure/unbounded/internal/version.BuildTime=$(BUILD_TIME)
 METALMAN_LDFLAGS=$(STAMP_LDFLAGS) -X github.com/Azure/unbounded/internal/metalman/commands.DefaultNetbootImage=$(NETBOOT_IMAGE)
 
-METALMAN_IMAGE=$(CONTAINER_REGISTRY)/metalman:$(VERSION)
+METALMAN_IMAGE=$(CONTAINER_REGISTRY)/metalman:$(VERSION_TAG)
 
 # Orca configuration
 ORCA_BIN=bin/orca
 ORCA_CMD=./cmd/orca
-ORCA_IMAGE ?= $(CONTAINER_REGISTRY)/orca:$(VERSION)
+ORCA_IMAGE ?= $(CONTAINER_REGISTRY)/orca:$(VERSION_TAG)
 ORCA_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
 ORCA_MANIFEST_TEMPLATES_DIR := deploy/orca
 ORCA_MANIFEST_RENDERED_DIR  := deploy/orca/rendered
@@ -209,8 +214,8 @@ KUBECTL_UNBOUNDED_LDFLAGS=$(STAMP_LDFLAGS)
 
 # --- Net (unbounded-net) configuration -------------------------------------
 # Container images for the net controller and node agent.
-NET_CONTROLLER_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-net-controller:$(VERSION)
-NET_NODE_IMAGE       ?= $(CONTAINER_REGISTRY)/unbounded-net-node:$(VERSION)
+NET_CONTROLLER_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-net-controller:$(VERSION_TAG)
+NET_NODE_IMAGE       ?= $(CONTAINER_REGISTRY)/unbounded-net-node:$(VERSION_TAG)
 
 # CNI plugins version baked into the net-node image. Keep in sync with the
 # defaults in images/net-{node,controller}/Dockerfile and the workflow envs.
@@ -986,7 +991,7 @@ image-machina-local: ## Build the machina container image locally (single-arch)
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_TIME=$(BUILD_TIME) \
-		-t machina:$(VERSION) -t $(MACHINA_IMAGE) \
+		-t machina:$(VERSION_TAG) -t $(MACHINA_IMAGE) \
 		-f ./images/machina/Containerfile .
 	$(call trivy-maybe,$(MACHINA_IMAGE))
 
@@ -1001,7 +1006,7 @@ image-machine-ops-controller-local: ## Build the machine-ops-controller containe
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_TIME=$(BUILD_TIME) \
-		-t machine-ops-controller:$(VERSION) -t $(MACHINE_OPS_CONTROLLER_IMAGE) \
+		-t machine-ops-controller:$(VERSION_TAG) -t $(MACHINE_OPS_CONTROLLER_IMAGE) \
 		-f ./images/machine-ops-controller/Containerfile .
 	$(call trivy-maybe,$(MACHINE_OPS_CONTROLLER_IMAGE))
 
@@ -1101,7 +1106,7 @@ image-metalman-local: ## Build the metalman container image locally (single-arch
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_TIME=$(BUILD_TIME) \
 		--build-arg CONTAINER_REGISTRY=$(CONTAINER_REGISTRY) \
-		-t metalman:$(VERSION) -t $(METALMAN_IMAGE) \
+		-t metalman:$(VERSION_TAG) -t $(METALMAN_IMAGE) \
 		-f ./images/metalman/Containerfile .
 	$(call trivy-maybe,$(METALMAN_IMAGE))
 
@@ -1118,7 +1123,7 @@ image-unbounded-operator-local: ## Build the unbounded-operator container image 
 		--build-arg NET_CONTROLLER_IMAGE=$(NET_CONTROLLER_IMAGE) \
 		--build-arg NET_NODE_IMAGE=$(NET_NODE_IMAGE) \
 		--build-arg MACHINA_IMAGE=$(MACHINA_IMAGE) \
-		-t unbounded-operator:$(VERSION) -t $(UNBOUNDED_OPERATOR_IMAGE) \
+		-t unbounded-operator:$(VERSION_TAG) -t $(UNBOUNDED_OPERATOR_IMAGE) \
 		-f ./images/unbounded-operator/Containerfile .
 	$(call trivy-maybe,$(UNBOUNDED_OPERATOR_IMAGE))
 
@@ -1139,7 +1144,7 @@ image-gantry-local: ## Build the gantry container image locally (single-arch)
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_TIME=$(BUILD_TIME) \
-		-t gantry:$(VERSION) -t $(GANTRY_IMAGE) \
+		-t gantry:$(VERSION_TAG) -t $(GANTRY_IMAGE) \
 		-f ./images/gantry/Containerfile .
 	$(call trivy-maybe,$(GANTRY_IMAGE))
 
@@ -1172,7 +1177,7 @@ image-orca-local: ## Build the orca container image locally (single-arch)
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_TIME=$(BUILD_TIME) \
-		-t orca:$(VERSION) -t $(ORCA_IMAGE) \
+		-t orca:$(VERSION_TAG) -t $(ORCA_IMAGE) \
 		-f ./images/orca/Containerfile .
 
 orca-oci: image-orca-local ## Alias for image-orca-local

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -94,7 +94,7 @@ func addInstallFlags(cmd *cobra.Command, handler *installHandler) {
 	cmd.Flags().StringVar(&handler.namespace, "namespace", unbounded.SystemNamespace(), "Namespace for unbounded-operator and default components")
 	cmd.Flags().StringVar(&handler.operatorImage, "operator-image", "", "unbounded-operator image override")
 	cmd.Flags().StringVar(&handler.metalmanImage, "metalman-image", "", "metalman image override")
-	cmd.Flags().StringVar(&handler.apiServerEndpoint, "api-server-endpoint", "", "Kubernetes API server endpoint advertised to provisioned machines; defaults to the kubeconfig server")
+	cmd.Flags().StringVar(&handler.apiServerEndpoint, "api-server-endpoint", "", "Override the Kubernetes API server endpoint advertised to provisioned machines; by default the operator auto-discovers it from kube-public/cluster-info")
 	cmd.Flags().BoolVar(&handler.wait, "wait", true, "Wait for unbounded-operator rollout")
 	cmd.Flags().DurationVar(&handler.timeout, "timeout", defaultInstallTimeout, "Timeout for rollout waits")
 }
@@ -274,11 +274,12 @@ func operatorConfigHash(data map[string]string) string {
 }
 
 func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
-	endpoint := h.apiServerEndpoint
-	if endpoint == "" && h.restConfig != nil {
-		endpoint = h.restConfig.Host
-	}
-
+	// The operator auto-discovers the API server endpoint from
+	// kube-public/cluster-info at runtime, so the endpoint is only stored when
+	// explicitly overridden via --api-server-endpoint. A previously stored
+	// override is preserved across reinstalls (like the reaper flag) rather than
+	// being cleared or replaced with the kubeconfig host.
+	endpoint := ""
 	reapLegacyResources := true
 	configMap := &unstructured.Unstructured{}
 	configMap.SetAPIVersion("v1")
@@ -295,6 +296,8 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 			return fmt.Errorf("get existing unbounded-operator-config data: %w", err)
 		}
 
+		endpoint = data["UNBOUNDED_API_SERVER_ENDPOINT"]
+
 		if value, found := data["UNBOUNDED_REAP_LEGACY_RESOURCES"]; found {
 			parsed, err := strconv.ParseBool(value)
 			if err != nil {
@@ -303,6 +306,10 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 
 			reapLegacyResources = parsed
 		}
+	}
+
+	if h.apiServerEndpoint != "" {
+		endpoint = h.apiServerEndpoint
 	}
 
 	h.operatorConfigData = map[string]string{

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -319,7 +319,10 @@ func TestInstallExecuteReinitializesDerivedConfig(t *testing.T) {
 			"name":      "unbounded-operator-config",
 			"namespace": "unbounded-system",
 		},
-		"data": map[string]any{"UNBOUNDED_REAP_LEGACY_RESOURCES": "false"},
+		"data": map[string]any{
+			"UNBOUNDED_REAP_LEGACY_RESOURCES": "false",
+			"UNBOUNDED_API_SERVER_ENDPOINT":   "https://preserved.example.test:6443",
+		},
 	}}
 	firstClient, first := newCapturingInstallClient(existing)
 	h := installHandler{
@@ -334,7 +337,7 @@ func TestInstallExecuteReinitializesDerivedConfig(t *testing.T) {
 	firstData, _, err := unstructured.NestedStringMap(first.configMap.Object, "data")
 	require.NoError(t, err)
 	require.Equal(t, "false", firstData["UNBOUNDED_REAP_LEGACY_RESOURCES"])
-	require.Equal(t, "https://first.example.test:6443", firstData["UNBOUNDED_API_SERVER_ENDPOINT"])
+	require.Equal(t, "https://preserved.example.test:6443", firstData["UNBOUNDED_API_SERVER_ENDPOINT"])
 
 	secondClient, second := newCapturingInstallClient()
 	h.kubeResourcesCli = secondClient
@@ -346,7 +349,7 @@ func TestInstallExecuteReinitializesDerivedConfig(t *testing.T) {
 	secondData, _, err := unstructured.NestedStringMap(second.configMap.Object, "data")
 	require.NoError(t, err)
 	require.Equal(t, "true", secondData["UNBOUNDED_REAP_LEGACY_RESOURCES"])
-	require.Equal(t, "https://second.example.test:6443", secondData["UNBOUNDED_API_SERVER_ENDPOINT"])
+	require.Equal(t, "", secondData["UNBOUNDED_API_SERVER_ENDPOINT"])
 
 	_, found, err := unstructured.NestedString(second.deployment.Object, "spec", "template", "metadata", "annotations", operatorCRDRepairAnnotation)
 	require.NoError(t, err)

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -19,6 +19,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -29,6 +30,7 @@ import (
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
+	"github.com/Azure/unbounded/internal/clusterinfo"
 	"github.com/Azure/unbounded/internal/operator"
 	"github.com/Azure/unbounded/internal/unbounded"
 	"github.com/Azure/unbounded/internal/version"
@@ -72,7 +74,7 @@ func newCommand(runFn func(context.Context, config) error) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.leaderElectionNamespace, "leader-elect-namespace", unbounded.SystemNamespace(), "Namespace for the leader election lease")
 	cmd.Flags().StringVar(&cfg.namespace, "namespace", unbounded.SystemNamespace(), "Namespace the operator reconciles components into and migrates legacy state to")
 	cmd.Flags().StringVar(&cfg.metalmanImage, "metalman-image", "", "Default metalman image")
-	cmd.Flags().StringVar(&cfg.apiServerEndpoint, "api-server-endpoint", os.Getenv("UNBOUNDED_API_SERVER_ENDPOINT"), "Kubernetes API server endpoint advertised by machina (defaults to $UNBOUNDED_API_SERVER_ENDPOINT)")
+	cmd.Flags().StringVar(&cfg.apiServerEndpoint, "api-server-endpoint", os.Getenv("UNBOUNDED_API_SERVER_ENDPOINT"), "Kubernetes API server endpoint advertised by machina; overrides auto-discovery from kube-public/cluster-info (defaults to $UNBOUNDED_API_SERVER_ENDPOINT)")
 	cmd.Flags().BoolVar(&cfg.reapLegacyResources, "reap-legacy-resources", true, "Translate legacy net-group Sites, migrate state into unbounded-system, and reap the pre-consolidation namespaces (defaults to $UNBOUNDED_REAP_LEGACY_RESOURCES or true)")
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
@@ -107,6 +109,25 @@ func envBoolDefault(name string, fallback bool) (bool, error) {
 	return value, nil
 }
 
+// resolveAPIServerEndpoint returns the Kubernetes API server endpoint advertised
+// to provisioned machines. An explicit override (from --api-server-endpoint /
+// $UNBOUNDED_API_SERVER_ENDPOINT) always wins; otherwise it is discovered from
+// the standard kube-public/cluster-info ConfigMap. Machina and metalman cannot
+// function without an endpoint, so an empty override with no discoverable value
+// is a hard error.
+func resolveAPIServerEndpoint(ctx context.Context, override string, clientset kubernetes.Interface) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+
+	info, err := clusterinfo.Resolve(ctx, clientset)
+	if err != nil {
+		return "", fmt.Errorf("no API server endpoint configured (set --api-server-endpoint or $UNBOUNDED_API_SERVER_ENDPOINT) and cluster-info discovery failed: %w", err)
+	}
+
+	return info.ApiserverURL, nil
+}
+
 func run(ctx context.Context, cfg config) error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -118,6 +139,22 @@ func run(ctx context.Context, cfg config) error {
 	}
 
 	restConfig := ctrl.GetConfigOrDie()
+
+	// Resolve the API server endpoint advertised to provisioned machines before
+	// wiring the reconciler/reaper: an explicit override wins, otherwise it is
+	// discovered from kube-public/cluster-info. Fail hard if neither is
+	// available since machina and metalman require it.
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("create kubernetes clientset: %w", err)
+	}
+
+	apiServerEndpoint, err := resolveAPIServerEndpoint(ctx, cfg.apiServerEndpoint, clientset)
+	if err != nil {
+		return err
+	}
+
+	cfg.apiServerEndpoint = apiServerEndpoint
 
 	// Install/upgrade the CRDs before starting the manager: the typed Site
 	// informer cannot sync until the Site CRD is served, and the operator owns

--- a/cmd/unbounded-operator/main_test.go
+++ b/cmd/unbounded-operator/main_test.go
@@ -8,6 +8,10 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestReapLegacyResourcesConfiguration(t *testing.T) {
@@ -83,6 +87,55 @@ func TestReapLegacyResourcesConfiguration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveAPIServerEndpoint(t *testing.T) {
+	const clusterInfoKubeconfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: dGVzdC1jYQ==
+    server: https://discovered.example:6443
+  name: ""
+kind: Config
+`
+
+	clusterInfoCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespacePublic, Name: "cluster-info"},
+		Data:       map[string]string{"kubeconfig": clusterInfoKubeconfig},
+	}
+
+	t.Run("override wins without discovery", func(t *testing.T) {
+		client := fake.NewSimpleClientset() // no cluster-info; must not be consulted
+
+		got, err := resolveAPIServerEndpoint(context.Background(), "https://override.example:6443", client)
+		if err != nil {
+			t.Fatalf("resolveAPIServerEndpoint: %v", err)
+		}
+
+		if got != "https://override.example:6443" {
+			t.Fatalf("endpoint = %q, want override", got)
+		}
+	})
+
+	t.Run("discovers from cluster-info when override empty", func(t *testing.T) {
+		client := fake.NewSimpleClientset(clusterInfoCM)
+
+		got, err := resolveAPIServerEndpoint(context.Background(), "", client)
+		if err != nil {
+			t.Fatalf("resolveAPIServerEndpoint: %v", err)
+		}
+
+		if got != "https://discovered.example:6443" {
+			t.Fatalf("endpoint = %q, want discovered", got)
+		}
+	})
+
+	t.Run("fails hard when empty override and no cluster-info", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		if _, err := resolveAPIServerEndpoint(context.Background(), "", client); err == nil {
+			t.Fatal("expected hard error when no override and cluster-info missing")
+		}
+	})
 }
 
 func unsetenv(t *testing.T, key string) {

--- a/deploy/unbounded-operator/03-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/03-configmap.yaml.tmpl
@@ -21,10 +21,13 @@ metadata:
     app.kubernetes.io/component: controller
 data:
   # External Kubernetes API endpoint advertised to provisioned machines. Remote
-  # nodes dial this to join, so it must be reachable from outside the cluster and
-  # cannot be derived in-cluster. Set this before enabling machina provisioning.
-  # Rendered from .APIServerEndpoint so make/GitOps deploys can set it via
-  # --set APIServerEndpoint=; `kubectl unbounded install` overrides it in place.
+  # nodes dial this to join, so it must be reachable from outside the cluster.
+  # Leave empty to let the operator auto-discover it from the standard
+  # kube-public/cluster-info ConfigMap at startup; set a value only to override
+  # discovery or when the cluster does not publish cluster-info. Rendered from
+  # .APIServerEndpoint so make/GitOps deploys can override via
+  # --set APIServerEndpoint=; `kubectl unbounded install --api-server-endpoint`
+  # overrides it in place (an empty value is preserved across reinstalls).
   UNBOUNDED_API_SERVER_ENDPOINT: {{ default "" .APIServerEndpoint | quote }}
   # Whether the operator translates legacy net-group Sites, migrates state into
   # this namespace, and reaps the pre-consolidation namespaces.

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -68,7 +68,7 @@ Optional flags:
 | `--namespace` | `string` | `unbounded-system` | Namespace for the operator and default components |
 | `--wait` | `bool` | `true` | Wait for the operator rollout and CRD establishment |
 | `--timeout` | `duration` | `5m0s` | Timeout for rollout waits |
-| `--api-server-endpoint` | `string` | kubeconfig server | API server endpoint advertised to provisioned machines |
+| `--api-server-endpoint` | `string` | auto-discovered | Override the API server endpoint advertised to provisioned machines; by default the operator discovers it from `kube-public/cluster-info` |
 
 > **Breaking change:** the `--skip-crds` flag has been removed. CRDs are now owned
 > and installed by the operator at startup (`operator.BootstrapCRDs`), so there is

--- a/hack/smoke-metalman-http.py
+++ b/hack/smoke-metalman-http.py
@@ -277,7 +277,7 @@ def start_fixture(blank_efi: Path, active_efi: Path) -> None:
 
 def start_metalman_and_replace() -> None:
     kubeconfig = TMP / "metalman.kubeconfig"
-    smoke.write_service_account_kubeconfig("unbounded-kube", "metalman-controller", kubeconfig)
+    smoke.write_service_account_kubeconfig(smoke.METALMAN_NAMESPACE, "metalman-controller", kubeconfig)
     # The guest cannot resolve Docker's kind-control-plane hostname. Use the
     # control-plane address attached directly to this test's L2 network.
     api_url = f"https://{KIND_IP}:6443"

--- a/internal/clusterinfo/clusterinfo.go
+++ b/internal/clusterinfo/clusterinfo.go
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package clusterinfo discovers the external Kubernetes API server endpoint and
+// trust anchor from the standard cluster-info ConfigMap in the kube-public
+// namespace. Every conformant cluster (kubeadm, kind, AKS, ...) publishes this
+// ConfigMap, making it the canonical way to discover the externally-reachable
+// API server URL without requiring it to be configured explicitly.
+package clusterinfo
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ClusterInfo holds the API server URL and CA certificate discovered from the
+// standard cluster-info ConfigMap in kube-public.
+type ClusterInfo struct {
+	// ApiserverURL is the external API server URL (e.g. "https://10.0.0.1:6443").
+	ApiserverURL string
+	// CACertPEM is the PEM-encoded cluster CA certificate.
+	CACertPEM []byte
+}
+
+// Resolve reads the standard cluster-info ConfigMap from the kube-public
+// namespace and returns both the API server URL and the CA certificate from the
+// embedded kubeconfig. Every conformant cluster publishes this ConfigMap,
+// making it the canonical way to discover the external API server endpoint and
+// trust anchor.
+func Resolve(ctx context.Context, clientset kubernetes.Interface) (*ClusterInfo, error) {
+	cm, err := clientset.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(ctx, "cluster-info", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get cluster-info ConfigMap from kube-public: %w", err)
+	}
+
+	kubeconfig, ok := cm.Data["kubeconfig"]
+	if !ok {
+		return nil, fmt.Errorf("kubeconfig key not found in cluster-info ConfigMap")
+	}
+
+	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
+	if err != nil {
+		return nil, fmt.Errorf("parsing kubeconfig from cluster-info ConfigMap: %w", err)
+	}
+
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("cluster-info kubeconfig has no server URL")
+	}
+
+	if len(cfg.CAData) == 0 {
+		return nil, fmt.Errorf("cluster-info kubeconfig has no CA certificate")
+	}
+
+	return &ClusterInfo{
+		ApiserverURL: cfg.Host,
+		CACertPEM:    cfg.CAData,
+	}, nil
+}
+
+// ResolveApiserverURL reads the standard cluster-info ConfigMap from the
+// kube-public namespace and returns the Kubernetes API server URL contained in
+// the embedded kubeconfig.
+//
+// Deprecated: Use Resolve instead, which also returns the CA certificate from
+// the same kubeconfig.
+func ResolveApiserverURL(ctx context.Context, clientset kubernetes.Interface) (string, error) {
+	info, err := Resolve(ctx, clientset)
+	if err != nil {
+		return "", err
+	}
+
+	return info.ApiserverURL, nil
+}

--- a/internal/clusterinfo/clusterinfo_test.go
+++ b/internal/clusterinfo/clusterinfo_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package clusterinfo
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// validKubeconfig is a minimal cluster-info kubeconfig with a server URL and a
+// (dummy) CA certificate, matching the shape kubeadm publishes.
+const validKubeconfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: dGVzdC1jYQ==
+    server: https://control-plane.example:6443
+  name: ""
+contexts: null
+current-context: ""
+kind: Config
+preferences: {}
+users: null
+`
+
+func clusterInfoCM(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespacePublic, Name: "cluster-info"},
+		Data:       data,
+	}
+}
+
+func TestResolveReturnsURLAndCA(t *testing.T) {
+	client := fake.NewSimpleClientset(clusterInfoCM(map[string]string{"kubeconfig": validKubeconfig}))
+
+	info, err := Resolve(context.Background(), client)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if info.ApiserverURL != "https://control-plane.example:6443" {
+		t.Fatalf("ApiserverURL = %q, want https://control-plane.example:6443", info.ApiserverURL)
+	}
+
+	if string(info.CACertPEM) != "test-ca" {
+		t.Fatalf("CACertPEM = %q, want test-ca", info.CACertPEM)
+	}
+}
+
+func TestResolveApiserverURL(t *testing.T) {
+	client := fake.NewSimpleClientset(clusterInfoCM(map[string]string{"kubeconfig": validKubeconfig}))
+
+	url, err := ResolveApiserverURL(context.Background(), client)
+	if err != nil {
+		t.Fatalf("ResolveApiserverURL: %v", err)
+	}
+
+	if url != "https://control-plane.example:6443" {
+		t.Fatalf("url = %q, want https://control-plane.example:6443", url)
+	}
+}
+
+func TestResolveErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		objects []*corev1.ConfigMap
+	}{
+		{
+			name:    "missing configmap",
+			objects: nil,
+		},
+		{
+			name:    "missing kubeconfig key",
+			objects: []*corev1.ConfigMap{clusterInfoCM(map[string]string{"other": "x"})},
+		},
+		{
+			name:    "malformed kubeconfig",
+			objects: []*corev1.ConfigMap{clusterInfoCM(map[string]string{"kubeconfig": "not: [valid"})},
+		},
+		{
+			name: "no server url",
+			objects: []*corev1.ConfigMap{clusterInfoCM(map[string]string{"kubeconfig": `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: dGVzdC1jYQ==
+    server: ""
+  name: ""
+kind: Config
+`})},
+		},
+		{
+			name: "no ca",
+			objects: []*corev1.ConfigMap{clusterInfoCM(map[string]string{"kubeconfig": `apiVersion: v1
+clusters:
+- cluster:
+    server: https://control-plane.example:6443
+  name: ""
+kind: Config
+`})},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			for _, obj := range tc.objects {
+				if _, err := client.CoreV1().ConfigMaps(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("seed configmap: %v", err)
+				}
+			}
+
+			if _, err := Resolve(context.Background(), client); err == nil {
+				t.Fatal("Resolve: expected error, got nil")
+			}
+		})
+	}
+}

--- a/internal/metalman/commands/cluster_config.go
+++ b/internal/metalman/commands/cluster_config.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/Azure/unbounded/internal/clusterinfo"
 	"github.com/Azure/unbounded/internal/metalman/netboot"
 )
 
@@ -114,7 +115,7 @@ func (w *ClusterInfoWatcher) Start(ctx context.Context) error {
 
 // refresh re-resolves the cluster-info from the Kubernetes API.
 func (w *ClusterInfoWatcher) refresh(ctx context.Context) error {
-	resolved, err := ResolveClusterInfo(ctx, w.clientset)
+	resolved, err := clusterinfo.Resolve(ctx, w.clientset)
 	if err != nil {
 		return fmt.Errorf("resolving cluster info: %w", err)
 	}

--- a/internal/metalman/commands/helpers.go
+++ b/internal/metalman/commands/helpers.go
@@ -12,13 +12,10 @@ import (
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
@@ -143,67 +140,6 @@ func InterfaceForIP(ip net.IP) (string, error) {
 	}
 
 	return "", fmt.Errorf("no interface found for IP %s", ip)
-}
-
-// ClusterInfo holds the API server URL and CA certificate discovered from
-// the standard cluster-info ConfigMap in kube-public.
-type ClusterInfo struct {
-	// ApiserverURL is the external API server URL (e.g. "https://10.0.0.1:6443").
-	ApiserverURL string
-	// CACertPEM is the PEM-encoded cluster CA certificate.
-	CACertPEM []byte
-}
-
-// ResolveClusterInfo reads the standard cluster-info ConfigMap from the
-// kube-public namespace and returns both the API server URL and the CA
-// certificate from the embedded kubeconfig. Every conformant cluster
-// publishes this ConfigMap, making it the canonical way to discover the
-// external API server endpoint and trust anchor.
-func ResolveClusterInfo(ctx context.Context, clientset kubernetes.Interface) (*ClusterInfo, error) {
-	cm, err := clientset.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(ctx, "cluster-info", metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("get cluster-info ConfigMap from kube-public: %w", err)
-	}
-
-	kubeconfig, ok := cm.Data["kubeconfig"]
-	if !ok {
-		return nil, fmt.Errorf("kubeconfig key not found in cluster-info ConfigMap")
-	}
-
-	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
-	if err != nil {
-		return nil, fmt.Errorf("parsing kubeconfig from cluster-info ConfigMap: %w", err)
-	}
-
-	if cfg.Host == "" {
-		return nil, fmt.Errorf("cluster-info kubeconfig has no server URL")
-	}
-
-	if len(cfg.CAData) == 0 {
-		return nil, fmt.Errorf("cluster-info kubeconfig has no CA certificate")
-	}
-
-	return &ClusterInfo{
-		ApiserverURL: cfg.Host,
-		CACertPEM:    cfg.CAData,
-	}, nil
-}
-
-// ResolveApiserverURL reads the standard cluster-info ConfigMap from the
-// kube-public namespace and returns the Kubernetes API server URL contained
-// in the embedded kubeconfig. Every conformant cluster publishes this
-// ConfigMap, making it the canonical way to discover the external API
-// server endpoint.
-//
-// Deprecated: Use ResolveClusterInfo instead, which also returns the CA
-// certificate from the same kubeconfig.
-func ResolveApiserverURL(ctx context.Context, clientset kubernetes.Interface) (string, error) {
-	info, err := ResolveClusterInfo(ctx, clientset)
-	if err != nil {
-		return "", err
-	}
-
-	return info.ApiserverURL, nil
 }
 
 func InterfaceIPv4(name string) (net.IP, error) {


### PR DESCRIPTION
## Summary
Makes the operator's API server endpoint configuration optional by auto-discovering it from the standard `kube-public/cluster-info` ConfigMap, per reviewer feedback. It is now only required as an override or when the cluster does not publish cluster-info.

## Behavior
- **Operator (startup):** resolves the endpoint with precedence **override -> cluster-info discovery -> fail hard**. An explicit `--api-server-endpoint` / `$UNBOUNDED_API_SERVER_ENDPOINT` wins; otherwise it reads the `server` field from `kube-public/cluster-info`. With neither, the operator **fails hard** (machina and metalman cannot function without an endpoint).
- **`kubectl unbounded install`:** only writes `UNBOUNDED_API_SERVER_ENDPOINT` when `--api-server-endpoint` is passed; otherwise preserves any existing value and no longer falls back to the kubeconfig host, so auto-discovery takes effect on a plain install.
- No RBAC change: the operator ClusterRole already grants cluster-wide `configmaps get/list/watch`.

## Changes
- New shared `internal/clusterinfo` package (cluster-info reader); `internal/metalman/commands` migrated onto it (removes the duplicate).
- `cmd/unbounded-operator/main.go`: `resolveAPIServerEndpoint` (override/discover/fail-hard) wired into startup.
- `cmd/kubectl-unbounded/app/install.go`: preserve/override endpoint, drop kubeconfig fallback.
- Docs + ConfigMap template comments updated to describe discovery/override.
- **Build fix (separate commit):** `git describe` can yield a slash-containing tag (`agent-artifacts/v20260710-...`) that is invalid as a Docker tag and broke image builds and rendered manifest image refs. Added `VERSION_TAG` (`/`->`-`) used for all image tags, keeping `VERSION` for ldflags/release paths. This unblocked the e2e image build.
- **Smoke fix (separate commit):** the `internal/metalman/**` change trips the `smoke-metalman` workflow path filter, which surfaced a pre-existing break on the `feature/unbounded-system` base: the layered DHCP-free HTTP smoke (`hack/smoke-metalman-http.py`) still resolved the `metalman-controller` ServiceAccount from the legacy `unbounded-kube` namespace, while the rendered metalman RBAC now creates it in `unbounded-system`. `kubectl -n unbounded-kube create token metalman-controller` failed before metalman could start, reddening the `layered-http-smoke` job (`pxe-smoke` already used the new namespace and passed). Fixed by reusing the shared `smoke.METALMAN_NAMESPACE` constant so the HTTP smoke stays in lockstep with the PXE smoke and the namespace rename.

## Verification
- `make fmt` / `lint` / `build` / `test` and `go test -race` on touched packages: green.
- Real-kind `TestOperatorReaperMigration`: pass.
- **Live focused validation on kind:**
  - Install without `--api-server-endpoint` -> `UNBOUNDED_API_SERVER_ENDPOINT` left empty -> operator **auto-discovers** and becomes Ready (reconciler + reaper run).
  - Deleting `kube-public/cluster-info` with no override -> operator **crash-loops** with `no API server endpoint configured (...) and cluster-info discovery failed: ... configmaps "cluster-info" not found` (fail-hard confirmed).
  - Operator/machina/net/orca image builds now produce valid tags (previously `invalid reference format`).
  - `smoke-metalman` workflow: both `pxe-smoke` and `layered-http-smoke` now target `unbounded-system` (previously `layered-http-smoke` failed on the `unbounded-kube` token request).

## Scope
Operator -> machina only. `machine-ops-controller` (`--api-server-endpoint`) and net (`apiserverURL`) keep their parallel mechanisms and could adopt `internal/clusterinfo` later.

Note: the faithful upgrade e2e (`e2e.py`, nightly/manual) now naturally exercises discovery since it installs without `--api-server-endpoint`.

