### PR TITLE
operator: pluggable component reconciler interface

### DIFF
--- a/api/machina/v1alpha3/site_types.go
+++ b/api/machina/v1alpha3/site_types.go
@@ -108,6 +108,11 @@ type SiteSpec struct {
 // SiteComponents declares optional components managed by the unbounded operator.
 // Networking (unbounded-net) is not a component: it is a cluster singleton the
 // operator deploys whenever at least one Site exists.
+//
+// Each field corresponds to a component reconciler registered with the operator.
+// To add a new component, add a typed field here and implement
+// component.ClusterComponent or component.SiteComponent in a package under
+// internal/operator/components, then register it in operator.DefaultRegistry.
 type SiteComponents struct {
 	// Machina configures the machina controller for this site.
 	// +optional

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -193,6 +193,7 @@ func run(ctx context.Context, cfg config) error {
 		Client:    mgr.GetClient(),
 		Scheme:    scheme,
 		Namespace: namespace,
+		Registry:  operator.DefaultRegistry(),
 		Config: operator.Config{
 			MetalmanImage:     cfg.metalmanImage,
 			APIServerEndpoint: cfg.apiServerEndpoint,

--- a/internal/operator/bootstrap.go
+++ b/internal/operator/bootstrap.go
@@ -23,13 +23,10 @@ import (
 
 	machinamanifests "github.com/Azure/unbounded/deploy/machina"
 	netmanifests "github.com/Azure/unbounded/deploy/net"
+	"github.com/Azure/unbounded/internal/operator/component"
 )
 
 const (
-	// crdKind is the Kind of a CustomResourceDefinition object in the embedded
-	// manifests.
-	crdKind = "CustomResourceDefinition"
-
 	// crdEstablishedPoll is the poll interval while waiting for CRDs to become
 	// Established.
 	crdEstablishedPoll = time.Second
@@ -173,7 +170,7 @@ func bootstrapCRDs(ctx context.Context, c client.Client, timeout time.Duration) 
 // applyCRDsFromFS applies every CRD found in the given manifest filesystem and
 // returns the names it applied.
 func applyCRDsFromFS(ctx context.Context, logger logr.Logger, c client.Client, manifests fs.FS) ([]string, error) {
-	files, err := yamlFiles(manifests)
+	files, err := component.YamlFiles(manifests)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +195,7 @@ func applyCRDsFromFS(ctx context.Context, logger logr.Logger, c client.Client, m
 				return nil, fmt.Errorf("decode %s: %w", file, err)
 			}
 
-			if obj.Object == nil || obj.GetKind() != crdKind {
+			if obj.Object == nil || obj.GetKind() != component.CRDKind {
 				continue
 			}
 

--- a/internal/operator/compat.go
+++ b/internal/operator/compat.go
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/operator/components/machina"
+	"github.com/Azure/unbounded/internal/operator/components/metalman"
+	"github.com/Azure/unbounded/internal/operator/components/storage"
+)
+
+// Component name identifiers. These mirror each component's Name() and are used
+// by the legacy reaper (migrate.go) to gate per-component migration.
+const (
+	ComponentNet      = "net"
+	ComponentMachina  = "machina"
+	ComponentMetalman = "metalman"
+	ComponentStorage  = "storage"
+)
+
+// Per-site resource name helpers, sourced from the component packages so the
+// reaper and the components agree on the object names.
+var (
+	metalmanDeploymentName = metalman.DeploymentName
+	storageConfigName      = storage.SiteConfigName
+	storageDaemonSetName   = storage.SiteDaemonSetName
+)
+
+// componentEnabled reports whether a Site enables the named component. It is used
+// by the legacy reaper to decide whether a component's per-site resources should
+// exist in the target namespace.
+func componentEnabled(site *unboundedv1alpha3.Site, name string) bool {
+	switch name {
+	case ComponentMachina:
+		return machina.EnabledFor(site)
+	case ComponentMetalman:
+		return metalman.Component{}.Enabled(site)
+	case ComponentStorage:
+		return storage.Component{}.Enabled(site)
+	default:
+		return false
+	}
+}

--- a/internal/operator/component/component.go
+++ b/internal/operator/component/component.go
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+// ClusterComponent is a cluster-wide unit of desired state (for example net or
+// machina). It reconciles once per pass from the full set of Sites and is never
+// tied to a single Site, so it also runs on the Site-less pass (a Site deletion
+// or a managed singleton-resource event).
+type ClusterComponent interface {
+	// Name is the stable, unique component identifier (for example "net"). It is
+	// used in logs and must be unique within a Registry.
+	Name() string
+
+	// ConditionType is the Site status condition type published for this
+	// component (for example "NetReady"). It must be CamelCase alphanumeric and
+	// unique within a Registry.
+	ConditionType() string
+
+	// Reconcile drives the component to its desired state given every Site and
+	// reports the outcome.
+	Reconcile(ctx context.Context, env *Env, sites []unboundedv1alpha3.Site) Result
+}
+
+// SiteComponent is a per-Site unit of desired state (for example metalman or
+// storage). The SiteReconciler runs it only when a Site is present, so
+// Reconcile and Cleanup always receive a non-nil Site. The driver owns the
+// enable/disable branch: it calls Reconcile when Enabled reports true and
+// Cleanup when it reports false (or the Site is deleted via owner-reference
+// garbage collection).
+type SiteComponent interface {
+	// Name is the stable, unique component identifier (for example "metalman").
+	Name() string
+
+	// ConditionType is the Site status condition type published for this
+	// component (for example "MetalmanReady").
+	ConditionType() string
+
+	// Enabled reports whether the component should run for the Site.
+	Enabled(site *unboundedv1alpha3.Site) bool
+
+	// Reconcile applies the component's desired state for the Site.
+	Reconcile(ctx context.Context, env *Env, site *unboundedv1alpha3.Site) Result
+
+	// Cleanup removes the component's per-Site resources when it is disabled.
+	Cleanup(ctx context.Context, env *Env, site *unboundedv1alpha3.Site) error
+}
+
+// WatchProvider is implemented by a ClusterComponent or SiteComponent that owns
+// or watches resources whose churn should re-trigger its reconcile. The
+// SiteReconciler calls SetupWatches on every component that implements it when
+// wiring the controller.
+type WatchProvider interface {
+	SetupWatches(b *builder.Builder, env *Env)
+}
+
+// Registry is the ordered set of components the SiteReconciler drives. Cluster
+// components run in every pass; Site components run only when a Site is present.
+// Conditions are published Cluster-first then Site, so the order of these slices
+// is the stable condition order on the Site status.
+type Registry struct {
+	Cluster []ClusterComponent
+	Site    []SiteComponent
+}
+
+// Validate rejects an empty registry and duplicate Name or ConditionType values
+// across both lists, so a misconfigured registry fails fast at startup rather
+// than silently dropping or double-publishing a condition.
+func (r *Registry) Validate() error {
+	if len(r.Cluster)+len(r.Site) == 0 {
+		return fmt.Errorf("registry has no components")
+	}
+
+	names := map[string]struct{}{}
+	conditions := map[string]struct{}{}
+
+	register := func(kind, name, condition string) error {
+		if name == "" {
+			return fmt.Errorf("%s component has an empty name", kind)
+		}
+
+		if condition == "" {
+			return fmt.Errorf("%s component %q has an empty condition type", kind, name)
+		}
+
+		if _, exists := names[name]; exists {
+			return fmt.Errorf("component %q is registered more than once", name)
+		}
+
+		if _, exists := conditions[condition]; exists {
+			return fmt.Errorf("condition type %q is registered more than once", condition)
+		}
+
+		names[name] = struct{}{}
+		conditions[condition] = struct{}{}
+
+		return nil
+	}
+
+	for _, c := range r.Cluster {
+		if err := register("cluster", c.Name(), c.ConditionType()); err != nil {
+			return err
+		}
+	}
+
+	for _, c := range r.Site {
+		if err := register("site", c.Name(), c.ConditionType()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/operator/component/component.go
+++ b/internal/operator/component/component.go
@@ -16,6 +16,13 @@ import (
 // machina). It reconciles once per pass from the full set of Sites and is never
 // tied to a single Site, so it also runs on the Site-less pass (a Site deletion
 // or a managed singleton-resource event).
+//
+// Reconcile runs on every pass and must be idempotent. A not-ready Result does
+// not by itself schedule a retry: the driver requeues on Result.Err or after
+// Result.RequeueAfter, otherwise the component only re-runs when one of the
+// watches it registers via WatchProvider fires. On the Site-less pass there is
+// no Site status to publish, so a not-ready Result there is meaningful only
+// through its Err or RequeueAfter.
 type ClusterComponent interface {
 	// Name is the stable, unique component identifier (for example "net"). It is
 	// used in logs and must be unique within a Registry.
@@ -37,6 +44,11 @@ type ClusterComponent interface {
 // enable/disable branch: it calls Reconcile when Enabled reports true and
 // Cleanup when it reports false (or the Site is deleted via owner-reference
 // garbage collection).
+//
+// Reconcile runs on every Site event and must be idempotent. To self-heal owned
+// resources on drift or deletion, set a controller owner reference (see
+// Env.SiteOwnerReference) and register Owns via WatchProvider; a not-ready
+// Result requeues only through Result.Err or Result.RequeueAfter.
 type SiteComponent interface {
 	// Name is the stable, unique component identifier (for example "metalman").
 	Name() string

--- a/internal/operator/component/configmap.go
+++ b/internal/operator/component/configmap.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ConfigMapPayloadHash hashes the complete ConfigMap payload. JSON provides a
+// deterministic encoding for string-keyed maps, including binary values.
+func ConfigMapPayloadHash(config *corev1.ConfigMap) string {
+	payload, err := json.Marshal(struct {
+		Data       map[string]string `json:"data"`
+		BinaryData map[string][]byte `json:"binaryData"`
+	}{
+		Data:       config.Data,
+		BinaryData: config.BinaryData,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("encode ConfigMap payload: %v", err))
+	}
+
+	sum := sha256.Sum256(payload)
+
+	return hex.EncodeToString(sum[:])
+}
+
+// ConfigMapPayloadChanged reports whether two ConfigMaps differ in payload.
+func ConfigMapPayloadChanged(oldConfig, newConfig *corev1.ConfigMap) bool {
+	return ConfigMapPayloadHash(oldConfig) != ConfigMapPayloadHash(newConfig)
+}

--- a/internal/operator/component/env.go
+++ b/internal/operator/component/env.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
@@ -335,24 +336,51 @@ func ToUnstructured(obj client.Object) *unstructured.Unstructured {
 	return &unstructured.Unstructured{Object: objectMap}
 }
 
-// SiteOwnerReference builds the owner reference used for per-site resources.
-// Using owner references rather than a Site finalizer lets Kubernetes garbage
-// collect per-site workloads if a Site is deleted while the operator is down.
+// IsRBACObject reports whether obj is an RBAC object (ServiceAccount, Role,
+// RoleBinding, ClusterRole, or ClusterRoleBinding) whose name contains
+// nameContains. It single-sources the shared decision of which RBAC objects in a
+// bundled manifest set belong to a given component, so a cluster component that
+// skips another component's RBAC and the per-Site component that applies it
+// cannot drift apart.
+func IsRBACObject(obj *unstructured.Unstructured, nameContains string) bool {
+	switch obj.GetKind() {
+	case "ServiceAccount", "Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding":
+		return strings.Contains(obj.GetName(), nameContains)
+	default:
+		return false
+	}
+}
+
+// SiteOwnerReference builds the controller owner reference used for per-site
+// resources. Using owner references rather than a Site finalizer lets Kubernetes
+// garbage collect per-site workloads if a Site is deleted while the operator is
+// down.
+//
+// Controller is set so controller-runtime's Owns() watch (which enqueues only
+// via metav1.GetControllerOf) re-reconciles the Site when an owned resource
+// drifts or is deleted. BlockOwnerDeletion is intentionally left unset: setting
+// it triggers the OwnerReferencesPermissionEnforcement admission check for
+// update on sites/finalizers, which the operator ServiceAccount does not hold,
+// and would cause every owned-object apply to be rejected.
 func SiteOwnerReference(site *unboundedv1alpha3.Site) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: unboundedv1alpha3.GroupVersion.String(),
 		Kind:       "Site",
 		Name:       site.Name,
 		UID:        site.UID,
+		Controller: ptr.To(true),
 	}
 }
 
 // UpsertOwnerReference adds or updates owner in refs, returning whether the slice
-// changed.
+// changed. An existing reference to the same owner (matched by UID, Kind, and
+// APIVersion) is rewritten when its Name or Controller flag differs, so a
+// resource adopted before Controller ownership was introduced converges to a
+// controller reference on the next reconcile.
 func UpsertOwnerReference(refs []metav1.OwnerReference, owner metav1.OwnerReference) ([]metav1.OwnerReference, bool) {
 	for i := range refs {
 		if refs[i].UID == owner.UID && refs[i].Kind == owner.Kind && refs[i].APIVersion == owner.APIVersion {
-			if refs[i].Name == owner.Name {
+			if refs[i].Name == owner.Name && controllerEqual(refs[i].Controller, owner.Controller) {
 				return refs, false
 			}
 
@@ -367,6 +395,12 @@ func UpsertOwnerReference(refs []metav1.OwnerReference, owner metav1.OwnerRefere
 	out = append(out, owner)
 
 	return out, true
+}
+
+// controllerEqual compares two owner-reference Controller pointers, treating a
+// nil pointer as false.
+func controllerEqual(a, b *bool) bool {
+	return ptr.Deref(a, false) == ptr.Deref(b, false)
 }
 
 // SiteNodeAffinity matches Nodes carrying either the canonical site label or the

--- a/internal/operator/component/env.go
+++ b/internal/operator/component/env.go
@@ -1,0 +1,395 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/unbounded"
+)
+
+const (
+	// FieldOwner is the server-side apply field manager the operator uses for
+	// every object it applies.
+	FieldOwner = "unbounded-operator"
+
+	// CRDKind is the Kind of a CustomResourceDefinition object in the embedded
+	// manifests. The operator installs CRDs once at startup, so components skip
+	// them during reconcile.
+	CRDKind = "CustomResourceDefinition"
+
+	// SiteLabelKey is the canonical node label for site membership
+	// (unbounded-cloud.io/site). Per-site components node-select on it.
+	SiteLabelKey = unboundedv1alpha3.MachineSiteLabelKey
+
+	// DeprecatedSiteLabelKey is the node site-membership label used by released
+	// net controllers before the switch to unbounded-cloud.io/site. Per-site
+	// workloads target either key during the deprecation window so they schedule
+	// before the upgraded net has converged all Nodes to the canonical label.
+	DeprecatedSiteLabelKey = "net.unbounded-cloud.io/site"
+
+	// SingletonRequestName cannot collide with a valid Site name. Managed
+	// singleton resource events use it independently of Site fan-out.
+	SingletonRequestName = "__singletons"
+
+	// BuildDefaultNamespace is the namespace baked into the embedded component
+	// manifests at build time. RetargetNamespace rewrites it to the operator's
+	// configured namespace when they differ.
+	BuildDefaultNamespace = unbounded.DefaultSystemNamespace
+)
+
+// DefaultNamespace is the namespace the operator installs components into. It
+// follows the operator's own namespace (unbounded.SystemNamespace()).
+var DefaultNamespace = unbounded.SystemNamespace()
+
+// Config carries operator-level settings components read while reconciling.
+type Config struct {
+	// MetalmanImage is the image for the synthesized per-site metalman
+	// Deployment.
+	MetalmanImage string
+
+	// APIServerEndpoint is injected into the machina controller config and
+	// advertised to metalman.
+	APIServerEndpoint string
+}
+
+// Env is the shared execution context handed to every component. It bundles the
+// Kubernetes client, scheme, target namespace, and operator Config together with
+// the manifest-apply and helper machinery components use to reconcile.
+type Env struct {
+	Client    client.Client
+	Scheme    *runtime.Scheme
+	Namespace string
+	Config    Config
+}
+
+// ApplyManifestFS server-side applies every YAML object in the manifest
+// filesystem, running mutate on each decoded object first. A mutate that nils
+// out obj.Object skips that object.
+func (e *Env) ApplyManifestFS(ctx context.Context, manifests fs.FS, mutate func(*unstructured.Unstructured) error) error {
+	files, err := YamlFiles(manifests)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		data, err := fs.ReadFile(manifests, file)
+		if err != nil {
+			return fmt.Errorf("read manifest %s: %w", file, err)
+		}
+
+		if err := e.applyManifestData(ctx, data, mutate); err != nil {
+			return fmt.Errorf("apply manifest %s: %w", file, err)
+		}
+	}
+
+	return nil
+}
+
+func (e *Env) applyManifestData(ctx context.Context, data []byte, mutate func(*unstructured.Unstructured) error) error {
+	decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+	for {
+		obj := &unstructured.Unstructured{}
+		if err := decoder.Decode(obj); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return fmt.Errorf("decode resource: %w", err)
+		}
+
+		if obj.Object == nil {
+			continue
+		}
+
+		if mutate != nil {
+			if err := mutate(obj); err != nil {
+				return err
+			}
+		}
+
+		if obj.Object == nil {
+			continue
+		}
+
+		e.RetargetNamespace(obj)
+
+		if err := e.ApplyObject(ctx, obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ApplyObject server-side applies a single object with the operator field owner.
+func (e *Env) ApplyObject(ctx context.Context, obj client.Object) error {
+	applyCfg := client.ApplyConfigurationFromUnstructured(ToUnstructured(obj))
+	if err := e.Client.Apply(ctx, applyCfg, client.FieldOwner(FieldOwner), client.ForceOwnership); err != nil {
+		return fmt.Errorf("apply %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	return nil
+}
+
+// ListSites returns every Site in the cluster.
+func (e *Env) ListSites(ctx context.Context) ([]unboundedv1alpha3.Site, error) {
+	var sites unboundedv1alpha3.SiteList
+	if err := e.Client.List(ctx, &sites); err != nil {
+		return nil, fmt.Errorf("list sites: %w", err)
+	}
+
+	return sites.Items, nil
+}
+
+// DeleteIfExists deletes an object, treating an already-absent object as success.
+func (e *Env) DeleteIfExists(ctx context.Context, obj client.Object) error {
+	if err := e.Client.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete %s %s/%s: %w",
+			obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	return nil
+}
+
+// DefaultConfigMap extracts the named ConfigMap from a manifest filesystem and
+// retargets it to the operator namespace. component names the manifest set for
+// error messages.
+func (e *Env) DefaultConfigMap(manifests fs.FS, name, component string) (*corev1.ConfigMap, error) {
+	files, err := YamlFiles(manifests)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		data, err := fs.ReadFile(manifests, file)
+		if err != nil {
+			return nil, fmt.Errorf("read %s manifest %s: %w", component, file, err)
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+		for {
+			obj := &unstructured.Unstructured{}
+			if err := decoder.Decode(obj); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, fmt.Errorf("decode %s manifest %s: %w", component, file, err)
+			}
+
+			if obj.Object == nil || obj.GetKind() != "ConfigMap" || obj.GetName() != name {
+				continue
+			}
+
+			cm := &corev1.ConfigMap{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, cm); err != nil {
+				return nil, fmt.Errorf("convert %s config template: %w", component, err)
+			}
+
+			cm.Namespace = e.Namespace
+
+			return cm, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%s config template not found", component)
+}
+
+// RetargetNamespace rewrites embedded-manifest references from the build-time
+// default namespace (BuildDefaultNamespace) to the operator's configured
+// namespace. It is a no-op in the default install where the two are identical.
+func (e *Env) RetargetNamespace(obj *unstructured.Unstructured) {
+	ns := e.Namespace
+	if ns == "" || ns == BuildDefaultNamespace {
+		return
+	}
+
+	if obj.GetKind() == "Namespace" {
+		if obj.GetName() == BuildDefaultNamespace {
+			obj.SetName(ns)
+		}
+
+		return
+	}
+
+	if obj.GetNamespace() == BuildDefaultNamespace {
+		obj.SetNamespace(ns)
+	}
+
+	rewriteNamespaceValues(obj.Object, BuildDefaultNamespace, ns)
+}
+
+// rewriteNamespaceValues recursively retargets every string value that embeds the
+// old namespace to the new one, covering exact matches, service-account
+// usernames in CEL, and flag values, while leaving unrelated strings (image
+// references) untouched.
+func rewriteNamespaceValues(value any, oldNS, newNS string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, v := range typed {
+			if str, ok := v.(string); ok {
+				typed[key] = retargetNamespaceInString(str, oldNS, newNS)
+				continue
+			}
+
+			rewriteNamespaceValues(v, oldNS, newNS)
+		}
+	case []any:
+		for i, v := range typed {
+			if str, ok := v.(string); ok {
+				typed[i] = retargetNamespaceInString(str, oldNS, newNS)
+				continue
+			}
+
+			rewriteNamespaceValues(v, oldNS, newNS)
+		}
+	}
+}
+
+func retargetNamespaceInString(s, oldNS, newNS string) string {
+	if s == oldNS {
+		return newNS
+	}
+
+	if strings.Contains(s, "system:serviceaccount:"+oldNS+":") {
+		s = strings.ReplaceAll(s, "system:serviceaccount:"+oldNS+":", "system:serviceaccount:"+newNS+":")
+	}
+
+	if strings.HasPrefix(s, "--") && strings.HasSuffix(s, "="+oldNS) {
+		s = strings.TrimSuffix(s, "="+oldNS) + "=" + newNS
+	}
+
+	return s
+}
+
+// YamlFiles returns the sorted list of YAML files in a manifest filesystem.
+func YamlFiles(fsys fs.FS) ([]string, error) {
+	var files []string
+
+	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		ext := strings.ToLower(pathExt(path))
+		if ext == ".yaml" || ext == ".yml" {
+			files = append(files, path)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	sort.Strings(files)
+
+	return files, nil
+}
+
+// pathExt returns the file extension of a slash-separated FS path.
+func pathExt(path string) string {
+	for i := len(path) - 1; i >= 0 && path[i] != '/'; i-- {
+		if path[i] == '.' {
+			return path[i:]
+		}
+	}
+
+	return ""
+}
+
+// ToUnstructured converts a client.Object into its unstructured form.
+func ToUnstructured(obj client.Object) *unstructured.Unstructured {
+	if unstr, ok := obj.(*unstructured.Unstructured); ok {
+		return unstr
+	}
+
+	objectMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	return &unstructured.Unstructured{Object: objectMap}
+}
+
+// SiteOwnerReference builds the owner reference used for per-site resources.
+// Using owner references rather than a Site finalizer lets Kubernetes garbage
+// collect per-site workloads if a Site is deleted while the operator is down.
+func SiteOwnerReference(site *unboundedv1alpha3.Site) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: unboundedv1alpha3.GroupVersion.String(),
+		Kind:       "Site",
+		Name:       site.Name,
+		UID:        site.UID,
+	}
+}
+
+// UpsertOwnerReference adds or updates owner in refs, returning whether the slice
+// changed.
+func UpsertOwnerReference(refs []metav1.OwnerReference, owner metav1.OwnerReference) ([]metav1.OwnerReference, bool) {
+	for i := range refs {
+		if refs[i].UID == owner.UID && refs[i].Kind == owner.Kind && refs[i].APIVersion == owner.APIVersion {
+			if refs[i].Name == owner.Name {
+				return refs, false
+			}
+
+			out := append([]metav1.OwnerReference(nil), refs...)
+			out[i] = owner
+
+			return out, true
+		}
+	}
+
+	out := append([]metav1.OwnerReference(nil), refs...)
+	out = append(out, owner)
+
+	return out, true
+}
+
+// SiteNodeAffinity matches Nodes carrying either the canonical site label or the
+// deprecated net-prefixed site label. The OR is required during migration.
+func SiteNodeAffinity(siteName string) *corev1.Affinity {
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					siteNodeSelectorTerm(SiteLabelKey, siteName),
+					siteNodeSelectorTerm(DeprecatedSiteLabelKey, siteName),
+				},
+			},
+		},
+	}
+}
+
+func siteNodeSelectorTerm(key, siteName string) corev1.NodeSelectorTerm {
+	return corev1.NodeSelectorTerm{
+		MatchExpressions: []corev1.NodeSelectorRequirement{{
+			Key:      key,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{siteName},
+		}},
+	}
+}

--- a/internal/operator/component/env_test.go
+++ b/internal/operator/component/env_test.go
@@ -10,13 +10,18 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 )
@@ -315,5 +320,177 @@ func TestToUnstructuredRoundTrip(t *testing.T) {
 	// An already-unstructured object is returned as-is.
 	if got := ToUnstructured(u); got != u {
 		t.Fatal("unstructured input was copied")
+	}
+}
+
+func TestSiteOwnerReferenceIsController(t *testing.T) {
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
+	ref := SiteOwnerReference(site)
+
+	// Owns() enqueues via metav1.GetControllerOf, so the reference must be a
+	// controller reference or per-site self-heal watches never fire.
+	if ref.Controller == nil || !*ref.Controller {
+		t.Fatalf("SiteOwnerReference is not a controller reference: %#v", ref)
+	}
+
+	// BlockOwnerDeletion must stay unset: setting it requires update on
+	// sites/finalizers, which the operator ServiceAccount does not hold.
+	if ref.BlockOwnerDeletion != nil {
+		t.Fatalf("BlockOwnerDeletion should be unset, got %v", *ref.BlockOwnerDeletion)
+	}
+
+	obj := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:            "metalman-controller-rack-a",
+		OwnerReferences: []metav1.OwnerReference{ref},
+	}}
+	if controller := metav1.GetControllerOf(obj); controller == nil || controller.Name != "rack-a" {
+		t.Fatalf("GetControllerOf did not return the Site owner: %#v", controller)
+	}
+}
+
+func TestUpsertOwnerReferenceConvergesControllerFlag(t *testing.T) {
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
+	owner := SiteOwnerReference(site)
+
+	// A reference adopted before controller ownership existed (Controller unset).
+	legacy := owner
+	legacy.Controller = nil
+
+	refs, changed := UpsertOwnerReference([]metav1.OwnerReference{legacy}, owner)
+	if !changed {
+		t.Fatal("upsert did not converge a non-controller reference to a controller reference")
+	}
+
+	if len(refs) != 1 || refs[0].Controller == nil || !*refs[0].Controller {
+		t.Fatalf("owner reference not upgraded to controller: %#v", refs)
+	}
+
+	// Idempotent once converged.
+	if _, again := UpsertOwnerReference(refs, owner); again {
+		t.Fatal("upsert reported a change for an already-controller reference")
+	}
+
+	// A different owner is appended, not replaced.
+	other := SiteOwnerReference(&unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-b", UID: "other-uid"}})
+
+	appended, changed := UpsertOwnerReference(refs, other)
+	if !changed || len(appended) != 2 {
+		t.Fatalf("upsert of a distinct owner = (%v, %#v)", changed, appended)
+	}
+}
+
+func TestOwnedWorkloadPredicate(t *testing.T) {
+	env := &Env{Namespace: "target"}
+	pred := env.OwnedWorkloadPredicate()
+
+	workload := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: "metalman-controller-rack-a"}}
+
+	if !pred.Create(event.CreateEvent{Object: workload}) {
+		t.Fatal("owned create was filtered")
+	}
+
+	if !pred.Delete(event.DeleteEvent{Object: workload}) {
+		t.Fatal("owned delete was filtered (self-heal on deletion would not fire)")
+	}
+
+	bumped := workload.DeepCopy()
+	bumped.SetGeneration(workload.GetGeneration() + 1)
+
+	if !pred.Update(event.UpdateEvent{ObjectOld: workload, ObjectNew: bumped}) {
+		t.Fatal("spec drift (generation change) was filtered")
+	}
+
+	// A status-only update (same generation, e.g. replica counts) must be
+	// dropped so pod churn does not re-apply the workload.
+	if pred.Update(event.UpdateEvent{ObjectOld: bumped, ObjectNew: bumped.DeepCopy()}) {
+		t.Fatal("status-only update was accepted; Owns would re-apply on pod churn")
+	}
+
+	if pred.Generic(event.GenericEvent{Object: workload}) {
+		t.Fatal("generic event was accepted")
+	}
+}
+
+func TestSiteOwnedResourceEnqueuesViaOwnsHandler(t *testing.T) {
+	scheme := testScheme(t)
+
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{unboundedv1alpha3.GroupVersion})
+	mapper.Add(unboundedv1alpha3.GroupVersion.WithKind("Site"), meta.RESTScopeRoot)
+
+	// Mirror controller-runtime's builder.Owns() wiring exactly: enqueue the
+	// owner only for the controller owner reference.
+	h := handler.EnqueueRequestForOwner(scheme, mapper, &unboundedv1alpha3.Site{}, handler.OnlyControllerOwner())
+
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
+	owned := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Namespace:       "unbounded-system",
+		Name:            "metalman-controller-rack-a",
+		OwnerReferences: []metav1.OwnerReference{SiteOwnerReference(site)},
+	}}
+
+	newQueue := func() workqueue.TypedRateLimitingInterface[reconcile.Request] {
+		return workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	}
+
+	created := newQueue()
+	h.Create(t.Context(), event.CreateEvent{Object: owned}, created)
+
+	if created.Len() != 1 {
+		t.Fatalf("controller-owned resource did not enqueue its Site: queue len = %d", created.Len())
+	}
+
+	req, _ := created.Get()
+	if req.Name != "rack-a" || req.Namespace != "" {
+		t.Fatalf("enqueued request = %#v, want cluster-scoped Site rack-a", req)
+	}
+
+	// Deletion must also enqueue so the resource is recreated.
+	deleted := newQueue()
+	h.Delete(t.Context(), event.DeleteEvent{Object: owned}, deleted)
+
+	if deleted.Len() != 1 {
+		t.Fatal("deletion of a controller-owned resource did not enqueue its Site")
+	}
+
+	// A non-controller owner reference (the pre-fix regression) enqueues nothing,
+	// so Owns() would never self-heal.
+	legacy := SiteOwnerReference(site)
+	legacy.Controller = nil
+	nonController := owned.DeepCopy()
+	nonController.OwnerReferences = []metav1.OwnerReference{legacy}
+
+	ignored := newQueue()
+	h.Create(t.Context(), event.CreateEvent{Object: nonController}, ignored)
+
+	if ignored.Len() != 0 {
+		t.Fatal("non-controller owner reference unexpectedly enqueued; guard for the self-heal regression")
+	}
+}
+
+func TestIsRBACObject(t *testing.T) {
+	rbac := func(kind, name string) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetKind(kind)
+		obj.SetName(name)
+
+		return obj
+	}
+
+	cases := []struct {
+		obj  *unstructured.Unstructured
+		want bool
+	}{
+		{rbac("ServiceAccount", "metalman-controller"), true},
+		{rbac("ClusterRole", "unbounded-metalman"), true},
+		{rbac("RoleBinding", "metalman-lease"), true},
+		{rbac("ServiceAccount", "machina-controller"), false},
+		{rbac("Deployment", "metalman-controller"), false},
+		{rbac("ConfigMap", "metalman-config"), false},
+	}
+
+	for _, tc := range cases {
+		if got := IsRBACObject(tc.obj, "metalman"); got != tc.want {
+			t.Fatalf("IsRBACObject(%s/%s) = %v, want %v", tc.obj.GetKind(), tc.obj.GetName(), got, tc.want)
+		}
 	}
 }

--- a/internal/operator/component/env_test.go
+++ b/internal/operator/component/env_test.go
@@ -1,0 +1,319 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for name, add := range map[string]func(*runtime.Scheme) error{
+		"apps/v1":     appsv1.AddToScheme,
+		"core/v1":     corev1.AddToScheme,
+		"machina API": unboundedv1alpha3.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add %s to scheme: %v", name, err)
+		}
+	}
+
+	return scheme
+}
+
+func TestConfigMapPayloadHashIncludesDataAndBinaryData(t *testing.T) {
+	first := &corev1.ConfigMap{
+		Data:       map[string]string{"b": "2", "a": "1"},
+		BinaryData: map[string][]byte{"z": {3}, "x": {1, 2}},
+	}
+	orderedDifferently := &corev1.ConfigMap{
+		Data:       map[string]string{"a": "1", "b": "2"},
+		BinaryData: map[string][]byte{"x": {1, 2}, "z": {3}},
+	}
+
+	if ConfigMapPayloadHash(first) != ConfigMapPayloadHash(orderedDifferently) {
+		t.Fatal("payload hash depends on map iteration order")
+	}
+
+	changedData := first.DeepCopy()
+	changedData.Data["a"] = "changed"
+	changedBinary := first.DeepCopy()
+	changedBinary.BinaryData["x"] = []byte{2, 1}
+
+	if ConfigMapPayloadHash(first) == ConfigMapPayloadHash(changedData) ||
+		ConfigMapPayloadHash(first) == ConfigMapPayloadHash(changedBinary) {
+		t.Fatal("payload hash did not include all Data and BinaryData")
+	}
+}
+
+func TestRetargetNamespaceRewritesToCustomNamespace(t *testing.T) {
+	env := &Env{Namespace: "custom-ns"}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "x", "namespace": "unbounded-system"},
+		"subjects":   []any{map[string]any{"namespace": "unbounded-system"}},
+	}}
+
+	env.RetargetNamespace(obj)
+
+	if got := obj.GetNamespace(); got != "custom-ns" {
+		t.Fatalf("namespace = %q, want custom-ns", got)
+	}
+
+	subjects, _, _ := unstructured.NestedSlice(obj.Object, "subjects")
+	if subjects[0].(map[string]any)["namespace"] != "custom-ns" {
+		t.Fatalf("subject namespace not rewritten: %v", subjects[0])
+	}
+
+	// Default install is a no-op.
+	def := &Env{Namespace: BuildDefaultNamespace}
+	nsObj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata":   map[string]any{"name": "unbounded-system"},
+	}}
+	def.RetargetNamespace(nsObj)
+
+	if nsObj.GetName() != "unbounded-system" {
+		t.Fatalf("default install rewrote namespace to %q", nsObj.GetName())
+	}
+}
+
+func TestRetargetNamespaceRewritesServiceAccountAndArgs(t *testing.T) {
+	env := &Env{Namespace: "custom-ns"}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "admissionregistration.k8s.io/v1",
+		"kind":       "ValidatingAdmissionPolicy",
+		"metadata":   map[string]any{"name": "p"},
+		"spec": map[string]any{
+			"matchConditions": []any{
+				map[string]any{"expression": "request.userInfo.username == 'system:serviceaccount:unbounded-system:unbounded-net-controller'"},
+			},
+			"args":  []any{"--leader-elect-resource-namespace=unbounded-system"},
+			"image": "ghcr.io/azure/unbounded-system:v1",
+		},
+	}}
+
+	env.RetargetNamespace(obj)
+
+	conds, _, _ := unstructured.NestedSlice(obj.Object, "spec", "matchConditions")
+	gotExpr := conds[0].(map[string]any)["expression"].(string)
+
+	if gotExpr != "request.userInfo.username == 'system:serviceaccount:custom-ns:unbounded-net-controller'" {
+		t.Fatalf("SA username not rewritten: %q", gotExpr)
+	}
+
+	args, _, _ := unstructured.NestedStringSlice(obj.Object, "spec", "args")
+	if len(args) != 1 || args[0] != "--leader-elect-resource-namespace=custom-ns" {
+		t.Fatalf("flag value not rewritten: %v", args)
+	}
+
+	if img, _, _ := unstructured.NestedString(obj.Object, "spec", "image"); img != "ghcr.io/azure/unbounded-system:v1" {
+		t.Fatalf("image ref must not be rewritten, got %q", img)
+	}
+}
+
+func TestRetargetNamespaceInString(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"unbounded-system", "custom-ns"},
+		{"system:serviceaccount:unbounded-system:sa", "system:serviceaccount:custom-ns:sa"},
+		{"--leader-elect-resource-namespace=unbounded-system", "--leader-elect-resource-namespace=custom-ns"},
+		{"ghcr.io/azure/unbounded-system:v1", "ghcr.io/azure/unbounded-system:v1"},
+		{"unbounded-system-other", "unbounded-system-other"},
+	}
+
+	for _, tc := range cases {
+		if got := retargetNamespaceInString(tc.in, "unbounded-system", "custom-ns"); got != tc.want {
+			t.Fatalf("retargetNamespaceInString(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestApplyObject(t *testing.T) {
+	env := &Env{Client: fake.NewClientBuilder().WithScheme(testScheme(t)).Build()}
+	deployment := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}}},
+		},
+	}
+
+	if err := env.ApplyObject(t.Context(), deployment); err != nil {
+		t.Fatalf("ApplyObject returned error: %v", err)
+	}
+}
+
+func TestManagedConfigPredicate(t *testing.T) {
+	env := &Env{Namespace: "target"}
+	predicate := env.ManagedConfigPredicate(env.InNamespaceNamed("machina-config", "unbounded-net-config"))
+
+	for _, name := range []string{"machina-config", "unbounded-net-config"} {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: name}}
+		if !predicate.Create(event.CreateEvent{Object: cm}) {
+			t.Fatalf("%s create was filtered", name)
+		}
+	}
+
+	if predicate.Create(event.CreateEvent{Object: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "other", Name: "machina-config"}}}) {
+		t.Fatal("config in a different namespace was accepted")
+	}
+
+	oldConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: "machina-config"},
+		Data:       map[string]string{"config.yaml": "same"},
+		BinaryData: map[string][]byte{"x": {1}},
+	}
+	metadataOnly := oldConfig.DeepCopy()
+	metadataOnly.Labels = map[string]string{"changed": "true"}
+
+	if predicate.Update(event.UpdateEvent{ObjectOld: oldConfig, ObjectNew: metadataOnly}) {
+		t.Fatal("metadata-only update should not enqueue")
+	}
+
+	payloadChange := oldConfig.DeepCopy()
+	payloadChange.BinaryData["x"] = []byte{2}
+
+	if !predicate.Update(event.UpdateEvent{ObjectOld: oldConfig, ObjectNew: payloadChange}) {
+		t.Fatal("payload update should enqueue")
+	}
+}
+
+func TestManagedWorkloadPredicate(t *testing.T) {
+	env := &Env{Namespace: "target"}
+	predicate := env.ManagedWorkloadPredicate(env.InNamespaceNamed("machina-controller", "unbounded-net-controller"))
+
+	workload := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: "machina-controller"}}
+
+	if !predicate.Create(event.CreateEvent{Object: workload}) {
+		t.Fatal("startup create was filtered")
+	}
+
+	if !predicate.Delete(event.DeleteEvent{Object: workload}) {
+		t.Fatal("delete was filtered")
+	}
+
+	updated := workload.DeepCopy()
+	updated.SetGeneration(workload.GetGeneration() + 1)
+
+	if !predicate.Update(event.UpdateEvent{ObjectOld: workload, ObjectNew: updated}) {
+		t.Fatal("generation change was filtered")
+	}
+
+	if predicate.Update(event.UpdateEvent{ObjectOld: updated, ObjectNew: updated.DeepCopy()}) {
+		t.Fatal("same-generation update was accepted")
+	}
+
+	unmanaged := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: "metalman-controller-edge"}}
+	if predicate.Create(event.CreateEvent{Object: unmanaged}) {
+		t.Fatal("unmanaged workload create was accepted")
+	}
+}
+
+func TestSingletonRequestBuilders(t *testing.T) {
+	env := &Env{Client: fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(
+		&unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge"}},
+		&unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+	).Build()}
+
+	if got := env.singletonRequest(); len(got) != 1 || got[0].Name != SingletonRequestName {
+		t.Fatalf("singletonRequest = %#v", got)
+	}
+
+	requests := env.singletonAndAllSiteRequests(t.Context())
+
+	names := map[string]bool{}
+	for _, request := range requests {
+		names[request.Name] = true
+	}
+
+	if len(requests) != 3 || !names[SingletonRequestName] || !names["edge"] || !names["cluster"] {
+		t.Fatalf("singletonAndAllSiteRequests = %#v, want singleton, edge, cluster", requests)
+	}
+}
+
+func TestSingletonAndAllSiteRequestsPreservesSingletonOnListError(t *testing.T) {
+	listErr := errors.New("Site list failed")
+	env := &Env{Client: fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+				return listErr
+			},
+		}).
+		Build()}
+
+	requests := env.singletonAndAllSiteRequests(t.Context())
+	if len(requests) != 1 || requests[0].Name != SingletonRequestName {
+		t.Fatalf("singletonAndAllSiteRequests = %#v, want singleton after list failure", requests)
+	}
+}
+
+func TestApplyManifestDataSkipsNilledObjects(t *testing.T) {
+	env := &Env{
+		Client:    fake.NewClientBuilder().WithScheme(testScheme(t)).Build(),
+		Namespace: "unbounded-system",
+	}
+
+	applied := 0
+	data := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: keep\n  namespace: unbounded-system\n")
+
+	err := env.applyManifestData(t.Context(), data, func(obj *unstructured.Unstructured) error {
+		applied++
+		obj.Object = nil // skip
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("applyManifestData: %v", err)
+	}
+
+	if applied != 1 {
+		t.Fatalf("mutate called %d times, want 1", applied)
+	}
+
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: "unbounded-system", Name: "keep"}, &corev1.ConfigMap{}); err == nil {
+		t.Fatal("nilled object was applied")
+	}
+}
+
+func TestToUnstructuredRoundTrip(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "y"},
+		Data:       map[string]string{"a": "b"},
+	}
+
+	u := ToUnstructured(cm)
+	if u.GetName() != "x" || u.GetNamespace() != "y" {
+		t.Fatalf("unstructured = %#v", u.Object)
+	}
+
+	// An already-unstructured object is returned as-is.
+	if got := ToUnstructured(u); got != u {
+		t.Fatal("unstructured input was copied")
+	}
+}

--- a/internal/operator/component/registry_test.go
+++ b/internal/operator/component/registry_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"context"
+	"testing"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+// fakeCluster is a minimal ClusterComponent for registry tests.
+type fakeCluster struct {
+	name      string
+	condition string
+}
+
+func (f fakeCluster) Name() string          { return f.name }
+func (f fakeCluster) ConditionType() string { return f.condition }
+func (fakeCluster) Reconcile(context.Context, *Env, []unboundedv1alpha3.Site) Result {
+	return Reconciled()
+}
+
+// fakeSite is a minimal SiteComponent for registry tests.
+type fakeSite struct {
+	name      string
+	condition string
+}
+
+func (f fakeSite) Name() string                       { return f.name }
+func (f fakeSite) ConditionType() string              { return f.condition }
+func (fakeSite) Enabled(*unboundedv1alpha3.Site) bool { return true }
+func (fakeSite) Reconcile(context.Context, *Env, *unboundedv1alpha3.Site) Result {
+	return Reconciled()
+}
+func (fakeSite) Cleanup(context.Context, *Env, *unboundedv1alpha3.Site) error { return nil }
+
+func TestRegistryValidate(t *testing.T) {
+	cases := []struct {
+		name     string
+		registry Registry
+		wantErr  bool
+	}{
+		{
+			name:    "empty",
+			wantErr: true,
+		},
+		{
+			name: "valid",
+			registry: Registry{
+				Cluster: []ClusterComponent{fakeCluster{name: "net", condition: "NetReady"}},
+				Site:    []SiteComponent{fakeSite{name: "storage", condition: "StorageReady"}},
+			},
+		},
+		{
+			name: "duplicate name across lists",
+			registry: Registry{
+				Cluster: []ClusterComponent{fakeCluster{name: "dup", condition: "AReady"}},
+				Site:    []SiteComponent{fakeSite{name: "dup", condition: "BReady"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate condition type",
+			registry: Registry{
+				Cluster: []ClusterComponent{fakeCluster{name: "a", condition: "SameReady"}},
+				Site:    []SiteComponent{fakeSite{name: "b", condition: "SameReady"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty name",
+			registry: Registry{
+				Cluster: []ClusterComponent{fakeCluster{name: "", condition: "AReady"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty condition",
+			registry: Registry{
+				Site: []SiteComponent{fakeSite{name: "a", condition: ""}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.registry.Validate()
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("Validate() error = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/operator/component/result.go
+++ b/internal/operator/component/result.go
@@ -11,6 +11,8 @@
 // driven from the registry.
 package component
 
+import "time"
+
 // Reason strings published on Site.status.conditions. They must be CamelCase
 // alphanumeric to satisfy metav1.Condition validation.
 const (
@@ -24,11 +26,22 @@ const (
 // SiteReconciler translates it into a Site status condition
 // (Ready -> ConditionTrue/False, Reason, Message) and aggregates Err into the
 // reconcile error so a failing component requeues the Site.
+//
+// A not-ready Result without an Err does not by itself trigger a retry: the
+// driver requeues on Err (with backoff) or after the smallest positive
+// RequeueAfter across components. A component that is waiting on state it does
+// not watch should set RequeueAfter (see NotReadyAfter) so it is re-checked;
+// otherwise it only re-runs when one of its watches fires.
 type Result struct {
 	Ready   bool
 	Reason  string
 	Message string
 	Err     error
+
+	// RequeueAfter, when positive, asks the driver to re-run the Site after the
+	// given duration even without an error or a watch event. The driver uses the
+	// smallest positive RequeueAfter across all components in a pass.
+	RequeueAfter time.Duration
 }
 
 // Reconciled reports a successfully reconciled component.
@@ -47,9 +60,17 @@ func NoSites(message string) Result {
 }
 
 // NotReady reports a component that is not yet ready for a caller-supplied
-// reason without treating it as a reconcile error.
+// reason without treating it as a reconcile error. It does not schedule a retry
+// on its own; use NotReadyAfter, set Err, or rely on a watch to re-trigger.
 func NotReady(reason, message string) Result {
 	return Result{Ready: false, Reason: reason, Message: message}
+}
+
+// NotReadyAfter reports a not-ready component and asks the driver to re-check the
+// Site after the given duration, for readiness that depends on state the
+// component does not watch (for example polling an external resource).
+func NotReadyAfter(reason, message string, after time.Duration) Result {
+	return Result{Ready: false, Reason: reason, Message: message, RequeueAfter: after}
 }
 
 // Failed reports a component reconcile error. The error is surfaced both as the

--- a/internal/operator/component/result.go
+++ b/internal/operator/component/result.go
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package component defines the extension contract for the unbounded operator.
+// A component is a unit of desired state the operator reconciles for Sites.
+// Implementations satisfy either ClusterComponent (cluster-wide singletons such
+// as net and machina) or SiteComponent (per-Site units such as metalman and
+// storage) and are assembled into a Registry the SiteReconciler drives. Adding a
+// component is a matter of implementing one interface and registering it; the
+// reconcile loop, status conditions, ordering, and the Site-less pass are all
+// driven from the registry.
+package component
+
+// Reason strings published on Site.status.conditions. They must be CamelCase
+// alphanumeric to satisfy metav1.Condition validation.
+const (
+	ReasonReconciled     = "Reconciled"
+	ReasonDisabled       = "Disabled"
+	ReasonNoSites        = "NoSites"
+	ReasonReconcileError = "ReconcileError"
+)
+
+// Result is the outcome of reconciling a single component for one pass. The
+// SiteReconciler translates it into a Site status condition
+// (Ready -> ConditionTrue/False, Reason, Message) and aggregates Err into the
+// reconcile error so a failing component requeues the Site.
+type Result struct {
+	Ready   bool
+	Reason  string
+	Message string
+	Err     error
+}
+
+// Reconciled reports a successfully reconciled component.
+func Reconciled() Result {
+	return Result{Ready: true, Reason: ReasonReconciled, Message: "component reconciled"}
+}
+
+// Disabled reports a component that is intentionally not running.
+func Disabled(message string) Result {
+	return Result{Ready: true, Reason: ReasonDisabled, Message: message}
+}
+
+// NoSites reports a cluster component retained while no Sites exist.
+func NoSites(message string) Result {
+	return Result{Ready: true, Reason: ReasonNoSites, Message: message}
+}
+
+// NotReady reports a component that is not yet ready for a caller-supplied
+// reason without treating it as a reconcile error.
+func NotReady(reason, message string) Result {
+	return Result{Ready: false, Reason: reason, Message: message}
+}
+
+// Failed reports a component reconcile error. The error is surfaced both as the
+// condition message and as the aggregated reconcile error.
+func Failed(err error) Result {
+	return Result{Ready: false, Reason: ReasonReconcileError, Message: err.Error(), Err: err}
+}

--- a/internal/operator/component/watch.go
+++ b/internal/operator/component/watch.go
@@ -5,6 +5,7 @@ package component
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -74,6 +75,32 @@ func (e *Env) InNamespaceNamed(names ...string) func(client.Object) bool {
 	}
 }
 
+// RequestSiteFromConfigName maps a per-site ConfigMap named "<prefix><site>"
+// back to a reconcile request for that Site. Names without the prefix, or with
+// an empty site suffix, are ignored.
+func (e *Env) RequestSiteFromConfigName(prefix string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []ctrl.Request {
+		site := strings.TrimPrefix(obj.GetName(), prefix)
+		if site == obj.GetName() || site == "" {
+			return nil
+		}
+
+		return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: site}}}
+	})
+}
+
+// InNamespaceWithPrefix returns a matcher for objects in the operator namespace
+// whose name carries prefix followed by a non-empty suffix (a per-site config).
+func (e *Env) InNamespaceWithPrefix(prefix string) func(client.Object) bool {
+	namespace := e.Namespace
+
+	return func(obj client.Object) bool {
+		return obj.GetNamespace() == namespace &&
+			strings.HasPrefix(obj.GetName(), prefix) &&
+			strings.TrimPrefix(obj.GetName(), prefix) != ""
+	}
+}
+
 // ManagedConfigPredicate fires for create and delete of ConfigMaps that match,
 // and for updates only when the ConfigMap payload actually changed. It filters
 // out status/metadata-only churn so a component is not re-applied on every event.
@@ -107,6 +134,22 @@ func (e *Env) ManagedWorkloadPredicate(match func(client.Object) bool) predicate
 		DeleteFunc: func(ev event.DeleteEvent) bool { return match(ev.Object) },
 		UpdateFunc: func(ev event.UpdateEvent) bool {
 			return match(ev.ObjectNew) && ev.ObjectOld.GetGeneration() != ev.ObjectNew.GetGeneration()
+		},
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+// OwnedWorkloadPredicate fires for create and delete of owned workloads, and for
+// updates only when the generation changed. It carries no name match because the
+// Owns() enqueue handler already scopes events to resources owned by the Site;
+// the predicate exists only to drop status-only churn (pod counts) so drift and
+// deletion self-heal without re-applying on every status update.
+func (e *Env) OwnedWorkloadPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool { return true },
+		DeleteFunc: func(event.DeleteEvent) bool { return true },
+		UpdateFunc: func(ev event.UpdateEvent) bool {
+			return ev.ObjectOld.GetGeneration() != ev.ObjectNew.GetGeneration()
 		},
 		GenericFunc: func(event.GenericEvent) bool { return false },
 	}

--- a/internal/operator/component/watch.go
+++ b/internal/operator/component/watch.go
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package component
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// RequestSingleton enqueues the synthetic singleton request. Cluster components
+// use it to map events on their managed singleton workloads back to a reconcile
+// that reconciles cluster-wide state without any specific Site.
+func (e *Env) RequestSingleton() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []ctrl.Request {
+		return e.singletonRequest()
+	})
+}
+
+func (e *Env) singletonRequest() []ctrl.Request {
+	return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: SingletonRequestName}}}
+}
+
+// RequestSingletonAndAllSites enqueues the singleton request plus every Site, so
+// a change to a shared cluster config re-reconciles cluster state and refreshes
+// each Site's status conditions.
+func (e *Env) RequestSingletonAndAllSites() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []ctrl.Request {
+		return e.singletonAndAllSiteRequests(ctx)
+	})
+}
+
+func (e *Env) singletonAndAllSiteRequests(ctx context.Context) []ctrl.Request {
+	requests := e.singletonRequest()
+
+	sites, err := e.ListSites(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "list Sites after managed config change")
+
+		return requests
+	}
+
+	for i := range sites {
+		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKey{Name: sites[i].Name}})
+	}
+
+	return requests
+}
+
+// InNamespaceNamed returns a matcher for objects in the operator namespace whose
+// name is one of names.
+func (e *Env) InNamespaceNamed(names ...string) func(client.Object) bool {
+	namespace := e.Namespace
+
+	return func(obj client.Object) bool {
+		if obj.GetNamespace() != namespace {
+			return false
+		}
+
+		for _, name := range names {
+			if obj.GetName() == name {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+// ManagedConfigPredicate fires for create and delete of ConfigMaps that match,
+// and for updates only when the ConfigMap payload actually changed. It filters
+// out status/metadata-only churn so a component is not re-applied on every event.
+func (e *Env) ManagedConfigPredicate(match func(client.Object) bool) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(ev event.CreateEvent) bool { return match(ev.Object) },
+		DeleteFunc: func(ev event.DeleteEvent) bool { return match(ev.Object) },
+		UpdateFunc: func(ev event.UpdateEvent) bool {
+			if !match(ev.ObjectNew) {
+				return false
+			}
+
+			oldConfig, oldOK := ev.ObjectOld.(*corev1.ConfigMap)
+
+			newConfig, newOK := ev.ObjectNew.(*corev1.ConfigMap)
+			if !oldOK || !newOK {
+				return false
+			}
+
+			return ConfigMapPayloadChanged(oldConfig, newConfig)
+		},
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+// ManagedWorkloadPredicate fires for create and delete of workloads that match,
+// and for updates only when the workload generation changed.
+func (e *Env) ManagedWorkloadPredicate(match func(client.Object) bool) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(ev event.CreateEvent) bool { return match(ev.Object) },
+		DeleteFunc: func(ev event.DeleteEvent) bool { return match(ev.Object) },
+		UpdateFunc: func(ev event.UpdateEvent) bool {
+			return match(ev.ObjectNew) && ev.ObjectOld.GetGeneration() != ev.ObjectNew.GetGeneration()
+		},
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}

--- a/internal/operator/components/machina/config.go
+++ b/internal/operator/components/machina/config.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package machina
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SetAPIServerEndpoint updates only the top-level apiServerEndpoint field. Using
+// a YAML node preserves all other migrated or user-managed fields.
+func SetAPIServerEndpoint(config, endpoint string) (string, error) {
+	if endpoint == "" {
+		return config, nil
+	}
+
+	var document yaml.Node
+	if config == "" {
+		document = yaml.Node{
+			Kind: yaml.DocumentNode,
+			Content: []*yaml.Node{{
+				Kind: yaml.MappingNode,
+				Tag:  "!!map",
+			}},
+		}
+	} else if err := yaml.Unmarshal([]byte(config), &document); err != nil {
+		return "", fmt.Errorf("parse machina config: %w", err)
+	}
+
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return "", fmt.Errorf("parse machina config: expected a top-level mapping")
+	}
+
+	mapping := document.Content[0]
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value != "apiServerEndpoint" {
+			continue
+		}
+
+		mapping.Content[i+1].Kind = yaml.ScalarNode
+		mapping.Content[i+1].Tag = "!!str"
+		mapping.Content[i+1].Value = endpoint
+		mapping.Content[i+1].Style = yaml.DoubleQuotedStyle
+
+		encoded, err := yaml.Marshal(&document)
+		if err != nil {
+			return "", fmt.Errorf("encode machina config: %w", err)
+		}
+
+		return string(encoded), nil
+	}
+
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "apiServerEndpoint"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: endpoint, Style: yaml.DoubleQuotedStyle},
+	)
+
+	encoded, err := yaml.Marshal(&document)
+	if err != nil {
+		return "", fmt.Errorf("encode machina config: %w", err)
+	}
+
+	return string(encoded), nil
+}

--- a/internal/operator/components/machina/machina.go
+++ b/internal/operator/components/machina/machina.go
@@ -9,7 +9,6 @@ package machina
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +20,7 @@ import (
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	machinamanifests "github.com/Azure/unbounded/deploy/machina"
 	"github.com/Azure/unbounded/internal/operator/component"
+	"github.com/Azure/unbounded/internal/operator/components/metalman"
 )
 
 const (
@@ -125,7 +125,7 @@ func applyMutator(configHash string) func(*unstructured.Unstructured) error {
 		// CRDs are installed once at operator startup, not from the reconcile
 		// loop; the metalman RBAC ships in the machina manifests but is applied
 		// per-site by the metalman component. Skip both here.
-		if obj.GetKind() == component.CRDKind || isMetalmanSupportObject(obj) {
+		if obj.GetKind() == component.CRDKind || metalman.IsSupportObject(obj) {
 			obj.Object = nil
 
 			return nil
@@ -145,18 +145,6 @@ func applyMutator(configHash string) func(*unstructured.Unstructured) error {
 		}
 
 		return nil
-	}
-}
-
-// isMetalmanSupportObject reports whether obj is the metalman RBAC that ships in
-// the machina manifests. It is kept in sync with the metalman component, which
-// owns and applies these objects.
-func isMetalmanSupportObject(obj *unstructured.Unstructured) bool {
-	switch obj.GetKind() {
-	case "ServiceAccount", "Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding":
-		return strings.Contains(obj.GetName(), "metalman")
-	default:
-		return false
 	}
 }
 

--- a/internal/operator/components/machina/machina.go
+++ b/internal/operator/components/machina/machina.go
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package machina implements the machina controller cluster component. Machina
+// is a singleton for now: it is deployed whenever any Site enables it and kept
+// reconciled when an installation already exists.
+package machina
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	machinamanifests "github.com/Azure/unbounded/deploy/machina"
+	"github.com/Azure/unbounded/internal/operator/component"
+)
+
+const (
+	configName     = "machina-config"
+	controllerName = "machina-controller"
+
+	ConfigHashAnnotation = "unbounded-cloud.io/machina-config-hash"
+)
+
+// Component reconciles the machina controller singleton.
+type Component struct{}
+
+// New returns the machina cluster component.
+func New() component.ClusterComponent { return Component{} }
+
+// Name implements component.ClusterComponent.
+func (Component) Name() string { return "machina" }
+
+// ConditionType implements component.ClusterComponent.
+func (Component) ConditionType() string { return "MachinaReady" }
+
+// Reconcile deploys the machina controller singleton whenever any Site enables
+// it and keeps an existing installation reconciled when none do.
+func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unboundedv1alpha3.Site) component.Result {
+	enabled := false
+
+	for i := range sites {
+		if EnabledFor(&sites[i]) {
+			enabled = true
+			break
+		}
+	}
+
+	if !enabled {
+		// Keep machina installed once the operator has taken ownership. Automatic
+		// singleton removal is surprising and can strand related
+		// controllers/RBAC; a future explicit uninstall flow should handle it.
+		retained, err := resourcesExist(ctx, env)
+		if err != nil {
+			return component.Failed(err)
+		}
+
+		if !retained {
+			return component.Disabled("no site enables machina; retained")
+		}
+	}
+
+	configHash, err := ensureConfig(ctx, env)
+	if err != nil {
+		return component.Failed(err)
+	}
+
+	if err := env.ApplyManifestFS(ctx, machinamanifests.Manifests, applyMutator(configHash)); err != nil {
+		return component.Failed(err)
+	}
+
+	return component.Reconciled()
+}
+
+// SetupWatches reconciles machina on changes to its config payload and on
+// create/delete/generation changes of its controller Deployment.
+func (Component) SetupWatches(b *builder.Builder, env *component.Env) {
+	b.Watches(&corev1.ConfigMap{}, env.RequestSingletonAndAllSites(),
+		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceNamed(configName))))
+	b.Watches(&appsv1.Deployment{}, env.RequestSingleton(),
+		builder.WithPredicates(env.ManagedWorkloadPredicate(env.InNamespaceNamed(controllerName))))
+}
+
+// EnabledFor reports whether a Site enables the machina component.
+func EnabledFor(site *unboundedv1alpha3.Site) bool {
+	if site.Spec.Components.Machina == nil {
+		return false
+	}
+
+	return unboundedv1alpha3.ComponentEnabled(&site.Spec.Components.Machina.SiteComponentSpec)
+}
+
+func resourcesExist(ctx context.Context, env *component.Env) (bool, error) {
+	for _, resource := range []struct {
+		name   string
+		object client.Object
+	}{
+		{name: configName, object: &corev1.ConfigMap{}},
+		{name: controllerName, object: &appsv1.Deployment{}},
+	} {
+		key := client.ObjectKey{Namespace: env.Namespace, Name: resource.name}
+		if err := env.Client.Get(ctx, key, resource.object); err == nil {
+			return true, nil
+		} else if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("get retained machina resource %s/%s: %w", key.Namespace, key.Name, err)
+		}
+	}
+
+	return false, nil
+}
+
+// applyMutator skips CRDs and the metalman RBAC (applied per-site by the
+// metalman component), skips the separately reconciled ConfigMap, and stamps its
+// exact content hash on the Deployment so every config change rolls Machina.
+func applyMutator(configHash string) func(*unstructured.Unstructured) error {
+	return func(obj *unstructured.Unstructured) error {
+		// CRDs are installed once at operator startup, not from the reconcile
+		// loop; the metalman RBAC ships in the machina manifests but is applied
+		// per-site by the metalman component. Skip both here.
+		if obj.GetKind() == component.CRDKind || isMetalmanSupportObject(obj) {
+			obj.Object = nil
+
+			return nil
+		}
+
+		if obj.GetKind() == "ConfigMap" && obj.GetName() == configName {
+			obj.Object = nil
+
+			return nil
+		}
+
+		if obj.GetKind() == "Deployment" && obj.GetName() == controllerName {
+			if err := unstructured.SetNestedField(obj.Object, configHash,
+				"spec", "template", "metadata", "annotations", ConfigHashAnnotation); err != nil {
+				return fmt.Errorf("set machina config hash annotation: %w", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+// isMetalmanSupportObject reports whether obj is the metalman RBAC that ships in
+// the machina manifests. It is kept in sync with the metalman component, which
+// owns and applies these objects.
+func isMetalmanSupportObject(obj *unstructured.Unstructured) bool {
+	switch obj.GetKind() {
+	case "ServiceAccount", "Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding":
+		return strings.Contains(obj.GetName(), "metalman")
+	default:
+		return false
+	}
+}
+
+func ensureConfig(ctx context.Context, env *component.Env) (string, error) {
+	desired, err := env.DefaultConfigMap(machinamanifests.Manifests, configName, "machina")
+	if err != nil {
+		return "", err
+	}
+
+	key := client.ObjectKeyFromObject(desired)
+	existing := &corev1.ConfigMap{}
+
+	err = env.Client.Get(ctx, key, existing)
+	if apierrors.IsNotFound(err) {
+		config, mergeErr := SetAPIServerEndpoint(desired.Data["config.yaml"], env.Config.APIServerEndpoint)
+		if mergeErr != nil {
+			return "", mergeErr
+		}
+
+		desired.Data["config.yaml"] = config
+		if createErr := env.Client.Create(ctx, desired); createErr != nil {
+			return "", fmt.Errorf("create machina config %s/%s: %w", key.Namespace, key.Name, createErr)
+		}
+
+		return component.ConfigMapPayloadHash(desired), nil
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("get machina config %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	config := existing.Data["config.yaml"]
+
+	merged, err := SetAPIServerEndpoint(config, env.Config.APIServerEndpoint)
+	if err != nil {
+		return "", err
+	}
+
+	if merged != config {
+		before := existing.DeepCopy()
+		if existing.Data == nil {
+			existing.Data = map[string]string{}
+		}
+
+		existing.Data["config.yaml"] = merged
+
+		patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
+		if err := env.Client.Patch(ctx, existing, patch); err != nil {
+			return "", fmt.Errorf("update machina config %s/%s: %w", key.Namespace, key.Name, err)
+		}
+	}
+
+	return component.ConfigMapPayloadHash(existing), nil
+}

--- a/internal/operator/components/machina/machina_test.go
+++ b/internal/operator/components/machina/machina_test.go
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package machina
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/operator/component"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{appsv1.AddToScheme, corev1.AddToScheme, unboundedv1alpha3.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add to scheme: %v", err)
+		}
+	}
+
+	return scheme
+}
+
+func siteEnabling(name string) *unboundedv1alpha3.Site {
+	enabled := true
+
+	return &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{
+			Machina: &unboundedv1alpha3.MachinaComponentSpec{
+				SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
+			},
+		}},
+	}
+}
+
+func TestEnabledFor(t *testing.T) {
+	if EnabledFor(&unboundedv1alpha3.Site{}) {
+		t.Fatal("machina enabled with no component spec")
+	}
+
+	if !EnabledFor(siteEnabling("edge")) {
+		t.Fatal("machina not enabled when spec enables it")
+	}
+}
+
+func TestApplyMutatorSkipsMetalmanSupportAndCRD(t *testing.T) {
+	for _, obj := range []*unstructured.Unstructured{
+		{Object: map[string]any{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata":   map[string]any{"name": "metalman-controller"},
+		}},
+		{Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       component.CRDKind,
+			"metadata":   map[string]any{"name": "sites.unbounded-cloud.io"},
+		}},
+	} {
+		if err := applyMutator("hash")(obj); err != nil {
+			t.Fatalf("applyMutator: %v", err)
+		}
+
+		if obj.Object != nil {
+			t.Fatalf("object was not skipped: %#v", obj.Object)
+		}
+	}
+}
+
+func TestApplyMutatorStampsConfigHash(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": controllerName},
+		"spec":       map[string]any{"template": map[string]any{"metadata": map[string]any{}}},
+	}}
+
+	const hash = "config-hash"
+	if err := applyMutator(hash)(obj); err != nil {
+		t.Fatalf("applyMutator: %v", err)
+	}
+
+	got, found, err := unstructured.NestedString(obj.Object,
+		"spec", "template", "metadata", "annotations", ConfigHashAnnotation)
+	if err != nil || !found || got != hash {
+		t.Fatalf("config hash = %q found=%t err=%v, want %q", got, found, err, hash)
+	}
+}
+
+func TestSetAPIServerEndpointPreservesConfig(t *testing.T) {
+	input := `# retained comment
+apiServerEndpoint: "https://old.example:6443"
+maxConcurrentReconciles: 17
+customField: keep-me
+`
+	endpoint := "https://api.example:6443/path?mode=\"strict\"&ready=true"
+
+	got, err := SetAPIServerEndpoint(input, endpoint)
+	if err != nil {
+		t.Fatalf("SetAPIServerEndpoint: %v", err)
+	}
+
+	var config map[string]any
+	if err := yaml.Unmarshal([]byte(got), &config); err != nil {
+		t.Fatalf("unmarshal merged config: %v", err)
+	}
+
+	if config["apiServerEndpoint"] != endpoint {
+		t.Fatalf("apiServerEndpoint = %q, want %q", config["apiServerEndpoint"], endpoint)
+	}
+
+	if config["maxConcurrentReconciles"] != 17 || config["customField"] != "keep-me" {
+		t.Fatalf("custom config was not preserved: %#v", config)
+	}
+
+	if !strings.Contains(got, "# retained comment") {
+		t.Fatalf("config comment was not preserved: %q", got)
+	}
+}
+
+func TestEnsureConfigUpdatesEndpointAndPreservesData(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: component.DefaultNamespace},
+		Data: map[string]string{
+			"config.yaml": "apiServerEndpoint: https://old.example:6443\ncustom: true\n",
+		},
+	}
+	env := &component.Env{
+		Client:    fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(existing).Build(),
+		Namespace: component.DefaultNamespace,
+		Config:    component.Config{APIServerEndpoint: "https://new.example:6443"},
+	}
+
+	hash, err := ensureConfig(t.Context(), env)
+	if err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
+		t.Fatalf("get machina config: %v", err)
+	}
+
+	var config map[string]any
+	if err := yaml.Unmarshal([]byte(got.Data["config.yaml"]), &config); err != nil {
+		t.Fatalf("unmarshal updated config: %v", err)
+	}
+
+	if config["apiServerEndpoint"] != "https://new.example:6443" || config["custom"] != true {
+		t.Fatalf("updated config = %#v", config)
+	}
+
+	if hash != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("hash = %q, want hash of exact stored config", hash)
+	}
+}
+
+func TestEnsureConfigOptimisticConflictReloadsFreshState(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: component.DefaultNamespace, ResourceVersion: "1"},
+		Data:       map[string]string{"config.yaml": "apiServerEndpoint: https://old.example:6443\n"},
+	}
+
+	base := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(existing).Build()
+	conflicted := false
+	cl := interceptor.NewClient(base, interceptor.Funcs{
+		Patch: func(ctx context.Context, underlying client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			data, err := patch.Data(obj)
+			if err != nil {
+				t.Fatalf("encode patch: %v", err)
+			}
+
+			if !bytes.Contains(data, []byte(`"resourceVersion":`)) {
+				t.Fatalf("optimistic patch does not include resourceVersion: %s", data)
+			}
+
+			if !conflicted {
+				conflicted = true
+
+				var latest corev1.ConfigMap
+				if err := underlying.Get(ctx, client.ObjectKeyFromObject(existing), &latest); err != nil {
+					t.Fatalf("get concurrent config: %v", err)
+				}
+
+				latest.Data["concurrent"] = "preserved"
+				if err := underlying.Update(ctx, &latest); err != nil {
+					t.Fatalf("write concurrent config: %v", err)
+				}
+
+				return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.GetName(), errors.New("concurrent edit"))
+			}
+
+			return underlying.Patch(ctx, obj, patch, opts...)
+		},
+	})
+	env := &component.Env{Client: cl, Namespace: component.DefaultNamespace, Config: component.Config{APIServerEndpoint: "https://new.example:6443"}}
+
+	if _, err := ensureConfig(t.Context(), env); !apierrors.IsConflict(err) {
+		t.Fatalf("first ensureConfig error = %v, want conflict", err)
+	}
+
+	if _, err := ensureConfig(t.Context(), env); err != nil {
+		t.Fatalf("retry ensureConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := base.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
+		t.Fatalf("get updated config: %v", err)
+	}
+
+	if got.Data["concurrent"] != "preserved" || !strings.Contains(got.Data["config.yaml"], "https://new.example:6443") {
+		t.Fatalf("retry did not preserve fresh config: %#v", got.Data)
+	}
+}
+
+func TestReconcileRetainedWithNoEnablingSitesUpdatesConfigAndHash(t *testing.T) {
+	config := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: configName},
+		Data: map[string]string{
+			"config.yaml": "apiServerEndpoint: https://old.example:6443\ncustom: retained\n",
+		},
+	}
+	env, appliedHashes := retainedEnv(t, config)
+	env.Config.APIServerEndpoint = "https://new.example:6443"
+
+	res := Component{}.Reconcile(t.Context(), env, nil)
+	if !res.Ready || res.Err != nil {
+		t.Fatalf("Reconcile = %+v, want ready", res)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(config), &got); err != nil {
+		t.Fatalf("get retained machina config: %v", err)
+	}
+
+	if !strings.Contains(got.Data["config.yaml"], "https://new.example:6443") ||
+		!strings.Contains(got.Data["config.yaml"], "custom: retained") {
+		t.Fatalf("retained machina config was not merged: %q", got.Data["config.yaml"])
+	}
+
+	wantHash := component.ConfigMapPayloadHash(&got)
+	if appliedHashes[controllerName] != wantHash {
+		t.Fatalf("applied Machina hash = %q, want %q", appliedHashes[controllerName], wantHash)
+	}
+}
+
+func TestReconcileDoesNotCreateFromNothingWithNoEnablingSites(t *testing.T) {
+	env, appliedHashes := retainedEnv(t)
+
+	res := Component{}.Reconcile(t.Context(), env, nil)
+	if !res.Ready || res.Reason != component.ReasonDisabled {
+		t.Fatalf("Reconcile = %+v, want ready with Disabled", res)
+	}
+
+	err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: configName}, &corev1.ConfigMap{})
+	if !apierrors.IsNotFound(err) || len(appliedHashes) != 0 {
+		t.Fatalf("zero-Site reconcile created Machina from nothing: config err=%v hashes=%#v", err, appliedHashes)
+	}
+}
+
+func TestReconcileAppliesWhenSiteEnables(t *testing.T) {
+	env, appliedHashes := retainedEnv(t)
+
+	res := Component{}.Reconcile(t.Context(), env, []unboundedv1alpha3.Site{*siteEnabling("edge")})
+	if !res.Ready || res.Err != nil {
+		t.Fatalf("Reconcile = %+v, want ready", res)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: configName}, &got); err != nil {
+		t.Fatalf("get created machina config: %v", err)
+	}
+
+	if appliedHashes[controllerName] != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("applied hash = %q, want %q", appliedHashes[controllerName], component.ConfigMapPayloadHash(&got))
+	}
+}
+
+func retainedEnv(t *testing.T, objects ...client.Object) (*component.Env, map[string]string) {
+	t.Helper()
+
+	scheme := testScheme(t)
+	appliedHashes := map[string]string{}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				applied, ok := obj.(interface {
+					GetName() string
+					GetKind() string
+					UnstructuredContent() map[string]any
+				})
+				if !ok {
+					t.Fatalf("applied object has unexpected type %T", obj)
+				}
+
+				if applied.GetKind() != "Deployment" || applied.GetName() != controllerName {
+					return nil
+				}
+
+				hash, _, err := unstructured.NestedString(
+					applied.UnstructuredContent(),
+					"spec", "template", "metadata", "annotations", ConfigHashAnnotation,
+				)
+				if err != nil {
+					t.Fatalf("get applied Machina hash: %v", err)
+				}
+
+				appliedHashes[applied.GetName()] = hash
+
+				return nil
+			},
+		}).
+		Build()
+
+	return &component.Env{Client: cl, Scheme: scheme, Namespace: component.DefaultNamespace}, appliedHashes
+}

--- a/internal/operator/components/machina/machina_test.go
+++ b/internal/operator/components/machina/machina_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -18,12 +20,15 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	machinamanifests "github.com/Azure/unbounded/deploy/machina"
 	"github.com/Azure/unbounded/internal/operator/component"
+	"github.com/Azure/unbounded/internal/operator/components/metalman"
 )
 
 func testScheme(t *testing.T) *runtime.Scheme {
@@ -82,6 +87,58 @@ func TestApplyMutatorSkipsMetalmanSupportAndCRD(t *testing.T) {
 		if obj.Object != nil {
 			t.Fatalf("object was not skipped: %#v", obj.Object)
 		}
+	}
+}
+
+// TestApplyMutatorSkipsExactlyMetalmanRBAC guards the cross-component invariant
+// that machina skips every metalman RBAC object metalman owns and applies. Both
+// sides now decide via component.IsRBACObject, so this catches any future drift
+// between them across the real machina manifest set.
+func TestApplyMutatorSkipsExactlyMetalmanRBAC(t *testing.T) {
+	files, err := component.YamlFiles(machinamanifests.Manifests)
+	if err != nil {
+		t.Fatalf("list machina manifests: %v", err)
+	}
+
+	supportSeen := 0
+
+	for _, file := range files {
+		data, err := fs.ReadFile(machinamanifests.Manifests, file)
+		if err != nil {
+			t.Fatalf("read manifest %s: %v", file, err)
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+		for {
+			obj := &unstructured.Unstructured{}
+			if err := decoder.Decode(obj); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				t.Fatalf("decode manifest %s: %v", file, err)
+			}
+
+			if obj.Object == nil || !metalman.IsSupportObject(obj) {
+				continue
+			}
+
+			supportSeen++
+
+			work := obj.DeepCopy()
+			if err := applyMutator("hash")(work); err != nil {
+				t.Fatalf("applyMutator: %v", err)
+			}
+
+			if work.Object != nil {
+				t.Fatalf("machina applied metalman RBAC %s/%s that the metalman component owns", obj.GetKind(), obj.GetName())
+			}
+		}
+	}
+
+	if supportSeen == 0 {
+		t.Fatal("no metalman RBAC found in machina manifests; the guard is vacuous")
 	}
 }
 

--- a/internal/operator/components/metalman/metalman.go
+++ b/internal/operator/components/metalman/metalman.go
@@ -6,8 +6,6 @@ package metalman
 
 import (
 	"context"
-	"path/filepath"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -66,37 +64,35 @@ func (Component) Cleanup(ctx context.Context, env *component.Env, site *unbounde
 }
 
 // SetupWatches recreates the per-site Deployment if it is deleted or drifts, via
-// its owner reference to the Site.
-func (Component) SetupWatches(b *builder.Builder, _ *component.Env) {
-	b.Owns(&appsv1.Deployment{})
+// its controller owner reference to the Site. The predicate drops status-only
+// updates so pod-count churn does not re-apply the Deployment.
+func (Component) SetupWatches(b *builder.Builder, env *component.Env) {
+	b.Owns(&appsv1.Deployment{}, builder.WithPredicates(env.OwnedWorkloadPredicate()))
 }
 
 // DeploymentName is the per-site metalman Deployment name.
 func DeploymentName(site string) string { return "metalman-controller-" + site }
 
+// SupportObjectNameSubstring identifies the metalman RBAC objects that ship in
+// the machina manifest set. It is exported so the machina component can skip
+// exactly the objects the metalman component owns and applies.
+const SupportObjectNameSubstring = "metalman"
+
+// IsSupportObject reports whether obj is the metalman RBAC that ships in the
+// machina manifests. The machina component skips these; the metalman component
+// applies them.
+func IsSupportObject(obj *unstructured.Unstructured) bool {
+	return component.IsRBACObject(obj, SupportObjectNameSubstring)
+}
+
 // mutateSupportObject keeps only the metalman RBAC objects from the machina
 // manifests (they are already rendered into the operator namespace).
 func mutateSupportObject(obj *unstructured.Unstructured) error {
-	if filepath.Base(obj.GetName()) == ".gitignore" {
-		return nil
-	}
-
-	if !isSupportObject(obj) {
+	if !IsSupportObject(obj) {
 		obj.Object = nil
 	}
 
 	return nil
-}
-
-// isSupportObject reports whether obj is the metalman RBAC that ships in the
-// machina manifests.
-func isSupportObject(obj *unstructured.Unstructured) bool {
-	switch obj.GetKind() {
-	case "ServiceAccount", "Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding":
-		return strings.Contains(obj.GetName(), "metalman")
-	default:
-		return false
-	}
 }
 
 func deployment(site *unboundedv1alpha3.Site, namespace string, cfg component.Config) *appsv1.Deployment {

--- a/internal/operator/components/metalman/metalman.go
+++ b/internal/operator/components/metalman/metalman.go
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package metalman implements the per-Site metalman PXE controller component.
+package metalman
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	machinamanifests "github.com/Azure/unbounded/deploy/machina"
+	"github.com/Azure/unbounded/internal/operator/component"
+)
+
+// Component reconciles the per-Site metalman PXE controller.
+type Component struct{}
+
+// New returns the metalman per-Site component.
+func New() component.SiteComponent { return Component{} }
+
+// Name implements component.SiteComponent.
+func (Component) Name() string { return "metalman" }
+
+// ConditionType implements component.SiteComponent.
+func (Component) ConditionType() string { return "MetalmanReady" }
+
+// Enabled reports whether the Site enables metalman.
+func (Component) Enabled(site *unboundedv1alpha3.Site) bool {
+	if site.Spec.Components.Metalman == nil {
+		return false
+	}
+
+	return unboundedv1alpha3.ComponentEnabled(&site.Spec.Components.Metalman.SiteComponentSpec)
+}
+
+// Reconcile deploys the per-site metalman PXE controller and its RBAC.
+func (Component) Reconcile(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) component.Result {
+	if err := env.ApplyManifestFS(ctx, machinamanifests.Manifests, mutateSupportObject); err != nil {
+		return component.Failed(err)
+	}
+
+	if err := env.ApplyObject(ctx, deployment(site, env.Namespace, env.Config)); err != nil {
+		return component.Failed(err)
+	}
+
+	return component.Reconciled()
+}
+
+// Cleanup removes the per-site metalman Deployment. The shared metalman RBAC is
+// left in place; it is harmless when unreferenced and may still be used by other
+// sites.
+func (Component) Cleanup(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) error {
+	return env.DeleteIfExists(ctx, &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: DeploymentName(site.Name), Namespace: env.Namespace},
+	})
+}
+
+// SetupWatches recreates the per-site Deployment if it is deleted or drifts, via
+// its owner reference to the Site.
+func (Component) SetupWatches(b *builder.Builder, _ *component.Env) {
+	b.Owns(&appsv1.Deployment{})
+}
+
+// DeploymentName is the per-site metalman Deployment name.
+func DeploymentName(site string) string { return "metalman-controller-" + site }
+
+// mutateSupportObject keeps only the metalman RBAC objects from the machina
+// manifests (they are already rendered into the operator namespace).
+func mutateSupportObject(obj *unstructured.Unstructured) error {
+	if filepath.Base(obj.GetName()) == ".gitignore" {
+		return nil
+	}
+
+	if !isSupportObject(obj) {
+		obj.Object = nil
+	}
+
+	return nil
+}
+
+// isSupportObject reports whether obj is the metalman RBAC that ships in the
+// machina manifests.
+func isSupportObject(obj *unstructured.Unstructured) bool {
+	switch obj.GetKind() {
+	case "ServiceAccount", "Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding":
+		return strings.Contains(obj.GetName(), "metalman")
+	default:
+		return false
+	}
+}
+
+func deployment(site *unboundedv1alpha3.Site, namespace string, cfg component.Config) *appsv1.Deployment {
+	image := cfg.MetalmanImage
+	name := DeploymentName(site.Name)
+	labels := map[string]string{
+		"app":                                 "unbounded-pxe",
+		"app.kubernetes.io/name":              "metalman-controller",
+		"app.kubernetes.io/component":         "metalman",
+		unboundedv1alpha3.MachineSiteLabelKey: site.Name,
+	}
+
+	args := []string{"serve-pxe", "--site=" + site.Name}
+	if site.Spec.Components.Metalman.DHCPAutoInterface != nil && *site.Spec.Components.Metalman.DHCPAutoInterface {
+		args = append(args, "--dhcp-auto-interface")
+	}
+
+	replicas := int32(1)
+	if site.Spec.Components.Metalman.Replicas != nil {
+		replicas = *site.Spec.Components.Metalman.Replicas
+	}
+
+	env := []corev1.EnvVar{{
+		// Metalman resolves its leader-election lease namespace from
+		// POD_NAMESPACE so the lease and its namespace-scoped RBAC stay
+		// co-located with the Deployment under any install namespace.
+		Name: "POD_NAMESPACE",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+		},
+	}}
+
+	// Advertise the operator-resolved API server endpoint to metalman so the
+	// kubeconfig it serves to provisioning nodes matches what machina writes,
+	// and so metalman does not need to rediscover it (managed control planes
+	// such as AKS do not publish kube-public/cluster-info). Metalman still
+	// sources the CA from the in-cluster service-account mount when cluster-info
+	// is unavailable.
+	if cfg.APIServerEndpoint != "" {
+		env = append(env, corev1.EnvVar{Name: "METALMAN_APISERVER_URL", Value: cfg.APIServerEndpoint})
+	}
+
+	// metalman is hostNetwork and binds host ports (DHCP/TFTP/HTTP), so a surge
+	// pod cannot start while the old pod holds them on the same node. Terminate
+	// the old pod before creating the new one to avoid a rollout deadlock.
+	maxSurge := intstr.FromInt32(0)
+	maxUnavailable := intstr.FromInt32(1)
+
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			OwnerReferences: []metav1.OwnerReference{component.SiteOwnerReference(site)},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					HostNetwork:        true,
+					ServiceAccountName: "metalman-controller",
+					// Match either the canonical or deprecated site label during
+					// the node-label deprecation window. Storage scopes its
+					// DaemonSet the same way.
+					Affinity: component.SiteNodeAffinity(site.Name),
+					Containers: []corev1.Container{{
+						Name:            "metalman",
+						Image:           image,
+						ImagePullPolicy: corev1.PullAlways,
+						Args:            args,
+						Env:             env,
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 8880, Protocol: corev1.ProtocolTCP},
+							{Name: "health", ContainerPort: 8081, Protocol: corev1.ProtocolTCP},
+							{Name: "dhcp", ContainerPort: 67, Protocol: corev1.ProtocolUDP},
+							{Name: "tftp", ContainerPort: 69, Protocol: corev1.ProtocolUDP},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "tmp", MountPath: "/tmp"},
+							{Name: "cache", MountPath: "/var/cache/metalman"},
+						},
+					}},
+					Volumes: []corev1.Volume{
+						{Name: "tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/operator/components/metalman/metalman_test.go
+++ b/internal/operator/components/metalman/metalman_test.go
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package metalman
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/operator/component"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{appsv1.AddToScheme, corev1.AddToScheme, unboundedv1alpha3.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add to scheme: %v", err)
+		}
+	}
+
+	return scheme
+}
+
+func TestEnabled(t *testing.T) {
+	if (Component{}).Enabled(&unboundedv1alpha3.Site{}) {
+		t.Fatal("metalman enabled with no component spec")
+	}
+
+	enabled := true
+	site := &unboundedv1alpha3.Site{Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{
+		Metalman: &unboundedv1alpha3.MetalmanComponentSpec{SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled}},
+	}}}
+
+	if !(Component{}).Enabled(site) {
+		t.Fatal("metalman not enabled when spec enables it")
+	}
+}
+
+func TestMutateSupportObject(t *testing.T) {
+	keep := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "Role",
+		"metadata":   map[string]any{"name": "metalman-controller"},
+	}}
+	if err := mutateSupportObject(keep); err != nil {
+		t.Fatalf("mutateSupportObject returned error: %v", err)
+	}
+
+	if keep.Object == nil {
+		t.Fatalf("metalman support object was dropped")
+	}
+
+	drop := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ServiceAccount",
+		"metadata":   map[string]any{"name": "machina-controller"},
+	}}
+	if err := mutateSupportObject(drop); err != nil {
+		t.Fatalf("mutateSupportObject returned error: %v", err)
+	}
+
+	if drop.Object != nil {
+		t.Fatalf("non-metalman object was not dropped")
+	}
+}
+
+func TestDeployment(t *testing.T) {
+	enabled := true
+	dhcpAuto := true
+	replicas := int32(3)
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"},
+		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
+			SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
+			DHCPAutoInterface: &dhcpAuto,
+			Replicas:          &replicas,
+		}}},
+	}
+
+	d := deployment(site, component.DefaultNamespace, component.Config{MetalmanImage: "example/metalman:default", APIServerEndpoint: "https://api.example:6443"})
+	if d.Name != "metalman-controller-rack-a" {
+		t.Fatalf("name = %q", d.Name)
+	}
+
+	if d.Namespace != component.DefaultNamespace {
+		t.Fatalf("namespace = %q, want %q", d.Namespace, component.DefaultNamespace)
+	}
+
+	container := d.Spec.Template.Spec.Containers[0]
+	if container.Image != "example/metalman:default" {
+		t.Fatalf("image = %q", container.Image)
+	}
+
+	if got := container.Args; len(got) != 3 || got[0] != "serve-pxe" || got[1] != "--site=rack-a" || got[2] != "--dhcp-auto-interface" {
+		t.Fatalf("args = %#v", got)
+	}
+
+	if d.Spec.Replicas == nil || *d.Spec.Replicas != 3 {
+		t.Fatalf("replicas = %v, want 3", d.Spec.Replicas)
+	}
+
+	for _, path := range []string{"deployment", "selector", "pod"} {
+		var got string
+
+		switch path {
+		case "deployment":
+			got = d.Labels[unboundedv1alpha3.MachineSiteLabelKey]
+		case "selector":
+			got = d.Spec.Selector.MatchLabels[unboundedv1alpha3.MachineSiteLabelKey]
+		case "pod":
+			got = d.Spec.Template.Labels[unboundedv1alpha3.MachineSiteLabelKey]
+		}
+
+		if got != "rack-a" {
+			t.Fatalf("%s site label = %q, want rack-a", path, got)
+		}
+	}
+
+	podNS := findEnv(container.Env, "POD_NAMESPACE")
+	if podNS == nil || podNS.ValueFrom == nil || podNS.ValueFrom.FieldRef == nil ||
+		podNS.ValueFrom.FieldRef.FieldPath != "metadata.namespace" {
+		t.Fatalf("POD_NAMESPACE env = %#v, want Downward API metadata.namespace", podNS)
+	}
+
+	if got := findEnv(container.Env, "METALMAN_APISERVER_URL"); got == nil || got.Value != "https://api.example:6443" {
+		t.Fatalf("METALMAN_APISERVER_URL env = %#v, want https://api.example:6443", got)
+	}
+
+	assertSiteOwnerRef(t, d.OwnerReferences, "rack-a", "site-uid")
+	assertSiteAffinity(t, d.Spec.Template.Spec.Affinity, "rack-a")
+
+	strategy := d.Spec.Strategy
+	if strategy.Type != appsv1.RollingUpdateDeploymentStrategyType || strategy.RollingUpdate == nil {
+		t.Fatalf("expected RollingUpdate strategy, got %+v", strategy)
+	}
+
+	if got := strategy.RollingUpdate.MaxSurge; got == nil || got.IntValue() != 0 {
+		t.Fatalf("expected maxSurge=0, got %v", got)
+	}
+
+	if got := strategy.RollingUpdate.MaxUnavailable; got == nil || got.IntValue() != 1 {
+		t.Fatalf("expected maxUnavailable=1, got %v", got)
+	}
+}
+
+func TestDeploymentRespectsNamespaceAndDefaults(t *testing.T) {
+	enabled := true
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
+		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
+			SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
+		}}},
+	}
+
+	d := deployment(site, "custom-ns", component.Config{MetalmanImage: "example/metalman:default"})
+	if d.Namespace != "custom-ns" {
+		t.Fatalf("namespace = %q, want custom-ns", d.Namespace)
+	}
+
+	if d.Spec.Replicas == nil || *d.Spec.Replicas != 1 {
+		t.Fatalf("replicas = %v, want default 1", d.Spec.Replicas)
+	}
+
+	if got := findEnv(d.Spec.Template.Spec.Containers[0].Env, "METALMAN_APISERVER_URL"); got != nil {
+		t.Fatalf("METALMAN_APISERVER_URL env = %#v, want unset when APIServerEndpoint is empty", got)
+	}
+}
+
+func TestDeploymentAllowsZeroReplicas(t *testing.T) {
+	enabled := true
+	replicas := int32(0)
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
+		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
+			SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
+			Replicas:          &replicas,
+		}}},
+	}
+
+	d := deployment(site, component.DefaultNamespace, component.Config{MetalmanImage: "example/metalman:default"})
+	if d.Spec.Replicas == nil || *d.Spec.Replicas != 0 {
+		t.Fatalf("replicas = %v, want 0", d.Spec.Replicas)
+	}
+}
+
+func TestCleanupDeletesDeployment(t *testing.T) {
+	deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "metalman-controller-rack-a", Namespace: component.DefaultNamespace}}
+	env := &component.Env{
+		Client:    fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(deploy).Build(),
+		Namespace: component.DefaultNamespace,
+	}
+
+	if err := (Component{}).Cleanup(t.Context(), env, &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(deploy), &appsv1.Deployment{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected Deployment deleted, got err=%v", err)
+	}
+}
+
+func findEnv(env []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range env {
+		if env[i].Name == name {
+			return &env[i]
+		}
+	}
+
+	return nil
+}
+
+func assertSiteOwnerRef(t *testing.T, refs []metav1.OwnerReference, siteName, uid string) {
+	t.Helper()
+
+	if len(refs) != 1 {
+		t.Fatalf("ownerReferences len = %d, want 1: %#v", len(refs), refs)
+	}
+
+	ref := refs[0]
+	if ref.APIVersion != unboundedv1alpha3.GroupVersion.String() || ref.Kind != "Site" || ref.Name != siteName {
+		t.Fatalf("unexpected ownerRef: %#v", ref)
+	}
+
+	if uid != "" && string(ref.UID) != uid {
+		t.Fatalf("ownerRef UID = %q, want %q", ref.UID, uid)
+	}
+}
+
+func assertSiteAffinity(t *testing.T, affinity *corev1.Affinity, siteName string) {
+	t.Helper()
+
+	if affinity == nil || affinity.NodeAffinity == nil || affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatalf("missing node affinity: %#v", affinity)
+	}
+
+	terms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 2 {
+		t.Fatalf("node selector terms len = %d, want 2: %#v", len(terms), terms)
+	}
+
+	want := map[string]bool{component.SiteLabelKey: false, component.DeprecatedSiteLabelKey: false}
+
+	for _, term := range terms {
+		if len(term.MatchExpressions) != 1 {
+			t.Fatalf("term must have one expression: %#v", term)
+		}
+
+		expr := term.MatchExpressions[0]
+		if expr.Operator != corev1.NodeSelectorOpIn || len(expr.Values) != 1 || expr.Values[0] != siteName {
+			t.Fatalf("unexpected site affinity expression: %#v", expr)
+		}
+
+		if _, ok := want[expr.Key]; !ok {
+			t.Fatalf("unexpected site affinity key %q", expr.Key)
+		}
+
+		want[expr.Key] = true
+	}
+
+	for key, seen := range want {
+		if !seen {
+			t.Fatalf("site affinity missing key %q", key)
+		}
+	}
+}

--- a/internal/operator/components/metalman/metalman_test.go
+++ b/internal/operator/components/metalman/metalman_test.go
@@ -235,6 +235,12 @@ func assertSiteOwnerRef(t *testing.T, refs []metav1.OwnerReference, siteName, ui
 	if uid != "" && string(ref.UID) != uid {
 		t.Fatalf("ownerRef UID = %q, want %q", ref.UID, uid)
 	}
+
+	// The reference must be a controller reference; Owns() enqueues only via
+	// metav1.GetControllerOf, so a non-controller ref breaks per-site self-heal.
+	if ref.Controller == nil || !*ref.Controller {
+		t.Fatalf("ownerRef is not a controller reference: %#v", ref)
+	}
 }
 
 func assertSiteAffinity(t *testing.T, affinity *corev1.Affinity, siteName string) {

--- a/internal/operator/components/net/net.go
+++ b/internal/operator/components/net/net.go
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package net implements the unbounded-net cluster component. Net is not a
+// per-Site component: one controller/node pair reads every Site, so it is
+// reconciled as a cluster singleton whenever at least one Site exists and kept
+// reconciled if it was already installed.
+package net
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	netmanifests "github.com/Azure/unbounded/deploy/net"
+	"github.com/Azure/unbounded/internal/operator/component"
+)
+
+const (
+	configName     = "unbounded-net-config"
+	controllerName = "unbounded-net-controller"
+	nodeName       = "unbounded-net-node"
+
+	ConfigHashAnnotation = "unbounded-cloud.io/net-config-hash"
+)
+
+// Component reconciles the unbounded-net cluster singleton.
+type Component struct{}
+
+// New returns the net cluster component.
+func New() component.ClusterComponent { return Component{} }
+
+// Name implements component.ClusterComponent.
+func (Component) Name() string { return "net" }
+
+// ConditionType implements component.ClusterComponent.
+func (Component) ConditionType() string { return "NetReady" }
+
+// Reconcile deploys the unbounded-net cluster singleton whenever at least one
+// Site exists and keeps an existing installation reconciled with no Sites.
+func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unboundedv1alpha3.Site) component.Result {
+	if len(sites) == 0 {
+		// Net is the cluster dataplane. Do not auto-delete it just because the
+		// last Site was removed; deleting net-node can break pod networking
+		// across the whole cluster. A future explicit uninstall flow should
+		// handle removal.
+		retained, err := resourcesExist(ctx, env)
+		if err != nil {
+			return component.Failed(err)
+		}
+
+		if !retained {
+			return component.NoSites("no sites; net retained")
+		}
+	}
+
+	configHash, err := ensureConfig(ctx, env)
+	if err != nil {
+		return component.Failed(err)
+	}
+
+	if err := env.ApplyManifestFS(ctx, netmanifests.Manifests, applyMutator(configHash)); err != nil {
+		return component.Failed(err)
+	}
+
+	return component.Reconciled()
+}
+
+// SetupWatches reconciles net on changes to its config payload and on
+// create/delete/generation changes of its managed workloads.
+func (Component) SetupWatches(b *builder.Builder, env *component.Env) {
+	b.Watches(&corev1.ConfigMap{}, env.RequestSingletonAndAllSites(),
+		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceNamed(configName))))
+	b.Watches(&appsv1.Deployment{}, env.RequestSingleton(),
+		builder.WithPredicates(env.ManagedWorkloadPredicate(env.InNamespaceNamed(controllerName))))
+	b.Watches(&appsv1.DaemonSet{}, env.RequestSingleton(),
+		builder.WithPredicates(env.ManagedWorkloadPredicate(env.InNamespaceNamed(nodeName))))
+}
+
+func resourcesExist(ctx context.Context, env *component.Env) (bool, error) {
+	for _, object := range []client.Object{
+		&corev1.ConfigMap{},
+		&appsv1.Deployment{},
+		&appsv1.DaemonSet{},
+	} {
+		name := configName
+
+		switch object.(type) {
+		case *appsv1.Deployment:
+			name = controllerName
+		case *appsv1.DaemonSet:
+			name = nodeName
+		}
+
+		key := client.ObjectKey{Namespace: env.Namespace, Name: name}
+		if err := env.Client.Get(ctx, key, object); err == nil {
+			return true, nil
+		} else if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("get retained net resource %s/%s: %w", env.Namespace, name, err)
+		}
+	}
+
+	return false, nil
+}
+
+// applyMutator skips the separately reconciled ConfigMap and stamps its exact
+// payload hash on both net workloads so config changes roll them together.
+func applyMutator(configHash string) func(*unstructured.Unstructured) error {
+	return func(obj *unstructured.Unstructured) error {
+		if obj.GetKind() == component.CRDKind {
+			obj.Object = nil
+
+			return nil
+		}
+
+		if obj.GetKind() == "ConfigMap" && obj.GetName() == configName {
+			obj.Object = nil
+
+			return nil
+		}
+
+		if (obj.GetKind() == "Deployment" && obj.GetName() == controllerName) ||
+			(obj.GetKind() == "DaemonSet" && obj.GetName() == nodeName) {
+			annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+			if err != nil {
+				return fmt.Errorf("get net pod template annotations: %w", err)
+			}
+
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
+
+			annotations[ConfigHashAnnotation] = configHash
+			if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
+				return fmt.Errorf("set net config hash annotation: %w", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+// ensureConfig creates the embedded default only when no config exists. Existing
+// migrated or user-managed payloads are never applied over.
+func ensureConfig(ctx context.Context, env *component.Env) (string, error) {
+	key := client.ObjectKey{Namespace: env.Namespace, Name: configName}
+	existing := &corev1.ConfigMap{}
+
+	err := env.Client.Get(ctx, key, existing)
+	if err == nil {
+		return component.ConfigMapPayloadHash(existing), nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("get net config %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	desired, err := env.DefaultConfigMap(netmanifests.Manifests, configName, "net")
+	if err != nil {
+		return "", err
+	}
+
+	if err := env.Client.Create(ctx, desired); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return "", fmt.Errorf("create net config %s/%s: %w", key.Namespace, key.Name, err)
+		}
+
+		if err := env.Client.Get(ctx, key, existing); err != nil {
+			return "", fmt.Errorf("get raced net config %s/%s: %w", key.Namespace, key.Name, err)
+		}
+
+		return component.ConfigMapPayloadHash(existing), nil
+	}
+
+	return component.ConfigMapPayloadHash(desired), nil
+}

--- a/internal/operator/components/net/net_test.go
+++ b/internal/operator/components/net/net_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package net
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/operator/component"
+)
+
+func testEnv(t *testing.T, objects ...client.Object) *component.Env {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{appsv1.AddToScheme, corev1.AddToScheme, unboundedv1alpha3.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add to scheme: %v", err)
+		}
+	}
+
+	return &component.Env{
+		Client:    fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build(),
+		Namespace: component.DefaultNamespace,
+	}
+}
+
+func TestEnsureConfigCreatesDefaultOnlyWhenAbsent(t *testing.T) {
+	env := testEnv(t)
+
+	hash, err := ensureConfig(t.Context(), env)
+	if err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+
+	key := client.ObjectKey{Namespace: component.DefaultNamespace, Name: configName}
+	if err := env.Client.Get(t.Context(), key, &got); err != nil {
+		t.Fatalf("get default net config: %v", err)
+	}
+
+	if got.Data["config.yaml"] == "" || hash != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("default net config/hash missing: hash=%q data=%#v", hash, got.Data)
+	}
+}
+
+func TestEnsureConfigPreservesExistingPayload(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: component.DefaultNamespace},
+		Data:       map[string]string{"config.yaml": "custom: true", "extra": "keep"},
+		BinaryData: map[string][]byte{"routing.bin": {0, 1, 2}},
+	}
+	env := testEnv(t, existing)
+
+	hash, err := ensureConfig(t.Context(), env)
+	if err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
+		t.Fatalf("get preserved net config: %v", err)
+	}
+
+	if got.Data["config.yaml"] != "custom: true" || got.Data["extra"] != "keep" {
+		t.Fatalf("existing net config changed: %#v", got.Data)
+	}
+
+	if hash != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("hash = %q, want exact payload hash", hash)
+	}
+}
+
+func TestApplyMutatorStampsBothWorkloads(t *testing.T) {
+	for _, tc := range []struct{ kind, name string }{
+		{kind: "Deployment", name: controllerName},
+		{kind: "DaemonSet", name: nodeName},
+	} {
+		t.Run(tc.kind, func(t *testing.T) {
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       tc.kind,
+				"metadata":   map[string]any{"name": tc.name},
+				"spec": map[string]any{"template": map[string]any{
+					"metadata": map[string]any{"annotations": map[string]any{"existing": "kept"}},
+				}},
+			}}
+
+			if err := applyMutator("net-hash")(obj); err != nil {
+				t.Fatalf("applyMutator: %v", err)
+			}
+
+			annotations, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+			if annotations[ConfigHashAnnotation] != "net-hash" || annotations["existing"] != "kept" {
+				t.Fatalf("pod template annotations = %#v", annotations)
+			}
+		})
+	}
+
+	config := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": configName},
+	}}
+	if err := applyMutator("net-hash")(config); err != nil || config.Object != nil {
+		t.Fatalf("embedded net ConfigMap was not skipped: err=%v object=%#v", err, config.Object)
+	}
+
+	crd := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1", "kind": component.CRDKind,
+		"metadata": map[string]any{"name": "sites.unbounded-cloud.io"},
+	}}
+	if err := applyMutator("net-hash")(crd); err != nil || crd.Object != nil {
+		t.Fatalf("CRD was not skipped: err=%v object=%#v", err, crd.Object)
+	}
+}
+
+func TestReconcileRetainedWithNoSites(t *testing.T) {
+	config := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: configName},
+		Data:       map[string]string{"config.yaml": "custom: retained"},
+	}
+	env, appliedHashes := retainedEnv(t, config)
+
+	res := Component{}.Reconcile(t.Context(), env, nil)
+	if !res.Ready || res.Err != nil {
+		t.Fatalf("Reconcile = %+v, want ready", res)
+	}
+
+	wantHash := component.ConfigMapPayloadHash(config)
+	for _, name := range []string{controllerName, nodeName} {
+		if appliedHashes[name] != wantHash {
+			t.Fatalf("%s applied hash = %q, want %q", name, appliedHashes[name], wantHash)
+		}
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(config), &got); err != nil {
+		t.Fatalf("get retained net config: %v", err)
+	}
+
+	if got.Data["config.yaml"] != "custom: retained" {
+		t.Fatalf("retained net config changed: %#v", got.Data)
+	}
+}
+
+func TestReconcileRecreatesDeletedRetainedConfigWithNoSites(t *testing.T) {
+	retained := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Namespace: component.DefaultNamespace,
+		Name:      controllerName,
+	}}
+	env, appliedHashes := retainedEnv(t, retained)
+
+	res := Component{}.Reconcile(t.Context(), env, nil)
+	if !res.Ready || res.Err != nil {
+		t.Fatalf("Reconcile = %+v, want ready", res)
+	}
+
+	var config corev1.ConfigMap
+
+	key := client.ObjectKey{Namespace: component.DefaultNamespace, Name: configName}
+	if err := env.Client.Get(t.Context(), key, &config); err != nil {
+		t.Fatalf("get recreated net config: %v", err)
+	}
+
+	wantHash := component.ConfigMapPayloadHash(&config)
+	if config.Data["config.yaml"] == "" || appliedHashes[controllerName] != wantHash || appliedHashes[nodeName] != wantHash {
+		t.Fatalf("recreated config/workload hashes = data=%#v hashes=%#v", config.Data, appliedHashes)
+	}
+}
+
+func TestReconcileDoesNotCreateFromNothingWithNoSites(t *testing.T) {
+	env, appliedHashes := retainedEnv(t)
+
+	res := Component{}.Reconcile(t.Context(), env, nil)
+	if !res.Ready || res.Reason != component.ReasonNoSites {
+		t.Fatalf("Reconcile = %+v, want ready with NoSites", res)
+	}
+
+	err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: configName}, &corev1.ConfigMap{})
+	if !apierrors.IsNotFound(err) || len(appliedHashes) != 0 {
+		t.Fatalf("zero-Site reconcile created net from nothing: config err=%v hashes=%#v", err, appliedHashes)
+	}
+}
+
+func retainedEnv(t *testing.T, objects ...client.Object) (*component.Env, map[string]string) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{appsv1.AddToScheme, corev1.AddToScheme, unboundedv1alpha3.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add to scheme: %v", err)
+		}
+	}
+
+	appliedHashes := map[string]string{}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				applied, ok := obj.(interface {
+					GetName() string
+					GetKind() string
+					UnstructuredContent() map[string]any
+				})
+				if !ok {
+					t.Fatalf("applied object has unexpected type %T", obj)
+				}
+
+				name := applied.GetName()
+				if (applied.GetKind() != "Deployment" || name != controllerName) &&
+					(applied.GetKind() != "DaemonSet" || name != nodeName) {
+					return nil
+				}
+
+				hash, _, err := unstructured.NestedString(
+					applied.UnstructuredContent(),
+					"spec", "template", "metadata", "annotations", ConfigHashAnnotation,
+				)
+				if err != nil {
+					t.Fatalf("get applied hash for %s: %v", name, err)
+				}
+
+				appliedHashes[name] = hash
+
+				return nil
+			},
+		}).
+		Build()
+
+	return &component.Env{Client: cl, Scheme: scheme, Namespace: component.DefaultNamespace}, appliedHashes
+}

--- a/internal/operator/components/storage/storage.go
+++ b/internal/operator/components/storage/storage.go
@@ -1,0 +1,333 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package storage implements the per-Site unbounded-storage supervisor
+// component. The supervisor runs as a site-scoped DaemonSet on the nodes
+// belonging to the Site, mounting a per-Site config ConfigMap.
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	storagemanifests "github.com/Azure/unbounded/deploy/unbounded-storage-supervisor"
+	"github.com/Azure/unbounded/internal/operator/component"
+)
+
+const (
+	daemonSetName = "unbounded-storage-supervisor"
+	configName    = "unbounded-storage-config"
+	configPrefix  = configName + "-"
+
+	ConfigHashAnnotation = "unbounded-cloud.io/storage-config-hash"
+)
+
+// Component reconciles the per-Site storage supervisor.
+type Component struct{}
+
+// New returns the storage per-Site component.
+func New() component.SiteComponent { return Component{} }
+
+// Name implements component.SiteComponent.
+func (Component) Name() string { return "storage" }
+
+// ConditionType implements component.SiteComponent.
+func (Component) ConditionType() string { return "StorageReady" }
+
+// Enabled reports whether the Site enables storage.
+func (Component) Enabled(site *unboundedv1alpha3.Site) bool {
+	if site.Spec.Components.Storage == nil {
+		return false
+	}
+
+	return unboundedv1alpha3.ComponentEnabled(&site.Spec.Components.Storage.SiteComponentSpec)
+}
+
+// Reconcile deploys a site-scoped storage supervisor DaemonSet that runs only on
+// the nodes belonging to the Site.
+func (Component) Reconcile(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) component.Result {
+	configHash, err := ensureConfig(ctx, env, site)
+	if err != nil {
+		return component.Failed(err)
+	}
+
+	if err := env.ApplyManifestFS(ctx, storagemanifests.Manifests, func(obj *unstructured.Unstructured) error {
+		return mutateObject(site, configHash, obj)
+	}); err != nil {
+		return component.Failed(err)
+	}
+
+	return component.Reconciled()
+}
+
+// Cleanup removes the per-site storage DaemonSet and ConfigMap.
+func (Component) Cleanup(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) error {
+	if err := env.DeleteIfExists(ctx, &appsv1.DaemonSet{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "DaemonSet"},
+		ObjectMeta: metav1.ObjectMeta{Name: SiteDaemonSetName(site.Name), Namespace: env.Namespace},
+	}); err != nil {
+		return err
+	}
+
+	return env.DeleteIfExists(ctx, &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName(site.Name), Namespace: env.Namespace},
+	})
+}
+
+// SetupWatches reconciles a Site on changes to its per-site config payload and
+// recreates the per-site DaemonSet if it is deleted or drifts.
+func (Component) SetupWatches(b *builder.Builder, env *component.Env) {
+	namespace := env.Namespace
+
+	b.Watches(&corev1.ConfigMap{},
+		handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []ctrl.Request {
+			site := strings.TrimPrefix(obj.GetName(), configPrefix)
+			if site == obj.GetName() || site == "" {
+				return nil
+			}
+
+			return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: site}}}
+		}),
+		builder.WithPredicates(env.ManagedConfigPredicate(func(obj client.Object) bool {
+			return obj.GetNamespace() == namespace &&
+				strings.HasPrefix(obj.GetName(), configPrefix) &&
+				strings.TrimPrefix(obj.GetName(), configPrefix) != ""
+		})),
+	)
+	b.Owns(&appsv1.DaemonSet{})
+}
+
+// SiteDaemonSetName is the per-site storage supervisor DaemonSet name.
+func SiteDaemonSetName(site string) string { return daemonSetName + "-" + site }
+
+// SiteConfigName is the per-site storage supervisor ConfigMap name. Storage
+// config is per-Site in the API, so each Site gets its own ConfigMap.
+func SiteConfigName(site string) string { return configPrefix + site }
+
+// ensureConfig creates the per-site storage ConfigMap from the embedded default
+// when it is absent. If an operator/user already created it (or the reaper
+// migrated it), the data is preserved and only adopted with a Site owner
+// reference so it is garbage-collected with the Site.
+func ensureConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) (string, error) {
+	key := client.ObjectKey{Namespace: env.Namespace, Name: SiteConfigName(site.Name)}
+	existing := &corev1.ConfigMap{}
+
+	err := env.Client.Get(ctx, key, existing)
+	switch {
+	case err == nil:
+		if err := adoptConfig(ctx, env, site, existing); err != nil {
+			return "", err
+		}
+
+		return component.ConfigMapPayloadHash(existing), nil
+	case !apierrors.IsNotFound(err):
+		return "", fmt.Errorf("get storage config %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	cm, err := defaultConfigMap(site, env.Namespace)
+	if err != nil {
+		return "", err
+	}
+
+	if err := env.Client.Create(ctx, cm); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return "", fmt.Errorf("create storage config %s/%s: %w", cm.Namespace, cm.Name, err)
+		}
+
+		// Race with a user/reaper create; adopt what won without touching data.
+		if getErr := env.Client.Get(ctx, key, existing); getErr != nil {
+			return "", fmt.Errorf("get raced storage config %s/%s: %w", key.Namespace, key.Name, getErr)
+		}
+
+		if err := adoptConfig(ctx, env, site, existing); err != nil {
+			return "", err
+		}
+
+		return component.ConfigMapPayloadHash(existing), nil
+	}
+
+	return component.ConfigMapPayloadHash(cm), nil
+}
+
+func adoptConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site, cm *corev1.ConfigMap) error {
+	owner := component.SiteOwnerReference(site)
+
+	refs, changed := component.UpsertOwnerReference(cm.OwnerReferences, owner)
+	if !changed {
+		return nil
+	}
+
+	before := cm.DeepCopy()
+	cm.OwnerReferences = refs
+
+	patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
+	if err := env.Client.Patch(ctx, cm, patch); err != nil {
+		return fmt.Errorf("adopt storage config %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	return nil
+}
+
+func defaultConfigMap(site *unboundedv1alpha3.Site, namespace string) (*corev1.ConfigMap, error) {
+	files, err := component.YamlFiles(storagemanifests.Manifests)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		data, err := fs.ReadFile(storagemanifests.Manifests, file)
+		if err != nil {
+			return nil, fmt.Errorf("read storage manifest %s: %w", file, err)
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+		for {
+			obj := &unstructured.Unstructured{}
+			if err := decoder.Decode(obj); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, fmt.Errorf("decode storage manifest %s: %w", file, err)
+			}
+
+			if obj.Object == nil || obj.GetKind() != "ConfigMap" || obj.GetName() != configName {
+				continue
+			}
+
+			cm := &corev1.ConfigMap{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, cm); err != nil {
+				return nil, fmt.Errorf("convert storage config template: %w", err)
+			}
+
+			cm.Name = SiteConfigName(site.Name)
+			cm.Namespace = namespace
+			cm.OwnerReferences = []metav1.OwnerReference{component.SiteOwnerReference(site)}
+
+			return cm, nil
+		}
+	}
+
+	return nil, errors.New("storage config template not found")
+}
+
+// mutateObject scopes the storage supervisor manifests to the Site. The
+// DaemonSet is per-site (name, labels, node affinity, and config mount). The
+// per-site ConfigMap is handled by ensureConfig so existing config data is
+// preserved; the ServiceAccount and RBAC are shared across sites.
+func mutateObject(site *unboundedv1alpha3.Site, configHash string, obj *unstructured.Unstructured) error {
+	switch {
+	case obj.GetKind() == "DaemonSet" && obj.GetName() == daemonSetName:
+		return scopeDaemonSetToSite(site, configHash, obj)
+	case obj.GetKind() == "ConfigMap" && obj.GetName() == configName:
+		obj.Object = nil
+
+		return nil
+	default:
+		return nil
+	}
+}
+
+func scopeDaemonSetToSite(site *unboundedv1alpha3.Site, configHash string, obj *unstructured.Unstructured) error {
+	obj.SetName(SiteDaemonSetName(site.Name))
+	obj.SetOwnerReferences([]metav1.OwnerReference{component.SiteOwnerReference(site)})
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	labels[component.SiteLabelKey] = site.Name
+	obj.SetLabels(labels)
+
+	for _, path := range [][]string{
+		{"spec", "selector", "matchLabels", component.SiteLabelKey},
+		{"spec", "template", "metadata", "labels", component.SiteLabelKey},
+	} {
+		if err := unstructured.SetNestedField(obj.Object, site.Name, path...); err != nil {
+			return fmt.Errorf("scope storage daemonset (%v): %w", path, err)
+		}
+	}
+
+	affinityMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(component.SiteNodeAffinity(site.Name))
+	if err != nil {
+		return fmt.Errorf("scope storage daemonset affinity: %w", err)
+	}
+
+	if err := unstructured.SetNestedMap(obj.Object, affinityMap, "spec", "template", "spec", "affinity"); err != nil {
+		return fmt.Errorf("set storage daemonset affinity: %w", err)
+	}
+
+	annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		return fmt.Errorf("get storage daemonset pod template annotations: %w", err)
+	}
+
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[ConfigHashAnnotation] = configHash
+	if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
+		return fmt.Errorf("set storage config hash annotation: %w", err)
+	}
+
+	return pointDaemonSetAtSiteConfig(site, obj)
+}
+
+// pointDaemonSetAtSiteConfig repoints the DaemonSet's config-source volume at the
+// Site's per-site ConfigMap so each Site mounts its own storage config.
+func pointDaemonSetAtSiteConfig(site *unboundedv1alpha3.Site, obj *unstructured.Unstructured) error {
+	volumes, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
+	if err != nil {
+		return fmt.Errorf("get storage daemonset volumes: %w", err)
+	}
+
+	if !found {
+		return nil
+	}
+
+	for i, v := range volumes {
+		vol, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		cm, ok := vol["configMap"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if cm["name"] == configName {
+			cm["name"] = SiteConfigName(site.Name)
+			vol["configMap"] = cm
+			volumes[i] = vol
+		}
+	}
+
+	if err := unstructured.SetNestedSlice(obj.Object, volumes, "spec", "template", "spec", "volumes"); err != nil {
+		return fmt.Errorf("set storage daemonset volumes: %w", err)
+	}
+
+	return nil
+}

--- a/internal/operator/components/storage/storage.go
+++ b/internal/operator/components/storage/storage.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -22,10 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	storagemanifests "github.com/Azure/unbounded/deploy/unbounded-storage-supervisor"
@@ -94,26 +91,14 @@ func (Component) Cleanup(ctx context.Context, env *component.Env, site *unbounde
 }
 
 // SetupWatches reconciles a Site on changes to its per-site config payload and
-// recreates the per-site DaemonSet if it is deleted or drifts.
+// recreates the per-site DaemonSet if it is deleted or drifts. The DaemonSet
+// predicate drops status-only updates so pod churn does not re-apply it.
 func (Component) SetupWatches(b *builder.Builder, env *component.Env) {
-	namespace := env.Namespace
-
 	b.Watches(&corev1.ConfigMap{},
-		handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []ctrl.Request {
-			site := strings.TrimPrefix(obj.GetName(), configPrefix)
-			if site == obj.GetName() || site == "" {
-				return nil
-			}
-
-			return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: site}}}
-		}),
-		builder.WithPredicates(env.ManagedConfigPredicate(func(obj client.Object) bool {
-			return obj.GetNamespace() == namespace &&
-				strings.HasPrefix(obj.GetName(), configPrefix) &&
-				strings.TrimPrefix(obj.GetName(), configPrefix) != ""
-		})),
+		env.RequestSiteFromConfigName(configPrefix),
+		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceWithPrefix(configPrefix))),
 	)
-	b.Owns(&appsv1.DaemonSet{})
+	b.Owns(&appsv1.DaemonSet{}, builder.WithPredicates(env.OwnedWorkloadPredicate()))
 }
 
 // SiteDaemonSetName is the per-site storage supervisor DaemonSet name.

--- a/internal/operator/components/storage/storage_test.go
+++ b/internal/operator/components/storage/storage_test.go
@@ -237,6 +237,12 @@ func assertSiteOwnerRef(t *testing.T, refs []metav1.OwnerReference, siteName, ui
 	if uid != "" && string(ref.UID) != uid {
 		t.Fatalf("ownerRef UID = %q, want %q", ref.UID, uid)
 	}
+
+	// The reference must be a controller reference; Owns() enqueues only via
+	// metav1.GetControllerOf, so a non-controller ref breaks per-site self-heal.
+	if ref.Controller == nil || !*ref.Controller {
+		t.Fatalf("ownerRef is not a controller reference: %#v", ref)
+	}
 }
 
 func assertSiteAffinityMap(t *testing.T, affinity map[string]any, siteName string) {

--- a/internal/operator/components/storage/storage_test.go
+++ b/internal/operator/components/storage/storage_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package storage
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/operator/component"
+)
+
+func testEnv(t *testing.T, objects ...client.Object) *component.Env {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{appsv1.AddToScheme, corev1.AddToScheme, unboundedv1alpha3.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add to scheme: %v", err)
+		}
+	}
+
+	return &component.Env{
+		Client:    fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build(),
+		Namespace: component.DefaultNamespace,
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	if (Component{}).Enabled(&unboundedv1alpha3.Site{}) {
+		t.Fatal("storage enabled with no component spec")
+	}
+
+	enabled := true
+	site := &unboundedv1alpha3.Site{Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{
+		Storage: &unboundedv1alpha3.StorageComponentSpec{SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled}},
+	}}}
+
+	if !(Component{}).Enabled(site) {
+		t.Fatal("storage not enabled when spec enables it")
+	}
+}
+
+func TestMutateObjectScopesDaemonSetToSite(t *testing.T) {
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "DaemonSet",
+		"metadata":   map[string]any{"name": daemonSetName},
+		"spec": map[string]any{
+			"selector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": daemonSetName}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app.kubernetes.io/name": daemonSetName}},
+				"spec":     map[string]any{"containers": []any{map[string]any{"name": "run"}}},
+			},
+		},
+	}}
+
+	if err := mutateObject(site, "storage-hash", obj); err != nil {
+		t.Fatalf("mutateObject returned error: %v", err)
+	}
+
+	if got := obj.GetName(); got != "unbounded-storage-supervisor-rack-a" {
+		t.Fatalf("name = %q, want unbounded-storage-supervisor-rack-a", got)
+	}
+
+	if got := obj.GetLabels()[component.SiteLabelKey]; got != "rack-a" {
+		t.Fatalf("metadata site label = %q, want rack-a", got)
+	}
+
+	for _, path := range [][]string{
+		{"spec", "selector", "matchLabels", component.SiteLabelKey},
+		{"spec", "template", "metadata", "labels", component.SiteLabelKey},
+	} {
+		got, ok, err := unstructured.NestedString(obj.Object, path...)
+		if err != nil || !ok {
+			t.Fatalf("missing %v: ok=%t err=%v", path, ok, err)
+		}
+
+		if got != "rack-a" {
+			t.Fatalf("%v = %q, want rack-a", path, got)
+		}
+	}
+
+	assertSiteOwnerRef(t, obj.GetOwnerReferences(), "rack-a", "site-uid")
+
+	annotations, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+	if annotations[ConfigHashAnnotation] != "storage-hash" {
+		t.Fatalf("storage config hash annotation = %q, want storage-hash", annotations[ConfigHashAnnotation])
+	}
+
+	affinity, ok, err := unstructured.NestedMap(obj.Object, "spec", "template", "spec", "affinity")
+	if err != nil || !ok {
+		t.Fatalf("missing storage affinity: ok=%t err=%v", ok, err)
+	}
+
+	assertSiteAffinityMap(t, affinity, "rack-a")
+}
+
+func TestDaemonSetPointsAtPerSiteConfig(t *testing.T) {
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "DaemonSet",
+		"metadata":   map[string]any{"name": daemonSetName},
+		"spec": map[string]any{
+			"selector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": daemonSetName}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app.kubernetes.io/name": daemonSetName}},
+				"spec": map[string]any{
+					"containers": []any{map[string]any{"name": "run"}},
+					"volumes": []any{map[string]any{
+						"name":      "config-source",
+						"configMap": map[string]any{"name": configName},
+					}},
+				},
+			},
+		},
+	}}
+
+	if err := mutateObject(site, "storage-hash", obj); err != nil {
+		t.Fatalf("mutateObject returned error: %v", err)
+	}
+
+	volumes, ok, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
+	if err != nil || !ok {
+		t.Fatalf("missing volumes: ok=%t err=%v", ok, err)
+	}
+
+	vol := volumes[0].(map[string]any)
+	cm := vol["configMap"].(map[string]any)
+
+	if cm["name"] != "unbounded-storage-config-rack-a" {
+		t.Fatalf("config volume name = %v, want unbounded-storage-config-rack-a", cm["name"])
+	}
+}
+
+func TestEnsureConfigCreatesDefaultWhenAbsent(t *testing.T) {
+	env := testEnv(t)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
+
+	hash, err := ensureConfig(t.Context(), env, site)
+	if err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: "unbounded-storage-config-rack-a"}, &got); err != nil {
+		t.Fatalf("get created configmap: %v", err)
+	}
+
+	if got.Data["config.yaml"] == "" {
+		t.Fatalf("default config.yaml was not seeded")
+	}
+
+	if hash != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("hash = %q, want exact stored payload hash", hash)
+	}
+
+	assertSiteOwnerRef(t, got.OwnerReferences, "rack-a", "site-uid")
+}
+
+func TestEnsureConfigAdoptsExistingAndPreservesData(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-config-rack-a", Namespace: component.DefaultNamespace},
+		Data:       map[string]string{"config.yaml": "custom: true"},
+	}
+	env := testEnv(t, existing)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
+
+	hash, err := ensureConfig(t.Context(), env, site)
+	if err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
+		t.Fatalf("get adopted configmap: %v", err)
+	}
+
+	if got.Data["config.yaml"] != "custom: true" {
+		t.Fatalf("existing config data was not preserved: %q", got.Data["config.yaml"])
+	}
+
+	if hash != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("hash = %q, want exact adopted payload hash", hash)
+	}
+
+	assertSiteOwnerRef(t, got.OwnerReferences, "rack-a", "site-uid")
+}
+
+func TestCleanupDeletesPerSiteResourcesOnly(t *testing.T) {
+	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-supervisor-rack-a", Namespace: component.DefaultNamespace}}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-config-rack-a", Namespace: component.DefaultNamespace}}
+	otherDS := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-supervisor-rack-b", Namespace: component.DefaultNamespace}}
+
+	env := testEnv(t, ds, cm, otherDS)
+
+	if err := (Component{}).Cleanup(t.Context(), env, &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(ds), &appsv1.DaemonSet{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected rack-a DaemonSet deleted, got err=%v", err)
+	}
+
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(cm), &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected rack-a ConfigMap deleted, got err=%v", err)
+	}
+
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(otherDS), &appsv1.DaemonSet{}); err != nil {
+		t.Fatalf("expected rack-b DaemonSet preserved, got err=%v", err)
+	}
+}
+
+func assertSiteOwnerRef(t *testing.T, refs []metav1.OwnerReference, siteName, uid string) {
+	t.Helper()
+
+	if len(refs) != 1 {
+		t.Fatalf("ownerReferences len = %d, want 1: %#v", len(refs), refs)
+	}
+
+	ref := refs[0]
+	if ref.APIVersion != unboundedv1alpha3.GroupVersion.String() || ref.Kind != "Site" || ref.Name != siteName {
+		t.Fatalf("unexpected ownerRef: %#v", ref)
+	}
+
+	if uid != "" && string(ref.UID) != uid {
+		t.Fatalf("ownerRef UID = %q, want %q", ref.UID, uid)
+	}
+}
+
+func assertSiteAffinityMap(t *testing.T, affinity map[string]any, siteName string) {
+	t.Helper()
+
+	converted := &corev1.Affinity{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(affinity, converted); err != nil {
+		t.Fatalf("convert affinity: %v", err)
+	}
+
+	if converted.NodeAffinity == nil || converted.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatalf("missing node affinity: %#v", converted)
+	}
+
+	terms := converted.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 2 {
+		t.Fatalf("node selector terms len = %d, want 2", len(terms))
+	}
+
+	want := map[string]bool{component.SiteLabelKey: false, component.DeprecatedSiteLabelKey: false}
+
+	for _, term := range terms {
+		expr := term.MatchExpressions[0]
+		if len(expr.Values) != 1 || expr.Values[0] != siteName {
+			t.Fatalf("unexpected site affinity expression: %#v", expr)
+		}
+
+		want[expr.Key] = true
+	}
+
+	for key, seen := range want {
+		if !seen {
+			t.Fatalf("site affinity missing key %q", key)
+		}
+	}
+}

--- a/internal/operator/config_map.go
+++ b/internal/operator/config_map.go
@@ -4,39 +4,18 @@
 package operator
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Azure/unbounded/internal/operator/component"
 )
 
-const (
-	machinaConfigHashAnnotation = "unbounded-cloud.io/machina-config-hash"
-	netConfigHashAnnotation     = "unbounded-cloud.io/net-config-hash"
-	storageConfigHashAnnotation = "unbounded-cloud.io/storage-config-hash"
-)
+// deprecatedSiteLabelKey is the node site-membership label used by released net
+// controllers before the switch to unbounded-cloud.io/site. It is re-exported
+// for the legacy reaper (see migrate.go).
+const deprecatedSiteLabelKey = component.DeprecatedSiteLabelKey
 
-// configMapPayloadHash hashes the complete ConfigMap payload. JSON provides a
-// deterministic encoding for string-keyed maps, including binary values.
+// configMapPayloadHash forwards to component.ConfigMapPayloadHash for the legacy
+// reaper (see migrate.go).
 func configMapPayloadHash(config *corev1.ConfigMap) string {
-	payload, err := json.Marshal(struct {
-		Data       map[string]string `json:"data"`
-		BinaryData map[string][]byte `json:"binaryData"`
-	}{
-		Data:       config.Data,
-		BinaryData: config.BinaryData,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("encode ConfigMap payload: %v", err))
-	}
-
-	sum := sha256.Sum256(payload)
-
-	return hex.EncodeToString(sum[:])
-}
-
-func configMapPayloadChanged(oldConfig, newConfig *corev1.ConfigMap) bool {
-	return configMapPayloadHash(oldConfig) != configMapPayloadHash(newConfig)
+	return component.ConfigMapPayloadHash(config)
 }

--- a/internal/operator/machina_config.go
+++ b/internal/operator/machina_config.go
@@ -4,63 +4,24 @@
 package operator
 
 import (
-	"fmt"
-
-	"gopkg.in/yaml.v3"
+	"github.com/Azure/unbounded/internal/operator/components/machina"
+	netcomponent "github.com/Azure/unbounded/internal/operator/components/net"
+	"github.com/Azure/unbounded/internal/operator/components/storage"
 )
 
-// setMachinaAPIServerEndpoint updates only the top-level apiServerEndpoint
-// field. Using a YAML node preserves all other migrated or user-managed fields.
+// The legacy reaper (migrate.go) verifies component rollout by comparing the
+// pod-template config-hash annotations the components stamp, and migrates the
+// machina config using the same endpoint-merge logic. These aliases keep that
+// single source of truth in the component packages while the reaper references
+// the historical operator-local names.
+const (
+	netConfigHashAnnotation     = netcomponent.ConfigHashAnnotation
+	machinaConfigHashAnnotation = machina.ConfigHashAnnotation
+	storageConfigHashAnnotation = storage.ConfigHashAnnotation
+)
+
+// setMachinaAPIServerEndpoint forwards to the machina component's endpoint merge
+// so the reaper and the component write machina config identically.
 func setMachinaAPIServerEndpoint(config, endpoint string) (string, error) {
-	if endpoint == "" {
-		return config, nil
-	}
-
-	var document yaml.Node
-	if config == "" {
-		document = yaml.Node{
-			Kind: yaml.DocumentNode,
-			Content: []*yaml.Node{{
-				Kind: yaml.MappingNode,
-				Tag:  "!!map",
-			}},
-		}
-	} else if err := yaml.Unmarshal([]byte(config), &document); err != nil {
-		return "", fmt.Errorf("parse machina config: %w", err)
-	}
-
-	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
-		return "", fmt.Errorf("parse machina config: expected a top-level mapping")
-	}
-
-	mapping := document.Content[0]
-	for i := 0; i < len(mapping.Content); i += 2 {
-		if mapping.Content[i].Value != "apiServerEndpoint" {
-			continue
-		}
-
-		mapping.Content[i+1].Kind = yaml.ScalarNode
-		mapping.Content[i+1].Tag = "!!str"
-		mapping.Content[i+1].Value = endpoint
-		mapping.Content[i+1].Style = yaml.DoubleQuotedStyle
-
-		encoded, err := yaml.Marshal(&document)
-		if err != nil {
-			return "", fmt.Errorf("encode machina config: %w", err)
-		}
-
-		return string(encoded), nil
-	}
-
-	mapping.Content = append(mapping.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "apiServerEndpoint"},
-		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: endpoint, Style: yaml.DoubleQuotedStyle},
-	)
-
-	encoded, err := yaml.Marshal(&document)
-	if err != nil {
-		return "", fmt.Errorf("encode machina config: %w", err)
-	}
-
-	return string(encoded), nil
+	return machina.SetAPIServerEndpoint(config, endpoint)
 }

--- a/internal/operator/manifests_guard_test.go
+++ b/internal/operator/manifests_guard_test.go
@@ -11,6 +11,7 @@ import (
 	machinamanifests "github.com/Azure/unbounded/deploy/machina"
 	netmanifests "github.com/Azure/unbounded/deploy/net"
 	storagemanifests "github.com/Azure/unbounded/deploy/unbounded-storage-supervisor"
+	"github.com/Azure/unbounded/internal/operator/component"
 )
 
 // TestEmbeddedManifestsHaveNoLatestImageTags guards that the component manifests
@@ -26,7 +27,7 @@ func TestEmbeddedManifestsHaveNoLatestImageTags(t *testing.T) {
 	}
 
 	for name, manifests := range sets {
-		files, err := yamlFiles(manifests)
+		files, err := component.YamlFiles(manifests)
 		if err != nil {
 			t.Fatalf("%s: list manifests: %v", name, err)
 		}

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -93,12 +94,17 @@ func (r *SiteReconciler) env() *component.Env {
 	}
 }
 
+// registry returns the component registry, materializing the default registry
+// once on first use. Materializing (rather than rebuilding DefaultRegistry on
+// every call) means watch wiring and every Reconcile share the same component
+// instances, so a component may safely hold state. SetupWithManager forces this
+// before the manager starts, so concurrent Reconciles only ever read r.Registry.
 func (r *SiteReconciler) registry() *component.Registry {
-	if r.Registry != nil {
-		return r.Registry
+	if r.Registry == nil {
+		r.Registry = DefaultRegistry()
 	}
 
-	return DefaultRegistry()
+	return r.Registry
 }
 
 func (r *SiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -112,65 +118,119 @@ func (r *SiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	switch {
 	case apierrors.IsNotFound(err):
 		// A Site was deleted, or a managed singleton event used the synthetic
-		// request. Reconcile the cluster components with no specific Site; there
-		// is no Site status to publish.
-		return ctrl.Result{}, r.reconcileClusters(ctx, env, reg)
+		// request. Run the cluster components with no specific Site; there is no
+		// Site status to publish.
+		return r.runComponents(ctx, logger, env, reg, nil)
 	case err != nil:
 		return ctrl.Result{}, err
 	}
 
+	return r.runComponents(ctx, logger, env, reg, &site)
+}
+
+// runComponents drives the registry for one reconcile pass. Cluster components
+// run on every pass from the full set of Sites; per-Site components run only when
+// site is non-nil. When site is non-nil the component outcomes are published as
+// Site status conditions in registry order (cluster first, then site) so callers
+// can `kubectl wait --for=condition=NetReady`, and conditions left by components
+// no longer in the registry are pruned. The Site-less pass (deletion or a
+// synthetic singleton request) has no Site status to write, so it only surfaces
+// component errors and requeue requests.
+//
+// The pass requeues on any component Err (with controller backoff) or, absent an
+// error, after the smallest positive RequeueAfter across the components.
+func (r *SiteReconciler) runComponents(ctx context.Context, logger logr.Logger, env *component.Env, reg *component.Registry, site *unboundedv1alpha3.Site) (ctrl.Result, error) {
 	sites, err := env.ListSites(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	patch := client.MergeFrom(site.DeepCopy())
+	// Capture the status baseline before any component mutates conditions so the
+	// merge patch carries exactly the condition changes.
+	var patch client.Patch
+	if site != nil {
+		patch = client.MergeFrom(site.DeepCopy())
+	}
 
-	var reconcileErrs []error
+	var (
+		reconcileErrs []error
+		requeueAfter  time.Duration
+	)
 
-	// Cluster singletons run on every Site event; per-Site components run for
-	// this Site. Conditions are published in registry order (cluster then site)
-	// so the status patch is deterministic and callers can
-	// `kubectl wait --for=condition=NetReady`.
-	for _, c := range reg.Cluster {
-		res := c.Reconcile(ctx, env, sites)
-		if err := setComponentResult(logger, &site, c.Name(), c.ConditionType(), res); err != nil {
-			reconcileErrs = append(reconcileErrs, err)
+	record := func(name, conditionType string, res component.Result) {
+		switch {
+		case site != nil:
+			if err := setComponentResult(logger, site, name, conditionType, res); err != nil {
+				reconcileErrs = append(reconcileErrs, err)
+			}
+		case res.Err != nil:
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("%s: %w", name, res.Err))
 		}
+
+		requeueAfter = nextRequeue(requeueAfter, res.RequeueAfter)
+	}
+
+	for _, c := range reg.Cluster {
+		record(c.Name(), c.ConditionType(), c.Reconcile(ctx, env, sites))
+	}
+
+	if site != nil {
+		for _, c := range reg.Site {
+			record(c.Name(), c.ConditionType(), reconcileSiteComponent(ctx, env, c, site))
+		}
+
+		pruneStaleConditions(site, reg)
+
+		if err := r.Status().Patch(ctx, site, patch); err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("patch site status: %w", err))
+		}
+	}
+
+	return ctrl.Result{RequeueAfter: requeueAfter}, errors.Join(reconcileErrs...)
+}
+
+// nextRequeue returns the smallest positive of the current and candidate
+// requeue-after durations, so the driver retries at the earliest requested time.
+func nextRequeue(current, candidate time.Duration) time.Duration {
+	if candidate <= 0 {
+		return current
+	}
+
+	if current <= 0 || candidate < current {
+		return candidate
+	}
+
+	return current
+}
+
+// pruneStaleConditions removes Site status conditions whose type is not published
+// by any component currently in the registry, so a Site does not carry orphaned
+// conditions after a component is removed or renamed. This is safe because the
+// SiteReconciler is the sole writer of Site.status.conditions; if another
+// controller ever writes Site conditions, this must be scoped to component
+// condition types.
+func pruneStaleConditions(site *unboundedv1alpha3.Site, reg *component.Registry) {
+	current := make(map[string]struct{}, len(reg.Cluster)+len(reg.Site))
+
+	for _, c := range reg.Cluster {
+		current[c.ConditionType()] = struct{}{}
 	}
 
 	for _, c := range reg.Site {
-		res := reconcileSiteComponent(ctx, env, c, &site)
-		if err := setComponentResult(logger, &site, c.Name(), c.ConditionType(), res); err != nil {
-			reconcileErrs = append(reconcileErrs, err)
+		current[c.ConditionType()] = struct{}{}
+	}
+
+	var stale []string
+
+	for i := range site.Status.Conditions {
+		if _, ok := current[site.Status.Conditions[i].Type]; !ok {
+			stale = append(stale, site.Status.Conditions[i].Type)
 		}
 	}
 
-	if err := r.Status().Patch(ctx, &site, patch); err != nil {
-		reconcileErrs = append(reconcileErrs, fmt.Errorf("patch site status: %w", err))
+	for _, conditionType := range stale {
+		apimeta.RemoveStatusCondition(&site.Status.Conditions, conditionType)
 	}
-
-	return ctrl.Result{}, errors.Join(reconcileErrs...)
-}
-
-// reconcileClusters reconciles just the cluster components; used for deleted
-// Sites and synthetic singleton requests, where there is no Site status.
-func (r *SiteReconciler) reconcileClusters(ctx context.Context, env *component.Env, reg *component.Registry) error {
-	sites, err := env.ListSites(ctx)
-	if err != nil {
-		return err
-	}
-
-	var errs []error
-
-	for _, c := range reg.Cluster {
-		res := c.Reconcile(ctx, env, sites)
-		if res.Err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", c.Name(), res.Err))
-		}
-	}
-
-	return errors.Join(errs...)
 }
 
 // reconcileSiteComponent reconciles a per-Site component when enabled and tears
@@ -215,6 +275,9 @@ func setComponentResult(logger logr.Logger, site *unboundedv1alpha3.Site, name, 
 }
 
 func (r *SiteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// registry() materializes r.Registry so watch wiring below and every later
+	// Reconcile share the same component instances (see registry). This runs
+	// before the manager starts, so the concurrent Reconciles only read it.
 	reg := r.registry()
 	if err := reg.Validate(); err != nil {
 		return fmt.Errorf("invalid component registry: %w", err)

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -4,101 +4,74 @@
 package operator
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"io/fs"
-	"path/filepath"
-	"sort"
-	"strings"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
-	machinamanifests "github.com/Azure/unbounded/deploy/machina"
-	netmanifests "github.com/Azure/unbounded/deploy/net"
-	storagemanifests "github.com/Azure/unbounded/deploy/unbounded-storage-supervisor"
-	"github.com/Azure/unbounded/internal/unbounded"
+	"github.com/Azure/unbounded/internal/operator/component"
+	"github.com/Azure/unbounded/internal/operator/components/machina"
+	"github.com/Azure/unbounded/internal/operator/components/metalman"
+	netcomponent "github.com/Azure/unbounded/internal/operator/components/net"
+	"github.com/Azure/unbounded/internal/operator/components/storage"
 )
 
-const (
-	FieldOwner = "unbounded-operator"
+// FieldOwner is the server-side apply field manager the operator uses. It is
+// re-exported from the component package for callers within this package.
+const FieldOwner = component.FieldOwner
 
-	ComponentNet      = "net"
-	ComponentMachina  = "machina"
-	ComponentMetalman = "metalman"
-	ComponentStorage  = "storage"
+// DefaultNamespace is the namespace the operator installs components into.
+var DefaultNamespace = component.DefaultNamespace
 
-	// Condition reasons published on Site.status.conditions. Reasons must be
-	// CamelCase alphanumeric to satisfy metav1.Condition validation.
-	reasonReconciled     = "Reconciled"
-	reasonDisabled       = "Disabled"
-	reasonNoSites        = "NoSites"
-	reasonReconcileError = "ReconcileError"
+// Config carries operator-level settings handed to components.
+type Config = component.Config
 
-	// siteLabelKey is the canonical node label for site membership
-	// (unbounded-cloud.io/site). The net controller applies it to Nodes and the
-	// operator uses it to node-select site-scoped components (storage, metalman).
-	siteLabelKey = unboundedv1alpha3.MachineSiteLabelKey
-
-	// deprecatedSiteLabelKey is the node site-membership label used by released
-	// net controllers before the switch to unbounded-cloud.io/site. Per-site
-	// workloads target either key during the deprecation window so they schedule
-	// before the upgraded net has converged all Nodes to the canonical label.
-	deprecatedSiteLabelKey = "net.unbounded-cloud.io/site"
-
-	// singletonRequestName cannot collide with a valid Site name. Managed
-	// singleton resource events use it independently of Site fan-out.
-	singletonRequestName = "__singletons"
-)
-
-// DefaultNamespace is the namespace the operator installs components into. It
-// follows the operator's own namespace (unbounded.SystemNamespace()).
-var DefaultNamespace = unbounded.SystemNamespace()
-
-// buildDefaultNamespace is the namespace baked into the embedded component
-// manifests at build time (the render default). retargetNamespace rewrites it to
-// the operator's configured namespace when they differ. It shares the single
-// build-default source of truth with the install tooling.
-const buildDefaultNamespace = unbounded.DefaultSystemNamespace
-
-type Config struct {
-	// MetalmanImage is the image for the synthesized per-site metalman
-	// Deployment. It is stamped to the operator's version by the operator
-	// Deployment; the other components carry their version-matched image in
-	// the embedded release manifests.
-	MetalmanImage string
-
-	// APIServerEndpoint is injected into the machina controller config.
-	APIServerEndpoint string
-}
-
+// SiteReconciler reconciles the registered components for every Site. It drives
+// a component.Registry: cluster components (net, machina) run on every pass, and
+// per-Site components (metalman, storage) run when a Site is present. Adding a
+// component is a matter of implementing component.ClusterComponent or
+// component.SiteComponent and adding it to the registry; this loop, the status
+// conditions, ordering, and the Site-less pass are all registry-driven.
 type SiteReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	Config Config
 
 	// Namespace is the namespace components are reconciled into. When empty it
-	// falls back to DefaultNamespace so the operator follows the namespace it
-	// is installed in (see cmd/unbounded-operator --namespace).
+	// falls back to component.DefaultNamespace so the operator follows the
+	// namespace it is installed in.
 	Namespace string
+
+	// Registry is the set of components to reconcile. When nil it defaults to
+	// DefaultRegistry.
+	Registry *component.Registry
+}
+
+// DefaultRegistry returns the built-in component registry: the net and machina
+// cluster singletons and the metalman and storage per-Site components. The slice
+// order is the stable Site status condition order (cluster first, then site).
+func DefaultRegistry() *component.Registry {
+	return &component.Registry{
+		Cluster: []component.ClusterComponent{
+			netcomponent.New(),
+			machina.New(),
+		},
+		Site: []component.SiteComponent{
+			metalman.New(),
+			storage.New(),
+		},
+	}
 }
 
 // namespace returns the namespace the reconciler installs components into,
@@ -108,72 +81,69 @@ func (r *SiteReconciler) namespace() string {
 		return r.Namespace
 	}
 
-	return DefaultNamespace
+	return component.DefaultNamespace
+}
+
+func (r *SiteReconciler) env() *component.Env {
+	return &component.Env{
+		Client:    r.Client,
+		Scheme:    r.Scheme,
+		Namespace: r.namespace(),
+		Config:    r.Config,
+	}
+}
+
+func (r *SiteReconciler) registry() *component.Registry {
+	if r.Registry != nil {
+		return r.Registry
+	}
+
+	return DefaultRegistry()
 }
 
 func (r *SiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+	env := r.env()
+	reg := r.registry()
 
 	var site unboundedv1alpha3.Site
-	if err := r.Get(ctx, req.NamespacedName, &site); err != nil {
-		if apierrors.IsNotFound(err) {
-			// A Site was deleted, or a managed singleton config event used the
-			// synthetic request; reconcile the cluster singletons without status.
-			return ctrl.Result{}, r.reconcileSingletons(ctx)
-		}
 
+	err := r.Get(ctx, req.NamespacedName, &site)
+	switch {
+	case apierrors.IsNotFound(err):
+		// A Site was deleted, or a managed singleton event used the synthetic
+		// request. Reconcile the cluster components with no specific Site; there
+		// is no Site status to publish.
+		return ctrl.Result{}, r.reconcileClusters(ctx, env, reg)
+	case err != nil:
 		return ctrl.Result{}, err
 	}
 
-	results := map[string]componentResult{}
-
-	// Cluster singletons: net is deployed whenever at least one Site exists and
-	// kept reconciled if retained; machina is deployed whenever any Site enables
-	// it. Reconcile them idempotently on every Site event and report status.
-	results[ComponentNet] = r.reconcileNet(ctx)
-	results[ComponentMachina] = r.reconcileMachina(ctx)
-
-	// Per-site components: reconcile when enabled, tear down when disabled so
-	// spec.components.*.enabled is declarative.
-	results[ComponentMetalman] = r.reconcilePerSiteComponent(
-		componentEnabled(&site, ComponentMetalman),
-		func() error { return r.reconcileMetalman(ctx, &site) },
-		func() error { return r.cleanupMetalman(ctx, &site) },
-	)
-	results[ComponentStorage] = r.reconcilePerSiteComponent(
-		componentEnabled(&site, ComponentStorage),
-		func() error { return r.reconcileStorage(ctx, &site) },
-		func() error { return r.cleanupStorage(ctx, &site) },
-	)
+	sites, err := env.ListSites(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	patch := client.MergeFrom(site.DeepCopy())
 
 	var reconcileErrs []error
 
-	// Publish one condition per component in a stable order so the status patch
-	// is deterministic and callers can `kubectl wait --for=condition=NetReady`.
-	for _, name := range []string{ComponentNet, ComponentMachina, ComponentMetalman, ComponentStorage} {
-		res := results[name]
-		if res.err != nil {
-			reconcileErrs = append(reconcileErrs, fmt.Errorf("%s: %w", name, res.err))
+	// Cluster singletons run on every Site event; per-Site components run for
+	// this Site. Conditions are published in registry order (cluster then site)
+	// so the status patch is deterministic and callers can
+	// `kubectl wait --for=condition=NetReady`.
+	for _, c := range reg.Cluster {
+		res := c.Reconcile(ctx, env, sites)
+		if err := setComponentResult(logger, &site, c.Name(), c.ConditionType(), res); err != nil {
+			reconcileErrs = append(reconcileErrs, err)
 		}
+	}
 
-		if !res.ready {
-			logger.Info("component not ready", "site", site.Name, "component", name, "message", res.message)
+	for _, c := range reg.Site {
+		res := reconcileSiteComponent(ctx, env, c, &site)
+		if err := setComponentResult(logger, &site, c.Name(), c.ConditionType(), res); err != nil {
+			reconcileErrs = append(reconcileErrs, err)
 		}
-
-		status := metav1.ConditionTrue
-		if !res.ready {
-			status = metav1.ConditionFalse
-		}
-
-		apimeta.SetStatusCondition(&site.Status.Conditions, metav1.Condition{
-			Type:               componentConditionType(name),
-			Status:             status,
-			Reason:             res.reason,
-			Message:            res.message,
-			ObservedGeneration: site.Generation,
-		})
 	}
 
 	if err := r.Status().Patch(ctx, &site, patch); err != nil {
@@ -183,1209 +153,94 @@ func (r *SiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	return ctrl.Result{}, errors.Join(reconcileErrs...)
 }
 
-// componentResult is the internal outcome of reconciling a single component,
-// translated into a Site status condition by Reconcile.
-type componentResult struct {
-	ready   bool
-	reason  string
-	message string
-	err     error
+// reconcileClusters reconciles just the cluster components; used for deleted
+// Sites and synthetic singleton requests, where there is no Site status.
+func (r *SiteReconciler) reconcileClusters(ctx context.Context, env *component.Env, reg *component.Registry) error {
+	sites, err := env.ListSites(ctx)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	for _, c := range reg.Cluster {
+		res := c.Reconcile(ctx, env, sites)
+		if res.Err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.Name(), res.Err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
-// componentConditionType maps a component name to its Site status condition
-// type (for example "net" -> "NetReady").
-func componentConditionType(component string) string {
-	switch component {
-	case ComponentNet:
-		return "NetReady"
-	case ComponentMachina:
-		return "MachinaReady"
-	case ComponentMetalman:
-		return "MetalmanReady"
-	case ComponentStorage:
-		return "StorageReady"
-	default:
-		return component + "Ready"
+// reconcileSiteComponent reconciles a per-Site component when enabled and tears
+// it down when disabled, turning the outcome into a component.Result.
+func reconcileSiteComponent(ctx context.Context, env *component.Env, c component.SiteComponent, site *unboundedv1alpha3.Site) component.Result {
+	if !c.Enabled(site) {
+		if err := c.Cleanup(ctx, env, site); err != nil {
+			return component.Failed(err)
+		}
+
+		return component.Disabled("component disabled")
 	}
+
+	return c.Reconcile(ctx, env, site)
+}
+
+// setComponentResult publishes a component's Result as a Site status condition
+// and returns the reconcile error to aggregate, if any.
+func setComponentResult(logger logr.Logger, site *unboundedv1alpha3.Site, name, conditionType string, res component.Result) error {
+	if !res.Ready {
+		logger.Info("component not ready", "site", site.Name, "component", name, "message", res.Message)
+	}
+
+	status := metav1.ConditionTrue
+	if !res.Ready {
+		status = metav1.ConditionFalse
+	}
+
+	apimeta.SetStatusCondition(&site.Status.Conditions, metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		Reason:             res.Reason,
+		Message:            res.Message,
+		ObservedGeneration: site.Generation,
+	})
+
+	if res.Err != nil {
+		return fmt.Errorf("%s: %w", name, res.Err)
+	}
+
+	return nil
 }
 
 func (r *SiteReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&unboundedv1alpha3.Site{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		// Site status is written by the net controller (nodeCount/sliceCount) on
-		// node churn; reconciling on those status-only updates would re-apply the
-		// full net + machina manifest sets on every event. Filter to spec/
-		// generation changes (Create/Delete still pass) so component reconcile is
-		// driven by intent, not status noise.
-		Watches(
-			&corev1.ConfigMap{},
-			handler.EnqueueRequestsFromMapFunc(r.requestsForManagedConfig),
-			builder.WithPredicates(predicate.Funcs{
-				CreateFunc: func(e event.CreateEvent) bool { return r.isManagedConfig(e.Object) },
-				DeleteFunc: func(e event.DeleteEvent) bool { return r.isManagedConfig(e.Object) },
-				UpdateFunc: func(e event.UpdateEvent) bool {
-					if !r.isManagedConfig(e.ObjectNew) {
-						return false
-					}
-
-					oldConfig, oldOK := e.ObjectOld.(*corev1.ConfigMap)
-
-					newConfig, newOK := e.ObjectNew.(*corev1.ConfigMap)
-					if !oldOK || !newOK {
-						return false
-					}
-
-					return configMapPayloadChanged(oldConfig, newConfig)
-				},
-				GenericFunc: func(event.GenericEvent) bool { return false },
-			}),
-		).
-		Watches(
-			&appsv1.Deployment{},
-			handler.EnqueueRequestsFromMapFunc(r.requestsForManagedSingletonWorkload),
-			builder.WithPredicates(r.managedSingletonWorkloadPredicates()),
-		).
-		Watches(
-			&appsv1.DaemonSet{},
-			handler.EnqueueRequestsFromMapFunc(r.requestsForManagedSingletonWorkload),
-			builder.WithPredicates(r.managedSingletonWorkloadPredicates()),
-		).
-		Complete(r)
-}
-
-func (r *SiteReconciler) isManagedConfig(obj client.Object) bool {
-	if obj.GetNamespace() != r.namespace() {
-		return false
+	reg := r.registry()
+	if err := reg.Validate(); err != nil {
+		return fmt.Errorf("invalid component registry: %w", err)
 	}
 
-	if obj.GetName() == "machina-config" || obj.GetName() == "unbounded-net-config" {
-		return true
-	}
+	env := r.env()
 
-	return strings.TrimPrefix(obj.GetName(), "unbounded-storage-config-") != obj.GetName() &&
-		strings.TrimPrefix(obj.GetName(), "unbounded-storage-config-") != ""
-}
+	// Site status is written by the net controller (nodeCount/sliceCount) on
+	// node churn; reconciling on those status-only updates would re-apply the
+	// full component manifest sets on every event. Filter to spec/generation
+	// changes (Create/Delete still pass) so component reconcile is driven by
+	// intent, not status noise.
+	b := ctrl.NewControllerManagedBy(mgr).
+		For(&unboundedv1alpha3.Site{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 
-func (r *SiteReconciler) requestsForManagedConfig(ctx context.Context, obj client.Object) []ctrl.Request {
-	if siteName := strings.TrimPrefix(obj.GetName(), "unbounded-storage-config-"); siteName != obj.GetName() && siteName != "" {
-		return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: siteName}}}
-	}
-
-	requests := []ctrl.Request{{NamespacedName: client.ObjectKey{Name: singletonRequestName}}}
-
-	sites, err := r.listSites(ctx)
-	if err != nil {
-		log.FromContext(ctx).Error(err, "list Sites after managed config change")
-
-		return requests
-	}
-
-	for i := range sites {
-		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKey{Name: sites[i].Name}})
-	}
-
-	return requests
-}
-
-func (r *SiteReconciler) requestsForManagedSingletonWorkload(context.Context, client.Object) []ctrl.Request {
-	return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: singletonRequestName}}}
-}
-
-func (r *SiteReconciler) managedSingletonWorkloadPredicates() predicate.Funcs {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool { return r.isManagedSingletonWorkload(e.Object) },
-		DeleteFunc: func(e event.DeleteEvent) bool { return r.isManagedSingletonWorkload(e.Object) },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return r.isManagedSingletonWorkload(e.ObjectNew) &&
-				e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
-		},
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
-}
-
-func (r *SiteReconciler) isManagedSingletonWorkload(obj client.Object) bool {
-	if obj.GetNamespace() != r.namespace() {
-		return false
-	}
-
-	switch obj.(type) {
-	case *appsv1.Deployment:
-		return obj.GetName() == "machina-controller" || obj.GetName() == "unbounded-net-controller"
-	case *appsv1.DaemonSet:
-		return obj.GetName() == "unbounded-net-node"
-	default:
-		return false
-	}
-}
-
-// reconcilePerSiteComponent reconciles a per-site component when enabled and
-// tears it down when disabled, turning the outcome into a componentResult.
-func (r *SiteReconciler) reconcilePerSiteComponent(enabled bool, reconcile, cleanup func() error) componentResult {
-	if !enabled {
-		if err := cleanup(); err != nil {
-			return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-		}
-
-		return componentResult{ready: true, reason: reasonDisabled, message: "component disabled"}
-	}
-
-	if err := reconcile(); err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-	}
-
-	return componentResult{ready: true, reason: reasonReconciled, message: "component reconciled"}
-}
-
-// reconcileSingletons reconciles just the cluster-singleton components (net,
-// machina); used for deleted Sites and synthetic singleton requests.
-func (r *SiteReconciler) reconcileSingletons(ctx context.Context) error {
-	if s := r.reconcileNet(ctx); !s.ready {
-		return fmt.Errorf("net: %s", s.message)
-	}
-
-	if s := r.reconcileMachina(ctx); !s.ready {
-		return fmt.Errorf("machina: %s", s.message)
-	}
-
-	return nil
-}
-
-// reconcileNet deploys the unbounded-net cluster singleton whenever at least
-// one Site exists and keeps an existing installation reconciled with no Sites.
-// Net is not a per-Site component: one controller/node pair reads every Site.
-func (r *SiteReconciler) reconcileNet(ctx context.Context) componentResult {
-	sites, err := r.listSites(ctx)
-	if err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-	}
-
-	if len(sites) == 0 {
-		// Net is the cluster dataplane. Do not auto-delete it just because the
-		// last Site was removed; deleting net-node can break pod networking across
-		// the whole cluster. A future explicit uninstall flow should handle removal.
-		retained, err := r.netResourcesExist(ctx)
-		if err != nil {
-			return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-		}
-
-		if !retained {
-			return componentResult{ready: true, reason: reasonNoSites, message: "no sites; net retained"}
+	for _, c := range reg.Cluster {
+		if wp, ok := c.(component.WatchProvider); ok {
+			wp.SetupWatches(b, env)
 		}
 	}
 
-	configHash, err := r.ensureNetConfig(ctx)
-	if err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-	}
-
-	if err := r.applyManifestFS(ctx, netmanifests.Manifests, r.netApplyMutator(configHash)); err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-	}
-
-	return componentResult{ready: true, reason: reasonReconciled, message: "component reconciled"}
-}
-
-func (r *SiteReconciler) netResourcesExist(ctx context.Context) (bool, error) {
-	key := func(name string) client.ObjectKey {
-		return client.ObjectKey{Namespace: r.namespace(), Name: name}
-	}
-
-	for _, object := range []client.Object{
-		&corev1.ConfigMap{},
-		&appsv1.Deployment{},
-		&appsv1.DaemonSet{},
-	} {
-		name := "unbounded-net-config"
-
-		switch object.(type) {
-		case *appsv1.Deployment:
-			name = "unbounded-net-controller"
-		case *appsv1.DaemonSet:
-			name = "unbounded-net-node"
-		}
-
-		if err := r.Get(ctx, key(name), object); err == nil {
-			return true, nil
-		} else if !apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("get retained net resource %s/%s: %w", r.namespace(), name, err)
+	for _, c := range reg.Site {
+		if wp, ok := c.(component.WatchProvider); ok {
+			wp.SetupWatches(b, env)
 		}
 	}
 
-	return false, nil
-}
-
-// netApplyMutator skips the separately reconciled ConfigMap and stamps its
-// exact payload hash on both net workloads so config changes roll them together.
-func (r *SiteReconciler) netApplyMutator(configHash string) func(*unstructured.Unstructured) error {
-	return func(obj *unstructured.Unstructured) error {
-		if obj.GetKind() == crdKind {
-			obj.Object = nil
-
-			return nil
-		}
-
-		if obj.GetKind() == "ConfigMap" && obj.GetName() == "unbounded-net-config" {
-			obj.Object = nil
-
-			return nil
-		}
-
-		if (obj.GetKind() == "Deployment" && obj.GetName() == "unbounded-net-controller") ||
-			(obj.GetKind() == "DaemonSet" && obj.GetName() == "unbounded-net-node") {
-			annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
-			if err != nil {
-				return fmt.Errorf("get net pod template annotations: %w", err)
-			}
-
-			if annotations == nil {
-				annotations = map[string]string{}
-			}
-
-			annotations[netConfigHashAnnotation] = configHash
-			if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
-				return fmt.Errorf("set net config hash annotation: %w", err)
-			}
-		}
-
-		return nil
-	}
-}
-
-// ensureNetConfig creates the embedded default only when no config exists.
-// Existing migrated or user-managed payloads are never applied over.
-func (r *SiteReconciler) ensureNetConfig(ctx context.Context) (string, error) {
-	key := client.ObjectKey{Namespace: r.namespace(), Name: "unbounded-net-config"}
-	existing := &corev1.ConfigMap{}
-
-	err := r.Get(ctx, key, existing)
-	if err == nil {
-		return configMapPayloadHash(existing), nil
-	}
-
-	if !apierrors.IsNotFound(err) {
-		return "", fmt.Errorf("get net config %s/%s: %w", key.Namespace, key.Name, err)
-	}
-
-	desired, err := defaultNetConfigMap(r.namespace())
-	if err != nil {
-		return "", err
-	}
-
-	if err := r.Create(ctx, desired); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return "", fmt.Errorf("create net config %s/%s: %w", key.Namespace, key.Name, err)
-		}
-
-		if err := r.Get(ctx, key, existing); err != nil {
-			return "", fmt.Errorf("get raced net config %s/%s: %w", key.Namespace, key.Name, err)
-		}
-
-		return configMapPayloadHash(existing), nil
-	}
-
-	return configMapPayloadHash(desired), nil
-}
-
-func defaultNetConfigMap(namespace string) (*corev1.ConfigMap, error) {
-	return defaultConfigMap(netmanifests.Manifests, namespace, "unbounded-net-config", "net")
-}
-
-// reconcileMachina deploys the machina controller singleton whenever any Site
-// enables it and keeps an existing installation reconciled when none do.
-// (Machina is a singleton for now; it may become site-scoped.)
-func (r *SiteReconciler) reconcileMachina(ctx context.Context) componentResult {
-	sites, err := r.listSites(ctx)
-	if err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-	}
-
-	enabled := false
-
-	for i := range sites {
-		if componentEnabled(&sites[i], ComponentMachina) {
-			enabled = true
-			break
-		}
-	}
-
-	if !enabled {
-		// Keep machina installed once the operator has taken ownership. Automatic
-		// singleton removal is surprising and can strand related controllers/RBAC;
-		// a future explicit uninstall flow should handle removal.
-		retained, err := r.machinaResourcesExist(ctx)
-		if err != nil {
-			return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-		}
-
-		if !retained {
-			return componentResult{ready: true, reason: reasonDisabled, message: "no site enables machina; retained"}
-		}
-	}
-
-	configHash, err := r.ensureMachinaConfig(ctx)
-	if err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-	}
-
-	if err := r.applyManifestFS(ctx, machinamanifests.Manifests, r.machinaApplyMutator(configHash)); err != nil {
-		return componentResult{ready: false, reason: reasonReconcileError, message: err.Error(), err: err}
-	}
-
-	return componentResult{ready: true, reason: reasonReconciled, message: "component reconciled"}
-}
-
-func (r *SiteReconciler) machinaResourcesExist(ctx context.Context) (bool, error) {
-	for _, resource := range []struct {
-		name   string
-		object client.Object
-	}{
-		{name: "machina-config", object: &corev1.ConfigMap{}},
-		{name: "machina-controller", object: &appsv1.Deployment{}},
-	} {
-		key := client.ObjectKey{Namespace: r.namespace(), Name: resource.name}
-		if err := r.Get(ctx, key, resource.object); err == nil {
-			return true, nil
-		} else if !apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("get retained machina resource %s/%s: %w", key.Namespace, key.Name, err)
-		}
-	}
-
-	return false, nil
-}
-
-// machinaApplyMutator skips the separately reconciled ConfigMap and stamps its
-// exact content hash on the Deployment so every config change rolls Machina.
-func (r *SiteReconciler) machinaApplyMutator(configHash string) func(*unstructured.Unstructured) error {
-	return func(obj *unstructured.Unstructured) error {
-		if err := r.mutateMachinaObject(obj); err != nil {
-			return err
-		}
-
-		if obj.Object == nil {
-			return nil
-		}
-
-		if obj.GetKind() == "ConfigMap" && obj.GetName() == "machina-config" {
-			obj.Object = nil
-
-			return nil
-		}
-
-		if obj.GetKind() == "Deployment" && obj.GetName() == "machina-controller" {
-			if err := unstructured.SetNestedField(obj.Object, configHash,
-				"spec", "template", "metadata", "annotations", machinaConfigHashAnnotation); err != nil {
-				return fmt.Errorf("set machina config hash annotation: %w", err)
-			}
-		}
-
-		return nil
-	}
-}
-
-func (r *SiteReconciler) ensureMachinaConfig(ctx context.Context) (string, error) {
-	desired, err := defaultMachinaConfigMap(r.namespace())
-	if err != nil {
-		return "", err
-	}
-
-	key := client.ObjectKeyFromObject(desired)
-	existing := &corev1.ConfigMap{}
-
-	err = r.Get(ctx, key, existing)
-	if apierrors.IsNotFound(err) {
-		config, mergeErr := setMachinaAPIServerEndpoint(desired.Data["config.yaml"], r.Config.APIServerEndpoint)
-		if mergeErr != nil {
-			return "", mergeErr
-		}
-
-		desired.Data["config.yaml"] = config
-		if createErr := r.Create(ctx, desired); createErr != nil {
-			return "", fmt.Errorf("create machina config %s/%s: %w", key.Namespace, key.Name, createErr)
-		}
-
-		return configMapPayloadHash(desired), nil
-	}
-
-	if err != nil {
-		return "", fmt.Errorf("get machina config %s/%s: %w", key.Namespace, key.Name, err)
-	}
-
-	config := existing.Data["config.yaml"]
-
-	merged, err := setMachinaAPIServerEndpoint(config, r.Config.APIServerEndpoint)
-	if err != nil {
-		return "", err
-	}
-
-	if merged != config {
-		before := existing.DeepCopy()
-		if existing.Data == nil {
-			existing.Data = map[string]string{}
-		}
-
-		existing.Data["config.yaml"] = merged
-
-		patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
-		if err := r.Patch(ctx, existing, patch); err != nil {
-			return "", fmt.Errorf("update machina config %s/%s: %w", key.Namespace, key.Name, err)
-		}
-	}
-
-	return configMapPayloadHash(existing), nil
-}
-
-func defaultMachinaConfigMap(namespace string) (*corev1.ConfigMap, error) {
-	return defaultConfigMap(machinamanifests.Manifests, namespace, "machina-config", "machina")
-}
-
-func defaultConfigMap(manifests fs.FS, namespace, name, component string) (*corev1.ConfigMap, error) {
-	files, err := yamlFiles(manifests)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, file := range files {
-		data, err := fs.ReadFile(manifests, file)
-		if err != nil {
-			return nil, fmt.Errorf("read %s manifest %s: %w", component, file, err)
-		}
-
-		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
-
-		for {
-			obj := &unstructured.Unstructured{}
-			if err := decoder.Decode(obj); err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-
-				return nil, fmt.Errorf("decode %s manifest %s: %w", component, file, err)
-			}
-
-			if obj.Object == nil || obj.GetKind() != "ConfigMap" || obj.GetName() != name {
-				continue
-			}
-
-			cm := &corev1.ConfigMap{}
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, cm); err != nil {
-				return nil, fmt.Errorf("convert %s config template: %w", component, err)
-			}
-
-			cm.Namespace = namespace
-
-			return cm, nil
-		}
-	}
-
-	return nil, fmt.Errorf("%s config template not found", component)
-}
-
-// reconcileMetalman deploys the per-site metalman PXE controller and its RBAC.
-func (r *SiteReconciler) reconcileMetalman(ctx context.Context, site *unboundedv1alpha3.Site) error {
-	if err := r.applyManifestFS(ctx, machinamanifests.Manifests, mutateMetalmanSupportObject); err != nil {
-		return err
-	}
-
-	return r.applyObject(ctx, metalmanDeployment(site, r.namespace(), r.Config))
-}
-
-// reconcileStorage deploys a site-scoped storage supervisor DaemonSet that runs
-// only on the nodes belonging to the Site.
-func (r *SiteReconciler) reconcileStorage(ctx context.Context, site *unboundedv1alpha3.Site) error {
-	configHash, err := r.ensureStorageConfig(ctx, site)
-	if err != nil {
-		return err
-	}
-
-	return r.applyManifestFS(ctx, storagemanifests.Manifests, func(obj *unstructured.Unstructured) error {
-		return mutateStorageObject(site, configHash, obj)
-	})
-}
-
-// ensureStorageConfig creates the per-site storage ConfigMap from the embedded
-// default when it is absent. If an operator/user already created it (or the
-// reaper migrated it), preserve the data and only adopt it with a Site ownerRef
-// so it is garbage-collected with the Site. Do not server-side-apply metadata
-// for existing ConfigMaps: if the operator previously owned data.config.yaml,
-// an apply that omits data would delete it.
-func (r *SiteReconciler) ensureStorageConfig(ctx context.Context, site *unboundedv1alpha3.Site) (string, error) {
-	key := client.ObjectKey{Namespace: r.namespace(), Name: storageConfigName(site.Name)}
-	existing := &corev1.ConfigMap{}
-
-	err := r.Get(ctx, key, existing)
-	switch {
-	case err == nil:
-		if err := r.adoptStorageConfig(ctx, site, existing); err != nil {
-			return "", err
-		}
-
-		return configMapPayloadHash(existing), nil
-	case !apierrors.IsNotFound(err):
-		return "", fmt.Errorf("get storage config %s/%s: %w", key.Namespace, key.Name, err)
-	}
-
-	cm, err := defaultStorageConfigMap(site, r.namespace())
-	if err != nil {
-		return "", err
-	}
-
-	if err := r.Create(ctx, cm); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return "", fmt.Errorf("create storage config %s/%s: %w", cm.Namespace, cm.Name, err)
-		}
-
-		// Race with a user/reaper create; adopt what won without touching data.
-		if getErr := r.Get(ctx, key, existing); getErr != nil {
-			return "", fmt.Errorf("get raced storage config %s/%s: %w", key.Namespace, key.Name, getErr)
-		}
-
-		if err := r.adoptStorageConfig(ctx, site, existing); err != nil {
-			return "", err
-		}
-
-		return configMapPayloadHash(existing), nil
-	}
-
-	return configMapPayloadHash(cm), nil
-}
-
-func (r *SiteReconciler) adoptStorageConfig(ctx context.Context, site *unboundedv1alpha3.Site, cm *corev1.ConfigMap) error {
-	owner := siteOwnerReference(site)
-
-	refs, changed := upsertOwnerReference(cm.OwnerReferences, owner)
-	if !changed {
-		return nil
-	}
-
-	before := cm.DeepCopy()
-	cm.OwnerReferences = refs
-
-	patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
-	if err := r.Patch(ctx, cm, patch); err != nil {
-		return fmt.Errorf("adopt storage config %s/%s: %w", cm.Namespace, cm.Name, err)
-	}
-
-	return nil
-}
-
-func defaultStorageConfigMap(site *unboundedv1alpha3.Site, namespace string) (*corev1.ConfigMap, error) {
-	files, err := yamlFiles(storagemanifests.Manifests)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, file := range files {
-		data, err := fs.ReadFile(storagemanifests.Manifests, file)
-		if err != nil {
-			return nil, fmt.Errorf("read storage manifest %s: %w", file, err)
-		}
-
-		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
-
-		for {
-			obj := &unstructured.Unstructured{}
-			if err := decoder.Decode(obj); err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-
-				return nil, fmt.Errorf("decode storage manifest %s: %w", file, err)
-			}
-
-			if obj.Object == nil || obj.GetKind() != "ConfigMap" || obj.GetName() != "unbounded-storage-config" {
-				continue
-			}
-
-			cm := &corev1.ConfigMap{}
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, cm); err != nil {
-				return nil, fmt.Errorf("convert storage config template: %w", err)
-			}
-
-			cm.Name = storageConfigName(site.Name)
-			cm.Namespace = namespace
-			cm.OwnerReferences = []metav1.OwnerReference{siteOwnerReference(site)}
-
-			return cm, nil
-		}
-	}
-
-	return nil, errors.New("storage config template not found")
-}
-
-// cleanupMetalman removes the per-site metalman Deployment when metalman is
-// disabled on the Site or the Site is being deleted. The shared metalman RBAC is
-// left in place; it is harmless when unreferenced and may still be used by other
-// sites.
-func (r *SiteReconciler) cleanupMetalman(ctx context.Context, site *unboundedv1alpha3.Site) error {
-	return r.deleteIfExists(ctx, &appsv1.Deployment{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
-		ObjectMeta: metav1.ObjectMeta{Name: metalmanDeploymentName(site.Name), Namespace: r.namespace()},
-	})
-}
-
-// cleanupStorage removes the per-site storage DaemonSet and ConfigMap when
-// storage is disabled on the Site or the Site is being deleted.
-func (r *SiteReconciler) cleanupStorage(ctx context.Context, site *unboundedv1alpha3.Site) error {
-	if err := r.deleteIfExists(ctx, &appsv1.DaemonSet{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "DaemonSet"},
-		ObjectMeta: metav1.ObjectMeta{Name: storageDaemonSetName(site.Name), Namespace: r.namespace()},
-	}); err != nil {
-		return err
-	}
-
-	return r.deleteIfExists(ctx, &corev1.ConfigMap{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
-		ObjectMeta: metav1.ObjectMeta{Name: storageConfigName(site.Name), Namespace: r.namespace()},
-	})
-}
-
-// deleteIfExists deletes an object, treating an already-absent object as success.
-func (r *SiteReconciler) deleteIfExists(ctx context.Context, obj client.Object) error {
-	if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("delete %s %s/%s: %w",
-			obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
-	}
-
-	return nil
-}
-
-func (r *SiteReconciler) listSites(ctx context.Context) ([]unboundedv1alpha3.Site, error) {
-	var sites unboundedv1alpha3.SiteList
-	if err := r.List(ctx, &sites); err != nil {
-		return nil, fmt.Errorf("list sites: %w", err)
-	}
-
-	return sites.Items, nil
-}
-
-func (r *SiteReconciler) applyManifestFS(ctx context.Context, manifests fs.FS, mutate func(*unstructured.Unstructured) error) error {
-	files, err := yamlFiles(manifests)
-	if err != nil {
-		return err
-	}
-
-	for _, file := range files {
-		data, err := fs.ReadFile(manifests, file)
-		if err != nil {
-			return fmt.Errorf("read manifest %s: %w", file, err)
-		}
-
-		if err := r.applyManifestData(ctx, data, mutate); err != nil {
-			return fmt.Errorf("apply manifest %s: %w", file, err)
-		}
-	}
-
-	return nil
-}
-
-func (r *SiteReconciler) applyManifestData(ctx context.Context, data []byte, mutate func(*unstructured.Unstructured) error) error {
-	decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
-
-	for {
-		obj := &unstructured.Unstructured{}
-		if err := decoder.Decode(obj); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-
-			return fmt.Errorf("decode resource: %w", err)
-		}
-
-		if obj.Object == nil {
-			continue
-		}
-
-		if mutate != nil {
-			if err := mutate(obj); err != nil {
-				return err
-			}
-		}
-
-		if obj.Object == nil {
-			continue
-		}
-
-		r.retargetNamespace(obj)
-
-		if err := r.applyObject(ctx, obj); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (r *SiteReconciler) applyObject(ctx context.Context, obj client.Object) error {
-	applyCfg := client.ApplyConfigurationFromUnstructured(toUnstructured(obj))
-	if err := r.Apply(ctx, applyCfg, client.FieldOwner(FieldOwner), client.ForceOwnership); err != nil {
-		return fmt.Errorf("apply %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
-	}
-
-	return nil
-}
-
-// retargetNamespace rewrites embedded-manifest namespace references from the
-// build-time default (buildDefaultNamespace) to the operator's configured
-// namespace, so components follow a custom install namespace. It is a no-op in
-// the default install where the two namespaces are identical.
-func (r *SiteReconciler) retargetNamespace(obj *unstructured.Unstructured) {
-	ns := r.namespace()
-	if ns == "" || ns == buildDefaultNamespace {
-		return
-	}
-
-	if obj.GetKind() == "Namespace" {
-		if obj.GetName() == buildDefaultNamespace {
-			obj.SetName(ns)
-		}
-
-		return
-	}
-
-	if obj.GetNamespace() == buildDefaultNamespace {
-		obj.SetNamespace(ns)
-	}
-
-	rewriteNamespaceValues(obj.Object, buildDefaultNamespace, ns)
-}
-
-// rewriteNamespaceValues recursively retargets every string value that embeds the
-// old namespace to the new one. Unlike a naive equality swap it also handles the
-// namespace appearing as a substring, which the rendered manifests rely on:
-//   - service-account usernames in ValidatingAdmissionPolicy CEL
-//     ("system:serviceaccount:<ns>:<sa>"), and
-//   - flag values ("--leader-elect-resource-namespace=<ns>").
-//
-// Runtime re-rendering of the templates is not an option here because the
-// component image references are baked into the rendered manifests at build time
-// and are not available to the operator process.
-func rewriteNamespaceValues(value any, oldNS, newNS string) {
-	switch typed := value.(type) {
-	case map[string]any:
-		for key, v := range typed {
-			if str, ok := v.(string); ok {
-				typed[key] = retargetNamespaceInString(str, oldNS, newNS)
-				continue
-			}
-
-			rewriteNamespaceValues(v, oldNS, newNS)
-		}
-	case []any:
-		for i, v := range typed {
-			if str, ok := v.(string); ok {
-				typed[i] = retargetNamespaceInString(str, oldNS, newNS)
-				continue
-			}
-
-			rewriteNamespaceValues(v, oldNS, newNS)
-		}
-	}
-}
-
-// retargetNamespaceInString rewrites the old namespace to the new one within a
-// single string value, covering exact matches, service-account usernames, and
-// flag values, while leaving unrelated strings (for example image references)
-// untouched.
-func retargetNamespaceInString(s, oldNS, newNS string) string {
-	if s == oldNS {
-		return newNS
-	}
-
-	if strings.Contains(s, "system:serviceaccount:"+oldNS+":") {
-		s = strings.ReplaceAll(s, "system:serviceaccount:"+oldNS+":", "system:serviceaccount:"+newNS+":")
-	}
-
-	if strings.HasPrefix(s, "--") && strings.HasSuffix(s, "="+oldNS) {
-		s = strings.TrimSuffix(s, "="+oldNS) + "=" + newNS
-	}
-
-	return s
-}
-
-func (r *SiteReconciler) mutateMachinaObject(obj *unstructured.Unstructured) error {
-	// CRDs are installed once at operator startup (BootstrapCRDs), not from the
-	// reconcile loop; skip them here so a Site event does not re-apply schemas.
-	if obj.GetKind() == crdKind {
-		obj.Object = nil
-		return nil
-	}
-
-	// Metalman RBAC ships in the machina manifests but is applied per-site by
-	// reconcileMetalman; skip it here so the singleton apply does not create it.
-	if isMetalmanSupportObject(obj) {
-		obj.Object = nil
-		return nil
-	}
-
-	return nil
-}
-
-// skipCRDObjects nils out CustomResourceDefinition objects so the reconcile
-// loop never applies CRDs; the operator installs them once at startup via
-// BootstrapCRDs.
-func skipCRDObjects(obj *unstructured.Unstructured) error {
-	if obj.GetKind() == crdKind {
-		obj.Object = nil
-	}
-
-	return nil
-}
-
-// mutateMetalmanSupportObject keeps only the metalman RBAC objects from the
-// machina manifests (they are already rendered into unbounded-system).
-func mutateMetalmanSupportObject(obj *unstructured.Unstructured) error {
-	if filepath.Base(obj.GetName()) == ".gitignore" {
-		return nil
-	}
-
-	if !isMetalmanSupportObject(obj) {
-		obj.Object = nil
-	}
-
-	return nil
-}
-
-// metalmanDeploymentName is the per-site metalman Deployment name.
-func metalmanDeploymentName(site string) string { return "metalman-controller-" + site }
-
-// storageDaemonSetName is the per-site storage supervisor DaemonSet name.
-func storageDaemonSetName(site string) string { return "unbounded-storage-supervisor-" + site }
-
-// storageConfigName is the per-site storage supervisor ConfigMap name. Storage
-// config is per-Site in the API, so each Site gets its own ConfigMap rather than
-// sharing a single one.
-func storageConfigName(site string) string { return "unbounded-storage-config-" + site }
-
-// siteOwnerReference builds the owner reference used for per-site resources.
-// Using ownerRefs rather than a Site finalizer lets Kubernetes garbage collect
-// per-site workloads if a Site is deleted while the operator is down.
-func siteOwnerReference(site *unboundedv1alpha3.Site) metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion: unboundedv1alpha3.GroupVersion.String(),
-		Kind:       "Site",
-		Name:       site.Name,
-		UID:        site.UID,
-	}
-}
-
-func upsertOwnerReference(refs []metav1.OwnerReference, owner metav1.OwnerReference) ([]metav1.OwnerReference, bool) {
-	for i := range refs {
-		if refs[i].UID == owner.UID && refs[i].Kind == owner.Kind && refs[i].APIVersion == owner.APIVersion {
-			if refs[i].Name == owner.Name {
-				return refs, false
-			}
-
-			out := append([]metav1.OwnerReference(nil), refs...)
-			out[i] = owner
-
-			return out, true
-		}
-	}
-
-	out := append([]metav1.OwnerReference(nil), refs...)
-	out = append(out, owner)
-
-	return out, true
-}
-
-// siteNodeAffinity matches Nodes carrying either the canonical site label or the
-// deprecated net-prefixed site label. The OR is required during migration: old
-// net labels Nodes with the deprecated key, while the upgraded net dual-writes
-// both. Remove the deprecated term when the deprecated label write is removed.
-func siteNodeAffinity(siteName string) *corev1.Affinity {
-	return &corev1.Affinity{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					siteNodeSelectorTerm(siteLabelKey, siteName),
-					siteNodeSelectorTerm(deprecatedSiteLabelKey, siteName),
-				},
-			},
-		},
-	}
-}
-
-func siteNodeSelectorTerm(key, siteName string) corev1.NodeSelectorTerm {
-	return corev1.NodeSelectorTerm{
-		MatchExpressions: []corev1.NodeSelectorRequirement{{
-			Key:      key,
-			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{siteName},
-		}},
-	}
-}
-
-// mutateStorageObject scopes the storage supervisor manifests to the Site. The
-// DaemonSet is per-site (name, labels, node affinity, and config mount). The
-// per-site ConfigMap is handled by ensureStorageConfig so existing config data
-// is preserved; the SA and RBAC are shared across sites.
-func mutateStorageObject(site *unboundedv1alpha3.Site, configHash string, obj *unstructured.Unstructured) error {
-	switch {
-	case obj.GetKind() == "DaemonSet" && obj.GetName() == "unbounded-storage-supervisor":
-		return scopeStorageDaemonSetToSite(site, configHash, obj)
-	case obj.GetKind() == "ConfigMap" && obj.GetName() == "unbounded-storage-config":
-		obj.Object = nil
-
-		return nil
-	default:
-		return nil
-	}
-}
-
-func scopeStorageDaemonSetToSite(site *unboundedv1alpha3.Site, configHash string, obj *unstructured.Unstructured) error {
-	obj.SetName(storageDaemonSetName(site.Name))
-	obj.SetOwnerReferences([]metav1.OwnerReference{siteOwnerReference(site)})
-
-	labels := obj.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
-	}
-
-	labels[siteLabelKey] = site.Name
-	obj.SetLabels(labels)
-
-	for _, path := range [][]string{
-		{"spec", "selector", "matchLabels", siteLabelKey},
-		{"spec", "template", "metadata", "labels", siteLabelKey},
-	} {
-		if err := unstructured.SetNestedField(obj.Object, site.Name, path...); err != nil {
-			return fmt.Errorf("scope storage daemonset (%v): %w", path, err)
-		}
-	}
-
-	affinityMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(siteNodeAffinity(site.Name))
-	if err != nil {
-		return fmt.Errorf("scope storage daemonset affinity: %w", err)
-	}
-
-	if err := unstructured.SetNestedMap(obj.Object, affinityMap, "spec", "template", "spec", "affinity"); err != nil {
-		return fmt.Errorf("set storage daemonset affinity: %w", err)
-	}
-
-	annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
-	if err != nil {
-		return fmt.Errorf("get storage daemonset pod template annotations: %w", err)
-	}
-
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-
-	annotations[storageConfigHashAnnotation] = configHash
-	if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
-		return fmt.Errorf("set storage config hash annotation: %w", err)
-	}
-
-	return pointDaemonSetAtSiteConfig(site, obj)
-}
-
-// pointDaemonSetAtSiteConfig repoints the DaemonSet's config-source volume at
-// the Site's per-site ConfigMap so each Site mounts its own storage config.
-func pointDaemonSetAtSiteConfig(site *unboundedv1alpha3.Site, obj *unstructured.Unstructured) error {
-	volumes, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
-	if err != nil {
-		return fmt.Errorf("get storage daemonset volumes: %w", err)
-	}
-
-	if !found {
-		return nil
-	}
-
-	for i, v := range volumes {
-		vol, ok := v.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		cm, ok := vol["configMap"].(map[string]any)
-		if !ok {
-			continue
-		}
-
-		if cm["name"] == "unbounded-storage-config" {
-			cm["name"] = storageConfigName(site.Name)
-			vol["configMap"] = cm
-			volumes[i] = vol
-		}
-	}
-
-	if err := unstructured.SetNestedSlice(obj.Object, volumes, "spec", "template", "spec", "volumes"); err != nil {
-		return fmt.Errorf("set storage daemonset volumes: %w", err)
-	}
-
-	return nil
-}
-
-func componentEnabled(site *unboundedv1alpha3.Site, component string) bool {
-	switch component {
-	case ComponentMachina:
-		if site.Spec.Components.Machina == nil {
-			return false
-		}
-
-		return unboundedv1alpha3.ComponentEnabled(&site.Spec.Components.Machina.SiteComponentSpec)
-	case ComponentMetalman:
-		if site.Spec.Components.Metalman == nil {
-			return false
-		}
-
-		return unboundedv1alpha3.ComponentEnabled(&site.Spec.Components.Metalman.SiteComponentSpec)
-	case ComponentStorage:
-		if site.Spec.Components.Storage == nil {
-			return false
-		}
-
-		return unboundedv1alpha3.ComponentEnabled(&site.Spec.Components.Storage.SiteComponentSpec)
-	default:
-		return false
-	}
-}
-
-func isMetalmanSupportObject(obj *unstructured.Unstructured) bool {
-	switch obj.GetKind() {
-	case "ServiceAccount", "Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding":
-		return strings.Contains(obj.GetName(), "metalman")
-	default:
-		return false
-	}
-}
-
-func metalmanDeployment(site *unboundedv1alpha3.Site, namespace string, cfg Config) *appsv1.Deployment {
-	image := cfg.MetalmanImage
-	name := metalmanDeploymentName(site.Name)
-	labels := map[string]string{
-		"app":                                 "unbounded-pxe",
-		"app.kubernetes.io/name":              "metalman-controller",
-		"app.kubernetes.io/component":         "metalman",
-		unboundedv1alpha3.MachineSiteLabelKey: site.Name,
-	}
-
-	args := []string{"serve-pxe", "--site=" + site.Name}
-	if site.Spec.Components.Metalman.DHCPAutoInterface != nil && *site.Spec.Components.Metalman.DHCPAutoInterface {
-		args = append(args, "--dhcp-auto-interface")
-	}
-
-	replicas := int32(1)
-	if site.Spec.Components.Metalman.Replicas != nil {
-		replicas = *site.Spec.Components.Metalman.Replicas
-	}
-
-	env := []corev1.EnvVar{{
-		// Metalman resolves its leader-election lease namespace from
-		// POD_NAMESPACE so the lease and its namespace-scoped RBAC stay
-		// co-located with the Deployment under any install namespace.
-		Name: "POD_NAMESPACE",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
-		},
-	}}
-
-	// Advertise the operator-resolved API server endpoint to metalman so the
-	// kubeconfig it serves to provisioning nodes matches what machina writes,
-	// and so metalman does not need to rediscover it (managed control planes
-	// such as AKS do not publish kube-public/cluster-info). Metalman still
-	// sources the CA from the in-cluster service-account mount when cluster-info
-	// is unavailable.
-	if cfg.APIServerEndpoint != "" {
-		env = append(env, corev1.EnvVar{Name: "METALMAN_APISERVER_URL", Value: cfg.APIServerEndpoint})
-	}
-
-	// metalman is hostNetwork and binds host ports (DHCP/TFTP/HTTP), so a surge
-	// pod cannot start while the old pod holds them on the same node. Terminate
-	// the old pod before creating the new one to avoid a rollout deadlock.
-	maxSurge := intstr.FromInt32(0)
-	maxUnavailable := intstr.FromInt32(1)
-
-	return &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       namespace,
-			Labels:          labels,
-			OwnerReferences: []metav1.OwnerReference{siteOwnerReference(site)},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RollingUpdateDeploymentStrategyType,
-				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxSurge:       &maxSurge,
-					MaxUnavailable: &maxUnavailable,
-				},
-			},
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
-				Spec: corev1.PodSpec{
-					HostNetwork:        true,
-					ServiceAccountName: "metalman-controller",
-					// Match either the canonical or deprecated site label during
-					// the node-label deprecation window. Storage scopes its
-					// DaemonSet the same way.
-					Affinity: siteNodeAffinity(site.Name),
-					Containers: []corev1.Container{{
-						Name:            "metalman",
-						Image:           image,
-						ImagePullPolicy: corev1.PullAlways,
-						Args:            args,
-						Env:             env,
-						Ports: []corev1.ContainerPort{
-							{Name: "http", ContainerPort: 8880, Protocol: corev1.ProtocolTCP},
-							{Name: "health", ContainerPort: 8081, Protocol: corev1.ProtocolTCP},
-							{Name: "dhcp", ContainerPort: 67, Protocol: corev1.ProtocolUDP},
-							{Name: "tftp", ContainerPort: 69, Protocol: corev1.ProtocolUDP},
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							{Name: "tmp", MountPath: "/tmp"},
-							{Name: "cache", MountPath: "/var/cache/metalman"},
-						},
-					}},
-					Volumes: []corev1.Volume{
-						{Name: "tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-						{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-					},
-				},
-			},
-		},
-	}
-}
-
-func yamlFiles(fsys fs.FS) ([]string, error) {
-	var files []string
-
-	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			return nil
-		}
-
-		ext := strings.ToLower(filepath.Ext(path))
-		if ext == ".yaml" || ext == ".yml" {
-			files = append(files, path)
-		}
-
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
-	sort.Strings(files)
-
-	return files, nil
-}
-
-func toUnstructured(obj client.Object) *unstructured.Unstructured {
-	if unstr, ok := obj.(*unstructured.Unstructured); ok {
-		return unstr
-	}
-
-	objectMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		panic(err)
-	}
-
-	return &unstructured.Unstructured{Object: objectMap}
+	return b.Complete(r)
 }

--- a/internal/operator/reconciler_test.go
+++ b/internal/operator/reconciler_test.go
@@ -4,63 +4,118 @@
 package operator
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/internal/operator/component"
 )
+
+// fakeCluster is a configurable ClusterComponent that records whether it ran.
+type fakeCluster struct {
+	name      string
+	condition string
+	result    component.Result
+	ran       *bool
+}
+
+func (f fakeCluster) Name() string          { return f.name }
+func (f fakeCluster) ConditionType() string { return f.condition }
+func (f fakeCluster) Reconcile(context.Context, *component.Env, []unboundedv1alpha3.Site) component.Result {
+	if f.ran != nil {
+		*f.ran = true
+	}
+
+	return f.result
+}
+
+// fakeSite is a configurable SiteComponent that records enable/reconcile/cleanup.
+type fakeSite struct {
+	name       string
+	condition  string
+	enabled    bool
+	result     component.Result
+	cleanupErr error
+	reconciled *bool
+	cleaned    *bool
+}
+
+func (f fakeSite) Name() string                         { return f.name }
+func (f fakeSite) ConditionType() string                { return f.condition }
+func (f fakeSite) Enabled(*unboundedv1alpha3.Site) bool { return f.enabled }
+func (f fakeSite) Reconcile(context.Context, *component.Env, *unboundedv1alpha3.Site) component.Result {
+	if f.reconciled != nil {
+		*f.reconciled = true
+	}
+
+	return f.result
+}
+
+func (f fakeSite) Cleanup(context.Context, *component.Env, *unboundedv1alpha3.Site) error {
+	if f.cleaned != nil {
+		*f.cleaned = true
+	}
+
+	return f.cleanupErr
+}
+
+func newReconcilerTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for name, add := range map[string]func(*runtime.Scheme) error{
+		"apps/v1":     appsv1.AddToScheme,
+		"core/v1":     corev1.AddToScheme,
+		"machina API": unboundedv1alpha3.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add %s to scheme: %v", name, err)
+		}
+	}
+
+	return scheme
+}
 
 func TestReconcilePatchesAllConditionsAndReturnsComponentErrors(t *testing.T) {
 	scheme := newReconcilerTestScheme(t)
-	site := &unboundedv1alpha3.Site{
-		ObjectMeta: metav1.ObjectMeta{Name: "rack-a", Generation: 7},
-	}
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", Generation: 7}}
+
 	netErr := errors.New("net reconcile failed")
 	machinaErr := errors.New("machina reconcile failed")
-	listErrs := []error{netErr, machinaErr}
-	listCalls := 0
 
-	cl := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(site).
-		WithStatusSubresource(site).
-		WithInterceptorFuncs(interceptor.Funcs{
-			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
-				if _, ok := list.(*unboundedv1alpha3.SiteList); !ok {
-					t.Fatalf("unexpected list type %T", list)
-				}
+	cleaned := false
+	registry := &component.Registry{
+		Cluster: []component.ClusterComponent{
+			fakeCluster{name: "net", condition: "NetReady", result: component.Failed(netErr)},
+			fakeCluster{name: "machina", condition: "MachinaReady", result: component.Failed(machinaErr)},
+		},
+		Site: []component.SiteComponent{
+			fakeSite{name: "metalman", condition: "MetalmanReady", enabled: false, cleaned: &cleaned},
+			fakeSite{name: "storage", condition: "StorageReady", enabled: false},
+		},
+	}
 
-				err := listErrs[listCalls]
-				listCalls++
-
-				return err
-			},
-		}).
-		Build()
-
-	r := &SiteReconciler{Client: cl, Scheme: scheme}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(site).WithStatusSubresource(site).Build()
+	r := &SiteReconciler{Client: cl, Scheme: scheme, Registry: registry}
 
 	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(site)})
 	if !errors.Is(err, netErr) || !errors.Is(err, machinaErr) {
 		t.Fatalf("Reconcile error = %v, want joined net and machina errors", err)
+	}
+
+	if !cleaned {
+		t.Fatal("disabled site component cleanup was not called")
 	}
 
 	var got unboundedv1alpha3.Site
@@ -72,10 +127,10 @@ func TestReconcilePatchesAllConditionsAndReturnsComponentErrors(t *testing.T) {
 		status metav1.ConditionStatus
 		reason string
 	}{
-		"NetReady":      {status: metav1.ConditionFalse, reason: reasonReconcileError},
-		"MachinaReady":  {status: metav1.ConditionFalse, reason: reasonReconcileError},
-		"MetalmanReady": {status: metav1.ConditionTrue, reason: reasonDisabled},
-		"StorageReady":  {status: metav1.ConditionTrue, reason: reasonDisabled},
+		"NetReady":      {status: metav1.ConditionFalse, reason: component.ReasonReconcileError},
+		"MachinaReady":  {status: metav1.ConditionFalse, reason: component.ReasonReconcileError},
+		"MetalmanReady": {status: metav1.ConditionTrue, reason: component.ReasonDisabled},
+		"StorageReady":  {status: metav1.ConditionTrue, reason: component.ReasonDisabled},
 	}
 
 	if len(got.Status.Conditions) != len(want) {
@@ -107,17 +162,7 @@ func TestReconcileJoinsStatusPatchError(t *testing.T) {
 		WithObjects(site).
 		WithStatusSubresource(site).
 		WithInterceptorFuncs(interceptor.Funcs{
-			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
-				return componentErr
-			},
-			SubResourcePatch: func(
-				_ context.Context,
-				_ client.Client,
-				subResourceName string,
-				obj client.Object,
-				_ client.Patch,
-				_ ...client.SubResourcePatchOption,
-			) error {
+			SubResourcePatch: func(_ context.Context, _ client.Client, subResourceName string, obj client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
 				if subResourceName != "status" {
 					t.Fatalf("subresource = %q, want status", subResourceName)
 				}
@@ -129,7 +174,17 @@ func TestReconcileJoinsStatusPatchError(t *testing.T) {
 		}).
 		Build()
 
-	r := &SiteReconciler{Client: cl, Scheme: scheme}
+	registry := &component.Registry{
+		Cluster: []component.ClusterComponent{
+			fakeCluster{name: "net", condition: "NetReady", result: component.Failed(componentErr)},
+			fakeCluster{name: "machina", condition: "MachinaReady", result: component.Reconciled()},
+		},
+		Site: []component.SiteComponent{
+			fakeSite{name: "metalman", condition: "MetalmanReady", enabled: false},
+			fakeSite{name: "storage", condition: "StorageReady", enabled: false},
+		},
+	}
+	r := &SiteReconciler{Client: cl, Scheme: scheme, Registry: registry}
 
 	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(site)})
 	if !errors.Is(err, componentErr) || !errors.Is(err, patchErr) {
@@ -141,897 +196,88 @@ func TestReconcileJoinsStatusPatchError(t *testing.T) {
 	}
 }
 
-func newReconcilerTestScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
+func TestReconcileSiteLessPassRunsClusterComponentsOnly(t *testing.T) {
+	scheme := newReconcilerTestScheme(t)
 
-	scheme := runtime.NewScheme()
-	for name, add := range map[string]func(*runtime.Scheme) error{
-		"apps/v1":     appsv1.AddToScheme,
-		"core/v1":     corev1.AddToScheme,
-		"machina API": unboundedv1alpha3.AddToScheme,
-	} {
-		if err := add(scheme); err != nil {
-			t.Fatalf("add %s to scheme: %v", name, err)
-		}
-	}
+	clusterRan := false
+	siteReconciled := false
+	siteCleaned := false
 
-	return scheme
-}
-
-func TestMutateStorageScopesDaemonSetToSite(t *testing.T) {
-	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
-	obj := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apps/v1",
-		"kind":       "DaemonSet",
-		"metadata":   map[string]any{"name": "unbounded-storage-supervisor"},
-		"spec": map[string]any{
-			"selector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "unbounded-storage-supervisor"}},
-			"template": map[string]any{
-				"metadata": map[string]any{"labels": map[string]any{"app.kubernetes.io/name": "unbounded-storage-supervisor"}},
-				"spec":     map[string]any{"containers": []any{map[string]any{"name": "run"}}},
-			},
+	registry := &component.Registry{
+		Cluster: []component.ClusterComponent{
+			fakeCluster{name: "net", condition: "NetReady", result: component.Reconciled(), ran: &clusterRan},
 		},
-	}}
-
-	if err := mutateStorageObject(site, "storage-hash", obj); err != nil {
-		t.Fatalf("mutateStorageObject returned error: %v", err)
+		Site: []component.SiteComponent{
+			fakeSite{name: "storage", condition: "StorageReady", enabled: true, result: component.Reconciled(), reconciled: &siteReconciled, cleaned: &siteCleaned},
+		},
 	}
 
-	if got := obj.GetName(); got != "unbounded-storage-supervisor-rack-a" {
-		t.Fatalf("name = %q, want unbounded-storage-supervisor-rack-a", got)
-	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SiteReconciler{Client: cl, Scheme: scheme, Registry: registry}
 
-	if got := obj.GetLabels()[siteLabelKey]; got != "rack-a" {
-		t.Fatalf("metadata site label = %q, want rack-a", got)
-	}
-
-	for _, path := range [][]string{
-		{"spec", "selector", "matchLabels", siteLabelKey},
-		{"spec", "template", "metadata", "labels", siteLabelKey},
-	} {
-		got, ok, err := unstructured.NestedString(obj.Object, path...)
-		if err != nil || !ok {
-			t.Fatalf("missing %v: ok=%t err=%v", path, ok, err)
-		}
-
-		if got != "rack-a" {
-			t.Fatalf("%v = %q, want rack-a", path, got)
-		}
-	}
-
-	assertSiteOwnerRef(t, obj.GetOwnerReferences(), "rack-a", "site-uid")
-
-	annotations, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
-	if annotations[storageConfigHashAnnotation] != "storage-hash" {
-		t.Fatalf("storage config hash annotation = %q, want storage-hash", annotations[storageConfigHashAnnotation])
-	}
-
-	affinity, ok, err := unstructured.NestedMap(obj.Object, "spec", "template", "spec", "affinity")
-	if err != nil || !ok {
-		t.Fatalf("missing storage affinity: ok=%t err=%v", ok, err)
-	}
-
-	assertSiteAffinityMap(t, affinity, "rack-a")
-}
-
-func TestMutateMachinaSkipsMetalmanSupport(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "rbac.authorization.k8s.io/v1",
-		"kind":       "ClusterRole",
-		"metadata":   map[string]any{"name": "metalman-controller"},
-	}}
-
-	r := &SiteReconciler{}
-	if err := r.mutateMachinaObject(obj); err != nil {
-		t.Fatalf("mutateMachinaObject returned error: %v", err)
-	}
-
-	if obj.Object != nil {
-		t.Fatalf("metalman support object was not skipped")
-	}
-}
-
-func TestSetMachinaAPIServerEndpointPreservesConfig(t *testing.T) {
-	input := `# retained comment
-apiServerEndpoint: "https://old.example:6443"
-maxConcurrentReconciles: 17
-customField: keep-me
-`
-	endpoint := "https://api.example:6443/path?mode=\"strict\"&ready=true"
-
-	got, err := setMachinaAPIServerEndpoint(input, endpoint)
+	// A request for a name with no Site (deletion or the synthetic singleton
+	// request) drives the Site-less pass.
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: component.SingletonRequestName}})
 	if err != nil {
-		t.Fatalf("setMachinaAPIServerEndpoint: %v", err)
+		t.Fatalf("Reconcile: %v", err)
 	}
 
-	var config map[string]any
-	if err := yaml.Unmarshal([]byte(got), &config); err != nil {
-		t.Fatalf("unmarshal merged config: %v", err)
+	if !clusterRan {
+		t.Fatal("cluster component did not run on the Site-less pass")
 	}
 
-	if config["apiServerEndpoint"] != endpoint {
-		t.Fatalf("apiServerEndpoint = %q, want %q", config["apiServerEndpoint"], endpoint)
-	}
-
-	if config["maxConcurrentReconciles"] != 17 || config["customField"] != "keep-me" {
-		t.Fatalf("custom config was not preserved: %#v", config)
-	}
-
-	if !strings.Contains(got, "# retained comment") {
-		t.Fatalf("config comment was not preserved: %q", got)
+	if siteReconciled || siteCleaned {
+		t.Fatalf("site component ran on the Site-less pass: reconciled=%t cleaned=%t", siteReconciled, siteCleaned)
 	}
 }
 
-func TestEnsureMachinaConfigUpdatesEndpointAndPreservesData(t *testing.T) {
+func TestReconcileSiteLessPassJoinsClusterErrors(t *testing.T) {
 	scheme := newReconcilerTestScheme(t)
-	existing := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "machina-config", Namespace: DefaultNamespace},
-		Data: map[string]string{
-			"config.yaml": "apiServerEndpoint: https://old.example:6443\ncustom: true\n",
+	netErr := errors.New("net failed on singleton pass")
+
+	registry := &component.Registry{
+		Cluster: []component.ClusterComponent{
+			fakeCluster{name: "net", condition: "NetReady", result: component.Failed(netErr)},
 		},
 	}
-	r := &SiteReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build(),
-		Config: Config{APIServerEndpoint: "https://new.example:6443"},
-	}
 
-	hash, err := r.ensureMachinaConfig(t.Context())
-	if err != nil {
-		t.Fatalf("ensureMachinaConfig: %v", err)
-	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SiteReconciler{Client: cl, Scheme: scheme, Registry: registry}
 
-	var got corev1.ConfigMap
-	if err := r.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
-		t.Fatalf("get machina config: %v", err)
-	}
-
-	var config map[string]any
-	if err := yaml.Unmarshal([]byte(got.Data["config.yaml"]), &config); err != nil {
-		t.Fatalf("unmarshal updated config: %v", err)
-	}
-
-	if config["apiServerEndpoint"] != "https://new.example:6443" || config["custom"] != true {
-		t.Fatalf("updated config = %#v", config)
-	}
-
-	if hash != configMapPayloadHash(&got) {
-		t.Fatalf("hash = %q, want hash of exact stored config", hash)
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: component.SingletonRequestName}})
+	if !errors.Is(err, netErr) {
+		t.Fatalf("Reconcile error = %v, want net error", err)
 	}
 }
 
-func TestEnsureMachinaConfigOptimisticConflictReloadsFreshState(t *testing.T) {
-	scheme := newReconcilerTestScheme(t)
-	existing := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "machina-config", Namespace: DefaultNamespace, ResourceVersion: "1"},
-		Data:       map[string]string{"config.yaml": "apiServerEndpoint: https://old.example:6443\n"},
+func TestReconcileSiteComponentDisabledRunsCleanup(t *testing.T) {
+	cleaned := false
+	c := fakeSite{name: "storage", condition: "StorageReady", enabled: false, cleaned: &cleaned}
+
+	res := reconcileSiteComponent(t.Context(), &component.Env{}, c, &unboundedv1alpha3.Site{})
+	if !cleaned {
+		t.Fatal("cleanup was not called for a disabled component")
 	}
 
-	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
-	conflicted := false
-	cl := interceptor.NewClient(base, interceptor.Funcs{
-		Patch: func(ctx context.Context, underlying client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			data, err := patch.Data(obj)
-			if err != nil {
-				t.Fatalf("encode patch: %v", err)
-			}
-
-			if !bytes.Contains(data, []byte(`"resourceVersion":`)) {
-				t.Fatalf("optimistic patch does not include resourceVersion: %s", data)
-			}
-
-			if !conflicted {
-				conflicted = true
-
-				var latest corev1.ConfigMap
-				if err := underlying.Get(ctx, client.ObjectKeyFromObject(existing), &latest); err != nil {
-					t.Fatalf("get concurrent config: %v", err)
-				}
-
-				latest.Data["concurrent"] = "preserved"
-				if err := underlying.Update(ctx, &latest); err != nil {
-					t.Fatalf("write concurrent config: %v", err)
-				}
-
-				return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.GetName(), errors.New("concurrent edit"))
-			}
-
-			return underlying.Patch(ctx, obj, patch, opts...)
-		},
-	})
-	r := &SiteReconciler{Client: cl, Config: Config{APIServerEndpoint: "https://new.example:6443"}}
-
-	if _, err := r.ensureMachinaConfig(t.Context()); !apierrors.IsConflict(err) {
-		t.Fatalf("first ensureMachinaConfig error = %v, want conflict", err)
-	}
-
-	if _, err := r.ensureMachinaConfig(t.Context()); err != nil {
-		t.Fatalf("retry ensureMachinaConfig: %v", err)
-	}
-
-	var got corev1.ConfigMap
-	if err := base.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
-		t.Fatalf("get updated config: %v", err)
-	}
-
-	if got.Data["concurrent"] != "preserved" || !strings.Contains(got.Data["config.yaml"], "https://new.example:6443") {
-		t.Fatalf("retry did not preserve fresh config: %#v", got.Data)
+	if !res.Ready || res.Reason != component.ReasonDisabled {
+		t.Fatalf("result = %+v, want ready with reason %q", res, component.ReasonDisabled)
 	}
 }
 
-func TestEnsureNetConfigCreatesDefaultOnlyWhenAbsent(t *testing.T) {
-	scheme := newReconcilerTestScheme(t)
-	r := &SiteReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+func TestReconcileSiteComponentDisabledCleanupErrorFails(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	c := fakeSite{name: "storage", condition: "StorageReady", enabled: false, cleanupErr: cleanupErr}
 
-	hash, err := r.ensureNetConfig(t.Context())
-	if err != nil {
-		t.Fatalf("ensureNetConfig: %v", err)
+	res := reconcileSiteComponent(t.Context(), &component.Env{}, c, &unboundedv1alpha3.Site{})
+	if res.Ready || !errors.Is(res.Err, cleanupErr) {
+		t.Fatalf("result = %+v, want failed with cleanup error", res)
 	}
-
-	var got corev1.ConfigMap
-
-	key := client.ObjectKey{Namespace: DefaultNamespace, Name: "unbounded-net-config"}
-	if err := r.Get(t.Context(), key, &got); err != nil {
-		t.Fatalf("get default net config: %v", err)
-	}
-
-	if got.Data["config.yaml"] == "" || hash != configMapPayloadHash(&got) {
-		t.Fatalf("default net config/hash missing: hash=%q data=%#v", hash, got.Data)
-	}
-}
-
-func TestEnsureNetConfigPreservesExistingPayload(t *testing.T) {
-	scheme := newReconcilerTestScheme(t)
-	existing := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "unbounded-net-config", Namespace: DefaultNamespace},
-		Data:       map[string]string{"config.yaml": "custom: true", "extra": "keep"},
-		BinaryData: map[string][]byte{"routing.bin": {0, 1, 2}},
-	}
-	r := &SiteReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()}
-
-	hash, err := r.ensureNetConfig(t.Context())
-	if err != nil {
-		t.Fatalf("ensureNetConfig: %v", err)
-	}
-
-	var got corev1.ConfigMap
-	if err := r.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
-		t.Fatalf("get preserved net config: %v", err)
-	}
-
-	if got.Data["config.yaml"] != "custom: true" || got.Data["extra"] != "keep" || !bytes.Equal(got.BinaryData["routing.bin"], []byte{0, 1, 2}) {
-		t.Fatalf("existing net config changed: data=%#v binaryData=%#v", got.Data, got.BinaryData)
-	}
-
-	if hash != configMapPayloadHash(&got) {
-		t.Fatalf("hash = %q, want exact payload hash", hash)
-	}
-}
-
-func TestConfigMapPayloadHashIncludesDataAndBinaryData(t *testing.T) {
-	first := &corev1.ConfigMap{
-		Data:       map[string]string{"b": "2", "a": "1"},
-		BinaryData: map[string][]byte{"z": {3}, "x": {1, 2}},
-	}
-	orderedDifferently := &corev1.ConfigMap{
-		Data:       map[string]string{"a": "1", "b": "2"},
-		BinaryData: map[string][]byte{"x": {1, 2}, "z": {3}},
-	}
-
-	if configMapPayloadHash(first) != configMapPayloadHash(orderedDifferently) {
-		t.Fatal("payload hash depends on map iteration order")
-	}
-
-	changedData := first.DeepCopy()
-	changedData.Data["a"] = "changed"
-	changedBinary := first.DeepCopy()
-	changedBinary.BinaryData["x"] = []byte{2, 1}
-
-	if configMapPayloadHash(first) == configMapPayloadHash(changedData) ||
-		configMapPayloadHash(first) == configMapPayloadHash(changedBinary) {
-		t.Fatal("payload hash did not include all Data and BinaryData")
-	}
-}
-
-func TestManagedConfigPayloadChangesAndNames(t *testing.T) {
-	r := &SiteReconciler{Namespace: "target"}
-	for _, name := range []string{"machina-config", "unbounded-net-config", "unbounded-storage-config-edge"} {
-		if !r.isManagedConfig(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: name}}) {
-			t.Fatalf("%s is not watched", name)
-		}
-	}
-
-	oldConfig := &corev1.ConfigMap{Data: map[string]string{"config.yaml": "same"}, BinaryData: map[string][]byte{"x": {1}}}
-	metadataOnly := oldConfig.DeepCopy()
-
-	metadataOnly.Labels = map[string]string{"changed": "true"}
-	if configMapPayloadChanged(oldConfig, metadataOnly) {
-		t.Fatal("metadata-only update should not enqueue Sites")
-	}
-
-	binaryChange := oldConfig.DeepCopy()
-
-	binaryChange.BinaryData["x"] = []byte{2}
-	if !configMapPayloadChanged(oldConfig, binaryChange) {
-		t.Fatal("BinaryData update should enqueue Sites")
-	}
-}
-
-func TestRequestsForManagedConfigEnqueuesAllSites(t *testing.T) {
-	scheme := newReconcilerTestScheme(t)
-	r := &SiteReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-		&unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge"}},
-		&unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
-	).Build()}
-
-	requests := r.requestsForManagedConfig(t.Context(), &corev1.ConfigMap{})
-
-	got := map[string]bool{}
-	for _, request := range requests {
-		got[request.Name] = true
-	}
-
-	if len(requests) != 3 || !got[singletonRequestName] || !got["edge"] || !got["cluster"] {
-		t.Fatalf("requestsForManagedConfig = %#v, want singleton, edge, and cluster", requests)
-	}
-}
-
-func TestRequestsForManagedConfigEnqueuesSingletonWithNoSites(t *testing.T) {
-	scheme := newReconcilerTestScheme(t)
-	r := &SiteReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
-
-	requests := r.requestsForManagedConfig(t.Context(), &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: DefaultNamespace, Name: "unbounded-net-config"},
-	})
-
-	if len(requests) != 1 || requests[0].Name != singletonRequestName {
-		t.Fatalf("requestsForManagedConfig = %#v, want singleton request", requests)
-	}
-}
-
-func TestRequestsForManagedConfigEnqueuesStorageSiteDirectly(t *testing.T) {
-	r := &SiteReconciler{}
-	requests := r.requestsForManagedConfig(t.Context(), &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-config-edge"},
-	})
-
-	if len(requests) != 1 || requests[0].Name != "edge" {
-		t.Fatalf("requestsForManagedConfig = %#v, want only edge", requests)
-	}
-}
-
-func TestRequestsForManagedConfigPreservesSingletonWhenSiteListFails(t *testing.T) {
-	scheme := newReconcilerTestScheme(t)
-	listErr := errors.New("Site list failed")
-	r := &SiteReconciler{Client: fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithInterceptorFuncs(interceptor.Funcs{
-			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
-				return listErr
-			},
-		}).
-		Build()}
-
-	requests := r.requestsForManagedConfig(t.Context(), &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: DefaultNamespace, Name: "machina-config"},
-	})
-
-	if len(requests) != 1 || requests[0].Name != singletonRequestName {
-		t.Fatalf("requestsForManagedConfig = %#v, want singleton request after list failure", requests)
-	}
-}
-
-func TestManagedSingletonWorkloadStartupEventsEnqueueSingleton(t *testing.T) {
-	r := &SiteReconciler{Namespace: "target"}
-	predicates := r.managedSingletonWorkloadPredicates()
-
-	for _, workload := range []client.Object{
-		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: "machina-controller"}},
-		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: "unbounded-net-controller"}},
-		&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: "unbounded-net-node"}},
-	} {
-		if !predicates.Create(event.CreateEvent{Object: workload}) {
-			t.Fatalf("startup Create event for %T %q was filtered", workload, workload.GetName())
-		}
-
-		requests := r.requestsForManagedSingletonWorkload(t.Context(), workload)
-		if len(requests) != 1 || requests[0].Name != singletonRequestName {
-			t.Fatalf("startup requests for %s = %#v, want singleton", workload.GetName(), requests)
-		}
-
-		if !predicates.Delete(event.DeleteEvent{Object: workload}) {
-			t.Fatalf("Delete event for %T %q was filtered", workload, workload.GetName())
-		}
-
-		updated := workload.DeepCopyObject().(client.Object)
-		updated.SetGeneration(workload.GetGeneration() + 1)
-
-		if !predicates.Update(event.UpdateEvent{ObjectOld: workload, ObjectNew: updated}) {
-			t.Fatalf("generation update for %T %q was filtered", workload, workload.GetName())
-		}
-
-		if predicates.Update(event.UpdateEvent{ObjectOld: updated, ObjectNew: updated.DeepCopyObject().(client.Object)}) {
-			t.Fatalf("same-generation update for %T %q was accepted", workload, workload.GetName())
-		}
-	}
-
-	unmanaged := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "target", Name: "metalman-controller-edge"}}
-	if predicates.Create(event.CreateEvent{Object: unmanaged}) {
-		t.Fatal("unmanaged Deployment Create event was accepted")
-	}
-}
-
-func TestNetApplyMutatorStampsBothWorkloads(t *testing.T) {
-	for _, tc := range []struct {
-		kind string
-		name string
-	}{
-		{kind: "Deployment", name: "unbounded-net-controller"},
-		{kind: "DaemonSet", name: "unbounded-net-node"},
-	} {
-		t.Run(tc.kind, func(t *testing.T) {
-			obj := &unstructured.Unstructured{Object: map[string]any{
-				"apiVersion": "apps/v1",
-				"kind":       tc.kind,
-				"metadata":   map[string]any{"name": tc.name},
-				"spec": map[string]any{"template": map[string]any{
-					"metadata": map[string]any{"annotations": map[string]any{"existing": "kept"}},
-				}},
-			}}
-
-			if err := (&SiteReconciler{}).netApplyMutator("net-hash")(obj); err != nil {
-				t.Fatalf("netApplyMutator: %v", err)
-			}
-
-			annotations, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
-			if annotations[netConfigHashAnnotation] != "net-hash" || annotations["existing"] != "kept" {
-				t.Fatalf("pod template annotations = %#v", annotations)
-			}
-		})
-	}
-
-	config := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "unbounded-net-config"},
-	}}
-	if err := (&SiteReconciler{}).netApplyMutator("net-hash")(config); err != nil || config.Object != nil {
-		t.Fatalf("embedded net ConfigMap was not skipped: err=%v object=%#v", err, config.Object)
-	}
-}
-
-func TestReconcileRetainedNetWithNoSites(t *testing.T) {
-	config := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: DefaultNamespace, Name: "unbounded-net-config"},
-		Data:       map[string]string{"config.yaml": "custom: retained"},
-	}
-	r, appliedHashes := retainedNetReconciler(t, config)
-
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: singletonRequestName}}); err != nil {
-		t.Fatalf("Reconcile: %v", err)
-	}
-
-	wantHash := configMapPayloadHash(config)
-	for _, name := range []string{"unbounded-net-controller", "unbounded-net-node"} {
-		if appliedHashes[name] != wantHash {
-			t.Fatalf("%s applied hash = %q, want %q", name, appliedHashes[name], wantHash)
-		}
-	}
-
-	var got corev1.ConfigMap
-	if err := r.Get(t.Context(), client.ObjectKeyFromObject(config), &got); err != nil {
-		t.Fatalf("get retained net config: %v", err)
-	}
-
-	if got.Data["config.yaml"] != "custom: retained" {
-		t.Fatalf("retained net config changed: %#v", got.Data)
-	}
-}
-
-func TestReconcileRecreatesDeletedRetainedNetConfigWithNoSites(t *testing.T) {
-	retained := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-		Namespace: DefaultNamespace,
-		Name:      "unbounded-net-controller",
-	}}
-	r, appliedHashes := retainedNetReconciler(t, retained)
-
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: singletonRequestName}}); err != nil {
-		t.Fatalf("Reconcile: %v", err)
-	}
-
-	var config corev1.ConfigMap
-
-	key := client.ObjectKey{Namespace: DefaultNamespace, Name: "unbounded-net-config"}
-	if err := r.Get(t.Context(), key, &config); err != nil {
-		t.Fatalf("get recreated net config: %v", err)
-	}
-
-	wantHash := configMapPayloadHash(&config)
-	if config.Data["config.yaml"] == "" || appliedHashes["unbounded-net-controller"] != wantHash ||
-		appliedHashes["unbounded-net-node"] != wantHash {
-		t.Fatalf("recreated config/workload hashes = data=%#v hashes=%#v", config.Data, appliedHashes)
-	}
-}
-
-func TestReconcileDoesNotCreateNetFromNothingWithNoSites(t *testing.T) {
-	r, appliedHashes := retainedNetReconciler(t)
-
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: singletonRequestName}}); err != nil {
-		t.Fatalf("Reconcile: %v", err)
-	}
-
-	err := r.Get(t.Context(), client.ObjectKey{Namespace: DefaultNamespace, Name: "unbounded-net-config"}, &corev1.ConfigMap{})
-	if !apierrors.IsNotFound(err) || len(appliedHashes) != 0 {
-		t.Fatalf("zero-Site reconcile created net from nothing: config err=%v hashes=%#v", err, appliedHashes)
-	}
-}
-
-func retainedNetReconciler(t *testing.T, objects ...client.Object) (*SiteReconciler, map[string]string) {
-	t.Helper()
-
-	scheme := newReconcilerTestScheme(t)
-	appliedHashes := map[string]string{}
-	cl := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(objects...).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
-				applied, ok := obj.(interface {
-					GetName() string
-					GetKind() string
-					UnstructuredContent() map[string]any
-				})
-				if !ok {
-					t.Fatalf("applied object has unexpected type %T", obj)
-				}
-
-				name := applied.GetName()
-				if (applied.GetKind() != "Deployment" || name != "unbounded-net-controller") &&
-					(applied.GetKind() != "DaemonSet" || name != "unbounded-net-node") {
-					return nil
-				}
-
-				hash, _, err := unstructured.NestedString(
-					applied.UnstructuredContent(),
-					"spec", "template", "metadata", "annotations", netConfigHashAnnotation,
-				)
-				if err != nil {
-					t.Fatalf("get applied hash for %s: %v", name, err)
-				}
-
-				appliedHashes[name] = hash
-
-				return nil
-			},
-		}).
-		Build()
-
-	return &SiteReconciler{Client: cl, Scheme: scheme}, appliedHashes
-}
-
-func TestMachinaApplyMutatorStampsConfigHash(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apps/v1",
-		"kind":       "Deployment",
-		"metadata":   map[string]any{"name": "machina-controller"},
-		"spec": map[string]any{
-			"template": map[string]any{"metadata": map[string]any{}},
-		},
-	}}
-
-	const hash = "config-hash"
-	if err := (&SiteReconciler{}).machinaApplyMutator(hash)(obj); err != nil {
-		t.Fatalf("machinaApplyMutator: %v", err)
-	}
-
-	got, found, err := unstructured.NestedString(obj.Object,
-		"spec", "template", "metadata", "annotations", machinaConfigHashAnnotation)
-	if err != nil || !found || got != hash {
-		t.Fatalf("config hash = %q found=%t err=%v, want %q", got, found, err, hash)
-	}
-}
-
-func TestReconcileRetainedMachinaWithNoSitesUpdatesConfigAndHash(t *testing.T) {
-	config := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: DefaultNamespace, Name: "machina-config"},
-		Data: map[string]string{
-			"config.yaml": "apiServerEndpoint: https://old.example:6443\ncustom: retained\n",
-		},
-	}
-	r, appliedHashes := retainedMachinaReconciler(t, config)
-	r.Config.APIServerEndpoint = "https://new.example:6443"
-
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: singletonRequestName}}); err != nil {
-		t.Fatalf("Reconcile: %v", err)
-	}
-
-	var got corev1.ConfigMap
-	if err := r.Get(t.Context(), client.ObjectKeyFromObject(config), &got); err != nil {
-		t.Fatalf("get retained machina config: %v", err)
-	}
-
-	if !strings.Contains(got.Data["config.yaml"], "https://new.example:6443") ||
-		!strings.Contains(got.Data["config.yaml"], "custom: retained") {
-		t.Fatalf("retained machina config was not merged: %q", got.Data["config.yaml"])
-	}
-
-	wantHash := configMapPayloadHash(&got)
-	if appliedHashes["machina-controller"] != wantHash {
-		t.Fatalf("applied Machina hash = %q, want %q", appliedHashes["machina-controller"], wantHash)
-	}
-}
-
-func TestReconcileRecreatesDeletedRetainedMachinaConfigWithNoSites(t *testing.T) {
-	retained := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-		Namespace: DefaultNamespace,
-		Name:      "machina-controller",
-	}}
-	deletedConfig := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: DefaultNamespace, Name: "machina-config"},
-		Data:       map[string]string{"config.yaml": "apiServerEndpoint: https://deleted.example:6443\n"},
-	}
-	r, appliedHashes := retainedMachinaReconciler(t, retained, deletedConfig)
-
-	r.Config.APIServerEndpoint = "https://api.example:6443"
-	if err := r.Delete(t.Context(), deletedConfig); err != nil {
-		t.Fatalf("delete machina config: %v", err)
-	}
-
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: singletonRequestName}}); err != nil {
-		t.Fatalf("Reconcile: %v", err)
-	}
-
-	var config corev1.ConfigMap
-
-	key := client.ObjectKey{Namespace: DefaultNamespace, Name: "machina-config"}
-	if err := r.Get(t.Context(), key, &config); err != nil {
-		t.Fatalf("get recreated machina config: %v", err)
-	}
-
-	wantHash := configMapPayloadHash(&config)
-	if !strings.Contains(config.Data["config.yaml"], "https://api.example:6443") ||
-		appliedHashes["machina-controller"] != wantHash {
-		t.Fatalf("recreated config/workload hash = data=%#v hashes=%#v", config.Data, appliedHashes)
-	}
-}
-
-func TestReconcileDoesNotCreateMachinaFromNothingWithNoSites(t *testing.T) {
-	r, appliedHashes := retainedMachinaReconciler(t)
-
-	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: singletonRequestName}}); err != nil {
-		t.Fatalf("Reconcile: %v", err)
-	}
-
-	err := r.Get(t.Context(), client.ObjectKey{Namespace: DefaultNamespace, Name: "machina-config"}, &corev1.ConfigMap{})
-	if !apierrors.IsNotFound(err) || len(appliedHashes) != 0 {
-		t.Fatalf("zero-Site reconcile created Machina from nothing: config err=%v hashes=%#v", err, appliedHashes)
-	}
-}
-
-func retainedMachinaReconciler(t *testing.T, objects ...client.Object) (*SiteReconciler, map[string]string) {
-	t.Helper()
-
-	scheme := newReconcilerTestScheme(t)
-	appliedHashes := map[string]string{}
-	cl := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(objects...).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
-				applied, ok := obj.(interface {
-					GetName() string
-					GetKind() string
-					UnstructuredContent() map[string]any
-				})
-				if !ok {
-					t.Fatalf("applied object has unexpected type %T", obj)
-				}
-
-				if applied.GetKind() != "Deployment" || applied.GetName() != "machina-controller" {
-					return nil
-				}
-
-				hash, _, err := unstructured.NestedString(
-					applied.UnstructuredContent(),
-					"spec", "template", "metadata", "annotations", machinaConfigHashAnnotation,
-				)
-				if err != nil {
-					t.Fatalf("get applied Machina hash: %v", err)
-				}
-
-				appliedHashes[applied.GetName()] = hash
-
-				return nil
-			},
-		}).
-		Build()
-
-	return &SiteReconciler{Client: cl, Scheme: scheme}, appliedHashes
-}
-
-func TestMutateMetalmanSupportObject(t *testing.T) {
-	keep := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "rbac.authorization.k8s.io/v1",
-		"kind":       "Role",
-		"metadata":   map[string]any{"name": "metalman-controller"},
-	}}
-	if err := mutateMetalmanSupportObject(keep); err != nil {
-		t.Fatalf("mutateMetalmanSupportObject returned error: %v", err)
-	}
-
-	if keep.Object == nil {
-		t.Fatalf("metalman support object was dropped")
-	}
-
-	drop := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "v1",
-		"kind":       "ServiceAccount",
-		"metadata":   map[string]any{"name": "machina-controller"},
-	}}
-	if err := mutateMetalmanSupportObject(drop); err != nil {
-		t.Fatalf("mutateMetalmanSupportObject returned error: %v", err)
-	}
-
-	if drop.Object != nil {
-		t.Fatalf("non-metalman object was not dropped")
-	}
-}
-
-func TestMetalmanDeployment(t *testing.T) {
-	enabled := true
-	dhcpAuto := true
-	replicas := int32(3)
-	site := &unboundedv1alpha3.Site{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "rack-a",
-			UID:    "site-uid",
-			Labels: map[string]string{unboundedv1alpha3.MachineSiteLabelKey: "lab-rack-a"},
-		},
-		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
-			SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
-			DHCPAutoInterface: &dhcpAuto,
-			Replicas:          &replicas,
-		}}},
-	}
-
-	deployment := metalmanDeployment(site, DefaultNamespace, Config{MetalmanImage: "example/metalman:default", APIServerEndpoint: "https://api.example:6443"})
-	if deployment.Name != "metalman-controller-rack-a" {
-		t.Fatalf("name = %q", deployment.Name)
-	}
-
-	if deployment.Namespace != DefaultNamespace {
-		t.Fatalf("namespace = %q, want %q", deployment.Namespace, DefaultNamespace)
-	}
-
-	container := deployment.Spec.Template.Spec.Containers[0]
-	if container.Image != "example/metalman:default" {
-		t.Fatalf("image = %q", container.Image)
-	}
-
-	if got := container.Args; len(got) != 3 || got[0] != "serve-pxe" || got[1] != "--site=rack-a" || got[2] != "--dhcp-auto-interface" {
-		t.Fatalf("args = %#v", got)
-	}
-
-	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 3 {
-		t.Fatalf("replicas = %v, want 3", deployment.Spec.Replicas)
-	}
-
-	if got := deployment.Labels[unboundedv1alpha3.MachineSiteLabelKey]; got != "rack-a" {
-		t.Fatalf("deployment site label = %q, want rack-a", got)
-	}
-
-	if got := deployment.Spec.Selector.MatchLabels[unboundedv1alpha3.MachineSiteLabelKey]; got != "rack-a" {
-		t.Fatalf("selector site label = %q, want rack-a", got)
-	}
-
-	if got := deployment.Spec.Template.Labels[unboundedv1alpha3.MachineSiteLabelKey]; got != "rack-a" {
-		t.Fatalf("pod site label = %q, want rack-a", got)
-	}
-
-	// POD_NAMESPACE is sourced from the Downward API so the lease/RBAC stay
-	// co-located with the Deployment under any install namespace.
-	podNS := findEnv(container.Env, "POD_NAMESPACE")
-	if podNS == nil || podNS.ValueFrom == nil || podNS.ValueFrom.FieldRef == nil ||
-		podNS.ValueFrom.FieldRef.FieldPath != "metadata.namespace" {
-		t.Fatalf("POD_NAMESPACE env = %#v, want Downward API metadata.namespace", podNS)
-	}
-
-	// The operator-resolved endpoint is handed to metalman as METALMAN_APISERVER_URL.
-	if got := findEnv(container.Env, "METALMAN_APISERVER_URL"); got == nil || got.Value != "https://api.example:6443" {
-		t.Fatalf("METALMAN_APISERVER_URL env = %#v, want https://api.example:6443", got)
-	}
-
-	assertSiteOwnerRef(t, deployment.OwnerReferences, "rack-a", "site-uid")
-	assertSiteAffinity(t, deployment.Spec.Template.Spec.Affinity, "rack-a")
-
-	// hostNetwork singleton: must terminate the old pod before creating the new
-	// one so it can rebind its host ports on a rolling restart.
-	strategy := deployment.Spec.Strategy
-	if strategy.Type != appsv1.RollingUpdateDeploymentStrategyType || strategy.RollingUpdate == nil {
-		t.Fatalf("expected RollingUpdate strategy, got %+v", strategy)
-	}
-
-	if got := strategy.RollingUpdate.MaxSurge; got == nil || got.IntValue() != 0 {
-		t.Fatalf("expected maxSurge=0, got %v", got)
-	}
-
-	if got := strategy.RollingUpdate.MaxUnavailable; got == nil || got.IntValue() != 1 {
-		t.Fatalf("expected maxUnavailable=1, got %v", got)
-	}
-}
-
-func TestMetalmanDeploymentRespectsNamespace(t *testing.T) {
-	enabled := true
-	site := &unboundedv1alpha3.Site{
-		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
-		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
-			SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
-		}}},
-	}
-
-	deployment := metalmanDeployment(site, "custom-ns", Config{MetalmanImage: "example/metalman:default"})
-	if deployment.Namespace != "custom-ns" {
-		t.Fatalf("namespace = %q, want custom-ns", deployment.Namespace)
-	}
-
-	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 1 {
-		t.Fatalf("replicas = %v, want default 1", deployment.Spec.Replicas)
-	}
-
-	if got := deployment.Spec.Template.Spec.Containers[0].Args[1]; got != "--site=rack-a" {
-		t.Fatalf("site argument = %q, want --site=rack-a", got)
-	}
-
-	if got := deployment.Labels[unboundedv1alpha3.MachineSiteLabelKey]; got != "rack-a" {
-		t.Fatalf("deployment site label = %q, want rack-a", got)
-	}
-}
-
-func TestMetalmanDeploymentAllowsZeroReplicas(t *testing.T) {
-	enabled := true
-	replicas := int32(0)
-	site := &unboundedv1alpha3.Site{
-		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
-		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
-			SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
-			Replicas:          &replicas,
-		}}},
-	}
-
-	deployment := metalmanDeployment(site, DefaultNamespace, Config{MetalmanImage: "example/metalman:default"})
-	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 {
-		t.Fatalf("replicas = %v, want 0", deployment.Spec.Replicas)
-	}
-}
-
-func TestMetalmanDeploymentOmitsEmptyAPIServerURL(t *testing.T) {
-	enabled := true
-	site := &unboundedv1alpha3.Site{
-		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
-		Spec: unboundedv1alpha3.SiteSpec{Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
-			SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
-		}}},
-	}
-
-	deployment := metalmanDeployment(site, DefaultNamespace, Config{MetalmanImage: "example/metalman:default"})
-
-	container := deployment.Spec.Template.Spec.Containers[0]
-	if got := findEnv(container.Env, "METALMAN_APISERVER_URL"); got != nil {
-		t.Fatalf("METALMAN_APISERVER_URL env = %#v, want unset when APIServerEndpoint is empty", got)
-	}
-}
-
-func findEnv(env []corev1.EnvVar, name string) *corev1.EnvVar {
-	for i := range env {
-		if env[i].Name == name {
-			return &env[i]
-		}
-	}
-
-	return nil
 }
 
 func TestReconcilerNamespaceFallsBackToDefault(t *testing.T) {
 	r := &SiteReconciler{}
-	if got := r.namespace(); got != DefaultNamespace {
-		t.Fatalf("namespace() = %q, want %q", got, DefaultNamespace)
+	if got := r.namespace(); got != component.DefaultNamespace {
+		t.Fatalf("namespace() = %q, want %q", got, component.DefaultNamespace)
 	}
 
 	r.Namespace = "custom-ns"
@@ -1040,363 +286,25 @@ func TestReconcilerNamespaceFallsBackToDefault(t *testing.T) {
 	}
 }
 
-func TestStorageDaemonSetPointsAtPerSiteConfig(t *testing.T) {
-	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}
-	obj := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apps/v1",
-		"kind":       "DaemonSet",
-		"metadata":   map[string]any{"name": "unbounded-storage-supervisor"},
-		"spec": map[string]any{
-			"selector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "unbounded-storage-supervisor"}},
-			"template": map[string]any{
-				"metadata": map[string]any{"labels": map[string]any{"app.kubernetes.io/name": "unbounded-storage-supervisor"}},
-				"spec": map[string]any{
-					"containers": []any{map[string]any{"name": "run"}},
-					"volumes": []any{map[string]any{
-						"name":      "config-source",
-						"configMap": map[string]any{"name": "unbounded-storage-config"},
-					}},
-				},
-			},
-		},
-	}}
-
-	if err := mutateStorageObject(site, "storage-hash", obj); err != nil {
-		t.Fatalf("mutateStorageObject returned error: %v", err)
+func TestDefaultRegistryIsValidAndComplete(t *testing.T) {
+	reg := DefaultRegistry()
+	if err := reg.Validate(); err != nil {
+		t.Fatalf("DefaultRegistry is invalid: %v", err)
 	}
 
-	volumes, ok, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
-	if err != nil || !ok {
-		t.Fatalf("missing volumes: ok=%t err=%v", ok, err)
+	wantConditions := map[string]bool{"NetReady": false, "MachinaReady": false, "MetalmanReady": false, "StorageReady": false}
+
+	for _, c := range reg.Cluster {
+		wantConditions[c.ConditionType()] = true
 	}
 
-	vol := volumes[0].(map[string]any)
-	cm := vol["configMap"].(map[string]any)
-
-	if cm["name"] != "unbounded-storage-config-rack-a" {
-		t.Fatalf("config volume name = %v, want unbounded-storage-config-rack-a", cm["name"])
-	}
-}
-
-func TestEnsureStorageConfigCreatesDefaultWhenAbsent(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1: %v", err)
+	for _, c := range reg.Site {
+		wantConditions[c.ConditionType()] = true
 	}
 
-	r := &SiteReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
-	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
-
-	hash, err := r.ensureStorageConfig(t.Context(), site)
-	if err != nil {
-		t.Fatalf("ensureStorageConfig: %v", err)
-	}
-
-	var got corev1.ConfigMap
-	if err := r.Get(t.Context(), client.ObjectKey{Namespace: DefaultNamespace, Name: "unbounded-storage-config-rack-a"}, &got); err != nil {
-		t.Fatalf("get created configmap: %v", err)
-	}
-
-	if got.Data["config.yaml"] == "" {
-		t.Fatalf("default config.yaml was not seeded")
-	}
-
-	if hash != configMapPayloadHash(&got) {
-		t.Fatalf("hash = %q, want exact stored payload hash", hash)
-	}
-
-	assertSiteOwnerRef(t, got.OwnerReferences, "rack-a", "site-uid")
-}
-
-func TestEnsureStorageConfigAdoptsExistingAndPreservesData(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1: %v", err)
-	}
-
-	existing := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-config-rack-a", Namespace: DefaultNamespace},
-		Data:       map[string]string{"config.yaml": "custom: true"},
-	}
-	r := &SiteReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()}
-	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a", UID: "site-uid"}}
-
-	hash, err := r.ensureStorageConfig(t.Context(), site)
-	if err != nil {
-		t.Fatalf("ensureStorageConfig: %v", err)
-	}
-
-	var got corev1.ConfigMap
-	if err := r.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
-		t.Fatalf("get adopted configmap: %v", err)
-	}
-
-	if got.Data["config.yaml"] != "custom: true" {
-		t.Fatalf("existing config data was not preserved: %q", got.Data["config.yaml"])
-	}
-
-	if hash != configMapPayloadHash(&got) {
-		t.Fatalf("hash = %q, want exact adopted payload hash", hash)
-	}
-
-	assertSiteOwnerRef(t, got.OwnerReferences, "rack-a", "site-uid")
-}
-
-func TestReconcilePerSiteComponentDisabledRunsCleanup(t *testing.T) {
-	cleaned := false
-	status := (&SiteReconciler{}).reconcilePerSiteComponent(
-		false,
-		func() error { t.Fatal("reconcile must not run when disabled"); return nil },
-		func() error { cleaned = true; return nil },
-	)
-
-	if !cleaned {
-		t.Fatal("cleanup was not called for a disabled component")
-	}
-
-	if !status.ready || status.reason != reasonDisabled {
-		t.Fatalf("status = %+v, want ready with reason %q", status, reasonDisabled)
-	}
-}
-
-func TestCleanupStorageDeletesPerSiteResourcesOnly(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := appsv1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add appsv1: %v", err)
-	}
-
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1: %v", err)
-	}
-
-	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-supervisor-rack-a", Namespace: DefaultNamespace}}
-	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-config-rack-a", Namespace: DefaultNamespace}}
-	otherDS := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "unbounded-storage-supervisor-rack-b", Namespace: DefaultNamespace}}
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ds, cm, otherDS).Build()
-	r := &SiteReconciler{Client: cl}
-
-	if err := r.cleanupStorage(t.Context(), &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}); err != nil {
-		t.Fatalf("cleanupStorage: %v", err)
-	}
-
-	if err := cl.Get(t.Context(), client.ObjectKeyFromObject(ds), &appsv1.DaemonSet{}); !apierrors.IsNotFound(err) {
-		t.Fatalf("expected rack-a DaemonSet deleted, got err=%v", err)
-	}
-
-	if err := cl.Get(t.Context(), client.ObjectKeyFromObject(cm), &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
-		t.Fatalf("expected rack-a ConfigMap deleted, got err=%v", err)
-	}
-
-	if err := cl.Get(t.Context(), client.ObjectKeyFromObject(otherDS), &appsv1.DaemonSet{}); err != nil {
-		t.Fatalf("expected rack-b DaemonSet preserved, got err=%v", err)
-	}
-}
-
-func TestRetargetNamespaceRewritesToCustomNamespace(t *testing.T) {
-	r := &SiteReconciler{Namespace: "custom-ns"}
-
-	obj := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apps/v1",
-		"kind":       "Deployment",
-		"metadata":   map[string]any{"name": "x", "namespace": "unbounded-system"},
-		"subjects":   []any{map[string]any{"namespace": "unbounded-system"}},
-	}}
-
-	r.retargetNamespace(obj)
-
-	if got := obj.GetNamespace(); got != "custom-ns" {
-		t.Fatalf("namespace = %q, want custom-ns", got)
-	}
-
-	subjects, _, _ := unstructured.NestedSlice(obj.Object, "subjects")
-	if subjects[0].(map[string]any)["namespace"] != "custom-ns" {
-		t.Fatalf("subject namespace not rewritten: %v", subjects[0])
-	}
-
-	// Default install is a no-op.
-	def := &SiteReconciler{}
-	nsObj := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "v1",
-		"kind":       "Namespace",
-		"metadata":   map[string]any{"name": "unbounded-system"},
-	}}
-	def.retargetNamespace(nsObj)
-
-	if nsObj.GetName() != "unbounded-system" {
-		t.Fatalf("default install rewrote namespace to %q", nsObj.GetName())
-	}
-}
-
-// Finding 4: retargeting a custom namespace must also rewrite the namespace
-// where it appears as a substring - service-account usernames in VAP CEL and
-// flag values - while leaving unrelated strings (image refs) untouched.
-func TestRetargetNamespaceRewritesServiceAccountAndArgs(t *testing.T) {
-	r := &SiteReconciler{Namespace: "custom-ns"}
-
-	obj := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "admissionregistration.k8s.io/v1",
-		"kind":       "ValidatingAdmissionPolicy",
-		"metadata":   map[string]any{"name": "p"},
-		"spec": map[string]any{
-			"matchConditions": []any{
-				map[string]any{"expression": "request.userInfo.username == 'system:serviceaccount:unbounded-system:unbounded-net-controller'"},
-			},
-			"args":  []any{"--leader-elect-resource-namespace=unbounded-system"},
-			"image": "ghcr.io/azure/unbounded-system:v1",
-		},
-	}}
-
-	r.retargetNamespace(obj)
-
-	conds, _, _ := unstructured.NestedSlice(obj.Object, "spec", "matchConditions")
-	gotExpr := conds[0].(map[string]any)["expression"].(string)
-
-	if gotExpr != "request.userInfo.username == 'system:serviceaccount:custom-ns:unbounded-net-controller'" {
-		t.Fatalf("SA username not rewritten: %q", gotExpr)
-	}
-
-	args, _, _ := unstructured.NestedStringSlice(obj.Object, "spec", "args")
-	if len(args) != 1 || args[0] != "--leader-elect-resource-namespace=custom-ns" {
-		t.Fatalf("flag value not rewritten: %v", args)
-	}
-
-	if img, _, _ := unstructured.NestedString(obj.Object, "spec", "image"); img != "ghcr.io/azure/unbounded-system:v1" {
-		t.Fatalf("image ref must not be rewritten, got %q", img)
-	}
-}
-
-func TestRetargetNamespaceInString(t *testing.T) {
-	cases := []struct {
-		in, want string
-	}{
-		{"unbounded-system", "custom-ns"},
-		{"system:serviceaccount:unbounded-system:sa", "system:serviceaccount:custom-ns:sa"},
-		{"--leader-elect-resource-namespace=unbounded-system", "--leader-elect-resource-namespace=custom-ns"},
-		{"ghcr.io/azure/unbounded-system:v1", "ghcr.io/azure/unbounded-system:v1"},
-		{"unbounded-system-other", "unbounded-system-other"},
-	}
-
-	for _, tc := range cases {
-		if got := retargetNamespaceInString(tc.in, "unbounded-system", "custom-ns"); got != tc.want {
-			t.Fatalf("retargetNamespaceInString(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
-
-// Finding 3: the reconcile loop never applies CRDs (the operator installs them
-// once at startup via BootstrapCRDs).
-func TestSkipCRDObjects(t *testing.T) {
-	crd := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apiextensions.k8s.io/v1",
-		"kind":       "CustomResourceDefinition",
-		"metadata":   map[string]any{"name": "sites.unbounded-cloud.io"},
-	}}
-
-	if err := skipCRDObjects(crd); err != nil {
-		t.Fatalf("skipCRDObjects: %v", err)
-	}
-
-	if crd.Object != nil {
-		t.Fatal("expected CRD object nilled out")
-	}
-
-	other := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "x"},
-	}}
-
-	if err := skipCRDObjects(other); err != nil {
-		t.Fatalf("skipCRDObjects: %v", err)
-	}
-
-	if other.Object == nil {
-		t.Fatal("non-CRD object must be preserved")
-	}
-}
-
-func assertSiteOwnerRef(t *testing.T, refs []metav1.OwnerReference, siteName, uid string) {
-	t.Helper()
-
-	if len(refs) != 1 {
-		t.Fatalf("ownerReferences len = %d, want 1: %#v", len(refs), refs)
-	}
-
-	ref := refs[0]
-	if ref.APIVersion != unboundedv1alpha3.GroupVersion.String() || ref.Kind != "Site" || ref.Name != siteName {
-		t.Fatalf("unexpected ownerRef: %#v", ref)
-	}
-
-	if uid != "" && string(ref.UID) != uid {
-		t.Fatalf("ownerRef UID = %q, want %q", ref.UID, uid)
-	}
-}
-
-func assertSiteAffinity(t *testing.T, affinity *corev1.Affinity, siteName string) {
-	t.Helper()
-
-	if affinity == nil || affinity.NodeAffinity == nil || affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-		t.Fatalf("missing node affinity: %#v", affinity)
-	}
-
-	terms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-	if len(terms) != 2 {
-		t.Fatalf("node selector terms len = %d, want 2: %#v", len(terms), terms)
-	}
-
-	want := map[string]bool{siteLabelKey: false, deprecatedSiteLabelKey: false}
-
-	for _, term := range terms {
-		if len(term.MatchExpressions) != 1 {
-			t.Fatalf("term must have one expression: %#v", term)
-		}
-
-		expr := term.MatchExpressions[0]
-		if expr.Operator != corev1.NodeSelectorOpIn || len(expr.Values) != 1 || expr.Values[0] != siteName {
-			t.Fatalf("unexpected site affinity expression: %#v", expr)
-		}
-
-		if _, ok := want[expr.Key]; !ok {
-			t.Fatalf("unexpected site affinity key %q", expr.Key)
-		}
-
-		want[expr.Key] = true
-	}
-
-	for key, seen := range want {
+	for condition, seen := range wantConditions {
 		if !seen {
-			t.Fatalf("site affinity missing key %q", key)
+			t.Fatalf("DefaultRegistry is missing condition %q", condition)
 		}
-	}
-}
-
-func assertSiteAffinityMap(t *testing.T, affinity map[string]any, siteName string) {
-	t.Helper()
-
-	converted := &corev1.Affinity{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(affinity, converted); err != nil {
-		t.Fatalf("convert affinity: %v", err)
-	}
-
-	assertSiteAffinity(t, converted, siteName)
-}
-
-func TestApplyObject(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := appsv1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add appsv1 to scheme: %v", err)
-	}
-
-	r := &SiteReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
-	deployment := &appsv1.Deployment{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
-		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
-			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}}},
-		},
-	}
-
-	if err := r.applyObject(t.Context(), deployment); err != nil {
-		t.Fatalf("applyObject returned error: %v", err)
 	}
 }

--- a/internal/operator/reconciler_test.go
+++ b/internal/operator/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -68,6 +69,21 @@ func (f fakeSite) Cleanup(context.Context, *component.Env, *unboundedv1alpha3.Si
 	}
 
 	return f.cleanupErr
+}
+
+// statefulCluster is a pointer-receiver ClusterComponent that counts how many
+// times it reconciled, used to prove the driver reuses a single registry
+// instance instead of rebuilding it each pass.
+type statefulCluster struct {
+	runs int
+}
+
+func (c *statefulCluster) Name() string          { return "stateful" }
+func (c *statefulCluster) ConditionType() string { return "StatefulReady" }
+func (c *statefulCluster) Reconcile(context.Context, *component.Env, []unboundedv1alpha3.Site) component.Result {
+	c.runs++
+
+	return component.Reconciled()
 }
 
 func newReconcilerTestScheme(t *testing.T) *runtime.Scheme {
@@ -306,5 +322,135 @@ func TestDefaultRegistryIsValidAndComplete(t *testing.T) {
 		if !seen {
 			t.Fatalf("DefaultRegistry is missing condition %q", condition)
 		}
+	}
+}
+
+func TestReconcileRequeuesAfterSmallestComponentInterval(t *testing.T) {
+	scheme := newReconcilerTestScheme(t)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}
+
+	registry := &component.Registry{
+		Cluster: []component.ClusterComponent{
+			fakeCluster{name: "net", condition: "NetReady", result: component.NotReadyAfter("Waiting", "net not ready", 5*time.Minute)},
+			fakeCluster{name: "machina", condition: "MachinaReady", result: component.NotReadyAfter("Waiting", "machina not ready", 30*time.Second)},
+		},
+		Site: []component.SiteComponent{
+			fakeSite{name: "storage", condition: "StorageReady", enabled: true, result: component.Reconciled()},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(site).WithStatusSubresource(site).Build()
+	r := &SiteReconciler{Client: cl, Scheme: scheme, Registry: registry}
+
+	res, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(site)})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if res.RequeueAfter != 30*time.Second {
+		t.Fatalf("RequeueAfter = %s, want the smallest positive interval 30s", res.RequeueAfter)
+	}
+}
+
+func TestReconcileSiteLessPassHonorsRequeue(t *testing.T) {
+	scheme := newReconcilerTestScheme(t)
+
+	registry := &component.Registry{
+		Cluster: []component.ClusterComponent{
+			fakeCluster{name: "net", condition: "NetReady", result: component.NotReadyAfter("Waiting", "net not ready", time.Minute)},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SiteReconciler{Client: cl, Scheme: scheme, Registry: registry}
+
+	// The Site-less pass has no status to publish, but a not-ready cluster
+	// component must still schedule a retry (regression: the old path dropped it).
+	res, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKey{Name: component.SingletonRequestName}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if res.RequeueAfter != time.Minute {
+		t.Fatalf("RequeueAfter = %s, want 1m on the Site-less pass", res.RequeueAfter)
+	}
+}
+
+func TestReconcilePrunesStaleConditions(t *testing.T) {
+	scheme := newReconcilerTestScheme(t)
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
+		Status: unboundedv1alpha3.SiteStatus{
+			Conditions: []metav1.Condition{{
+				// A condition from a component that has since been removed/renamed.
+				Type:   "LegacyReady",
+				Status: metav1.ConditionTrue,
+				Reason: "Reconciled",
+			}},
+		},
+	}
+
+	registry := &component.Registry{
+		Cluster: []component.ClusterComponent{
+			fakeCluster{name: "net", condition: "NetReady", result: component.Reconciled()},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(site).WithStatusSubresource(site).Build()
+	r := &SiteReconciler{Client: cl, Scheme: scheme, Registry: registry}
+
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(site)}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var got unboundedv1alpha3.Site
+	if err := cl.Get(t.Context(), client.ObjectKeyFromObject(site), &got); err != nil {
+		t.Fatalf("get reconciled Site: %v", err)
+	}
+
+	if apimeta.FindStatusCondition(got.Status.Conditions, "LegacyReady") != nil {
+		t.Fatalf("stale condition LegacyReady was not pruned: %#v", got.Status.Conditions)
+	}
+
+	if apimeta.FindStatusCondition(got.Status.Conditions, "NetReady") == nil {
+		t.Fatalf("current condition NetReady missing after prune: %#v", got.Status.Conditions)
+	}
+}
+
+func TestRegistryMaterializedOnceAndInstanceReused(t *testing.T) {
+	// registry() must materialize r.Registry once and return the same instance,
+	// so watch wiring and every Reconcile share components (not throwaway copies).
+	r := &SiteReconciler{}
+
+	first := r.registry()
+	if r.Registry == nil {
+		t.Fatal("registry() did not materialize r.Registry")
+	}
+
+	if second := r.registry(); second != first {
+		t.Fatal("registry() rebuilt the registry instead of reusing the materialized instance")
+	}
+
+	// A stateful component reused across reconciles retains its state, which is
+	// only possible because the same instance is reused each pass.
+	scheme := newReconcilerTestScheme(t)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}
+	stateful := &statefulCluster{}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(site).WithStatusSubresource(site).Build()
+	sr := &SiteReconciler{
+		Client:   cl,
+		Scheme:   scheme,
+		Registry: &component.Registry{Cluster: []component.ClusterComponent{stateful}},
+	}
+
+	for i := 0; i < 2; i++ {
+		if _, err := sr.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(site)}); err != nil {
+			t.Fatalf("Reconcile %d: %v", i, err)
+		}
+	}
+
+	if stateful.runs != 2 {
+		t.Fatalf("stateful component runs = %d, want 2 (instance not reused across reconciles)", stateful.runs)
 	}
 }


### PR DESCRIPTION
## Summary

Refactors the unbounded-operator's hand-wired reconcile loop into a small **registry of pluggable components**, so contributors can add a new component reconciler by implementing one interface and adding one registry line, without touching the driver, status plumbing, ordering, or watch wiring.

Previously, adding a component meant editing ~9 scattered places in `internal/operator/reconciler.go` (name const, condition mapping, enablement switch, bespoke reconcile/cleanup methods, the reconcile fan-out, the ordered condition slice, the singleton path, and two watch predicates). Now it is: implement an interface, add a typed `spec.components` field, and register it.

## Design

Two symmetric authoring interfaces, one generic driver:

- **`component.ClusterComponent`** (net, machina): reconciles from the full `[]Site`; runs on every pass including the Site-less pass (Site deletion / managed singleton-resource events).
- **`component.SiteComponent`** (metalman, storage): `Enabled`/`Reconcile`/`Cleanup` receive a guaranteed non-nil `*Site`; the driver owns the enable -> reconcile / disable -> cleanup branch, so implementers never handle the Site-less pass.
- **`component.Env`** carries the shared client + apply/manifest/watch machinery components use.
- **`component.Registry`** (`Cluster` + `Site` slices) is validated for unique names/condition types; `operator.DefaultRegistry()` assembles the built-ins.
- Optional **`component.WatchProvider`** lets each component contribute its own watches; `SetupWithManager` builds them from the registry.

## Layout

- `internal/operator/component/` - the extension contract/SDK (no import cycle: components and the driver both depend on it).
- `internal/operator/components/{net,machina,metalman,storage}/` - one package per component.
- `internal/operator/reconciler.go` - trimmed to the generic driver + `DefaultRegistry`.

## Behavior

Identical to before, with one intentional improvement: per-Site components now `Owns()` their resources (metalman Deployment, storage DaemonSet), so they self-heal on drift/deletion like the singletons already did. The reaper (`migrate.go`) is unchanged; shared names/annotations/endpoint logic are single-sourced from the component packages via thin aliases.

## Adding a component

1. Add a typed `*XComponentSpec` field to `SiteComponents`.
2. Implement `ClusterComponent` or `SiteComponent` in `internal/operator/components/x/`.
3. Register `x.New()` in `operator.DefaultRegistry()`.

## Testing

- Component-specific tests moved to the owning packages (config ensure, mutators, deployment/daemonset scoping, retained/cleanup behavior).
- New contract tests: `Registry.Validate()`, env apply/retarget/watch helpers, fake-component driver tests covering condition publishing, error joining, status-patch error joining, the Site-less pass (cluster-only), and the disable -> cleanup branch.
- `make fmt`, `make lint` (0 issues), `go build ./...`, and `go test ./internal/operator/... ./api/machina/...` all pass.

Note: two pre-existing `cmd/kubectl-unbounded` install tests fail in this environment because they require rendered operator manifests (`deploy/unbounded-operator/rendered/`, gitignored); they fail identically on `main` and are unrelated to this change.