### PR TITLE
Preconfigure Gantry containerd hosts in agent

### DIFF
--- a/cmd/agent/internal/daemon/nodeoperator.go
+++ b/cmd/agent/internal/daemon/nodeoperator.go
@@ -160,7 +160,15 @@ func hasDrift(applied, desired *provision.AgentConfig) bool {
 		return true
 	}
 
+	if gantryDisabled(applied) != gantryDisabled(desired) {
+		return true
+	}
+
 	return false
+}
+
+func gantryDisabled(cfg *provision.AgentConfig) bool {
+	return cfg.Gantry != nil && cfg.Gantry.Disabled
 }
 
 func (nspawnNodeOperator) RestartNode(ctx context.Context, log *slog.Logger, active *ActiveMachine) error {

--- a/cmd/agent/internal/daemon/nodeoperator_test.go
+++ b/cmd/agent/internal/daemon/nodeoperator_test.go
@@ -112,6 +112,20 @@ func Test_hasDrift_TaintsChange(t *testing.T) {
 	assert.True(t, hasDrift(applied, desired))
 }
 
+func Test_hasDrift_GantryChange(t *testing.T) {
+	applied := baseConfig()
+	desired := baseConfig()
+	desired.Gantry = &provision.GantryConfig{Disabled: true}
+	assert.True(t, hasDrift(applied, desired))
+}
+
+func Test_hasDrift_GantryExplicitFalseDoesNotDrift(t *testing.T) {
+	applied := baseConfig()
+	applied.Gantry = &provision.GantryConfig{}
+	desired := baseConfig()
+	assert.False(t, hasDrift(applied, desired))
+}
+
 // ---------------------------------------------------------------------------
 // Active machine config serialization
 // ---------------------------------------------------------------------------

--- a/deploy/gantry/README.md
+++ b/deploy/gantry/README.md
@@ -64,6 +64,15 @@ make image-gantry-local VERSION=v0.6.0
 
 ## Per-node containerd setup
 
+Nodes provisioned by `unbounded-agent` already have containerd configured to
+read `/etc/containerd/certs.d` and carry the managed default Gantry mirror
+entry in `/etc/containerd/certs.d/_default/hosts.toml`. On those nodes, install
+the Gantry DaemonSet normally; the mirror activates when the pod starts
+listening on `127.0.0.1:5000`.
+
+Use `node-config.yaml` only for standalone installs or non-agent-managed nodes
+that still need the default Gantry mirror entry written onto the node.
+
 For each upstream registry the cluster pulls from, drop a
 `hosts.toml` at:
 

--- a/internal/provision/agent_config.go
+++ b/internal/provision/agent_config.go
@@ -17,6 +17,7 @@ type (
 	AgentConfig           = config.AgentConfig
 	AgentClusterConfig    = config.AgentClusterConfig
 	AgentKubeletConfig    = config.AgentKubeletConfig
+	GantryConfig          = config.GantryConfig
 	KubeletAuthInfo       = config.KubeletAuthInfo
 	CRIConfig             = config.CRIConfig
 	ContainerdConfig      = config.ContainerdConfig

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -45,6 +45,7 @@ type AgentConfig struct {
 	Kubelet  AgentKubeletConfig `json:"Kubelet"`
 	CRI      CRIConfig          `json:"CRI"`
 	CNI      CNIConfig          `json:"CNI"`
+	Gantry   *GantryConfig      `json:"Gantry,omitempty"`
 
 	// OCIImage is the fully-qualified OCI image reference (e.g.
 	// "ghcr.io/org/repo:tag") used to bootstrap the machine rootfs.
@@ -73,6 +74,14 @@ type AgentConfig struct {
 // agent installs into the nspawn rootfs.
 type AgentOfflineArtifacts struct {
 	Source string `json:"Source,omitempty"`
+}
+
+// GantryConfig holds optional Gantry integration settings.
+type GantryConfig struct {
+	// Disabled skips writing the default containerd hosts.toml that points at
+	// Gantry. This is a breakglass setting for environments that need to own
+	// containerd registry routing independently.
+	Disabled bool `json:"Disabled,omitempty"`
 }
 
 // AdditionalHostMount configures a host path bind mount for the nspawn
@@ -158,7 +167,11 @@ func (a *AgentConfig) DeepCopy() *AgentConfig {
 
 	out.Kubelet.RegisterWithTaints = slices.Clone(a.Kubelet.RegisterWithTaints)
 	out.AdditionalHostDevices = slices.Clone(a.AdditionalHostDevices)
+
 	out.AdditionalHostMounts = slices.Clone(a.AdditionalHostMounts)
+	if a.Gantry != nil {
+		out.Gantry = &GantryConfig{Disabled: a.Gantry.Disabled}
+	}
 
 	out.OfflineArtifacts = a.OfflineArtifacts.DeepCopy()
 

--- a/pkg/agent/config/config_test.go
+++ b/pkg/agent/config/config_test.go
@@ -96,6 +96,7 @@ func TestCRIConfig_JSONRoundTrip(t *testing.T) {
 			Target:   "/etc/config",
 			ReadOnly: true,
 		}},
+		Gantry: &GantryConfig{Disabled: true},
 	}
 
 	data, err := json.Marshal(cfg)
@@ -113,6 +114,8 @@ func TestCRIConfig_JSONRoundTrip(t *testing.T) {
 		Target:   "/etc/config",
 		ReadOnly: true,
 	}}, decoded.AdditionalHostMounts)
+	require.NotNil(t, decoded.Gantry)
+	assert.True(t, decoded.Gantry.Disabled)
 }
 
 func TestIsSystemdDeviceGroupSpecifier(t *testing.T) {
@@ -334,6 +337,7 @@ func TestAgentConfig_DeepCopy(t *testing.T) {
 		AdditionalHostMounts: []AdditionalHostMount{{
 			Source: "/opt/config",
 		}},
+		Gantry: &GantryConfig{Disabled: true},
 	}
 
 	copy := original.DeepCopy()
@@ -344,11 +348,13 @@ func TestAgentConfig_DeepCopy(t *testing.T) {
 	copy.Kubelet.RegisterWithTaints[0] = "dedicated=prod:NoSchedule"
 	copy.AdditionalHostDevices[0] = "/dev/input/event0"
 	copy.AdditionalHostMounts[0].Source = "/opt/other"
+	copy.Gantry.Disabled = false
 
 	require.Equal(t, "test", original.Kubelet.Labels["env"])
 	require.Equal(t, "dedicated=test:NoSchedule", original.Kubelet.RegisterWithTaints[0])
 	require.Equal(t, "/dev/uinput", original.AdditionalHostDevices[0])
 	require.Equal(t, "/opt/config", original.AdditionalHostMounts[0].Source)
+	require.True(t, original.Gantry.Disabled)
 }
 
 func TestAgentConfig_DeepCopyNil(t *testing.T) {

--- a/pkg/agent/goalstates/constants.go
+++ b/pkg/agent/goalstates/constants.go
@@ -158,9 +158,12 @@ const (
 	DefaultAzureLinux3OCIImage       = "ghcr.io/azure/agent-azlinux3:v20260619"
 	DefaultAzureLinux3NvidiaOCIImage = "ghcr.io/azure/agent-azlinux3-nvidia:v20260626"
 
-	SystemdUnitContainerd   = "containerd.service"
-	ContainerdConfigPath    = "/etc/containerd/config.toml"
-	ContainerdConfDropInDir = "/etc/containerd/conf.d"
+	SystemdUnitContainerd      = "containerd.service"
+	ContainerdConfigPath       = "/etc/containerd/config.toml"
+	ContainerdConfDropInDir    = "/etc/containerd/conf.d"
+	ContainerdCertsDir         = "/etc/containerd/certs.d"
+	ContainerdDefaultHostsDir  = ContainerdCertsDir + "/_default"
+	ContainerdDefaultHostsPath = ContainerdDefaultHostsDir + "/hosts.toml"
 
 	SystemdUnitKubelet             = "kubelet.service"
 	KubeletKubeconfigPath          = "/var/lib/kubelet/kubeconfig"

--- a/pkg/agent/goalstates/nodestart.go
+++ b/pkg/agent/goalstates/nodestart.go
@@ -18,6 +18,7 @@ type NodeStart struct {
 
 	MachineDir string // e.g. /var/lib/machines/node
 	Containerd Containerd
+	Gantry     Gantry
 	Kubelet    Kubelet
 
 	// Nvidia holds NVIDIA GPU state discovered on the host. After the nspawn
@@ -25,4 +26,8 @@ type NodeStart struct {
 	// symlinks inside the container's library path pointing into the
 	// bind-mounted /run/host-nvidia/ directories.
 	Nvidia NvidiaHost
+}
+
+type Gantry struct {
+	Disabled bool
 }

--- a/pkg/agent/goalstates/resolve.go
+++ b/pkg/agent/goalstates/resolve.go
@@ -119,6 +119,7 @@ func ResolveMachine(log *slog.Logger, cfg *config.AgentConfig, machineName strin
 		NodeName:        cfg.NodeName,
 		MachineDir:      filepath.Join("/var/lib/machines", machineName),
 		Containerd:      ResolveContainerd(sandboxImage),
+		Gantry:          ResolveGantry(cfg.Gantry),
 		Kubelet:         kubelet,
 		Nvidia:          nvidia,
 	}
@@ -127,6 +128,10 @@ func ResolveMachine(log *slog.Logger, cfg *config.AgentConfig, machineName strin
 		RootFS:    rootFS,
 		NodeStart: nodeStart,
 	}, nil
+}
+
+func ResolveGantry(cfg *config.GantryConfig) Gantry {
+	return Gantry{Disabled: cfg != nil && cfg.Disabled}
 }
 
 // resolveKubelet builds the kubelet goal state from an agent config.

--- a/pkg/agent/goalstates/resolve_test.go
+++ b/pkg/agent/goalstates/resolve_test.go
@@ -371,6 +371,25 @@ func TestResolveMachine_UsesConfigNodeName(t *testing.T) {
 	assert.Equal(t, "machine-1", got.NodeStart.KubeMachineName)
 }
 
+func TestResolveMachine_GantryDisabled(t *testing.T) {
+	cfg := &config.AgentConfig{
+		MachineName: "machine-1",
+		NodeName:    "configured-node",
+		Cluster: config.AgentClusterConfig{
+			CaCertBase64: "Y2EtYnl0ZXM=",
+		},
+		Kubelet: config.AgentKubeletConfig{
+			ApiServer: "https://api.example.com",
+		},
+		Gantry: &config.GantryConfig{Disabled: true},
+	}
+
+	got, err := ResolveMachine(discardLogger(), cfg, "kube1", nil)
+	require.NoError(t, err)
+
+	assert.True(t, got.NodeStart.Gantry.Disabled)
+}
+
 func TestResolveMachine_AdditionalHostDevices(t *testing.T) {
 	cfg := &config.AgentConfig{
 		MachineName:           "machine-1",

--- a/pkg/agent/phases/nodestart/cri.go
+++ b/pkg/agent/phases/nodestart/cri.go
@@ -26,7 +26,15 @@ var assets embed.FS
 
 var assetsTemplate = template.Must(template.New("assets").ParseFS(assets, "assets/*"))
 
-const nvidiaRuntimeDropInName = "99-nvidia-runtime.toml"
+const (
+	nvidiaRuntimeDropInName  = "99-nvidia-runtime.toml"
+	gantryHostsManagedMarker = "# Managed by unbounded-agent for Gantry."
+	gantryHostsConfig        = gantryHostsManagedMarker + `
+[host."http://127.0.0.1:5000"]
+  capabilities = ["pull", "resolve"]
+  dial_timeout = "200ms"
+`
+)
 
 type configureContainerd struct {
 	goalState *goalstates.NodeStart
@@ -44,6 +52,12 @@ func (c *configureContainerd) Name() string { return "configure-containerd" }
 func (c *configureContainerd) Do(_ context.Context) error {
 	if err := c.ensureContainerdConfig(); err != nil {
 		return fmt.Errorf("ensure containerd config: %w", err)
+	}
+
+	if !c.goalState.Gantry.Disabled {
+		if err := c.ensureGantryHostsConfig(); err != nil {
+			return fmt.Errorf("ensure Gantry containerd hosts config: %w", err)
+		}
 	}
 
 	if err := c.ensureContainerdServiceUnit(); err != nil {
@@ -76,6 +90,37 @@ func (c *configureContainerd) ensureContainerdConfig() error {
 	dest := filepath.Join(c.goalState.MachineDir, goalstates.ContainerdConfigPath)
 
 	return utilio.WriteFile(dest, buf.Bytes(), 0o644)
+}
+
+func (c *configureContainerd) ensureGantryHostsConfig() error {
+	dest := filepath.Join(c.goalState.MachineDir, goalstates.ContainerdDefaultHostsPath)
+
+	existing, err := os.ReadFile(dest)
+	switch {
+	case err == nil:
+		if !hasGantryHostsManagedMarker(existing) {
+			return fmt.Errorf("refusing to overwrite unmanaged containerd hosts file %s", goalstates.ContainerdDefaultHostsPath)
+		}
+	case errors.Is(err, os.ErrNotExist):
+	default:
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+
+	return utilio.WriteFile(dest, []byte(gantryHostsConfig), 0o644)
+}
+
+func hasGantryHostsManagedMarker(content []byte) bool {
+	for _, line := range bytes.Split(content, []byte{'\n'}) {
+		if string(bytes.TrimSpace(line)) == gantryHostsManagedMarker {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ensureContainerdServiceUnit renders and writes the containerd systemd unit

--- a/pkg/agent/phases/nodestart/cri_test.go
+++ b/pkg/agent/phases/nodestart/cri_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package nodestart
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
+)
+
+func TestConfigureContainerdWritesGantryHostsConfig(t *testing.T) {
+	t.Parallel()
+
+	machineDir := t.TempDir()
+	goalState := &goalstates.NodeStart{
+		MachineDir: machineDir,
+		Containerd: goalstates.ResolveContainerd(""),
+	}
+
+	require.NoError(t, ConfigureContainerd(goalState).Do(context.Background()))
+
+	path := filepath.Join(machineDir, goalstates.ContainerdDefaultHostsPath)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, gantryHostsConfig, string(data))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+func TestConfigureContainerdUpdatesManagedGantryHostsConfig(t *testing.T) {
+	t.Parallel()
+
+	machineDir := t.TempDir()
+	path := filepath.Join(machineDir, goalstates.ContainerdDefaultHostsPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(gantryHostsManagedMarker+"\nold = true\n"), 0o600))
+
+	goalState := &goalstates.NodeStart{
+		MachineDir: machineDir,
+		Containerd: goalstates.ResolveContainerd(""),
+	}
+
+	require.NoError(t, ConfigureContainerd(goalState).Do(context.Background()))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, gantryHostsConfig, string(data))
+}
+
+func TestConfigureContainerdRefusesUnmanagedGantryHostsConfig(t *testing.T) {
+	t.Parallel()
+
+	machineDir := t.TempDir()
+	path := filepath.Join(machineDir, goalstates.ContainerdDefaultHostsPath)
+	original := []byte("# managed by someone else\n")
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, original, 0o644))
+
+	goalState := &goalstates.NodeStart{
+		MachineDir: machineDir,
+		Containerd: goalstates.ResolveContainerd(""),
+	}
+
+	err := ConfigureContainerd(goalState).Do(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to overwrite unmanaged containerd hosts file")
+
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	require.Equal(t, original, data)
+}
+
+func TestConfigureContainerdSkipsGantryHostsConfigWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	machineDir := t.TempDir()
+	path := filepath.Join(machineDir, goalstates.ContainerdDefaultHostsPath)
+	original := []byte("# managed by someone else\n")
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, original, 0o644))
+
+	goalState := &goalstates.NodeStart{
+		MachineDir: machineDir,
+		Containerd: goalstates.ResolveContainerd(""),
+		Gantry:     goalstates.Gantry{Disabled: true},
+	}
+
+	require.NoError(t, ConfigureContainerd(goalState).Do(context.Background()))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, original, data)
+}
+
+func TestConfigureContainerdLeavesPerRegistryHostsConfig(t *testing.T) {
+	t.Parallel()
+
+	machineDir := t.TempDir()
+	path := filepath.Join(machineDir, goalstates.ContainerdCertsDir, "ghcr.io", "hosts.toml")
+	original := []byte("server = \"https://ghcr.io\"\n")
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, original, 0o644))
+
+	goalState := &goalstates.NodeStart{
+		MachineDir: machineDir,
+		Containerd: goalstates.ResolveContainerd(""),
+	}
+
+	require.NoError(t, ConfigureContainerd(goalState).Do(context.Background()))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, original, data)
+}


### PR DESCRIPTION
## Summary
- preconfigure agent-provisioned nodes with a managed containerd `_default/hosts.toml` that points at Gantry on `127.0.0.1:5000`
- add `AgentConfig.Gantry.Disabled` as a breakglass flag to skip writing the Gantry hosts file
- refuse to overwrite unmanaged `_default/hosts.toml` while leaving per-registry hosts config untouched
- document that `deploy/gantry/node-config.yaml` remains for standalone/non-agent-managed nodes

## Validation
- `GOTOOLCHAIN=auto go test ./pkg/agent/config ./internal/provision ./pkg/agent/goalstates ./pkg/agent/phases/nodestart ./cmd/agent/internal/daemon`
- `GOTOOLCHAIN=auto make lint`
- `git diff --check`
- manual absent-mirror validation on temporary 1-node AKS cluster `ubg07201348`:
  - node: `aks-nodepool1-24892595-vmss000000`
  - containerd: `2.3.2-1`
  - installed the proposed `_default/hosts.toml` while Gantry was not installed/listening
  - pulled `docker.io/library/busybox:latest` with host `ctr --namespace k8s.io`
  - observed `ABSENT_MIRROR_TEST_PASS`
  - restore trap reported `removed temporary hosts.toml`

## Cleanup
- deleted the temporary test pod
- deleted temporary AKS resource groups `rg-ub-gantry-07201348` and `rg-ub-gantry-nodes-07201348`
