### PR TITLE
docs: use operator-managed deployment flow

### DIFF
--- a/docs/content/guides/pxe.md
+++ b/docs/content/guides/pxe.md
@@ -21,16 +21,27 @@ API group: `unbounded-cloud.io/v1alpha3`. CRD: **Machine** (`mach`), cluster-sco
 
 ## Deploy Metalman
 
-Apply the CRDs and controller manifests:
+Metalman is a per-site component managed by the unbounded operator. First install
+the operator (this also installs the CRDs):
 
 ```bash
-kubectl apply -f deploy/machina/crd/
-kubectl apply -f deploy/machina/
+kubectl unbounded install
 ```
 
-This creates the `unbounded-system` namespace, ServiceAccounts (`metalman-controller`, `metalman-bootstrap`), RBAC roles, and a Deployment.
+Then enable metalman on a Site by passing `--enable-metalman` to `site init`, or by
+setting the metalman entry in `Site.spec.components`:
 
-Key `serve-pxe` flags (set via the Deployment):
+```bash
+kubectl unbounded site init --name my-edge-site --enable-metalman
+```
+
+`kubectl unbounded site init` also runs `install` by default, so a fresh site only
+needs the single command above. The operator then reconciles the `unbounded-system`
+namespace, ServiceAccounts (`metalman-controller`, `metalman-bootstrap`), RBAC roles,
+and a metalman Deployment for the Site.
+
+Key `serve-pxe` flags (baked into the operator-managed per-site Deployment; `--site`
+scoping is inherent to the per-site component):
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/content/guides/ssh.md
+++ b/docs/content/guides/ssh.md
@@ -56,7 +56,7 @@ All five flags above are required. Optional flags:
 ## Creating Machines
 
 Use `kubectl unbounded machine register` to register a machine with the site.
-The command creates an SSH key Secret in `unbounded-kube` and applies a Machine
+The command creates an SSH key Secret in `unbounded-system` and applies a Machine
 CR to the cluster:
 
 ```bash
@@ -71,7 +71,7 @@ The three flags `--site`, `--host`, and `--ssh-username` are required.
 `--ssh-private-key` is also required unless bastion flags are provided.
 
 {{< callout type="important" >}}
-The SSH private key is read from disk and stored as a Kubernetes Secret named `ssh-<site>` (e.g. `ssh-mysite`) in the `unbounded-kube` namespace. If the Secret already exists, it is updated. Ensure your cluster's RBAC restricts access to Secrets in `unbounded-kube`.
+The SSH private key is read from disk and stored as a Kubernetes Secret named `ssh-<site>` (e.g. `ssh-mysite`) in the `unbounded-system` namespace. If the Secret already exists, it is updated. Ensure your cluster's RBAC restricts access to Secrets in `unbounded-system`.
 {{< /callout >}}
 
 The machine name is automatically prefixed with the site name. For example,
@@ -104,7 +104,7 @@ spec:
     username: ubuntu
     privateKeyRef:
       name: ssh-mysite
-      namespace: unbounded-kube
+      namespace: unbounded-system
       key: ssh-private-key
   kubernetes:
     version: "v1.34.0"
@@ -157,7 +157,7 @@ spec:
     username: ubuntu
     privateKeyRef:
       name: ssh-mysite
-      namespace: unbounded-kube
+      namespace: unbounded-system
       key: ssh-private-key
     bastion:
       host: "bastion.example.com"
@@ -200,7 +200,7 @@ groups.
 or script error:
 
 ```bash
-kubectl logs -n unbounded-kube deploy/machina-controller
+kubectl logs -n unbounded-system deploy/machina-controller
 ```
 
 Common causes: missing or incorrect SSH key Secret, wrong username, target
@@ -212,7 +212,7 @@ join errors. Verify the bootstrap token hasn't expired and that the machine has
 HTTPS connectivity to the API server.
 
 {{< callout type="warning" >}}
-**Security considerations** -- SSH host key verification is currently disabled. SSH keys are stored as Kubernetes Secrets in the `unbounded-kube` namespace. The install script runs as root via `sudo -E bash`. Ensure you trust the network path between the machina controller and target machines. All binary downloads use HTTPS. Supported key types: Ed25519, RSA, ECDSA.
+**Security considerations** -- SSH host key verification is currently disabled. SSH keys are stored as Kubernetes Secrets in the `unbounded-system` namespace. The install script runs as root via `sudo -E bash`. Ensure you trust the network path between the machina controller and target machines. All binary downloads use HTTPS. Supported key types: Ed25519, RSA, ECDSA.
 {{< /callout >}}
 
 ## See Also

--- a/docs/content/reference/architecture.md
+++ b/docs/content/reference/architecture.md
@@ -182,8 +182,11 @@ For a walkthrough, see the [PXE Provisioning Guide]({{< ref "guides/pxe" >}}).
 
 ## Deployment
 
-All components deploy into the `unbounded-system` namespace. Manifests are plain
-numbered YAML files (no Helm or Kustomize).
+All components deploy into the `unbounded-system` namespace. Installation is driven
+by the unbounded operator (`kubectl unbounded install` bootstraps the CRDs and the
+operator; `site init` reconciles component workloads from `Site.spec.components`).
+The manifests below are plain numbered YAML files (no Helm or Kustomize) that the
+operator renders and applies; they are not meant to be applied by hand.
 
 | Directory | Contents |
 |-----------|----------|

--- a/docs/content/reference/architecture.md
+++ b/docs/content/reference/architecture.md
@@ -183,10 +183,12 @@ For a walkthrough, see the [PXE Provisioning Guide]({{< ref "guides/pxe" >}}).
 ## Deployment
 
 All components deploy into the `unbounded-system` namespace. Installation is driven
-by the unbounded operator (`kubectl unbounded install` bootstraps the CRDs and the
-operator; `site init` reconciles component workloads from `Site.spec.components`).
-The manifests below are plain numbered YAML files (no Helm or Kustomize) that the
-operator renders and applies; they are not meant to be applied by hand.
+by the unbounded operator: `kubectl unbounded install` bootstraps the CRDs and the
+operator, and `site init` creates or updates `Site` resources (and writes the
+bootstrap token). The operator then reconciles component workloads from each
+`Site.spec.components`. The manifests below are plain numbered YAML files (no Helm
+or Kustomize) that the operator renders and applies; they are not meant to be
+applied by hand.
 
 | Directory | Contents |
 |-----------|----------|

--- a/docs/net/operations.md
+++ b/docs/net/operations.md
@@ -47,7 +47,7 @@ kubectl unbounded install
 Verify CRDs and the operator are installed:
 ```bash
 kubectl get crd | grep unbounded
-kubectl -n unbounded-kube get deploy unbounded-operator
+kubectl -n unbounded-system get deploy unbounded-operator
 ```
 
 Expected output:

--- a/docs/net/quickstart.md
+++ b/docs/net/quickstart.md
@@ -137,7 +137,7 @@ node agents are running:
 
 ```bash
 # Operator
-kubectl -n unbounded-kube get deploy unbounded-operator
+kubectl -n unbounded-system get deploy unbounded-operator
 
 # Controller pod
 kubectl -n unbounded-system get pods -l app.kubernetes.io/name=unbounded-net-controller

--- a/docs/static/img/architecture-resource-relationships.svg
+++ b/docs/static/img/architecture-resource-relationships.svg
@@ -21,20 +21,20 @@
   <!-- Left column: Referenced Resources                  -->
   <!-- ═══════════════════════════════════════════════════ -->
 
-  <!-- Secret (unbounded-kube) - SSH key -->
+  <!-- Secret (unbounded-system) - SSH key -->
   <rect x="30" y="22" width="220" height="36" rx="6" fill="#18181b" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.6"/>
   <!-- lock icon -->
   <rect x="42" y="32" width="10" height="8" rx="1.5" fill="none" stroke="#a78bfa" stroke-width="0.9"/>
   <path d="M44,32 L44,29 A3,3 0 0,1 50,29 L50,32" fill="none" stroke="#a78bfa" stroke-width="0.9"/>
   <text x="60" y="45" fill="#e4e4e7" font-size="11" font-weight="600">Secret</text>
-  <text x="106" y="45" fill="#a0a0a8" font-size="10">(unbounded-kube)</text>
+  <text x="106" y="45" fill="#a0a0a8" font-size="10">(unbounded-system)</text>
 
-  <!-- Secret (unbounded-kube) - Redfish password -->
+  <!-- Secret (unbounded-system) - Redfish password -->
   <rect x="30" y="72" width="220" height="36" rx="6" fill="#18181b" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.6"/>
   <rect x="42" y="82" width="10" height="8" rx="1.5" fill="none" stroke="#a78bfa" stroke-width="0.9"/>
   <path d="M44,82 L44,79 A3,3 0 0,1 50,79 L50,82" fill="none" stroke="#a78bfa" stroke-width="0.9"/>
   <text x="60" y="95" fill="#e4e4e7" font-size="11" font-weight="600">Secret</text>
-  <text x="106" y="95" fill="#a0a0a8" font-size="10">(unbounded-kube)</text>
+  <text x="106" y="95" fill="#a0a0a8" font-size="10">(unbounded-system)</text>
 
   <!-- Secret (kube-system) -->
   <rect x="30" y="122" width="220" height="36" rx="6" fill="#18181b" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.6"/>

--- a/docs/static/img/machina-crd-relationships.svg
+++ b/docs/static/img/machina-crd-relationships.svg
@@ -45,13 +45,13 @@
   <rect x="490" y="45" width="170" height="26" rx="5" fill="#18181b" stroke="#a78bfa" stroke-width="1.5" stroke-opacity="0.6"/>
   <text x="575" y="63" text-anchor="middle" fill="#a78bfa" font-size="11" font-weight="600">OCI Image</text>
 
-  <!-- Secret (unbounded-kube) -->
+  <!-- Secret (unbounded-system) -->
   <rect x="490" y="82" width="170" height="26" rx="5" fill="#18181b" stroke="#4d8eff" stroke-width="1.5" stroke-opacity="0.6"/>
   <!-- lock icon -->
   <rect x="502" y="89" width="8" height="6" rx="1" fill="none" stroke="#4d8eff" stroke-width="0.7"/>
   <path d="M504,89 L504,87 A2,2 0 0,1 508,87 L508,89" fill="none" stroke="#4d8eff" stroke-width="0.7"/>
   <text x="518" y="100" fill="#4d8eff" font-size="11" font-weight="600">Secret</text>
-  <text x="565" y="100" fill="#a0a0a8" font-size="9">(unbounded-kube)</text>
+  <text x="565" y="100" fill="#a0a0a8" font-size="9">(unbounded-system)</text>
 
   <!-- Secret -->
   <rect x="490" y="119" width="170" height="26" rx="5" fill="#18181b" stroke="#4d8eff" stroke-width="1.5" stroke-opacity="0.6"/>


### PR DESCRIPTION
- replace legacy manifest installation steps with the unbounded operator flow
- document per-site metalman enablement and operator reconciliation
- update stale component and Secret namespaces to `unbounded-system`
- clarify operator ownership of embedded deployment manifests