### PR TITLE
fix: unblock the first v0.1 -> v0.2 release upgrade (migration guard + empty operator component images)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -509,6 +509,46 @@ jobs:
             kubectl -n "$NS" rollout status "$1/$2" --timeout=5m
           done
 
+      - name: Diagnose failed rollout
+        # Runs only when a prior step failed (e.g. the operator never created a
+        # component workload). The operator is what materializes net/machina/etc.
+        # in unbounded-system, so its logs and the Site status are the ground
+        # truth. Every command is best-effort so diagnostics never mask the real
+        # failure. Explicitly surfaces the applied component images because an
+        # empty/invalid image is silently rejected by the API server, which
+        # presents as a workload that "never gets created".
+        if: failure()
+        run: |
+          set +e
+          NS=unbounded-system
+          echo "::group::Site CRDs"
+          kubectl get crd sites.unbounded-cloud.io sites.net.unbounded-cloud.io 2>&1
+          echo "::endgroup::"
+          echo "::group::Sites (new + legacy)"
+          kubectl get sites.unbounded-cloud.io -o wide 2>&1
+          kubectl get sites.unbounded-cloud.io -o yaml 2>&1
+          kubectl get sites.net.unbounded-cloud.io -A -o wide 2>&1
+          echo "::endgroup::"
+          echo "::group::Workloads in ${NS}"
+          kubectl -n "$NS" get deploy,ds,pods -o wide 2>&1
+          echo "::endgroup::"
+          echo "::group::Applied component images"
+          for kn in "deploy/unbounded-operator" "deploy/unbounded-net-controller" "ds/unbounded-net-node" "deploy/machina-controller"; do
+            img=$(kubectl -n "$NS" get "$kn" -o jsonpath='{.spec.template.spec.containers[*].image}' 2>/dev/null)
+            printf '%s image=[%s]\n' "$kn" "$img"
+          done
+          echo "::endgroup::"
+          echo "::group::Operator config"
+          kubectl -n "$NS" get configmap unbounded-operator-config -o yaml 2>&1
+          echo "::endgroup::"
+          echo "::group::Operator logs"
+          kubectl -n "$NS" logs deploy/unbounded-operator --all-containers --tail=300 2>&1
+          echo "::endgroup::"
+          echo "::group::Recent events in ${NS}"
+          kubectl -n "$NS" get events --sort-by=.lastTimestamp 2>&1 | tail -60
+          echo "::endgroup::"
+          exit 0
+
       - name: Summarize deploy
         if: always()
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -425,8 +425,19 @@ jobs:
             MODE=init
             echo "force_init=true; selecting init mode"
           elif kubectl get crd sites.net.unbounded-cloud.io >/dev/null 2>&1 && ! kubectl get crd sites.unbounded-cloud.io >/dev/null 2>&1; then
-            echo "::error::Old Site CRD sites.net.unbounded-cloud.io is present but sites.unbounded-cloud.io is absent. Apply an explicit Site API migration before deploying this snapshot."
-            exit 1
+            # First upgrade from the pre-redesign (v0.1) split-namespace layout:
+            # the old net-group Site CRD (sites.net.unbounded-cloud.io) exists but
+            # the new sites.unbounded-cloud.io CRD has not been bootstrapped yet.
+            # That CRD is created by the operator itself during the later
+            # 'Bootstrap CRDs and operator' step (kubectl unbounded install), so
+            # its absence here is expected for a first upgrade. Deploy in upgrade
+            # mode: install brings up the operator, whose always-on LegacyReaper
+            # translates the old Site into the new Site and migrates the split
+            # layout into unbounded-system automatically. Do NOT run 'site init'
+            # here; that would create a fresh Site instead of migrating the
+            # existing one.
+            MODE=upgrade
+            echo "Legacy Site CRD present and new Site CRD absent; first v0.1->v0.2 upgrade. Operator migrates automatically. Selecting upgrade mode"
           elif ! kubectl get crd sites.unbounded-cloud.io >/dev/null 2>&1; then
             MODE=init
             echo "Site CRD not present; selecting init mode"

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -395,6 +395,46 @@ jobs:
             kubectl -n "$NS" rollout status "$1/$2" --timeout=5m
           done
 
+      - name: Diagnose failed rollout
+        # Runs only when a prior step failed (e.g. the operator never created a
+        # component workload). The operator is what materializes net/machina/etc.
+        # in unbounded-system, so its logs and the Site status are the ground
+        # truth. Every command is best-effort so diagnostics never mask the real
+        # failure. Explicitly surfaces the applied component images because an
+        # empty/invalid image is silently rejected by the API server, which
+        # presents as a workload that "never gets created".
+        if: failure()
+        run: |
+          set +e
+          NS=unbounded-system
+          echo "::group::Site CRDs"
+          kubectl get crd sites.unbounded-cloud.io sites.net.unbounded-cloud.io 2>&1
+          echo "::endgroup::"
+          echo "::group::Sites (new + legacy)"
+          kubectl get sites.unbounded-cloud.io -o wide 2>&1
+          kubectl get sites.unbounded-cloud.io -o yaml 2>&1
+          kubectl get sites.net.unbounded-cloud.io -A -o wide 2>&1
+          echo "::endgroup::"
+          echo "::group::Workloads in ${NS}"
+          kubectl -n "$NS" get deploy,ds,pods -o wide 2>&1
+          echo "::endgroup::"
+          echo "::group::Applied component images"
+          for kn in "deploy/unbounded-operator" "deploy/unbounded-net-controller" "ds/unbounded-net-node" "deploy/machina-controller"; do
+            img=$(kubectl -n "$NS" get "$kn" -o jsonpath='{.spec.template.spec.containers[*].image}' 2>/dev/null)
+            printf '%s image=[%s]\n' "$kn" "$img"
+          done
+          echo "::endgroup::"
+          echo "::group::Operator config"
+          kubectl -n "$NS" get configmap unbounded-operator-config -o yaml 2>&1
+          echo "::endgroup::"
+          echo "::group::Operator logs"
+          kubectl -n "$NS" logs deploy/unbounded-operator --all-containers --tail=300 2>&1
+          echo "::endgroup::"
+          echo "::group::Recent events in ${NS}"
+          kubectl -n "$NS" get events --sort-by=.lastTimestamp 2>&1 | tail -60
+          echo "::endgroup::"
+          exit 0
+
       - name: Summarize deploy
         if: always()
         run: |

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -307,8 +307,19 @@ jobs:
             MODE=init
             echo "force_init=true; selecting init mode"
           elif kubectl get crd sites.net.unbounded-cloud.io >/dev/null 2>&1 && ! kubectl get crd sites.unbounded-cloud.io >/dev/null 2>&1; then
-            echo "::error::Old Site CRD sites.net.unbounded-cloud.io is present but sites.unbounded-cloud.io is absent. Apply an explicit Site API migration before deploying this release."
-            exit 1
+            # First upgrade from the pre-redesign (v0.1) split-namespace layout:
+            # the old net-group Site CRD (sites.net.unbounded-cloud.io) exists but
+            # the new sites.unbounded-cloud.io CRD has not been bootstrapped yet.
+            # That CRD is created by the operator itself during the later
+            # 'Bootstrap CRDs and operator' step (kubectl unbounded install), so
+            # its absence here is expected for a first upgrade. Deploy in upgrade
+            # mode: install brings up the operator, whose always-on LegacyReaper
+            # translates the old Site into the new Site and migrates the split
+            # layout into unbounded-system automatically. Do NOT run 'site init'
+            # here; that would create a fresh Site instead of migrating the
+            # existing one.
+            MODE=upgrade
+            echo "Legacy Site CRD present and new Site CRD absent; first v0.1->v0.2 upgrade. Operator migrates automatically. Selecting upgrade mode"
           elif ! kubectl get crd sites.unbounded-cloud.io >/dev/null 2>&1; then
             MODE=init
             echo "Site CRD not present; selecting init mode"

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,16 @@ AGENT_CMD=./cmd/agent
 
 MACHINA_BIN=bin/machina
 MACHINA_CMD=./cmd/machina
-MACHINA_IMAGE ?= $(CONTAINER_REGISTRY)/machina:$(VERSION_TAG)
+# Fall back to the default even when the variable is set to an empty string, not
+# just when unset. GNU make's `?=` treats a set-but-empty environment variable as
+# already defined; a Docker `ARG MACHINA_IMAGE=` exported into the operator image
+# build as "" therefore defeated `?=` and blanked the image baked into the
+# operator's embedded machina manifests. `override` also neutralizes an empty
+# value passed on the command line; `=` keeps CONTAINER_REGISTRY/VERSION_TAG
+# expansion deferred (VERSION_TAG is defined later in this file).
+ifeq ($(strip $(MACHINA_IMAGE)),)
+override MACHINA_IMAGE = $(CONTAINER_REGISTRY)/machina:$(VERSION_TAG)
+endif
 
 MACHINE_OPS_CONTROLLER_BIN=bin/machine-ops-controller
 MACHINE_OPS_CONTROLLER_CMD=./cmd/machine-ops-controller
@@ -214,8 +223,14 @@ KUBECTL_UNBOUNDED_LDFLAGS=$(STAMP_LDFLAGS)
 
 # --- Net (unbounded-net) configuration -------------------------------------
 # Container images for the net controller and node agent.
-NET_CONTROLLER_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-net-controller:$(VERSION_TAG)
-NET_NODE_IMAGE       ?= $(CONTAINER_REGISTRY)/unbounded-net-node:$(VERSION_TAG)
+# See the MACHINA_IMAGE note above: default when empty-or-unset so an empty
+# Docker ARG cannot blank the images baked into the embedded net manifests.
+ifeq ($(strip $(NET_CONTROLLER_IMAGE)),)
+override NET_CONTROLLER_IMAGE = $(CONTAINER_REGISTRY)/unbounded-net-controller:$(VERSION_TAG)
+endif
+ifeq ($(strip $(NET_NODE_IMAGE)),)
+override NET_NODE_IMAGE = $(CONTAINER_REGISTRY)/unbounded-net-node:$(VERSION_TAG)
+endif
 
 # CNI plugins version baked into the net-node image. Keep in sync with the
 # defaults in images/net-{node,controller}/Dockerfile and the workflow envs.
@@ -593,6 +608,9 @@ metalman-build: ## Build the metalman binary (no lint/test)
 metalman: test metalman-build ## Build the metalman controller (implies test)
 
 unbounded-operator-build: machina-manifests net-manifests unbounded-storage-supervisor-manifests unbounded-operator-manifests ## Build the unbounded-operator binary (no lint/test)
+	@for v in MACHINA_IMAGE=$(MACHINA_IMAGE) NET_CONTROLLER_IMAGE=$(NET_CONTROLLER_IMAGE) NET_NODE_IMAGE=$(NET_NODE_IMAGE); do \
+	  case "$$v" in *=) echo "error: $${v%=} is empty; the operator's embedded net/machina manifests would bake an empty image:" >&2; exit 1;; esac; \
+	done
 	$(GOBUILD) -ldflags '$(STAMP_LDFLAGS)' -o $(UNBOUNDED_OPERATOR_BIN) $(UNBOUNDED_OPERATOR_CMD)/main.go
 
 unbounded-operator: test unbounded-operator-build ## Build the unbounded-operator (implies test)

--- a/images/unbounded-operator/Containerfile
+++ b/images/unbounded-operator/Containerfile
@@ -36,7 +36,21 @@ ARG NET_CONTROLLER_IMAGE=
 ARG NET_NODE_IMAGE=
 ARG MACHINA_IMAGE=
 ARG STORAGE_SUPERVISOR_IMAGE=
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+# Unset any override that was left empty before invoking make. Docker exports
+# these ARGs into the RUN environment as empty strings when they are not
+# overridden, and GNU make treats an environment variable that is set (even to
+# "") as already defined, so the Makefile's `?=` defaults for MACHINA_IMAGE,
+# NET_CONTROLLER_IMAGE, and NET_NODE_IMAGE would NOT apply. That baked an empty
+# `image:` into the operator's embedded net/machina manifests, and the operator
+# then could not create those workloads (the API server rejects a Deployment
+# with an empty container image), so net-controller/machina-controller never
+# came up on upgrade. Unsetting the empties lets the Makefile defaults win while
+# still honoring any real override passed via --build-arg.
+RUN for v in NET_CONTROLLER_IMAGE NET_NODE_IMAGE MACHINA_IMAGE STORAGE_SUPERVISOR_IMAGE; do \
+        eval "val=\${$v-}"; \
+        [ -n "$val" ] || unset "$v"; \
+    done; \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     make unbounded-operator-build VERSION=${VERSION} ${GIT_COMMIT:+GIT_COMMIT=${GIT_COMMIT}} ${BUILD_TIME:+BUILD_TIME=${BUILD_TIME}} ${NET_CONTROLLER_IMAGE:+NET_CONTROLLER_IMAGE=${NET_CONTROLLER_IMAGE}} ${NET_NODE_IMAGE:+NET_NODE_IMAGE=${NET_NODE_IMAGE}} ${MACHINA_IMAGE:+MACHINA_IMAGE=${MACHINA_IMAGE}} ${STORAGE_SUPERVISOR_IMAGE:+UNBOUNDED_STORAGE_SUPERVISOR_IMAGE=${STORAGE_SUPERVISOR_IMAGE}}
 
 FROM ubuntu:noble


### PR DESCRIPTION
## Summary

The first release upgrade from the v0.1 split-namespace layout (unbounded-kube + unbounded-net) to the v0.2 operator-driven `unbounded-system` layout failed in two distinct places. This PR fixes both, plus adds regression hardening and deploy diagnostics so neither class of failure can recur silently.

Everything here is required for the very first `unbounded-system` release upgrade to succeed. The migration itself is automatic and operator-driven by design (`internal/operator/migrate.go` `LegacyReaper`, enabled by `kubectl unbounded install`); nothing here changes that intent - it just makes the release/upgrade tooling actually deliver it.

## Problem 1: the deploy workflow blocked the automatic migration

`release-upgrade.yaml` (and the identical `nightly.yaml`) `Determine deploy mode` step errored when the old net-group Site CRD (`sites.net.unbounded-cloud.io`) was present but the new `sites.unbounded-cloud.io` CRD was absent:

> Old Site CRD sites.net.unbounded-cloud.io is present but sites.unbounded-cloud.io is absent. Apply an explicit Site API migration before deploying this release.

That is exactly the first-upgrade state. The new CRD is bootstrapped by the operator itself during the later `Bootstrap CRDs and operator` step, so its absence at mode-determination time is normal. There is no "explicit Site API migration" to run - the operator's always-on `LegacyReaper` translates old Sites into new Sites automatically. (Original failing run: https://github.com/Azure/unbounded/actions/runs/29596188895)

**Fix:** for the "old Site CRD present, new absent" case, select `upgrade` mode (deploy the operator; let it migrate) instead of failing. `upgrade`, not `init`: `init` would run `site init` and create a fresh Site rather than migrate the existing one. This is the path the faithful upgrade e2e (`hack/operator-upgrade-e2e/e2e.py`) already exercises. Once migrated, the new CRD exists and subsequent deploys fall through to the normal site-exists path.

## Problem 2: the operator baked empty component images

With Problem 1 fixed, the deploy reached `upgrade` mode but then timed out at `Wait for rollouts`:

> timed out waiting for deploy/unbounded-net-controller in unbounded-system to be created

(run: https://github.com/Azure/unbounded/actions/runs/29597960120)

The operator applies its embedded net/machina manifests at runtime to create the component workloads. In the `v0.2.0-beta.1` operator image those manifests were rendered with an **empty `image:`** (from that release's build logs, run 29595130381):

```
Rendered machina manifests into deploy/machina/rendered (image: )
Rendered net manifests into deploy/net/rendered (controller: , node: )
```

A Deployment with an empty container image is rejected by the API server (`image: Required value`), so `unbounded-net-controller` was never created.

Root cause: `images/unbounded-operator/Containerfile` declares optional overrides `ARG NET_CONTROLLER_IMAGE=`, `ARG NET_NODE_IMAGE=`, `ARG MACHINA_IMAGE=`. Docker exports those as **empty environment variables** into the `RUN`, and GNU make treats a set-but-empty env var as already defined, so the Makefile's `?=` defaults did not apply. Storage/operator escaped because `UNBOUNDED_STORAGE_SUPERVISOR_IMAGE` uses `=` and a different name, and `UNBOUNDED_OPERATOR_IMAGE` has no matching ARG. This also explains why the e2e never caught it: the e2e passes those ARGs as non-empty local-registry values, so the empty-env path never triggers.

**Fix (two layers):**
- `images/unbounded-operator/Containerfile`: unset any override ARG that is empty before invoking `make`, so the Makefile defaults win while real `--build-arg` overrides are still honored.
- `Makefile`: replace the `?=` defaults for `MACHINA_IMAGE` / `NET_CONTROLLER_IMAGE` / `NET_NODE_IMAGE` with an `ifeq ($(strip $(VAR)),)` + `override =` guard so empty-or-unset behave identically (defense-in-depth). Plus a fail-fast guard in `unbounded-operator-build` that errors if any of the three images is empty, so a future regression surfaces at build time rather than as a workload that never gets created on deploy.

## Diagnostics

The original failure was a silent 5-minute rollout timeout with no operator output. Added an `if: failure()` **Diagnose failed rollout** step to `release-upgrade.yaml` and `nightly.yaml` that dumps the operator logs, Site status (both API groups), events, and the applied component images - the last specifically to make an empty/invalid image obvious.

## Changes

- `.github/workflows/release-upgrade.yaml`, `.github/workflows/nightly.yaml`
  - `Determine deploy mode`: first v0.1 -> v0.2 upgrade selects `upgrade` mode (operator migrates) instead of erroring.
  - New `Diagnose failed rollout` step on failure.
- `images/unbounded-operator/Containerfile`: unset empty override ARGs before `make`.
- `Makefile`: `ifeq`/`override` defaults for the three component images; fail-fast empty-image guard in `unbounded-operator-build`.

## Commits

1. `ci: let operator auto-migrate on first v0.1->v0.2 upgrade` - Problem 1.
2. `fix(operator-image): stop empty build ARGs from blanking net/machina images` - Problem 2 (Containerfile) + diagnostics.
3. `build: default net/machina image vars when empty, not just unset` - Problem 2 (Makefile hardening) + build guard.

## Testing

- **Problem 1 fix** is validated: run 29597960120 reached `upgrade` mode (previously errored). It runs from the branch's workflow definition, so `gh workflow run release-upgrade.yaml --ref <branch> -f tag=<tag> -f force_init=false` exercises it.
- **Problem 2 fixes** verified locally: `MACHINA_IMAGE= NET_CONTROLLER_IMAGE= NET_NODE_IMAGE= make ...` now resolves to `ghcr.io/azure/<component>:<tag>` (previously empty); non-empty overrides preserved; the build guard passes on valid images and exits 1 on an empty one.
- **End-to-end caveat:** Problems 2 and 3 change how the operator image is built, so they only take effect in a freshly built image. The broken image is already baked into `v0.2.0-beta.1`; re-running the deploy on that tag will still fail. After merge, cut a new prerelease (e.g. `v0.2.0-beta.2`) and confirm the operator-image build logs now show non-empty `Rendered net/machina manifests` images before release-upgrade deploys it.