### PR TITLE
metalman: don't fail operation when boot image is downloading

### DIFF
--- a/internal/metalman/machineops/controller.go
+++ b/internal/metalman/machineops/controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/metalman/netboot"
 	"github.com/Azure/unbounded/internal/metalman/redfish"
 )
 
@@ -716,6 +717,12 @@ func (r *Reconciler) waitForRepaveBoot(ctx context.Context, machine *v1alpha3.Ma
 
 	if machine.Spec.PXE.TargetBootProtocol() == v1alpha3.PXEBootProtocolHTTP {
 		if _, _, err := r.httpBootConfig(machine); err != nil {
+			if errors.Is(err, netboot.ErrNotYetDownloaded) {
+				target.Message = "waiting for OCI image to become available"
+
+				return targetChange{target: target}
+			}
+
 			return retryTarget(target, err, now, r.maxAttempts())
 		}
 	}

--- a/internal/metalman/machineops/controller_test.go
+++ b/internal/metalman/machineops/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/metalman/netboot"
 	"github.com/Azure/unbounded/internal/metalman/redfish"
 )
 
@@ -630,6 +631,56 @@ func TestReconcilerRetriesHTTPHostReplaceWithoutStaticLease(t *testing.T) {
 	require.Equal(t, v1alpha3.OperationPhaseInProgress, updated.Status.Targets[0].Phase)
 	require.Equal(t, "HTTP boot requires at least one static lease in spec.pxe.dhcpLeases", updated.Status.Targets[0].Message)
 	require.Empty(t, power.calls)
+}
+
+func TestReconcilerWaitsForHTTPBootImage(t *testing.T) {
+	t.Parallel()
+
+	s := testScheme(t)
+	machine := testBareMetalMachine("machine-1", "rack-a")
+	machine.Spec.PXE.BootProtocol = v1alpha3.PXEBootProtocolHTTP
+	machine.Spec.PXE.DHCPLeases = []v1alpha3.DHCPLease{httpBootLease()}
+	op := testOperation("op-replace-http-wait-image", v1alpha3.OperationHostReplace)
+	op.Spec.MachineRef = machine.Name
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine, op, testRedfishSecret()).WithStatusSubresource(op, machine).Build()
+	power := &recordingPowerClient{}
+	reconciler := testReconciler(c, power, "rack-a")
+	imageAvailable := false
+	reconciler.HTTPBootURL = func(m *v1alpha3.Machine) (string, error) {
+		require.Equal(t, machine.Name, m.Name)
+
+		if !imageAvailable {
+			return "", fmt.Errorf("resolve HTTP boot image: %w", netboot.ErrNotYetDownloaded)
+		}
+
+		return "http://10.0.0.10:8880/http/shimx64.efi", nil
+	}
+
+	for range reconciler.MaxAttempts + 1 {
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+		require.NoError(t, err)
+	}
+
+	var waiting v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &waiting))
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, waiting.Status.Phase)
+	require.Equal(t, v1alpha3.OperationPhaseInProgress, waiting.Status.Targets[0].Phase)
+	require.Zero(t, waiting.Status.Targets[0].Attempts)
+	require.Equal(t, "waiting for OCI image to become available", waiting.Status.Targets[0].Message)
+	require.Empty(t, power.calls)
+
+	imageAvailable = true
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: op.Name}})
+	require.NoError(t, err)
+
+	var resumed v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: op.Name}, &resumed))
+	require.Equal(t, v1alpha3.OperationStageWaitingRepave, resumed.Status.Targets[0].Stage)
+	require.Equal(t, int32(1), resumed.Status.Targets[0].Attempts)
+	require.NotEmpty(t, power.calls)
 }
 
 func TestReconcilerRestoresMissingHostReplaceTriggerConditions(t *testing.T) {

--- a/internal/metalman/netboot/netboot_test.go
+++ b/internal/metalman/netboot/netboot_test.go
@@ -2652,6 +2652,13 @@ func TestResolveFile_NotYetDownloaded(t *testing.T) {
 	}
 }
 
+func TestMetadataForRefArchitecture_NotYetDownloaded(t *testing.T) {
+	cache := NewOCICache(t.TempDir())
+
+	_, err := cache.MetadataForRefArchitecture("ghcr.io/test/missing:v1", "amd64")
+	require.ErrorIs(t, err, ErrNotYetDownloaded)
+}
+
 func TestHTTPServer_DisablePXE(t *testing.T) {
 	node := &v1alpha3.Machine{
 		ObjectMeta: metav1.ObjectMeta{Name: "pxe-node"},

--- a/internal/metalman/netboot/oci_cache.go
+++ b/internal/metalman/netboot/oci_cache.go
@@ -168,7 +168,7 @@ func (c *OCICache) MetadataForRef(imageRef string) (*ImageMetadata, error) {
 func (c *OCICache) MetadataForRefArchitecture(imageRef, architecture string) (*ImageMetadata, error) {
 	digest := c.DigestForArchitecture(imageRef, architecture)
 	if digest == "" {
-		return nil, fmt.Errorf("image %q for architecture %q not yet pulled", imageRef, normalizeArchitecture(architecture))
+		return nil, fmt.Errorf("%w: image %q for architecture %q not yet pulled", ErrNotYetDownloaded, imageRef, normalizeArchitecture(architecture))
 	}
 
 	return c.MetadataForArchitecture(digest, architecture)


### PR DESCRIPTION
Previously the MachineOperation would terminally fail if the metalman controller hadn't yet downloaded the boot image(s).