### PR TITLE
operator, metalman: discover API server endpoint and CA on clusters without cluster-info (AKS)

### DIFF
--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -94,7 +94,7 @@ func addInstallFlags(cmd *cobra.Command, handler *installHandler) {
 	cmd.Flags().StringVar(&handler.namespace, "namespace", unbounded.SystemNamespace(), "Namespace for unbounded-operator and default components")
 	cmd.Flags().StringVar(&handler.operatorImage, "operator-image", "", "unbounded-operator image override")
 	cmd.Flags().StringVar(&handler.metalmanImage, "metalman-image", "", "metalman image override")
-	cmd.Flags().StringVar(&handler.apiServerEndpoint, "api-server-endpoint", "", "Override the Kubernetes API server endpoint advertised to provisioned machines; by default the operator auto-discovers it from kube-public/cluster-info")
+	cmd.Flags().StringVar(&handler.apiServerEndpoint, "api-server-endpoint", "", "Override the Kubernetes API server endpoint advertised to provisioned machines; by default the operator auto-discovers it from kube-public/cluster-info, or the KUBERNETES_SERVICE_HOST FQDN on clusters (e.g. AKS) that do not publish cluster-info")
 	cmd.Flags().BoolVar(&handler.wait, "wait", true, "Wait for unbounded-operator rollout")
 	cmd.Flags().DurationVar(&handler.timeout, "timeout", defaultInstallTimeout, "Timeout for rollout waits")
 }

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -123,12 +123,12 @@ func resolveAPIServerEndpoint(ctx context.Context, override string, clientset ku
 		return override, nil
 	}
 
-	info, err := clusterinfo.Discover(ctx, clientset)
+	endpoint, err := clusterinfo.DiscoverURL(ctx, clientset)
 	if err != nil {
 		return "", fmt.Errorf("no API server endpoint configured (set --api-server-endpoint or $UNBOUNDED_API_SERVER_ENDPOINT) and endpoint discovery failed: %w", err)
 	}
 
-	return info.ApiserverURL, nil
+	return endpoint, nil
 }
 
 func run(ctx context.Context, cfg config) error {

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -74,7 +74,7 @@ func newCommand(runFn func(context.Context, config) error) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.leaderElectionNamespace, "leader-elect-namespace", unbounded.SystemNamespace(), "Namespace for the leader election lease")
 	cmd.Flags().StringVar(&cfg.namespace, "namespace", unbounded.SystemNamespace(), "Namespace the operator reconciles components into and migrates legacy state to")
 	cmd.Flags().StringVar(&cfg.metalmanImage, "metalman-image", "", "Default metalman image")
-	cmd.Flags().StringVar(&cfg.apiServerEndpoint, "api-server-endpoint", os.Getenv("UNBOUNDED_API_SERVER_ENDPOINT"), "Kubernetes API server endpoint advertised by machina; overrides auto-discovery from kube-public/cluster-info (defaults to $UNBOUNDED_API_SERVER_ENDPOINT)")
+	cmd.Flags().StringVar(&cfg.apiServerEndpoint, "api-server-endpoint", os.Getenv("UNBOUNDED_API_SERVER_ENDPOINT"), "Kubernetes API server endpoint advertised by machina; overrides auto-discovery from kube-public/cluster-info or the KUBERNETES_SERVICE_HOST FQDN (defaults to $UNBOUNDED_API_SERVER_ENDPOINT)")
 	cmd.Flags().BoolVar(&cfg.reapLegacyResources, "reap-legacy-resources", true, "Translate legacy net-group Sites, migrate state into unbounded-system, and reap the pre-consolidation namespaces (defaults to $UNBOUNDED_REAP_LEGACY_RESOURCES or true)")
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
@@ -112,7 +112,10 @@ func envBoolDefault(name string, fallback bool) (bool, error) {
 // resolveAPIServerEndpoint returns the Kubernetes API server endpoint advertised
 // to provisioned machines. An explicit override (from --api-server-endpoint /
 // $UNBOUNDED_API_SERVER_ENDPOINT) always wins; otherwise it is discovered from
-// the standard kube-public/cluster-info ConfigMap. Machina and metalman cannot
+// the standard kube-public/cluster-info ConfigMap, and failing that from the
+// KUBERNETES_SERVICE_HOST FQDN (managed control planes such as AKS do not
+// publish cluster-info; the kubernetes.azure.com/set-kube-service-host-fqdn pod
+// label makes that env the public API FQDN). Machina and metalman cannot
 // function without an endpoint, so an empty override with no discoverable value
 // is a hard error.
 func resolveAPIServerEndpoint(ctx context.Context, override string, clientset kubernetes.Interface) (string, error) {
@@ -120,9 +123,9 @@ func resolveAPIServerEndpoint(ctx context.Context, override string, clientset ku
 		return override, nil
 	}
 
-	info, err := clusterinfo.Resolve(ctx, clientset)
+	info, err := clusterinfo.Discover(ctx, clientset)
 	if err != nil {
-		return "", fmt.Errorf("no API server endpoint configured (set --api-server-endpoint or $UNBOUNDED_API_SERVER_ENDPOINT) and cluster-info discovery failed: %w", err)
+		return "", fmt.Errorf("no API server endpoint configured (set --api-server-endpoint or $UNBOUNDED_API_SERVER_ENDPOINT) and endpoint discovery failed: %w", err)
 	}
 
 	return info.ApiserverURL, nil

--- a/cmd/unbounded-operator/main_test.go
+++ b/cmd/unbounded-operator/main_test.go
@@ -131,9 +131,25 @@ kind: Config
 	})
 
 	t.Run("fails hard when empty override and no cluster-info", func(t *testing.T) {
+		// No cluster-info and no external KUBERNETES_SERVICE_HOST FQDN.
+		t.Setenv("KUBERNETES_SERVICE_HOST", "")
+		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "")
+
 		client := fake.NewSimpleClientset()
 		if _, err := resolveAPIServerEndpoint(context.Background(), "", client); err == nil {
 			t.Fatal("expected hard error when no override and cluster-info missing")
+		}
+	})
+
+	t.Run("fails hard when only the in-cluster ClusterIP is available", func(t *testing.T) {
+		// Without cluster-info, an in-cluster ClusterIP in KUBERNETES_SERVICE_HOST
+		// must not be advertised (a joining node cannot reach it).
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+
+		client := fake.NewSimpleClientset()
+		if _, err := resolveAPIServerEndpoint(context.Background(), "", client); err == nil {
+			t.Fatal("expected hard error when only the in-cluster ClusterIP is available")
 		}
 	})
 }

--- a/deploy/unbounded-operator/03-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/03-configmap.yaml.tmpl
@@ -22,9 +22,11 @@ metadata:
 data:
   # External Kubernetes API endpoint advertised to provisioned machines. Remote
   # nodes dial this to join, so it must be reachable from outside the cluster.
-  # Leave empty to let the operator auto-discover it from the standard
-  # kube-public/cluster-info ConfigMap at startup; set a value only to override
-  # discovery or when the cluster does not publish cluster-info. Rendered from
+  # Leave empty to let the operator auto-discover it: it prefers the standard
+  # kube-public/cluster-info ConfigMap and, for clusters that do not publish it
+  # (e.g. AKS), falls back to the KUBERNETES_SERVICE_HOST FQDN (the operator pod
+  # carries kubernetes.azure.com/set-kube-service-host-fqdn so that env is the
+  # public API FQDN). Set a value only to override discovery. Rendered from
   # .APIServerEndpoint so make/GitOps deploys can override via
   # --set APIServerEndpoint=; `kubectl unbounded install --api-server-endpoint`
   # overrides it in place (an empty value is preserved across reinstalls).

--- a/deploy/unbounded-operator/04-deployment.yaml.tmpl
+++ b/deploy/unbounded-operator/04-deployment.yaml.tmpl
@@ -23,6 +23,11 @@ spec:
       labels:
         app.kubernetes.io/name: unbounded-operator
         app.kubernetes.io/component: controller
+        # On AKS (which does not publish kube-public/cluster-info) this makes the
+        # pod's KUBERNETES_SERVICE_HOST the public API FQDN, which the operator
+        # uses as the last-resort source for the advertised API server endpoint.
+        # Inert on clusters that do not honor it.
+        kubernetes.azure.com/set-kube-service-host-fqdn: "true"
       annotations:
         # Rolls the operator when any ConfigMap data changes at render time.
         # Canonical JSON matches the `kubectl unbounded install` hash.

--- a/deploy/unbounded-operator/render_test.go
+++ b/deploy/unbounded-operator/render_test.go
@@ -61,6 +61,7 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 			Strategy map[string]any `yaml:"strategy"`
 			Template struct {
 				Metadata struct {
+					Labels      map[string]string `yaml:"labels"`
 					Annotations map[string]string `yaml:"annotations"`
 				} `yaml:"metadata"`
 				Spec struct {
@@ -89,6 +90,12 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 
 	if got := deploy.Spec.Template.Metadata.Annotations["unbounded-cloud.io/operator-config-hash"]; got != want {
 		t.Fatalf("deployment operator-config-hash annotation = %q, want %q (sha256 of complete ConfigMap data)", got, want)
+	}
+
+	// The pod carries the AKS FQDN label so KUBERNETES_SERVICE_HOST resolves to
+	// the public API FQDN, the last-resort source for the advertised endpoint.
+	if got := deploy.Spec.Template.Metadata.Labels["kubernetes.azure.com/set-kube-service-host-fqdn"]; got != "true" {
+		t.Fatalf("deployment pod label kubernetes.azure.com/set-kube-service-host-fqdn = %q, want \"true\"", got)
 	}
 
 	if deploy.Spec.Replicas != 1 {

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -68,7 +68,7 @@ Optional flags:
 | `--namespace` | `string` | `unbounded-system` | Namespace for the operator and default components |
 | `--wait` | `bool` | `true` | Wait for the operator rollout and CRD establishment |
 | `--timeout` | `duration` | `5m0s` | Timeout for rollout waits |
-| `--api-server-endpoint` | `string` | auto-discovered | Override the API server endpoint advertised to provisioned machines; by default the operator discovers it from `kube-public/cluster-info` |
+| `--api-server-endpoint` | `string` | auto-discovered | Override the API server endpoint advertised to provisioned machines; by default the operator discovers it from `kube-public/cluster-info`, or the `KUBERNETES_SERVICE_HOST` FQDN on clusters (e.g. AKS) that do not publish cluster-info |
 
 > **Breaking change:** the `--skip-crds` flag has been removed. CRDs are now owned
 > and installed by the operator at startup (`operator.BootstrapCRDs`), so there is

--- a/internal/clusterinfo/clusterinfo.go
+++ b/internal/clusterinfo/clusterinfo.go
@@ -2,20 +2,42 @@
 // Licensed under the MIT License.
 
 // Package clusterinfo discovers the external Kubernetes API server endpoint and
-// trust anchor from the standard cluster-info ConfigMap in the kube-public
-// namespace. Every conformant cluster (kubeadm, kind, AKS, ...) publishes this
-// ConfigMap, making it the canonical way to discover the externally-reachable
-// API server URL without requiring it to be configured explicitly.
+// trust anchor without requiring them to be configured explicitly.
+//
+// The primary source is the standard cluster-info ConfigMap in the kube-public
+// namespace, which kubeadm-provisioned clusters (including kind) publish. Some
+// managed control planes (notably AKS) do not publish it; for those, Discover
+// falls back to the KUBERNETES_SERVICE_HOST/PORT the kubelet injects, but only
+// when it resolves to an external FQDN rather than the in-cluster ClusterIP (on
+// AKS the kubernetes.azure.com/set-kube-service-host-fqdn pod label makes it the
+// public API FQDN), pairing it with the in-cluster service-account CA.
 package clusterinfo
 
 import (
 	"context"
 	"fmt"
+	"net"
+	"os"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+// inClusterCAPath is the projected service-account CA bundle the kubelet mounts
+// into every pod. It is a package variable so tests can point it at a fixture.
+var inClusterCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+// inClusterServiceDNSNames are the in-cluster DNS names for the API server
+// Service. They resolve only from inside the cluster, so they are never a valid
+// endpoint to advertise to a node that is still joining.
+var inClusterServiceDNSNames = map[string]struct{}{
+	"kubernetes":                           {},
+	"kubernetes.default":                   {},
+	"kubernetes.default.svc":               {},
+	"kubernetes.default.svc.cluster.local": {},
+}
 
 // ClusterInfo holds the API server URL and CA certificate discovered from the
 // standard cluster-info ConfigMap in kube-public.
@@ -28,9 +50,8 @@ type ClusterInfo struct {
 
 // Resolve reads the standard cluster-info ConfigMap from the kube-public
 // namespace and returns both the API server URL and the CA certificate from the
-// embedded kubeconfig. Every conformant cluster publishes this ConfigMap,
-// making it the canonical way to discover the external API server endpoint and
-// trust anchor.
+// embedded kubeconfig. Clusters provisioned by kubeadm (including kind) publish
+// this ConfigMap; Discover layers a fallback on top for those that do not.
 func Resolve(ctx context.Context, clientset kubernetes.Interface) (*ClusterInfo, error) {
 	cm, err := clientset.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(ctx, "cluster-info", metav1.GetOptions{})
 	if err != nil {
@@ -74,4 +95,84 @@ func ResolveApiserverURL(ctx context.Context, clientset kubernetes.Interface) (s
 	}
 
 	return info.ApiserverURL, nil
+}
+
+// Discover resolves the external API server URL and CA certificate, preferring
+// the kube-public/cluster-info ConfigMap and falling back to the
+// KUBERNETES_SERVICE_HOST FQDN paired with the in-cluster service-account CA.
+//
+// The fallback exists for managed control planes (e.g. AKS) that do not publish
+// cluster-info. It is only taken when KUBERNETES_SERVICE_HOST is an external
+// FQDN (see KubeServiceHostEndpoint); an in-cluster ClusterIP is rejected so we
+// never advertise an endpoint a joining node cannot reach.
+func Discover(ctx context.Context, clientset kubernetes.Interface) (*ClusterInfo, error) {
+	info, cmErr := Resolve(ctx, clientset)
+	if cmErr == nil {
+		return info, nil
+	}
+
+	endpoint, ok := KubeServiceHostEndpoint()
+	if !ok {
+		return nil, fmt.Errorf("cluster-info discovery failed (%w) and no external KUBERNETES_SERVICE_HOST FQDN is available", cmErr)
+	}
+
+	caPEM, caErr := InClusterCA()
+	if caErr != nil {
+		return nil, fmt.Errorf("cluster-info discovery failed (%w); reading in-cluster CA for the KUBERNETES_SERVICE_HOST fallback: %w", cmErr, caErr)
+	}
+
+	return &ClusterInfo{ApiserverURL: endpoint, CACertPEM: caPEM}, nil
+}
+
+// KubeServiceHostEndpoint builds the API server URL from the
+// KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT_HTTPS/PORT environment
+// variables the kubelet injects into pods.
+//
+// It returns ok=false unless the host is an external FQDN: an empty value, an IP
+// literal (the in-cluster ClusterIP), or an in-cluster Service DNS name
+// (kubernetes.default.svc, ...) is rejected, since none of those are reachable
+// by a node that is still joining the cluster. On AKS the
+// kubernetes.azure.com/set-kube-service-host-fqdn pod label makes this env the
+// public API FQDN, which is accepted.
+func KubeServiceHostEndpoint() (string, bool) {
+	host := strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_HOST"))
+	if host == "" {
+		return "", false
+	}
+
+	if net.ParseIP(host) != nil {
+		return "", false
+	}
+
+	if _, ok := inClusterServiceDNSNames[strings.ToLower(strings.TrimSuffix(host, "."))]; ok {
+		return "", false
+	}
+
+	port := strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_PORT_HTTPS"))
+	if port == "" {
+		port = strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_PORT"))
+	}
+
+	if port == "" {
+		port = "443"
+	}
+
+	return "https://" + net.JoinHostPort(host, port), true
+}
+
+// InClusterCA reads the service-account CA bundle the kubelet mounts into every
+// pod. It is the cluster CA and signs the API server serving certificate
+// (including the AKS FQDN SAN), so it is the correct trust anchor for the
+// KUBERNETES_SERVICE_HOST fallback when cluster-info is unavailable.
+func InClusterCA() ([]byte, error) {
+	caPEM, err := os.ReadFile(inClusterCAPath)
+	if err != nil {
+		return nil, fmt.Errorf("read in-cluster CA %q: %w", inClusterCAPath, err)
+	}
+
+	if len(caPEM) == 0 {
+		return nil, fmt.Errorf("in-cluster CA %q is empty", inClusterCAPath)
+	}
+
+	return caPEM, nil
 }

--- a/internal/clusterinfo/clusterinfo.go
+++ b/internal/clusterinfo/clusterinfo.go
@@ -6,11 +6,12 @@
 //
 // The primary source is the standard cluster-info ConfigMap in the kube-public
 // namespace, which kubeadm-provisioned clusters (including kind) publish. Some
-// managed control planes (notably AKS) do not publish it; for those, Discover
+// managed control planes (notably AKS) do not publish it; for those, DiscoverURL
 // falls back to the KUBERNETES_SERVICE_HOST/PORT the kubelet injects, but only
 // when it resolves to an external FQDN rather than the in-cluster ClusterIP (on
 // AKS the kubernetes.azure.com/set-kube-service-host-fqdn pod label makes it the
-// public API FQDN), pairing it with the in-cluster service-account CA.
+// public API FQDN). The CA for that fallback comes from the in-cluster
+// service-account mount (see InClusterCA).
 package clusterinfo
 
 import (
@@ -97,31 +98,25 @@ func ResolveApiserverURL(ctx context.Context, clientset kubernetes.Interface) (s
 	return info.ApiserverURL, nil
 }
 
-// Discover resolves the external API server URL and CA certificate, preferring
-// the kube-public/cluster-info ConfigMap and falling back to the
-// KUBERNETES_SERVICE_HOST FQDN paired with the in-cluster service-account CA.
+// DiscoverURL resolves only the external API server URL, preferring the
+// kube-public/cluster-info ConfigMap and falling back to the
+// KUBERNETES_SERVICE_HOST FQDN (see KubeServiceHostEndpoint).
 //
-// The fallback exists for managed control planes (e.g. AKS) that do not publish
-// cluster-info. It is only taken when KUBERNETES_SERVICE_HOST is an external
-// FQDN (see KubeServiceHostEndpoint); an in-cluster ClusterIP is rejected so we
-// never advertise an endpoint a joining node cannot reach.
-func Discover(ctx context.Context, clientset kubernetes.Interface) (*ClusterInfo, error) {
+// Unlike a CA-inclusive resolve it never reads the in-cluster CA, so callers
+// that advertise only the endpoint (e.g. the operator) do not fail when the CA
+// mount is unavailable or unreadable.
+func DiscoverURL(ctx context.Context, clientset kubernetes.Interface) (string, error) {
 	info, cmErr := Resolve(ctx, clientset)
 	if cmErr == nil {
-		return info, nil
+		return info.ApiserverURL, nil
 	}
 
 	endpoint, ok := KubeServiceHostEndpoint()
 	if !ok {
-		return nil, fmt.Errorf("cluster-info discovery failed (%w) and no external KUBERNETES_SERVICE_HOST FQDN is available", cmErr)
+		return "", fmt.Errorf("cluster-info discovery failed (%w) and no external KUBERNETES_SERVICE_HOST FQDN is available", cmErr)
 	}
 
-	caPEM, caErr := InClusterCA()
-	if caErr != nil {
-		return nil, fmt.Errorf("cluster-info discovery failed (%w); reading in-cluster CA for the KUBERNETES_SERVICE_HOST fallback: %w", cmErr, caErr)
-	}
-
-	return &ClusterInfo{ApiserverURL: endpoint, CACertPEM: caPEM}, nil
+	return endpoint, nil
 }
 
 // KubeServiceHostEndpoint builds the API server URL from the

--- a/internal/clusterinfo/clusterinfo_discover_test.go
+++ b/internal/clusterinfo/clusterinfo_discover_test.go
@@ -134,48 +134,46 @@ func TestInClusterCA(t *testing.T) {
 	})
 }
 
-func TestDiscover(t *testing.T) {
-	t.Run("cluster-info wins when present", func(t *testing.T) {
+func TestDiscoverURL(t *testing.T) {
+	t.Run("cluster-info URL wins when present", func(t *testing.T) {
 		client := fake.NewSimpleClientset(clusterInfoCM(map[string]string{"kubeconfig": validKubeconfig}))
 		// A usable FQDN fallback exists too; cluster-info must take precedence.
 		t.Setenv("KUBERNETES_SERVICE_HOST", "fallback.example.com")
 		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
 
-		info, err := Discover(context.Background(), client)
+		url, err := DiscoverURL(context.Background(), client)
 		if err != nil {
-			t.Fatalf("Discover: %v", err)
+			t.Fatalf("DiscoverURL: %v", err)
 		}
 
-		if info.ApiserverURL != "https://control-plane.example:6443" {
-			t.Fatalf("ApiserverURL = %q, want cluster-info value", info.ApiserverURL)
-		}
-
-		if string(info.CACertPEM) != "test-ca" {
-			t.Fatalf("CACertPEM = %q, want cluster-info CA", info.CACertPEM)
+		if url != "https://control-plane.example:6443" {
+			t.Fatalf("url = %q, want cluster-info value", url)
 		}
 	})
 
-	t.Run("falls back to FQDN + in-cluster CA when cluster-info absent", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "ca.crt")
-		if err := os.WriteFile(path, []byte("in-cluster-ca"), 0o600); err != nil {
-			t.Fatalf("write CA: %v", err)
-		}
-
-		withInClusterCAPath(t, path)
+	t.Run("falls back to FQDN when cluster-info absent", func(t *testing.T) {
 		t.Setenv("KUBERNETES_SERVICE_HOST", "my-aks.hcp.eastus.azmk8s.io")
 		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
 
-		info, err := Discover(context.Background(), fake.NewSimpleClientset())
+		url, err := DiscoverURL(context.Background(), fake.NewSimpleClientset())
 		if err != nil {
-			t.Fatalf("Discover: %v", err)
+			t.Fatalf("DiscoverURL: %v", err)
 		}
 
-		if info.ApiserverURL != "https://my-aks.hcp.eastus.azmk8s.io:443" {
-			t.Fatalf("ApiserverURL = %q, want FQDN fallback", info.ApiserverURL)
+		if url != "https://my-aks.hcp.eastus.azmk8s.io:443" {
+			t.Fatalf("url = %q, want FQDN fallback", url)
 		}
+	})
 
-		if string(info.CACertPEM) != "in-cluster-ca" {
-			t.Fatalf("CACertPEM = %q, want in-cluster CA", info.CACertPEM)
+	t.Run("succeeds without reading the in-cluster CA", func(t *testing.T) {
+		// The URL path must never touch the CA: an unreadable CA mount must not
+		// prevent endpoint resolution.
+		withInClusterCAPath(t, filepath.Join(t.TempDir(), "absent.crt"))
+		t.Setenv("KUBERNETES_SERVICE_HOST", "my-aks.hcp.eastus.azmk8s.io")
+		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+
+		if _, err := DiscoverURL(context.Background(), fake.NewSimpleClientset()); err != nil {
+			t.Fatalf("DiscoverURL: %v", err)
 		}
 	})
 
@@ -183,18 +181,8 @@ func TestDiscover(t *testing.T) {
 		t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
 		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
 
-		if _, err := Discover(context.Background(), fake.NewSimpleClientset()); err == nil {
-			t.Fatal("Discover: expected error, got nil")
-		}
-	})
-
-	t.Run("errors when FQDN available but in-cluster CA unreadable", func(t *testing.T) {
-		withInClusterCAPath(t, filepath.Join(t.TempDir(), "absent.crt"))
-		t.Setenv("KUBERNETES_SERVICE_HOST", "my-aks.hcp.eastus.azmk8s.io")
-		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
-
-		if _, err := Discover(context.Background(), fake.NewSimpleClientset()); err == nil {
-			t.Fatal("Discover: expected error, got nil")
+		if _, err := DiscoverURL(context.Background(), fake.NewSimpleClientset()); err == nil {
+			t.Fatal("DiscoverURL: expected error, got nil")
 		}
 	})
 }

--- a/internal/clusterinfo/clusterinfo_discover_test.go
+++ b/internal/clusterinfo/clusterinfo_discover_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package clusterinfo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubeServiceHostEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		host    string
+		portEnv map[string]string
+		want    string
+		wantOK  bool
+	}{
+		{
+			name:    "external FQDN with https port",
+			host:    "my-aks-dns-abcd1234.hcp.eastus.azmk8s.io",
+			portEnv: map[string]string{"KUBERNETES_SERVICE_PORT_HTTPS": "443"},
+			want:    "https://my-aks-dns-abcd1234.hcp.eastus.azmk8s.io:443",
+			wantOK:  true,
+		},
+		{
+			name:   "external FQDN defaults to 443 when no port env",
+			host:   "control-plane.example.com",
+			want:   "https://control-plane.example.com:443",
+			wantOK: true,
+		},
+		{
+			name:    "external FQDN falls back to KUBERNETES_SERVICE_PORT",
+			host:    "control-plane.example.com",
+			portEnv: map[string]string{"KUBERNETES_SERVICE_PORT": "6443"},
+			want:    "https://control-plane.example.com:6443",
+			wantOK:  true,
+		},
+		{
+			name:   "empty host rejected",
+			host:   "",
+			wantOK: false,
+		},
+		{
+			name:   "IPv4 ClusterIP rejected",
+			host:   "10.0.0.1",
+			wantOK: false,
+		},
+		{
+			name:   "IPv6 ClusterIP rejected",
+			host:   "fd00::1",
+			wantOK: false,
+		},
+		{
+			name:   "in-cluster service DNS rejected",
+			host:   "kubernetes.default.svc",
+			wantOK: false,
+		},
+		{
+			name:   "in-cluster service FQDN rejected",
+			host:   "kubernetes.default.svc.cluster.local",
+			wantOK: false,
+		},
+		{
+			name:   "bare kubernetes rejected",
+			host:   "kubernetes",
+			wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear the port envs by default; set per-case below.
+			t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "")
+			t.Setenv("KUBERNETES_SERVICE_PORT", "")
+			t.Setenv("KUBERNETES_SERVICE_HOST", tc.host)
+
+			for k, v := range tc.portEnv {
+				t.Setenv(k, v)
+			}
+
+			got, ok := KubeServiceHostEndpoint()
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (got %q)", ok, tc.wantOK, got)
+			}
+
+			if ok && got != tc.want {
+				t.Fatalf("endpoint = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInClusterCA(t *testing.T) {
+	t.Run("reads mounted CA", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "ca.crt")
+		if err := os.WriteFile(path, []byte("test-ca"), 0o600); err != nil {
+			t.Fatalf("write CA: %v", err)
+		}
+
+		withInClusterCAPath(t, path)
+
+		got, err := InClusterCA()
+		if err != nil {
+			t.Fatalf("InClusterCA: %v", err)
+		}
+
+		if string(got) != "test-ca" {
+			t.Fatalf("CA = %q, want test-ca", got)
+		}
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		withInClusterCAPath(t, filepath.Join(t.TempDir(), "absent.crt"))
+
+		if _, err := InClusterCA(); err == nil {
+			t.Fatal("InClusterCA: expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("empty file errors", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.crt")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatalf("write CA: %v", err)
+		}
+
+		withInClusterCAPath(t, path)
+
+		if _, err := InClusterCA(); err == nil {
+			t.Fatal("InClusterCA: expected error for empty file, got nil")
+		}
+	})
+}
+
+func TestDiscover(t *testing.T) {
+	t.Run("cluster-info wins when present", func(t *testing.T) {
+		client := fake.NewSimpleClientset(clusterInfoCM(map[string]string{"kubeconfig": validKubeconfig}))
+		// A usable FQDN fallback exists too; cluster-info must take precedence.
+		t.Setenv("KUBERNETES_SERVICE_HOST", "fallback.example.com")
+		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+
+		info, err := Discover(context.Background(), client)
+		if err != nil {
+			t.Fatalf("Discover: %v", err)
+		}
+
+		if info.ApiserverURL != "https://control-plane.example:6443" {
+			t.Fatalf("ApiserverURL = %q, want cluster-info value", info.ApiserverURL)
+		}
+
+		if string(info.CACertPEM) != "test-ca" {
+			t.Fatalf("CACertPEM = %q, want cluster-info CA", info.CACertPEM)
+		}
+	})
+
+	t.Run("falls back to FQDN + in-cluster CA when cluster-info absent", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "ca.crt")
+		if err := os.WriteFile(path, []byte("in-cluster-ca"), 0o600); err != nil {
+			t.Fatalf("write CA: %v", err)
+		}
+
+		withInClusterCAPath(t, path)
+		t.Setenv("KUBERNETES_SERVICE_HOST", "my-aks.hcp.eastus.azmk8s.io")
+		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+
+		info, err := Discover(context.Background(), fake.NewSimpleClientset())
+		if err != nil {
+			t.Fatalf("Discover: %v", err)
+		}
+
+		if info.ApiserverURL != "https://my-aks.hcp.eastus.azmk8s.io:443" {
+			t.Fatalf("ApiserverURL = %q, want FQDN fallback", info.ApiserverURL)
+		}
+
+		if string(info.CACertPEM) != "in-cluster-ca" {
+			t.Fatalf("CACertPEM = %q, want in-cluster CA", info.CACertPEM)
+		}
+	})
+
+	t.Run("errors when cluster-info absent and host is a ClusterIP", func(t *testing.T) {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+
+		if _, err := Discover(context.Background(), fake.NewSimpleClientset()); err == nil {
+			t.Fatal("Discover: expected error, got nil")
+		}
+	})
+
+	t.Run("errors when FQDN available but in-cluster CA unreadable", func(t *testing.T) {
+		withInClusterCAPath(t, filepath.Join(t.TempDir(), "absent.crt"))
+		t.Setenv("KUBERNETES_SERVICE_HOST", "my-aks.hcp.eastus.azmk8s.io")
+		t.Setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+
+		if _, err := Discover(context.Background(), fake.NewSimpleClientset()); err == nil {
+			t.Fatal("Discover: expected error, got nil")
+		}
+	})
+}
+
+// withInClusterCAPath points the package-level CA path at a fixture for the
+// duration of the test and restores it afterwards.
+func withInClusterCAPath(t *testing.T, path string) {
+	t.Helper()
+
+	previous := inClusterCAPath
+	inClusterCAPath = path
+
+	t.Cleanup(func() { inClusterCAPath = previous })
+}

--- a/internal/metalman/commands/cluster_config.go
+++ b/internal/metalman/commands/cluster_config.go
@@ -33,12 +33,23 @@ const (
 	apiserverURLOverrideEnv = "METALMAN_APISERVER_URL"
 )
 
+// clusterInfoPollInterval is how often the watcher re-resolves the API server
+// URL and CA regardless of ConfigMap events, so refresh cadence is identical on
+// every provider (including AKS, which publishes no cluster-info to watch).
+const clusterInfoPollInterval = 5 * time.Minute
+
 // ClusterInfoWatcher watches the cluster-info ConfigMap in the kube-public
 // namespace and provides up-to-date API server URL and CA certificate to
 // the FileResolver through the ClusterInfoProvider interface.
 //
-// It uses a shared informer so that changes at runtime (e.g. API server
-// URL rotation) are picked up automatically.
+// It combines an informer for prompt pickup where cluster-info is published
+// with a periodic re-resolve (clusterInfoPollInterval) as a provider-agnostic
+// floor: clusters that do not publish cluster-info (e.g. AKS) deliver no
+// ConfigMap event, and in-cluster service-account CA rotation is a file change
+// the ConfigMap informer cannot observe, so the poll keeps the CA current on
+// every cluster. When the operator injects METALMAN_APISERVER_URL the served
+// URL is pinned to that value and only the CA is refreshed; without an override
+// the cluster-info URL is refreshed too.
 type ClusterInfoWatcher struct {
 	clientset            kubernetes.Interface
 	log                  *slog.Logger
@@ -96,13 +107,15 @@ func (w *ClusterInfoWatcher) ClusterInfo() netboot.ClusterInfo {
 	return w.info
 }
 
-// Start implements manager.Runnable. It sets up an informer for the
-// cluster-info ConfigMap in kube-public and re-resolves the API server
-// URL and CA certificate whenever that ConfigMap changes.
+// Start implements manager.Runnable. It watches the cluster-info ConfigMap in
+// kube-public for prompt updates and, on a fixed interval, re-resolves the API
+// server URL and CA certificate regardless of provider.
 func (w *ClusterInfoWatcher) Start(ctx context.Context) error {
-	// Watch ConfigMaps in kube-public (for cluster-info).
+	// Watch ConfigMaps in kube-public (for cluster-info). Resync is disabled
+	// (period 0) so the periodic re-resolve below is the single owner of
+	// interval-based refresh; the informer fires only on real Add/Update events.
 	pubFactory := informers.NewSharedInformerFactoryWithOptions(
-		w.clientset, 5*time.Minute,
+		w.clientset, 0,
 		informers.WithNamespace(metav1.NamespacePublic),
 	)
 
@@ -117,10 +130,24 @@ func (w *ClusterInfoWatcher) Start(ctx context.Context) error {
 	pubFactory.Start(ctx.Done())
 	pubFactory.WaitForCacheSync(ctx.Done())
 
-	w.log.Info("cluster-info watcher started")
-	<-ctx.Done()
+	// Periodic re-resolve as a provider-agnostic floor. Clusters that do not
+	// publish cluster-info (e.g. AKS) never deliver a ConfigMap event, and CA
+	// rotation on the in-cluster service-account mount is a file change the
+	// ConfigMap informer cannot observe; the ticker keeps both current on every
+	// cluster within clusterInfoPollInterval.
+	ticker := time.NewTicker(clusterInfoPollInterval)
+	defer ticker.Stop()
 
-	return nil
+	w.log.Info("cluster-info watcher started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			w.refreshQuiet(ctx)
+		}
+	}
 }
 
 // refresh re-resolves the cluster-info from the Kubernetes API.
@@ -137,7 +164,9 @@ func (w *ClusterInfoWatcher) refresh(ctx context.Context) error {
 	)
 
 	if resolved, err := clusterinfo.Resolve(ctx, w.clientset); err != nil {
-		w.log.Info("cluster-info unavailable; relying on overrides and the in-cluster CA", "error", err)
+		// Debug, not Info: on clusters without cluster-info (e.g. AKS) this is
+		// the steady state and the periodic poll would otherwise log it forever.
+		w.log.Debug("cluster-info unavailable; relying on overrides and the in-cluster CA", "error", err)
 	} else {
 		apiserverURL = resolved.ApiserverURL
 		caPEM = resolved.CACertPEM

--- a/internal/metalman/commands/cluster_config.go
+++ b/internal/metalman/commands/cluster_config.go
@@ -24,9 +24,12 @@ import (
 const (
 	// apiserverURLOverrideEnv, when set, overrides the API server URL
 	// discovered from the cluster-info ConfigMap in kube-public. The CA
-	// certificate is still read from the ConfigMap. This is useful in
-	// test environments (e.g. kind) where the ConfigMap contains a
-	// hostname that is unreachable from provisioned nodes.
+	// certificate comes from the ConfigMap when available, otherwise from the
+	// in-cluster service-account mount. The operator injects this with the
+	// endpoint it resolved; it is also useful in test environments (e.g. kind)
+	// where the ConfigMap contains a hostname unreachable from provisioned
+	// nodes, and on managed control planes (e.g. AKS) that do not publish
+	// cluster-info at all.
 	apiserverURLOverrideEnv = "METALMAN_APISERVER_URL"
 )
 
@@ -41,6 +44,11 @@ type ClusterInfoWatcher struct {
 	log                  *slog.Logger
 	apiserverURLOverride string
 
+	// inClusterCA reads the fallback CA when cluster-info is unavailable. It is
+	// a field so tests can inject a fixture; it defaults to
+	// clusterinfo.InClusterCA.
+	inClusterCA func() ([]byte, error)
+
 	mu   sync.RWMutex
 	info netboot.ClusterInfo
 }
@@ -51,8 +59,9 @@ type ClusterInfoWatcher struct {
 // before the first template render.
 //
 // If the METALMAN_APISERVER_URL environment variable is set, its value
-// overrides the API server URL from the ConfigMap on every refresh. The
-// CA certificate is always read from the ConfigMap.
+// overrides the API server URL from the ConfigMap on every refresh. When
+// cluster-info is unavailable (e.g. AKS), the API server URL comes from that
+// override and the CA from the in-cluster service-account mount.
 func NewClusterInfoWatcher(
 	ctx context.Context,
 	clientset kubernetes.Interface,
@@ -62,6 +71,7 @@ func NewClusterInfoWatcher(
 		clientset:            clientset,
 		log:                  log,
 		apiserverURLOverride: os.Getenv(apiserverURLOverrideEnv),
+		inClusterCA:          clusterinfo.InClusterCA,
 	}
 
 	if w.apiserverURLOverride != "" {
@@ -114,20 +124,50 @@ func (w *ClusterInfoWatcher) Start(ctx context.Context) error {
 }
 
 // refresh re-resolves the cluster-info from the Kubernetes API.
+//
+// The API server URL comes from the METALMAN_APISERVER_URL override when set
+// (the operator injects the endpoint it resolved), otherwise from
+// kube-public/cluster-info. The CA comes from cluster-info when available and
+// otherwise from the in-cluster service-account mount, so metalman still works
+// on managed control planes (e.g. AKS) that do not publish cluster-info.
 func (w *ClusterInfoWatcher) refresh(ctx context.Context) error {
-	resolved, err := clusterinfo.Resolve(ctx, w.clientset)
-	if err != nil {
-		return fmt.Errorf("resolving cluster info: %w", err)
+	var (
+		apiserverURL string
+		caPEM        []byte
+	)
+
+	if resolved, err := clusterinfo.Resolve(ctx, w.clientset); err != nil {
+		w.log.Info("cluster-info unavailable; relying on overrides and the in-cluster CA", "error", err)
+	} else {
+		apiserverURL = resolved.ApiserverURL
+		caPEM = resolved.CACertPEM
 	}
 
-	apiserverURL := resolved.ApiserverURL
 	if w.apiserverURLOverride != "" {
 		apiserverURL = w.apiserverURLOverride
 	}
 
+	if len(caPEM) == 0 {
+		readCA := w.inClusterCA
+		if readCA == nil {
+			readCA = clusterinfo.InClusterCA
+		}
+
+		ca, err := readCA()
+		if err != nil {
+			return fmt.Errorf("no CA available: cluster-info absent and reading the in-cluster CA failed: %w", err)
+		}
+
+		caPEM = ca
+	}
+
+	if apiserverURL == "" {
+		return fmt.Errorf("no API server URL available: set %s or publish kube-public/cluster-info", apiserverURLOverrideEnv)
+	}
+
 	info := netboot.ClusterInfo{
 		ApiserverURL: apiserverURL,
-		CACertBase64: base64.StdEncoding.EncodeToString(resolved.CACertPEM),
+		CACertBase64: base64.StdEncoding.EncodeToString(caPEM),
 	}
 
 	w.mu.Lock()

--- a/internal/metalman/commands/cluster_config_test.go
+++ b/internal/metalman/commands/cluster_config_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package commands
+
+import (
+	"context"
+	"encoding/base64"
+	"log/slog"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const testClusterInfoKubeconfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Y2x1c3Rlci1pbmZvLWNh
+    server: https://control-plane.example:6443
+  name: ""
+kind: Config
+`
+
+func clusterInfoConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespacePublic, Name: "cluster-info"},
+		Data:       map[string]string{"kubeconfig": testClusterInfoKubeconfig},
+	}
+}
+
+func newTestWatcher(clientset *fake.Clientset, override string, caReader func() ([]byte, error)) *ClusterInfoWatcher {
+	return &ClusterInfoWatcher{
+		clientset:            clientset,
+		log:                  slog.Default(),
+		apiserverURLOverride: override,
+		inClusterCA:          caReader,
+	}
+}
+
+func failCAReader(t *testing.T) func() ([]byte, error) {
+	t.Helper()
+
+	return func() ([]byte, error) {
+		t.Fatal("in-cluster CA reader should not be called when cluster-info supplies a CA")
+		return nil, nil
+	}
+}
+
+func TestClusterInfoWatcherRefresh(t *testing.T) {
+	t.Run("uses cluster-info URL and CA", func(t *testing.T) {
+		w := newTestWatcher(fake.NewSimpleClientset(clusterInfoConfigMap()), "", failCAReader(t))
+
+		if err := w.refresh(context.Background()); err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+
+		info := w.ClusterInfo()
+		if info.ApiserverURL != "https://control-plane.example:6443" {
+			t.Fatalf("ApiserverURL = %q, want cluster-info value", info.ApiserverURL)
+		}
+
+		if decodeCA(t, info.CACertBase64) != "cluster-info-ca" {
+			t.Fatalf("CA = %q, want cluster-info-ca", decodeCA(t, info.CACertBase64))
+		}
+	})
+
+	t.Run("override URL wins, cluster-info CA retained", func(t *testing.T) {
+		w := newTestWatcher(fake.NewSimpleClientset(clusterInfoConfigMap()), "https://override.example:6443", failCAReader(t))
+
+		if err := w.refresh(context.Background()); err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+
+		info := w.ClusterInfo()
+		if info.ApiserverURL != "https://override.example:6443" {
+			t.Fatalf("ApiserverURL = %q, want override", info.ApiserverURL)
+		}
+
+		if decodeCA(t, info.CACertBase64) != "cluster-info-ca" {
+			t.Fatalf("CA = %q, want cluster-info-ca", decodeCA(t, info.CACertBase64))
+		}
+	})
+
+	t.Run("AKS: no cluster-info, override URL + in-cluster CA", func(t *testing.T) {
+		w := newTestWatcher(fake.NewSimpleClientset(), "https://my-aks.hcp.eastus.azmk8s.io:443",
+			func() ([]byte, error) { return []byte("in-cluster-ca"), nil })
+
+		if err := w.refresh(context.Background()); err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+
+		info := w.ClusterInfo()
+		if info.ApiserverURL != "https://my-aks.hcp.eastus.azmk8s.io:443" {
+			t.Fatalf("ApiserverURL = %q, want override", info.ApiserverURL)
+		}
+
+		if decodeCA(t, info.CACertBase64) != "in-cluster-ca" {
+			t.Fatalf("CA = %q, want in-cluster-ca", decodeCA(t, info.CACertBase64))
+		}
+	})
+
+	t.Run("errors when no URL is available", func(t *testing.T) {
+		w := newTestWatcher(fake.NewSimpleClientset(), "",
+			func() ([]byte, error) { return []byte("in-cluster-ca"), nil })
+
+		if err := w.refresh(context.Background()); err == nil {
+			t.Fatal("refresh: expected error when no URL is available")
+		}
+	})
+
+	t.Run("errors when no CA is available", func(t *testing.T) {
+		w := newTestWatcher(fake.NewSimpleClientset(), "https://my-aks.hcp.eastus.azmk8s.io:443",
+			func() ([]byte, error) { return nil, context.DeadlineExceeded })
+
+		if err := w.refresh(context.Background()); err == nil {
+			t.Fatal("refresh: expected error when no CA is available")
+		}
+	})
+}
+
+func decodeCA(t *testing.T, encoded string) string {
+	t.Helper()
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode CA: %v", err)
+	}
+
+	return string(raw)
+}

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -1265,6 +1265,26 @@ func metalmanDeployment(site *unboundedv1alpha3.Site, namespace string, cfg Conf
 		args = append(args, "--dhcp-auto-interface")
 	}
 
+	env := []corev1.EnvVar{{
+		// Metalman resolves its leader-election lease namespace from
+		// POD_NAMESPACE so the lease and its namespace-scoped RBAC stay
+		// co-located with the Deployment under any install namespace.
+		Name: "POD_NAMESPACE",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+		},
+	}}
+
+	// Advertise the operator-resolved API server endpoint to metalman so the
+	// kubeconfig it serves to provisioning nodes matches what machina writes,
+	// and so metalman does not need to rediscover it (managed control planes
+	// such as AKS do not publish kube-public/cluster-info). Metalman still
+	// sources the CA from the in-cluster service-account mount when cluster-info
+	// is unavailable.
+	if cfg.APIServerEndpoint != "" {
+		env = append(env, corev1.EnvVar{Name: "METALMAN_APISERVER_URL", Value: cfg.APIServerEndpoint})
+	}
+
 	// metalman is hostNetwork and binds host ports (DHCP/TFTP/HTTP), so a surge
 	// pod cannot start while the old pod holds them on the same node. Terminate
 	// the old pod before creating the new one to avoid a rollout deadlock.
@@ -1303,16 +1323,7 @@ func metalmanDeployment(site *unboundedv1alpha3.Site, namespace string, cfg Conf
 						Image:           image,
 						ImagePullPolicy: corev1.PullAlways,
 						Args:            args,
-						Env: []corev1.EnvVar{{
-							// Metalman resolves its leader-election lease
-							// namespace from POD_NAMESPACE so the lease and its
-							// namespace-scoped RBAC stay co-located with the
-							// Deployment under any install namespace.
-							Name: "POD_NAMESPACE",
-							ValueFrom: &corev1.EnvVarSource{
-								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
-							},
-						}},
+						Env:             env,
 						Ports: []corev1.ContainerPort{
 							{Name: "http", ContainerPort: 8880, Protocol: corev1.ProtocolTCP},
 							{Name: "health", ContainerPort: 8081, Protocol: corev1.ProtocolTCP},

--- a/internal/operator/reconciler_test.go
+++ b/internal/operator/reconciler_test.go
@@ -885,7 +885,7 @@ func TestMetalmanDeployment(t *testing.T) {
 		}}},
 	}
 
-	deployment := metalmanDeployment(site, DefaultNamespace, Config{MetalmanImage: "example/metalman:default"})
+	deployment := metalmanDeployment(site, DefaultNamespace, Config{MetalmanImage: "example/metalman:default", APIServerEndpoint: "https://api.example:6443"})
 	if deployment.Name != "metalman-controller-rack-a" {
 		t.Fatalf("name = %q", deployment.Name)
 	}
@@ -901,6 +901,19 @@ func TestMetalmanDeployment(t *testing.T) {
 
 	if got := container.Args; len(got) != 3 || got[0] != "serve-pxe" || got[1] != "--site=rack-a" || got[2] != "--dhcp-auto-interface" {
 		t.Fatalf("args = %#v", got)
+	}
+
+	// POD_NAMESPACE is sourced from the Downward API so the lease/RBAC stay
+	// co-located with the Deployment under any install namespace.
+	podNS := findEnv(container.Env, "POD_NAMESPACE")
+	if podNS == nil || podNS.ValueFrom == nil || podNS.ValueFrom.FieldRef == nil ||
+		podNS.ValueFrom.FieldRef.FieldPath != "metadata.namespace" {
+		t.Fatalf("POD_NAMESPACE env = %#v, want Downward API metadata.namespace", podNS)
+	}
+
+	// The operator-resolved endpoint is handed to metalman as METALMAN_APISERVER_URL.
+	if got := findEnv(container.Env, "METALMAN_APISERVER_URL"); got == nil || got.Value != "https://api.example:6443" {
+		t.Fatalf("METALMAN_APISERVER_URL env = %#v, want https://api.example:6443", got)
 	}
 
 	assertSiteOwnerRef(t, deployment.OwnerReferences, "rack-a", "site-uid")
@@ -935,6 +948,33 @@ func TestMetalmanDeploymentRespectsNamespace(t *testing.T) {
 	if deployment.Namespace != "custom-ns" {
 		t.Fatalf("namespace = %q, want custom-ns", deployment.Namespace)
 	}
+}
+
+func TestMetalmanDeploymentOmitsEmptyAPIServerURL(t *testing.T) {
+	enabled := true
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
+		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
+			SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
+		}}},
+	}
+
+	deployment := metalmanDeployment(site, DefaultNamespace, Config{MetalmanImage: "example/metalman:default"})
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	if got := findEnv(container.Env, "METALMAN_APISERVER_URL"); got != nil {
+		t.Fatalf("METALMAN_APISERVER_URL env = %#v, want unset when APIServerEndpoint is empty", got)
+	}
+}
+
+func findEnv(env []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range env {
+		if env[i].Name == name {
+			return &env[i]
+		}
+	}
+
+	return nil
 }
 
 func TestReconcilerNamespaceFallsBackToDefault(t *testing.T) {


### PR DESCRIPTION
## Summary

Lets the operator auto-discover the API server endpoint on managed control planes that do not publish `kube-public/cluster-info` (notably AKS), and unblocks metalman's CA on those clusters. Previously such clusters required `--api-server-endpoint` to be set explicitly, and metalman could not obtain a CA at all.

## Problem

The operator advertises an external API server endpoint to provisioned machines so they can join the control plane. Two components need it independently: the operator writes it into the `machina-config` ConfigMap that the machina controller reads, and metalman embeds the API server URL (and CA) in the node bootstrap kubeconfig it serves. Both derived it from the standard `kube-public/cluster-info` ConfigMap. AKS does not publish that ConfigMap, so:

- the operator failed hard unless `--api-server-endpoint` was passed, and
- metalman had no source for the **CA** it embeds in the kubeconfig it serves, so the remote-node join path was broken even when an endpoint was supplied.

## Changes

**Operator endpoint resolution** (`override -> cluster-info -> KUBERNETES_SERVICE_HOST FQDN -> fail hard`)
- The operator pod now carries `kubernetes.azure.com/set-kube-service-host-fqdn: "true"` (matching machina/net/machine-ops/playpen), which makes `KUBERNETES_SERVICE_HOST` the public API FQDN on AKS and is inert elsewhere.
- The env fallback is **guarded**: only accepted when the value is an external FQDN, never an in-cluster ClusterIP or the `kubernetes.default.svc` DNS name. Without cluster-info and without an FQDN env the operator keeps failing hard with an actionable error rather than advertising an unreachable endpoint.
- The operator resolves a **URL only** (`clusterinfo.DiscoverURL`); it never reads the in-cluster CA it would otherwise discard, so an unreadable CA mount does not break endpoint resolution on the FQDN path.
- Shared logic in `internal/clusterinfo`: `DiscoverURL`, `KubeServiceHostEndpoint`, `InClusterCA`.

**Metalman CA + refresh**
- The operator injects `METALMAN_APISERVER_URL` with the endpoint it already resolved, so metalman advertises the operator-resolved endpoint (the same value written into `machina-config`) instead of re-discovering it from cluster-info.
- `ClusterInfoWatcher` makes cluster-info best-effort: URL from the override (or cluster-info), CA from cluster-info when available and otherwise from the in-cluster service-account mount, whose cluster CA signs the API server serving cert (including the AKS FQDN SAN).
- Refresh cadence is now **provider-agnostic**: the cluster-info informer (prompt pickup where published) is backed by a periodic re-resolve (5m). Clusters without cluster-info (AKS) deliver no ConfigMap event, and SA-mount CA rotation is a file change the informer cannot observe; the poll keeps the CA (and, without an override, the URL) current on every cluster.

## Resolution precedence

| Source | Operator endpoint | Metalman URL | Metalman CA |
|---|---|---|---|
| explicit override | `--api-server-endpoint` / `$UNBOUNDED_API_SERVER_ENDPOINT` | `METALMAN_APISERVER_URL` (operator-injected) | - |
| cluster-info | yes | yes | yes |
| KUBERNETES_SERVICE_HOST FQDN | yes (guarded) | via injected override | - |
| in-cluster SA mount | - | - | yes |

## Reviewer notes

- The FQDN guard (`KubeServiceHostEndpoint`) is the safety-critical bit: `internal/clusterinfo/clusterinfo.go` + table tests in `clusterinfo_discover_test.go`.
- Operator resolution is URL-only (`DiscoverURL`); the CA-inclusive variant was removed as it had no remaining caller.
- The label is only needed on the **operator** pod (its own tier-3 resolution). Metalman receives the URL via the injected env and the CA from the SA mount, so it needs neither the label nor its own env fallback.
