### PR TITLE
[unbounded-system] harden released-cluster migration and install

### DIFF
--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -191,7 +191,16 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 		return nil
 	}
 
-	rewriteNamespace(obj, unbounded.SystemNamespace(), h.namespace)
+	// Retarget the build-time namespace baked into the rendered operator
+	// manifests to the install namespace. The rewrite source MUST be the
+	// build-time literal (DefaultSystemNamespace), not SystemNamespace(): the
+	// latter reflects this process's own POD_NAMESPACE, so when POD_NAMESPACE is
+	// set (an in-cluster installer) or the default namespace is used, the "from"
+	// value would no longer match the baked "unbounded-system" and cluster-scoped
+	// references that only rewriteNamespace can fix (for example the
+	// ClusterRoleBinding subject namespace) would be left pointing at the wrong
+	// namespace, leaving the operator with no RBAC.
+	rewriteNamespace(obj, unbounded.DefaultSystemNamespace, h.namespace)
 	setNamespace(obj, h.namespace)
 
 	// The api-server-endpoint is delivered to the operator via the

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -402,6 +402,46 @@ func TestMutateOperatorObjectRetargetsNamespace(t *testing.T) {
 	require.Contains(t, args, "--leader-elect-namespace=custom-system")
 }
 
+// TestMutateOperatorObjectRetargetsClusterRoleBindingSubjectWithPodNamespaceSet
+// guards against a regression where the namespace rewrite source was
+// SystemNamespace() instead of the build-time literal. A ClusterRoleBinding is
+// cluster-scoped, so its subject namespace can only be corrected by
+// rewriteNamespace (setNamespace never touches it). When POD_NAMESPACE is set
+// (an in-cluster installer) the old source no longer matched the baked
+// "unbounded-system", so the subject was left pointing at the wrong namespace
+// and the operator ServiceAccount got no ClusterRole grant.
+func TestMutateOperatorObjectRetargetsClusterRoleBindingSubjectWithPodNamespaceSet(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "installer-ns")
+
+	h := &installHandler{namespace: "custom-system"}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]any{"name": "unbounded-operator"},
+		"roleRef": map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "ClusterRole",
+			"name":     "unbounded-operator",
+		},
+		"subjects": []any{map[string]any{
+			"kind":      "ServiceAccount",
+			"name":      "unbounded-operator",
+			"namespace": "unbounded-system",
+		}},
+	}}
+
+	require.NoError(t, h.mutateOperatorObject(obj))
+
+	subjects, _, err := unstructured.NestedSlice(obj.Object, "subjects")
+	require.NoError(t, err)
+	require.Len(t, subjects, 1)
+
+	ns, _, err := unstructured.NestedString(subjects[0].(map[string]any), "namespace")
+	require.NoError(t, err)
+	require.Equal(t, "custom-system", ns, "ClusterRoleBinding subject namespace must be retargeted even when POD_NAMESPACE is set")
+}
+
 func TestCRDEstablished(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/net/controller/02-rbac.yaml.tmpl
+++ b/deploy/net/controller/02-rbac.yaml.tmpl
@@ -34,6 +34,14 @@ rules:
   - apiGroups: ["unbounded-cloud.io"]
     resources: ["sites/status"]
     verbs: ["get", "patch", "update"]
+  # Legacy net-group Sites: read-only, used only by SiteNodeSlice orphan cleanup
+  # during the unbounded-system migration window to distinguish a Site that has
+  # not been translated into the machina group yet (still present here) from one
+  # that is genuinely gone. Can be removed once legacy net-group Sites are fully
+  # retired.
+  - apiGroups: ["net.unbounded-cloud.io"]
+    resources: ["sites"]
+    verbs: ["get", "list", "watch"]
   # GatewayPools: read access and finalizer management for controllers
   - apiGroups: ["net.unbounded-cloud.io"]
     resources: ["gatewaypools"]

--- a/e2e/operator/reaper_e2e_test.go
+++ b/e2e/operator/reaper_e2e_test.go
@@ -1030,6 +1030,9 @@ func stageRestrictedSiteControllerIdentity(ctx context.Context, t *testing.T, ku
 			{APIGroups: []string{""}, Resources: []string{"nodes"}, Verbs: []string{"get", "list", "watch", "patch", "update"}},
 			{APIGroups: []string{"unbounded-cloud.io"}, Resources: []string{"sites"}, Verbs: []string{"get", "list", "watch", "update", "patch"}},
 			{APIGroups: []string{"unbounded-cloud.io"}, Resources: []string{"sites/status"}, Verbs: []string{"get", "patch", "update"}},
+			// Legacy net-group Sites: read-only, for the SiteNodeSlice orphan
+			// cleanup migration-window check (mirrors the production net RBAC).
+			{APIGroups: []string{"net.unbounded-cloud.io"}, Resources: []string{"sites"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"net.unbounded-cloud.io"}, Resources: []string{"gatewaypools"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"net.unbounded-cloud.io"}, Resources: []string{"sitenodeslices"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
 		},

--- a/e2e/operator/reaper_e2e_test.go
+++ b/e2e/operator/reaper_e2e_test.go
@@ -972,19 +972,25 @@ func configMapHash(config *corev1.ConfigMap) string {
 func createCluster(t *testing.T) string {
 	t.Helper()
 
+	return createClusterNamed(t, clusterName)
+}
+
+func createClusterNamed(t *testing.T, name string) string {
+	t.Helper()
+
 	kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
 
-	if err := run(context.Background(), "kind", "create", "cluster", "--name", clusterName, "--wait", "120s", "--kubeconfig", kubeconfig); err != nil {
+	if err := run(context.Background(), "kind", "create", "cluster", "--name", name, "--wait", "120s", "--kubeconfig", kubeconfig); err != nil {
 		t.Fatalf("kind create cluster: %v", err)
 	}
 
 	t.Cleanup(func() {
 		if os.Getenv("E2E_KEEP") == "1" {
-			t.Logf("E2E_KEEP=1; leaving kind cluster %q", clusterName)
+			t.Logf("E2E_KEEP=1; leaving kind cluster %q", name)
 			return
 		}
 
-		_ = run(context.Background(), "kind", "delete", "cluster", "--name", clusterName)
+		_ = run(context.Background(), "kind", "delete", "cluster", "--name", name)
 	})
 
 	return kubeconfig

--- a/e2e/operator/slice_window_e2e_test.go
+++ b/e2e/operator/slice_window_e2e_test.go
@@ -1,0 +1,334 @@
+//go:build e2e
+
+// This file holds a focused kind-based e2e that reproduces the released-cluster
+// migration/upgrade window and proves the net SiteController never deletes live
+// SiteNodeSlices (the source of truth for WireGuard peers and pod-CIDR routes)
+// while the machina Site set is empty or only partially translated. It runs the
+// real SiteController against a real API server, so it exercises informer sync,
+// RBAC, and list/get semantics the fake-client unit tests cannot.
+//
+// Run via `go test -tags=e2e -run TestSiteControllerPreservesSlicesDuringMigrationWindow ./e2e/operator/...`.
+package operatore2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const sliceWindowClusterName = "operator-slice-window-e2e"
+
+// TestSiteControllerPreservesSlicesDuringMigrationWindow drives the real net
+// SiteController through the migration/upgrade window against a real API server
+// and asserts the dataplane's source of truth (SiteNodeSlices) is never torn
+// down:
+//
+//   - Phase 1 (empty machina window): with legacy Sites + slices present but NO
+//     machina Sites yet, the slice must remain continuously present. This is the
+//     regression #1 fixes; the pre-fix controller deleted every slice here.
+//   - Phase 2 (convergence): once the machina Site is created, the slice is
+//     re-owned and still present.
+//   - Phase 3 (partial migration): with the machina set non-empty, a slice whose
+//     Site is still only in the legacy group must survive (legacySiteExists).
+//   - Phase 4 (genuine orphan): a slice whose Site is absent from both groups is
+//     still cleaned up, proving the guard did not neuter cleanup.
+func TestSiteControllerPreservesSlicesDuringMigrationWindow(t *testing.T) {
+	requireBins(t, "kind", "kubectl", "docker")
+
+	if err := run(context.Background(), "docker", "info"); err != nil {
+		t.Skipf("docker engine unreachable (%v); skipping suite", err)
+	}
+
+	repoRoot := repoRootFromWD(t)
+	kubeconfig := createClusterNamed(t, sliceWindowClusterName)
+
+	applyCRDs(t, kubeconfig, repoRoot)
+
+	cli := newClient(t, kubeconfig)
+	ctx := log.IntoContext(context.Background(), zap.New(zap.UseDevMode(true)))
+
+	// The restricted SiteController identity's ServiceAccount lives in targetNS.
+	mustCreate(ctx, t, cli, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNS}})
+	restrictedConfig := stageRestrictedSiteControllerIdentity(ctx, t, kubeconfig, cli)
+
+	node, internalIPs := firstKindNode(ctx, t, cli)
+
+	nodeIP := net.ParseIP(internalIPs[0])
+	if nodeIP == nil {
+		t.Fatalf("kind node InternalIP %q is invalid", internalIPs[0])
+	}
+
+	bits := 128
+	if nodeIP.To4() != nil {
+		bits = 32
+	}
+
+	nodeCIDR := fmt.Sprintf("%s/%d", nodeIP.String(), bits)
+	nodeData := sliceNodeData(node, internalIPs)
+
+	// Stage the released-cluster state: a legacy net-group Site that owns the
+	// node, plus its SiteNodeSlice. No machina Site exists yet.
+	winSite := legacySite("win-site", nodeCIDR, "10.244.0.0/16")
+	winSite.Object["spec"] = map[string]any{
+		"nodeCidrs":       []any{nodeCIDR},
+		"manageCniPlugin": false,
+		"podCidrAssignments": []any{
+			map[string]any{"cidrBlocks": []any{"10.244.0.0/16"}, "assignmentEnabled": false},
+		},
+	}
+	mustCreate(ctx, t, cli, winSite)
+
+	stageLegacyOwnedSlice(ctx, t, cli, "win-site-0", "win-site", winSite.GetUID(), nodeData)
+
+	// Start the real SiteController with NO machina Sites present.
+	controllerCtx, cancelController := context.WithCancel(ctx)
+	defer cancelController()
+
+	controllerResult := startRestrictedSiteController(controllerCtx, t, restrictedConfig)
+
+	// Phase 1: empty machina window. The slice must never disappear while the
+	// controller reconciles with zero machina Sites.
+	assertSliceContinuouslyPresent(controllerCtx, t, cli, "win-site-0", 12*time.Second, controllerResult)
+	assertSliceOwnerGroup(ctx, t, cli, "win-site-0", legacySiteGVK.Group)
+
+	// Phase 2: convergence. Create the machina Site; the controller re-owns the
+	// slice and keeps it.
+	mustCreate(ctx, t, cli, machinaSiteObj("win-site", nodeCIDR, "10.244.0.0/16"))
+	waitForMachinaSliceOwner(controllerCtx, t, cli, "win-site-0", "win-site", controllerResult)
+
+	// Phase 3: partial migration. A legacy-only Site's slice must survive while
+	// the machina set is non-empty (exercises the legacy-group check).
+	edgeSite := legacySite("edge-site", "192.0.2.0/24", "10.245.0.0/16")
+	mustCreate(ctx, t, cli, edgeSite)
+	stageLegacyOwnedSlice(ctx, t, cli, "edge-site-0", "edge-site", edgeSite.GetUID(), nodeData)
+	assertSliceContinuouslyPresent(controllerCtx, t, cli, "edge-site-0", 8*time.Second, controllerResult)
+
+	// Phase 4: genuine orphan. A slice whose Site exists in neither group must be
+	// deleted, proving the guard did not disable cleanup.
+	stageLegacyOwnedSlice(ctx, t, cli, "ghost-0", "ghost", "", nodeData)
+	waitForSliceDeleted(controllerCtx, t, cli, "ghost-0", controllerResult)
+
+	cancelController()
+
+	select {
+	case err := <-controllerResult:
+		if err != nil {
+			t.Fatalf("restricted SiteController stopped with error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("restricted SiteController did not stop")
+	}
+}
+
+// firstKindNode returns the single kind node and its InternalIPs.
+func firstKindNode(ctx context.Context, t *testing.T, cli client.Client) (*corev1.Node, []string) {
+	t.Helper()
+
+	var nodeList corev1.NodeList
+	if err := cli.List(ctx, &nodeList); err != nil {
+		t.Fatalf("list kind nodes: %v", err)
+	}
+
+	if len(nodeList.Items) != 1 {
+		t.Fatalf("kind node count = %d, want 1", len(nodeList.Items))
+	}
+
+	node := &nodeList.Items[0]
+
+	internalIPs := make([]string, 0, len(node.Status.Addresses))
+
+	for _, address := range node.Status.Addresses {
+		if address.Type == corev1.NodeInternalIP {
+			internalIPs = append(internalIPs, address.Address)
+		}
+	}
+
+	if len(internalIPs) == 0 {
+		t.Fatalf("kind node %s has no InternalIP", node.Name)
+	}
+
+	return node, internalIPs
+}
+
+// sliceNodeData builds the SiteNodeSlice node entry for the kind node.
+func sliceNodeData(node *corev1.Node, internalIPs []string) map[string]any {
+	nodeData := map[string]any{
+		"name":        node.Name,
+		"internalIPs": stringSliceToAny(internalIPs),
+	}
+	if len(node.Spec.PodCIDRs) > 0 {
+		nodeData["podCIDRs"] = stringSliceToAny(node.Spec.PodCIDRs)
+	}
+
+	return nodeData
+}
+
+// machinaSiteObj builds a machina-group Site that node-selects the kind node.
+func machinaSiteObj(name, nodeCidr, podCidr string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(machinaSiteGVK)
+	obj.SetName(name)
+	obj.Object["spec"] = map[string]any{
+		"nodeCidrs":       []any{nodeCidr},
+		"manageCniPlugin": false,
+		"podCidrAssignments": []any{
+			map[string]any{"cidrBlocks": []any{podCidr}, "assignmentEnabled": false},
+		},
+	}
+
+	return obj
+}
+
+// stageLegacyOwnedSlice creates a SiteNodeSlice referencing siteName. When
+// siteUID is non-empty the slice carries a controller owner reference to the
+// legacy Site (the released-cluster shape); an empty UID leaves it ownerless so
+// garbage collection does not race the orphan-cleanup assertion.
+func stageLegacyOwnedSlice(ctx context.Context, t *testing.T, cli client.Client, sliceName, siteName string, siteUID types.UID, nodeData map[string]any) {
+	t.Helper()
+
+	slice := &unstructured.Unstructured{}
+	slice.SetGroupVersionKind(siteNodeSliceGVK)
+	slice.SetName(sliceName)
+
+	if siteUID != "" {
+		controllerRef := true
+		blockOwnerDeletion := true
+		slice.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion:         legacySiteGVK.GroupVersion().String(),
+			Kind:               legacySiteGVK.Kind,
+			Name:               siteName,
+			UID:                siteUID,
+			Controller:         &controllerRef,
+			BlockOwnerDeletion: &blockOwnerDeletion,
+		}})
+	}
+
+	slice.Object["siteName"] = siteName
+	slice.Object["sliceIndex"] = int64(0)
+	slice.Object["nodes"] = []any{nodeData}
+	slice.Object["nodeCount"] = int64(1)
+
+	mustCreate(ctx, t, cli, slice)
+}
+
+// assertSliceContinuouslyPresent samples the slice every 250ms for the given
+// duration and fails if it is ever observed absent (or the controller exits).
+func assertSliceContinuouslyPresent(ctx context.Context, t *testing.T, cli client.Client, sliceName string, duration time.Duration, controllerResult <-chan error) {
+	t.Helper()
+
+	deadline := time.Now().Add(duration)
+	samples := 0
+
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-controllerResult:
+			t.Fatalf("SiteController exited during continuity window: %v", err)
+		default:
+		}
+
+		slice := &unstructured.Unstructured{}
+		slice.SetGroupVersionKind(siteNodeSliceGVK)
+
+		if err := cli.Get(ctx, client.ObjectKey{Name: sliceName}, slice); err != nil {
+			t.Fatalf("slice %s disappeared during migration window (sample %d): %v", sliceName, samples, err)
+		}
+
+		samples++
+
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	if samples == 0 {
+		t.Fatalf("continuity window produced no samples for %s", sliceName)
+	}
+
+	t.Logf("slice %s stayed present across %d samples over %s", sliceName, samples, duration)
+}
+
+// assertSliceOwnerGroup asserts the slice's sole owner reference is in the given
+// API group.
+func assertSliceOwnerGroup(ctx context.Context, t *testing.T, cli client.Client, sliceName, group string) {
+	t.Helper()
+
+	slice := &unstructured.Unstructured{}
+	slice.SetGroupVersionKind(siteNodeSliceGVK)
+
+	if err := cli.Get(ctx, client.ObjectKey{Name: sliceName}, slice); err != nil {
+		t.Fatalf("get slice %s: %v", sliceName, err)
+	}
+
+	refs := slice.GetOwnerReferences()
+	if len(refs) != 1 {
+		t.Fatalf("slice %s owner refs = %#v, want exactly one", sliceName, refs)
+	}
+
+	if gv := refs[0].APIVersion; gv != group+"/v1alpha1" && gv != group+"/v1alpha3" {
+		t.Fatalf("slice %s owner group = %q, want %q", sliceName, gv, group)
+	}
+}
+
+// waitForMachinaSliceOwner waits until the slice is re-owned by the machina Site
+// and is still present.
+func waitForMachinaSliceOwner(ctx context.Context, t *testing.T, cli client.Client, sliceName, siteName string, controllerResult <-chan error) {
+	t.Helper()
+
+	err := utilwait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		select {
+		case err := <-controllerResult:
+			return false, fmt.Errorf("SiteController exited before re-owning slice: %w", err)
+		default:
+		}
+
+		site := getMachinaSite(ctx, t, cli, siteName)
+
+		slice := &unstructured.Unstructured{}
+		slice.SetGroupVersionKind(siteNodeSliceGVK)
+
+		if err := cli.Get(ctx, client.ObjectKey{Name: sliceName}, slice); err != nil {
+			return false, err
+		}
+
+		return hasExactCurrentSiteOwner(slice.GetOwnerReferences(), site), nil
+	})
+	if err != nil {
+		t.Fatalf("wait for machina owner on slice %s: %v", sliceName, err)
+	}
+}
+
+// waitForSliceDeleted waits until the slice is deleted by the controller.
+func waitForSliceDeleted(ctx context.Context, t *testing.T, cli client.Client, sliceName string, controllerResult <-chan error) {
+	t.Helper()
+
+	err := utilwait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		select {
+		case err := <-controllerResult:
+			return false, fmt.Errorf("SiteController exited before deleting orphan slice: %w", err)
+		default:
+		}
+
+		slice := &unstructured.Unstructured{}
+		slice.SetGroupVersionKind(siteNodeSliceGVK)
+
+		err := cli.Get(ctx, client.ObjectKey{Name: sliceName}, slice)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+
+		return false, client.IgnoreNotFound(err)
+	})
+	if err != nil {
+		t.Fatalf("wait for orphan slice %s deletion: %v", sliceName, err)
+	}
+}

--- a/hack/operator-upgrade-e2e/e2e.py
+++ b/hack/operator-upgrade-e2e/e2e.py
@@ -69,6 +69,7 @@ import platform
 import subprocess
 import sys
 import tarfile
+import threading
 import time
 import urllib.request
 from pathlib import Path
@@ -1050,13 +1051,173 @@ def cmd_cleanup(args: argparse.Namespace) -> None:
     run(["docker", "rm", "-f", REGISTRY_CONTAINER], check=False, quiet=True)
 
 
+# --------------------------------------------------------------------------- #
+# continuity monitor
+# --------------------------------------------------------------------------- #
+class ContinuityMonitor:
+    """Background monitor that samples the net dataplane's source of truth during
+    the migration and fails the run on a regression.
+
+    The primary signal is SiteNodeSlice presence: net-node programs WireGuard
+    peers and pod-CIDR routes from SiteNodeSlices, so a slice that is present and
+    then vanishes (rather than being updated in place) means the dataplane for
+    that site was torn down. This is exactly the outage the orphan-cleanup fix
+    prevents during the migration window. A slice absent for two consecutive
+    samples (debounced against transient API read hiccups) is flagged, as is the
+    whole slice set emptying after having been non-empty.
+
+    With --probe-dataplane it additionally samples WireGuard peer counts inside
+    the net-node pods and flags a collapse to zero peers after peers were seen.
+    That probe is best-effort: if `wg` peer data cannot be read (tooling/mode) it
+    disables itself rather than producing false failures. NOTE: this harness runs
+    CNI-free alongside kindnet, so pod-to-pod traffic uses kindnet, not the
+    unbounded WireGuard mesh; a cross-node pod ping would therefore NOT reflect
+    the unbounded dataplane, which is why slice/peer continuity are used instead.
+    """
+
+    def __init__(self, interval: float, probe_dataplane: bool) -> None:
+        self._interval = max(interval, 0.5)
+        self._probe_dataplane = probe_dataplane
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._loop, name="continuity-monitor", daemon=True)
+        self._violations: list[str] = []
+        self._seen_slices: set[str] = set()
+        self._absent_streak: dict[str, int] = {}
+        self._wg_peers_seen = False
+        self._wg_disabled = False
+        self._samples = 0
+
+    def start(self) -> None:
+        log(f"continuity monitor: started (interval={self._interval}s, "
+            f"probe_dataplane={self._probe_dataplane})")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=30)
+        log(f"continuity monitor: stopped after {self._samples} samples; "
+            f"{len(self._seen_slices)} distinct SiteNodeSlices observed")
+        if self._violations:
+            die("continuity monitor detected dataplane regressions during "
+                "migration:\n  - " + "\n  - ".join(self._violations))
+        log("continuity monitor: no dataplane regression observed")
+
+    def _record(self, violation: str) -> None:
+        if violation not in self._violations:
+            self._violations.append(violation)
+            log("continuity VIOLATION: " + violation)
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            self._sample()
+            self._stop.wait(self._interval)
+        self._sample()
+
+    def _sample(self) -> None:
+        names = self._slice_names()
+        if names is None:
+            return  # transient API read hiccup; skip this tick
+
+        self._samples += 1
+
+        # Debounced disappearance detection: a previously-seen slice missing for
+        # two consecutive samples is a regression.
+        for slice_name in sorted(self._seen_slices):
+            if slice_name in names:
+                self._absent_streak[slice_name] = 0
+                continue
+
+            streak = self._absent_streak.get(slice_name, 0) + 1
+            self._absent_streak[slice_name] = streak
+            if streak >= 2:
+                self._record(
+                    f"SiteNodeSlice {slice_name} was present and then "
+                    f"disappeared during migration")
+
+        self._seen_slices |= names
+
+        if self._seen_slices and not names:
+            self._record("all SiteNodeSlices vanished at once during migration")
+
+        if self._probe_dataplane and not self._wg_disabled:
+            self._sample_wireguard()
+
+    def _slice_names(self) -> set[str] | None:
+        out = kubectl_out(
+            ["get", "sitenodeslices.net.unbounded-cloud.io", "-o", "json"],
+            check=False)
+        if not out.strip():
+            return None
+        try:
+            items = json.loads(out).get("items", [])
+        except json.JSONDecodeError:
+            return None
+        return {item["metadata"]["name"] for item in items}
+
+    def _sample_wireguard(self) -> None:
+        pods = self._net_node_pods()
+        if not pods:
+            return
+
+        any_peers = False
+        for pod in pods:
+            peers = self._wg_peer_count(pod)
+            if peers is None:
+                # Could not read wg peer data anywhere; disable the probe once so
+                # it never produces false failures.
+                self._wg_disabled = True
+                log("continuity monitor: WireGuard probe disabled "
+                    "(peer data unavailable in net-node pods)")
+                return
+            if peers > 0:
+                any_peers = True
+
+        if any_peers:
+            self._wg_peers_seen = True
+        elif self._wg_peers_seen:
+            self._record("WireGuard peers collapsed to zero across all "
+                         "net-node pods during migration")
+
+    def _net_node_pods(self) -> list[str]:
+        out = kubectl_out(
+            ["-n", TARGET_NS, "get", "pods", "-l", "app=unbounded-net-node",
+             "-o", "jsonpath={.items[*].metadata.name}"], check=False)
+        return out.split()
+
+    def _wg_peer_count(self, pod: str) -> int | None:
+        # Best-effort: `wg show all peers` lists one peer per line.
+        out = run_out(
+            ["kubectl", "--kubeconfig", str(KUBECONFIG), "-n", TARGET_NS,
+             "exec", pod, "--", "wg", "show", "all", "peers"], check=False)
+        if not out.strip():
+            # Distinguish "no peers" from "wg unavailable" is not reliable here;
+            # treat empty as unreadable so the probe self-disables rather than
+            # false-flagging. A populated mesh returns peer lines.
+            return None
+        return len([line for line in out.splitlines() if line.strip()])
+
+
+# --------------------------------------------------------------------------- #
+# orchestration
+# --------------------------------------------------------------------------- #
 def cmd_all(args: argparse.Namespace) -> None:
     try:
         cmd_setup(args)
         cmd_build_images(args)
         cmd_install_old(args)
-        cmd_upgrade(args)
-        cmd_verify(args)
+        monitor = ContinuityMonitor(
+            interval=args.continuity_interval,
+            probe_dataplane=args.probe_dataplane,
+        )
+        monitor.start()
+        try:
+            cmd_upgrade(args)
+            cmd_verify(args)
+        finally:
+            # Assert the dataplane source of truth stayed continuous across the
+            # whole migration window (install -> reaper completion).
+            monitor.stop()
         log("ALL PASS")
     finally:
         cmd_cleanup(args)
@@ -1089,6 +1250,13 @@ def main() -> None:
                         help="skip building/pushing images (reuse existing)")
     parser.add_argument("--verify-timeout", type=int, default=1500,
                         help="seconds to wait for the migration to complete")
+    parser.add_argument("--continuity-interval", type=float, default=1.0,
+                        help="seconds between SiteNodeSlice continuity samples "
+                             "during the migration (0.5 minimum)")
+    parser.add_argument("--probe-dataplane", action="store_true",
+                        help="additionally sample WireGuard peer counts in the "
+                             "net-node pods during migration (best-effort; "
+                             "self-disables if peer data is unavailable)")
     args = parser.parse_args()
 
     dispatch = {

--- a/internal/net/controller/site_controller.go
+++ b/internal/net/controller/site_controller.go
@@ -85,6 +85,18 @@ var siteNodeSliceGVR = schema.GroupVersionResource{
 	Resource: "sitenodeslices",
 }
 
+// legacySiteGVR is the pre-migration net-group Site resource. During the
+// unbounded-system migration a SiteNodeSlice may still reference a Site that
+// has not yet been translated into the machina group (siteGVR); that Site
+// continues to exist here until the operator's reaper deletes the legacy CRD.
+// Orphan cleanup consults this group so it never deletes a live site's slices
+// mid-migration.
+var legacySiteGVR = schema.GroupVersionResource{
+	Group:    "net.unbounded-cloud.io",
+	Version:  "v1alpha1",
+	Resource: "sites",
+}
+
 var gatewayPoolGVRSite = schema.GroupVersionResource{
 	Group:    "net.unbounded-cloud.io",
 	Version:  "v1alpha1",
@@ -1235,11 +1247,42 @@ func (sc *SiteController) getLiveSiteWithUID(ctx context.Context, name string, e
 
 func (sc *SiteController) cleanupOrphanSiteNodeSlices(ctx context.Context) error {
 	resource := sc.dynamicClient.Resource(siteNodeSliceGVR)
-	siteResource := sc.dynamicClient.Resource(siteGVR)
+
+	cachedSlices := sc.sliceInformer.GetStore().List()
+	if len(cachedSlices) == 0 {
+		return nil
+	}
+
+	// Establish that the Site source is healthy and populated before concluding
+	// that any slice is orphaned. A failed or empty live Site listing (Sites not
+	// yet translated into the machina group during the unbounded-system
+	// migration, or the Site CRD briefly unavailable) must never be read as
+	// "every Site was deleted": doing so would delete every SiteNodeSlice
+	// cluster-wide and tear down all inter-node tunnels. Legitimate whole-Site
+	// deletion is handled by owner-reference garbage collection, so skipping
+	// cleanup in that state is safe.
+	liveSites, err := sc.dynamicClient.Resource(siteGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list sites for orphan slice cleanup: %w", err)
+	}
+
+	if len(liveSites.Items) == 0 {
+		klog.V(2).Infof(
+			"Skipping orphan SiteNodeSlice cleanup: no Sites present but %d slice(s) exist (Site source not yet populated)",
+			len(cachedSlices),
+		)
+
+		return nil
+	}
+
+	liveSiteNames := make(map[string]struct{}, len(liveSites.Items))
+	for i := range liveSites.Items {
+		liveSiteNames[liveSites.Items[i].GetName()] = struct{}{}
+	}
 
 	var cleanupErrors []error
 
-	for _, item := range sc.sliceInformer.GetStore().List() {
+	for _, item := range cachedSlices {
 		cachedSlice, ok := item.(*unstructured.Unstructured)
 		if !ok {
 			continue
@@ -1266,24 +1309,55 @@ func (sc *SiteController) cleanupOrphanSiteNodeSlices(ctx context.Context) error
 		}
 
 		if found && siteName != "" {
-			_, err = siteResource.Get(ctx, siteName, metav1.GetOptions{})
-			if err == nil {
+			// The referenced Site still exists in the machina group: keep it.
+			if _, live := liveSiteNames[siteName]; live {
 				continue
 			}
 
-			if !apierrors.IsNotFound(err) {
-				cleanupErrors = append(cleanupErrors, fmt.Errorf("check site %s for slice %s: %w", siteName, name, err))
+			// Migration guard: the Site may not have been translated into the
+			// machina group yet while its legacy net-group Site still exists.
+			// Such a slice is not an orphan; deleting it would tear down a live
+			// site's tunnels mid-migration. Only a Site absent from BOTH groups
+			// is genuinely gone.
+			legacyPresent, err := sc.legacySiteExists(ctx, siteName)
+			if err != nil {
+				cleanupErrors = append(cleanupErrors, fmt.Errorf("check legacy site %s for slice %s: %w", siteName, name, err))
 
+				continue
+			}
+
+			if legacyPresent {
 				continue
 			}
 		}
 
+		// Either the slice carries no siteName (it can never be reconciled) or
+		// its Site is absent from both the machina and legacy groups. The Site
+		// source is confirmed healthy and non-empty, so this is a genuine orphan.
 		if err := deleteLiveSiteNodeSlice(ctx, resource, liveSlice); err != nil && !apierrors.IsNotFound(err) {
 			cleanupErrors = append(cleanupErrors, fmt.Errorf("delete orphan slice %s: %w", name, err))
 		}
 	}
 
 	return errors.Join(cleanupErrors...)
+}
+
+// legacySiteExists reports whether a pre-migration net-group Site with the given
+// name still exists. It lets orphan cleanup avoid deleting SiteNodeSlices for
+// Sites that have not yet been translated into the machina group during the
+// unbounded-system migration. A missing legacy Site object, or a legacy Site CRD
+// that has already been reaped (its API path returns NotFound), both report
+// false.
+func (sc *SiteController) legacySiteExists(ctx context.Context, name string) (bool, error) {
+	_, err := sc.dynamicClient.Resource(legacySiteGVR).Get(ctx, name, metav1.GetOptions{})
+	switch {
+	case err == nil:
+		return true, nil
+	case apierrors.IsNotFound(err):
+		return false, nil
+	default:
+		return false, fmt.Errorf("get legacy site %s: %w", name, err)
+	}
 }
 
 func deleteLiveSiteNodeSlice(ctx context.Context, resource dynamic.ResourceInterface, liveSlice *unstructured.Unstructured) error {

--- a/internal/net/controller/site_controller_helpers_test.go
+++ b/internal/net/controller/site_controller_helpers_test.go
@@ -350,6 +350,21 @@ func siteUnstructured(t *testing.T, site unboundedv1alpha3.Site) *unstructured.U
 	return &unstructured.Unstructured{Object: object}
 }
 
+// legacySiteUnstructured builds a minimal pre-migration net-group Site object
+// (net.unbounded-cloud.io/v1alpha1) for orphan-cleanup tests that exercise the
+// migration guard.
+func legacySiteUnstructured(name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   legacySiteGVR.Group,
+		Version: legacySiteGVR.Version,
+		Kind:    "Site",
+	})
+	obj.SetName(name)
+
+	return obj
+}
+
 // TestNodeSiteLabelFallback verifies the canonical-first, deprecated-fallback
 // read of a Node's site membership.
 func TestNodeSiteLabelFallback(t *testing.T) {
@@ -969,25 +984,25 @@ func TestCreateOrUpdateSliceDoesNotUseSameNameReplacementSite(t *testing.T) {
 }
 
 func TestCleanupOrphanSiteNodeSlicesRevalidatesSitesAndDeletePreconditions(t *testing.T) {
-	oldSite := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "old-site-uid"}}
-	replacement := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: oldSite.Name, UID: "replacement-site-uid"}}
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"}}
 
-	emptySiteName := (&SiteController{}).buildSliceObject(oldSite, "empty-site-name", 0, nil)
+	emptySiteName := (&SiteController{}).buildSliceObject(site, "empty-site-name", 0, nil)
 	emptySiteName.Object["siteName"] = ""
 	emptySiteName.SetUID("empty-uid")
 	emptySiteName.SetResourceVersion("empty-rv")
 
-	missingSite := (&SiteController{}).buildSliceObject(oldSite, "missing-site", 0, nil)
+	missingSite := (&SiteController{}).buildSliceObject(site, "missing-site", 0, nil)
 	missingSite.Object["siteName"] = "missing"
 	missingSite.SetUID("missing-uid")
 	missingSite.SetResourceVersion("missing-rv")
 
-	recreatedSite := (&SiteController{}).buildSliceObject(oldSite, "recreated-site", 0, nil)
-	recreatedSite.SetUID("recreated-slice-uid")
-	recreatedSite.SetResourceVersion("recreated-slice-rv")
+	presentSite := (&SiteController{}).buildSliceObject(site, "present-site", 0, nil)
+	presentSite.Object["siteName"] = site.Name
+	presentSite.SetUID("present-slice-uid")
+	presentSite.SetResourceVersion("present-slice-rv")
 
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	for _, slice := range []*unstructured.Unstructured{emptySiteName, missingSite, recreatedSite} {
+	for _, slice := range []*unstructured.Unstructured{emptySiteName, missingSite, presentSite} {
 		if err := store.Add(slice.DeepCopy()); err != nil {
 			t.Fatalf("add slice %s to cache: %v", slice.GetName(), err)
 		}
@@ -997,30 +1012,14 @@ func TestCleanupOrphanSiteNodeSlicesRevalidatesSitesAndDeletePreconditions(t *te
 		runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
 			siteGVR:          "SiteList",
+			legacySiteGVR:    "SiteList",
 			siteNodeSliceGVR: "SiteNodeSliceList",
 		},
-		siteUnstructured(t, oldSite),
+		siteUnstructured(t, site),
 		emptySiteName.DeepCopy(),
 		missingSite.DeepCopy(),
-		recreatedSite.DeepCopy(),
+		presentSite.DeepCopy(),
 	)
-
-	dynamicClient.PrependReactor("get", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		getAction := action.(clienttesting.GetAction) //nolint:errcheck
-		if getAction.GetName() != oldSite.Name {
-			return false, nil, nil
-		}
-
-		if err := dynamicClient.Tracker().Delete(siteGVR, "", oldSite.Name); err != nil {
-			t.Fatalf("delete old site: %v", err)
-		}
-
-		if err := dynamicClient.Tracker().Add(siteUnstructured(t, replacement)); err != nil {
-			t.Fatalf("add replacement site: %v", err)
-		}
-
-		return false, nil, nil
-	})
 
 	sc := &SiteController{
 		dynamicClient: dynamicClient,
@@ -1030,8 +1029,8 @@ func TestCleanupOrphanSiteNodeSlicesRevalidatesSitesAndDeletePreconditions(t *te
 		t.Fatalf("cleanupOrphanSiteNodeSlices: %v", err)
 	}
 
-	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), recreatedSite.GetName(), metav1.GetOptions{}); err != nil {
-		t.Fatalf("slice for recreated same-name Site was deleted: %v", err)
+	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), presentSite.GetName(), metav1.GetOptions{}); err != nil {
+		t.Fatalf("slice for present Site was deleted: %v", err)
 	}
 
 	wantPreconditions := map[string]metav1.Preconditions{
@@ -1086,12 +1085,15 @@ func TestCleanupOrphanSiteNodeSlicesPreservesSliceOnSiteLookupError(t *testing.T
 		runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
 			siteGVR:          "SiteList",
+			legacySiteGVR:    "SiteList",
 			siteNodeSliceGVR: "SiteNodeSliceList",
 		},
 		slice.DeepCopy(),
 	)
-	dynamicClient.PrependReactor("get", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewForbidden(siteGVR.GroupResource(), site.Name, errors.New("test denial"))
+	// The live Site listing is the health check that gates all deletion. If it
+	// cannot be read the routine must not delete anything.
+	dynamicClient.PrependReactor("list", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(siteGVR.GroupResource(), "", errors.New("test denial"))
 	})
 
 	sc := &SiteController{
@@ -1106,6 +1108,104 @@ func TestCleanupOrphanSiteNodeSlicesPreservesSliceOnSiteLookupError(t *testing.T
 
 	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), slice.GetName(), metav1.GetOptions{}); err != nil {
 		t.Fatalf("slice was deleted after conservative Site lookup failure: %v", err)
+	}
+}
+
+// TestCleanupOrphanSiteNodeSlicesSkipsWhenNoSitesPresent covers the
+// migration/upgrade window where the machina Site set is observed empty (Sites
+// not yet translated) while legacy slices still exist. Deleting them would tear
+// down every inter-node tunnel cluster-wide, so cleanup must be a no-op.
+func TestCleanupOrphanSiteNodeSlicesSkipsWhenNoSitesPresent(t *testing.T) {
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "site-a", UID: "site-uid"}}
+	slice := (&SiteController{}).buildSliceObject(site, "site-a-0", 0, nil)
+	slice.Object["siteName"] = site.Name
+	slice.SetUID("slice-uid")
+	slice.SetResourceVersion("slice-rv")
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(slice.DeepCopy()); err != nil {
+		t.Fatalf("add slice to cache: %v", err)
+	}
+
+	// No Site objects registered: the live Site listing returns zero items.
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			legacySiteGVR:    "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		slice.DeepCopy(),
+	)
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+
+	if err := sc.cleanupOrphanSiteNodeSlices(context.Background()); err != nil {
+		t.Fatalf("cleanupOrphanSiteNodeSlices: %v", err)
+	}
+
+	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), slice.GetName(), metav1.GetOptions{}); err != nil {
+		t.Fatalf("slice was deleted while no Sites were present: %v", err)
+	}
+
+	for _, action := range dynamicClient.Actions() {
+		if _, ok := action.(clienttesting.DeleteAction); ok && action.GetResource() == siteNodeSliceGVR {
+			t.Fatalf("unexpected slice delete while Site source was empty")
+		}
+	}
+}
+
+// TestCleanupOrphanSiteNodeSlicesKeepsSliceForUntranslatedLegacySite covers a
+// partially-migrated cluster: at least one Site has been translated into the
+// machina group, but this slice references a Site that is still only in the
+// legacy net group. It is not an orphan and must be preserved.
+func TestCleanupOrphanSiteNodeSlicesKeepsSliceForUntranslatedLegacySite(t *testing.T) {
+	translated := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "translated", UID: "translated-uid"}}
+
+	const legacyName = "legacy-site"
+
+	slice := (&SiteController{}).buildSliceObject(translated, "legacy-site-0", 0, nil)
+	slice.Object["siteName"] = legacyName
+	slice.SetUID("slice-uid")
+	slice.SetResourceVersion("slice-rv")
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(slice.DeepCopy()); err != nil {
+		t.Fatalf("add slice to cache: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			legacySiteGVR:    "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, translated),
+		legacySiteUnstructured(legacyName),
+		slice.DeepCopy(),
+	)
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+
+	if err := sc.cleanupOrphanSiteNodeSlices(context.Background()); err != nil {
+		t.Fatalf("cleanupOrphanSiteNodeSlices: %v", err)
+	}
+
+	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), slice.GetName(), metav1.GetOptions{}); err != nil {
+		t.Fatalf("slice for untranslated legacy Site was deleted: %v", err)
+	}
+
+	for _, action := range dynamicClient.Actions() {
+		if _, ok := action.(clienttesting.DeleteAction); ok && action.GetResource() == siteNodeSliceGVR {
+			t.Fatalf("unexpected slice delete for an untranslated legacy Site")
+		}
 	}
 }
 

--- a/internal/net/controller/site_controller_helpers_test.go
+++ b/internal/net/controller/site_controller_helpers_test.go
@@ -1209,6 +1209,63 @@ func TestCleanupOrphanSiteNodeSlicesKeepsSliceForUntranslatedLegacySite(t *testi
 	}
 }
 
+// TestCleanupOrphanSiteNodeSlicesPreservesSliceOnLegacySiteLookupError asserts
+// that if the legacy net-group Site lookup is denied (e.g. the net controller is
+// missing the read grant on net.unbounded-cloud.io/sites), cleanup preserves the
+// slice rather than deleting it. The check is safe-by-default: a lookup error is
+// never read as "the Site is gone".
+func TestCleanupOrphanSiteNodeSlicesPreservesSliceOnLegacySiteLookupError(t *testing.T) {
+	// A translated Site exists so the empty-source guard does not short-circuit.
+	present := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "present", UID: "present-uid"}}
+
+	// This slice references a Site absent from the machina group, so cleanup
+	// consults the legacy group - which is denied below.
+	slice := (&SiteController{}).buildSliceObject(present, "untranslated-0", 0, nil)
+	slice.Object["siteName"] = "untranslated"
+	slice.SetUID("slice-uid")
+	slice.SetResourceVersion("slice-rv")
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(slice.DeepCopy()); err != nil {
+		t.Fatalf("add slice to cache: %v", err)
+	}
+
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			siteGVR:          "SiteList",
+			legacySiteGVR:    "SiteList",
+			siteNodeSliceGVR: "SiteNodeSliceList",
+		},
+		siteUnstructured(t, present),
+		slice.DeepCopy(),
+	)
+	// Deny only the legacy net-group Site GET (the migration-window check).
+	dynamicClient.PrependReactor("get", "sites", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.GetResource().Group != legacySiteGVR.Group {
+			return false, nil, nil
+		}
+
+		getAction := action.(clienttesting.GetAction) //nolint:errcheck
+
+		return true, nil, apierrors.NewForbidden(legacySiteGVR.GroupResource(), getAction.GetName(), errors.New("test denial"))
+	})
+
+	sc := &SiteController{
+		dynamicClient: dynamicClient,
+		sliceInformer: &fakeInformer{store: store},
+	}
+
+	err := sc.cleanupOrphanSiteNodeSlices(context.Background())
+	if err == nil || !apierrors.IsForbidden(err) {
+		t.Fatalf("cleanupOrphanSiteNodeSlices error = %v, want forbidden", err)
+	}
+
+	if _, err := dynamicClient.Resource(siteNodeSliceGVR).Get(context.Background(), slice.GetName(), metav1.GetOptions{}); err != nil {
+		t.Fatalf("slice was deleted after legacy Site lookup was denied: %v", err)
+	}
+}
+
 func TestSliceMutationFailurePropagatesRedirtiesAndSkipsStatus(t *testing.T) {
 	site := unboundedv1alpha3.Site{
 		TypeMeta: metav1.TypeMeta{APIVersion: unboundedv1alpha3.GroupVersion.String(), Kind: "Site"},

--- a/internal/operator/bootstrap.go
+++ b/internal/operator/bootstrap.go
@@ -39,11 +39,6 @@ const (
 	crdEstablishedTimeout = 2 * time.Minute
 
 	defaultCRDMaintenanceInterval = time.Minute
-
-	// defaultCRDMaintenanceFailures is the number of consecutive CRD maintenance
-	// failures tolerated before the maintainer stops the manager and lets the
-	// pod restart.
-	defaultCRDMaintenanceFailures = 3
 )
 
 // CRDBootstrapTimeout bounds the complete CRD bootstrap, including manifest
@@ -87,34 +82,27 @@ func BootstrapCRDs(ctx context.Context, c client.Client) error {
 }
 
 // CRDMaintainer periodically reapplies the operator-owned CRDs using an
-// uncached client. Transient maintenance failures are retried on the next
-// interval; only a run of MaxFailures consecutive failures stops the manager,
-// so the pod is restarted and retries after any terminating CRD has finished
-// deleting.
+// uncached client. Maintenance failures are logged and retried on the next
+// interval; they never stop the manager. CRDs that are already established stay
+// served by the apiserver regardless of the operator's liveness, so stopping on
+// maintenance failures would needlessly take down the Site reconciler and the
+// migration reaper for what is typically a transient apiserver blip.
 type CRDMaintainer struct {
-	Client   client.Client
-	Interval time.Duration
-	// MaxFailures is the number of consecutive maintenance failures tolerated
-	// before Start returns an error and stops the manager. Defaults to
-	// defaultCRDMaintenanceFailures.
-	MaxFailures int
-	Bootstrap   func(context.Context, client.Client) error
+	Client    client.Client
+	Interval  time.Duration
+	Bootstrap func(context.Context, client.Client) error
 }
 
 // NeedLeaderElection ensures only the elected operator replica maintains CRDs.
 func (*CRDMaintainer) NeedLeaderElection() bool { return true }
 
-// Start runs CRD maintenance until the manager stops or maintenance fails
-// MaxFailures times in a row.
+// Start runs CRD maintenance until the manager stops (context cancellation).
+// Maintenance failures are logged and retried on the next interval; they do not
+// stop the manager.
 func (m *CRDMaintainer) Start(ctx context.Context) error {
 	interval := m.Interval
 	if interval <= 0 {
 		interval = defaultCRDMaintenanceInterval
-	}
-
-	maxFailures := m.MaxFailures
-	if maxFailures <= 0 {
-		maxFailures = defaultCRDMaintenanceFailures
 	}
 
 	bootstrap := m.Bootstrap
@@ -140,11 +128,8 @@ func (m *CRDMaintainer) Start(ctx context.Context) error {
 				}
 
 				failures++
-				if failures >= maxFailures {
-					return fmt.Errorf("maintain CRDs after %d consecutive failures: %w", failures, err)
-				}
 
-				logger.Error(err, "CRD maintenance failed; will retry", "failures", failures, "maxFailures", maxFailures)
+				logger.Error(err, "CRD maintenance failed; will retry on the next interval", "consecutiveFailures", failures)
 
 				continue
 			}

--- a/internal/operator/bootstrap_test.go
+++ b/internal/operator/bootstrap_test.go
@@ -79,26 +79,43 @@ func TestCRDMaintainerCancellation(t *testing.T) {
 	}
 }
 
-func TestCRDMaintainerReturnsBootstrapError(t *testing.T) {
+func TestCRDMaintainerKeepsRetryingOnPersistentFailureWithoutStopping(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	wantErr := errors.New("apply failed")
-	calls := 0
+	calls := make(chan struct{}, 16)
+
 	maintainer := &CRDMaintainer{
-		Interval:    time.Millisecond,
-		MaxFailures: 3,
+		Interval: time.Millisecond,
 		Bootstrap: func(context.Context, client.Client) error {
-			calls++
+			select {
+			case calls <- struct{}{}:
+			default:
+			}
 
 			return wantErr
 		},
 	}
 
-	err := maintainer.Start(context.Background())
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("Start error = %v, want %v", err, wantErr)
+	done := make(chan error, 1)
+
+	go func() { done <- maintainer.Start(ctx) }()
+
+	// A persistent failure must not stop the manager: established CRDs stay
+	// served regardless, so the maintainer keeps retrying rather than returning.
+	for i := 0; i < 4; i++ {
+		select {
+		case <-calls:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("maintainer stopped retrying after %d persistent failures", i)
+		}
 	}
 
-	if calls != 3 {
-		t.Fatalf("Bootstrap called %d times, want 3 consecutive failures before crashing", calls)
+	cancel()
+
+	if err := <-done; err != nil {
+		t.Fatalf("Start on persistent failure = %v, want nil (context cancel is the only clean stop)", err)
 	}
 }
 
@@ -111,8 +128,7 @@ func TestCRDMaintainerRetriesTransientFailureWithoutCrashing(t *testing.T) {
 	calls := 0
 
 	maintainer := &CRDMaintainer{
-		Interval:    time.Millisecond,
-		MaxFailures: 3,
+		Interval: time.Millisecond,
 		Bootstrap: func(context.Context, client.Client) error {
 			calls++
 

--- a/internal/operator/migrate.go
+++ b/internal/operator/migrate.go
@@ -1724,30 +1724,89 @@ func (r *LegacyReaper) netControllerAvailable(ctx context.Context, target string
 }
 
 // warnOnForeignWorkloads logs a warning and emits an Event when a legacy
-// namespace still holds workloads the reaper did not create, so operators are
-// alerted before the whole-namespace delete removes them too. Deletion still
-// proceeds (the namespace is the migration target); the warning surfaces
-// unexpected residents rather than blocking the migration.
+// namespace still holds resources the migration does not copy, so operators are
+// alerted before the whole-namespace delete removes them too. It surfaces both
+// foreign workloads the reaper did not create and data-bearing resources the
+// migration never copies (PersistentVolumeClaims and deliberately-skipped
+// Secrets). Deletion still proceeds (the namespace is the migration target); the
+// warning surfaces unexpected residents rather than blocking the migration.
 func (r *LegacyReaper) warnOnForeignWorkloads(ctx context.Context, logger logr.Logger, nsName string) error {
 	foreign, err := r.foreignWorkloads(ctx, nsName)
 	if err != nil {
 		return err
 	}
 
+	atRisk, err := r.dataBearingResourcesAtRisk(ctx, nsName)
+	if err != nil {
+		return err
+	}
+
+	foreign = append(foreign, atRisk...)
+
 	if len(foreign) == 0 {
 		return nil
 	}
 
-	logger.Info("legacy namespace still holds non-operator workloads; they will be deleted with the namespace",
-		"namespace", nsName, "workloads", foreign)
+	sort.Strings(foreign)
+
+	logger.Info("legacy namespace still holds resources the migration does not copy; they will be deleted with the namespace",
+		"namespace", nsName, "resources", foreign)
 
 	if r.Recorder != nil {
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 		r.Recorder.Eventf(ns, nil, corev1.EventTypeWarning, "ForeignWorkloadsDeleted", "DeleteLegacyNamespace",
-			"deleting drained legacy namespace %s which still holds non-operator workloads: %v", nsName, foreign)
+			"deleting drained legacy namespace %s which still holds resources the migration does not copy: %v", nsName, foreign)
 	}
 
 	return nil
+}
+
+// dataBearingResourcesAtRisk returns sorted "Kind/name" entries for namespaced
+// resources that the whole-namespace delete will destroy but the migration does
+// NOT copy out, so an operator sees the full blast radius before the namespace
+// is deleted. It surfaces:
+//
+//   - every PersistentVolumeClaim (the reaper never migrates PVCs, and they may
+//     be data-bearing), and
+//   - every Secret the migration deliberately skips (r.SkipSecretNames);
+//     migrateSecrets copies all other non-auto-managed Secrets, so only skipped
+//     ones are lost.
+//
+// It intentionally does not enumerate ConfigMaps by name: the migration copies
+// several ConfigMap sets with dynamic names (machine cloud-init and per-site
+// storage config), so a per-name "not migrated" classification would produce
+// false positives. The warning text notes ConfigMaps generally instead.
+func (r *LegacyReaper) dataBearingResourcesAtRisk(ctx context.Context, nsName string) ([]string, error) {
+	reader := r.liveReader()
+	opts := []client.ListOption{client.InNamespace(nsName)}
+
+	var names []string
+
+	var pvcs corev1.PersistentVolumeClaimList
+	if err := reader.List(ctx, &pvcs, opts...); err != nil {
+		return nil, err
+	}
+
+	for i := range pvcs.Items {
+		names = append(names, "PersistentVolumeClaim/"+pvcs.Items[i].Name)
+	}
+
+	if len(r.SkipSecretNames) > 0 {
+		var secrets corev1.SecretList
+		if err := reader.List(ctx, &secrets, opts...); err != nil {
+			return nil, err
+		}
+
+		for i := range secrets.Items {
+			if _, skipped := r.SkipSecretNames[secrets.Items[i].Name]; skipped {
+				names = append(names, "Secret/"+secrets.Items[i].Name)
+			}
+		}
+	}
+
+	sort.Strings(names)
+
+	return names, nil
 }
 
 // foreignWorkloads returns sorted "Kind/name" entries for every top-level or

--- a/internal/operator/migrate_gates_test.go
+++ b/internal/operator/migrate_gates_test.go
@@ -833,6 +833,49 @@ func TestForeignWorkloads(t *testing.T) {
 	}
 }
 
+// Finding 3: the whole-namespace delete also destroys resources the migration
+// never copies. The audit surfaces PersistentVolumeClaims and deliberately
+// skipped Secrets so operators see the full blast radius before deletion.
+func TestDataBearingResourcesAtRiskSurfacesPVCsAndSkippedSecrets(t *testing.T) {
+	r := newReaper(t,
+		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Namespace: legacyKubeNamespace, Name: "data"}},
+		// Skipped by migration (SkipSecretNames): never copied, so at risk.
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: legacyKubeNamespace, Name: "unbounded-net-serving-cert"}},
+		// Copied by migrateSecrets: not at risk, must not be reported.
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: legacyKubeNamespace, Name: "user-secret"}},
+	)
+
+	got, err := r.dataBearingResourcesAtRisk(t.Context(), legacyKubeNamespace)
+	if err != nil {
+		t.Fatalf("dataBearingResourcesAtRisk: %v", err)
+	}
+
+	want := []string{
+		"PersistentVolumeClaim/data",
+		"Secret/unbounded-net-serving-cert",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dataBearingResourcesAtRisk = %v, want %v", got, want)
+	}
+
+	// The at-risk resources must be surfaced through the warning Event too.
+	recorder := events.NewFakeRecorder(1)
+	r.Recorder = recorder
+
+	if err := r.warnOnForeignWorkloads(t.Context(), logr.Discard(), legacyKubeNamespace); err != nil {
+		t.Fatalf("warnOnForeignWorkloads: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, "PersistentVolumeClaim/data") || !strings.Contains(event, "Secret/unbounded-net-serving-cert") {
+			t.Fatalf("warning Event missing at-risk resources: %q", event)
+		}
+	default:
+		t.Fatal("at-risk resources did not emit a warning Event")
+	}
+}
+
 func TestForeignWorkloadsSkipsListedControllerDescendants(t *testing.T) {
 	controller := boolPtr(true)
 	owner := func(apiVersion, kind, name, uid string) metav1.OwnerReference {

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -75,9 +75,9 @@ var DefaultNamespace = unbounded.SystemNamespace()
 
 // buildDefaultNamespace is the namespace baked into the embedded component
 // manifests at build time (the render default). retargetNamespace rewrites it to
-// the operator's configured namespace when they differ. It must match the
-// manifest render default and internal/unbounded.systemNamespace.
-const buildDefaultNamespace = "unbounded-system"
+// the operator's configured namespace when they differ. It shares the single
+// build-default source of truth with the install tooling.
+const buildDefaultNamespace = unbounded.DefaultSystemNamespace
 
 type Config struct {
 	// MetalmanImage is the image for the synthesized per-site metalman

--- a/internal/unbounded/unbounded.go
+++ b/internal/unbounded/unbounded.go
@@ -9,12 +9,21 @@ package unbounded
 
 import "os"
 
+// DefaultSystemNamespace is the namespace baked into the rendered manifests at
+// build time and the default install namespace for unbounded components. It is
+// the build-time literal that manifest namespace references carry
+// (`{{ default "unbounded-system" .Namespace }}`), so tooling that retargets a
+// manifest to a custom namespace must use this constant as the rewrite source,
+// NOT SystemNamespace() (which reflects the caller's own POD_NAMESPACE and would
+// leave build-time references unrewritten). The Makefile UNBOUNDED_NAMESPACE
+// variable and the manifest template defaults must agree with this value; that
+// invariant is enforced by the drift-guard test in this package.
+const DefaultSystemNamespace = "unbounded-system"
+
 // systemNamespace is the default Kubernetes namespace that unbounded components
 // install into. It is the Go-side source of truth for binary defaults and
-// fallbacks. The Makefile UNBOUNDED_NAMESPACE variable and the manifest template
-// defaults (`{{ default "unbounded-system" .Namespace }}`) must agree with this
-// value; that invariant is enforced by the drift-guard test in this package.
-const systemNamespace = "unbounded-system"
+// fallbacks.
+const systemNamespace = DefaultSystemNamespace
 
 // SystemNamespace returns the namespace unbounded components run in. When
 // POD_NAMESPACE is set (injected into pods via the Downward API) it is used, so


### PR DESCRIPTION
## Summary

Hardens four correctness/outage risks in the unbounded-system work (the new `unbounded-operator`, released-cluster migration, single-namespace consolidation, and net SiteNodeSlice ownership), and adds end-to-end verification that the highest-severity fix actually prevents a cluster-wide dataplane outage. All findings are scoped to this branch's own changes (verified against `origin/main`). Two are pre-production blockers; two are robustness/visibility hardening. The happy path (default install, healthy apiserver, fully-translated Sites) is unchanged.

## 1. net: orphan cleanup could tear down the whole dataplane during migration (blocker)

**Problem.** `cleanupOrphanSiteNodeSlices` decided a slice was orphaned from a per-slice Site `GET` returning `NotFound`, and ran unconditionally before the `len(sites)==0` guard in `updateAllSiteSlices`. The Site GVR now points at the machina group.

**Impact.** On a released-cluster upgrade, the operator installs the machina Site CRD and rolls out the new net controller before the reaper has translated the legacy net-group Sites into the machina group. The controller's informer syncs, observes **zero** machina Sites, and cleanup deletes **every** `SiteNodeSlice` (each Site `GET` is `NotFound`). Because cleanup ran before the empty-set guard, the slices are **not** recreated. SiteNodeSlices are the source of truth for each node's WireGuard peers and pod-CIDR routes, so inter-node pod traffic is cut **cluster-wide** until the reaper finishes translating Sites.

**Fix.** Cleanup now (a) lists live machina Sites once - fixing the per-pass O(slices) Site-GET amplification and deleting nothing if the list fails; (b) skips entirely when zero Sites are present while slices exist (legitimate whole-Site deletion is handled by owner-reference GC); (c) keeps a slice whose Site still exists in the **legacy net group**, so an untranslated Site's slices are never deleted mid-migration; (d) deletes only genuine orphans (empty `siteName`, or a Site absent from both groups) with UID+ResourceVersion preconditions. Completing this, the net controller is granted read (`get/list/watch`) on `net.unbounded-cloud.io/sites`: without it the legacy check `403`s during the partial-migration window (the slice is still preserved because a lookup error is never read as "gone", but the intended legacy-present->keep path never runs and the controller logs errors every pass).

**Verification.** New real-apiserver e2e (`TestSiteControllerPreservesSlicesDuringMigrationWindow`) runs the real `SiteController` through the migration window and asserts the slice stays continuously present (empty-machina window), is re-owned on convergence, survives as a legacy-only slice, and that a genuine orphan is still deleted. Confirmed this test **fails on the reverted fix** (the buggy controller deletes the slice on the first sample) and passes on the fix.

## 2. kubectl install: broken operator RBAC when POD_NAMESPACE is set (blocker)

**Problem.** `install` rewrote the namespace baked into the rendered operator manifests using `unbounded.SystemNamespace()` as the rewrite *source*, which returns `$POD_NAMESPACE` when set - so it no longer matched the build-time literal `unbounded-system`.

**Impact.** An in-cluster installer (bootstrap Job/init container) has `POD_NAMESPACE` injected. The cluster-scoped `ClusterRoleBinding` subject namespace - the one reference `setNamespace` cannot fix - is left at `unbounded-system` while the ServiceAccount is created in the target namespace. The operator SA has no ClusterRole grant: forbidden on every call, never Ready, install times out despite manifests appearing applied.

**Fix.** Rewrite from the build-time constant `unbounded.DefaultSystemNamespace` and unify the operator's `buildDefaultNamespace` onto it. Regression test sets `POD_NAMESPACE` and asserts the ClusterRoleBinding subject is retargeted (verified failing on the old code).

## 3. operator: reaper whole-namespace delete could destroy unaudited state

**Problem.** The reaper deletes each drained legacy namespace wholesale, but the migration only copies Secrets (minus `SkipSecretNames`) and named/cloud-init/storage ConfigMaps out; `warnOnForeignWorkloads` audited only workload kinds.

**Impact.** A `PersistentVolumeClaim` (and its data) or the deliberately-skipped `unbounded-net-serving-cert` Secret left in `unbounded-kube` would be destroyed on namespace deletion with only a workload-scoped warning (operator-managed components use hostPath, so this is visibility hardening, not a default-path data-loss regression).

**Fix.** The pre-delete audit now also surfaces every PVC and every skipped Secret in the same warning/Event so operators see the full blast radius. Warn-and-proceed is unchanged. ConfigMaps aren't enumerated per-name (the migration copies dynamically-named cloud-init/storage ConfigMaps, which would false-positive).

## 4. operator: CRD-maintenance failures shouldn't stop the whole operator

**Problem.** `CRDMaintainer.Start` returned an error after 3 consecutive failures, which in controller-runtime stops the entire manager and exits the pod.

**Impact.** A ~90s apiserver blip during a control-plane upgrade fails the reapply three times and stops the manager - taking the Site reconciler and the **migration reaper mid-drain** down with it, so a half-complete migration stalls until the pod is rescheduled. The CRDs were `Established` and served the whole time, so nothing needed the restart.

**Fix.** Maintenance failures are logged with a consecutive-failure count and retried on the next interval; only context cancellation stops the loop. Removes the unused `MaxFailures` escalation.

## Verification / testing

- Unit tests for every cleanup branch (empty-source skip, legacy-present keep, denied-legacy-lookup preserve, genuine-orphan delete), the install `POD_NAMESPACE` regression, the CRD-maintainer retry contract, and the reaper PVC/Secret audit.
- `TestSiteControllerPreservesSlicesDuringMigrationWindow` (real kind apiserver) proves the #1 dataplane-continuity guarantee end-to-end, and was validated to fail on a reverted fix.
- The faithful upgrade e2e (`hack/operator-upgrade-e2e/e2e.py`) gains a background `ContinuityMonitor` that samples `SiteNodeSlice` presence across the whole migration (install -> reaper completion) and fails on any debounced disappearance, plus an optional best-effort `--probe-dataplane` WireGuard-peer check. (A cross-node pod ping is deliberately not used: the harness runs CNI-free alongside kindnet, so pod traffic wouldn't traverse the unbounded dataplane.)
- `make fmt`, `golangci-lint` (incl. e2e tag), `go build ./...`, `go vet` all clean.

## Scope / method

Findings identified against `origin/main` (three-dot diff) so only this branch's own changes are in scope.

## Not in this PR (follow-ups)

Shared namespace-retarget helper (dedup install vs operator), `ensureMachinaConfig` AlreadyExists race, multi-document `config.yaml` handling, `hack/net` `deploy-crds` Site CRD, dead `clusterinfo.ResolveApiserverURL`, inventory secret default.
