### PR TITLE
Remove legacy netlink dataplane documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For a deeper dive, see the [Project Overview](https://azure.github.io/unbounded/
 
 ## Key Features
 
-- **Multi-site networking** — Transparent pod-to-pod connectivity across sites using WireGuard, GENEVE, VXLAN, IPIP, or direct routing with an eBPF or netlink dataplane.
+- **Multi-site networking** -- Transparent pod-to-pod connectivity across sites using WireGuard, GENEVE, VXLAN, IPIP, or direct routing through an eBPF dataplane.
 - **SSH-based provisioning** — Join existing Linux machines to the cluster over SSH with a single command.
 - **Cloud API provisioning** — Auto-provision instances from Nebius, CoreWeave, OCI, Azure, AWS, and others via Karpenter in response to unschedulable pods.
 - **Bare-metal PXE boot** — PXE-boot servers with integrated DHCP, TFTP, HTTP, Redfish BMC power management, and TPM 2.0 attestation.

--- a/docs/content/concepts/networking.md
+++ b/docs/content/concepts/networking.md
@@ -39,7 +39,7 @@ the data plane:
 
 - Writes CNI bridge configuration for local pod networking.
 - Manages WireGuard keys and tunnel interfaces.
-- Programs routes using eBPF or netlink.
+- Programs routes through eBPF maps and kernel networking interfaces.
 - Monitors gateway health with UDP probes.
 
 ## Core Concepts
@@ -147,26 +147,16 @@ Choosing `None` on a `SitePeering` with `meshNodes: false` is the standard
 pattern for sites already connected over a dedicated private link. Traffic
 travels at full line rate with no encapsulation overhead.
 
-## Dataplane Modes
+## Dataplane
 
-The node agent supports two dataplanes for programming routes:
-
-### eBPF (default)
-
-The eBPF dataplane attaches a TC egress BPF program to a `unbounded0` dummy
+The node agent uses an eBPF dataplane to program routes. It attaches a TC
+egress BPF program to a `unbounded0` dummy
 interface. It uses LPM (Longest Prefix Match) trie maps for per-destination
 tunnel endpoint resolution. Tunnel interfaces (`geneve0`, `vxlan0`, `ipip0`)
 are shared across all peers using flow-based encapsulation.
 
-**Advantages:** Fewer kernel objects at scale, shared tunnel interfaces,
-efficient map-based lookups.
-
-### Netlink (legacy)
-
-The netlink dataplane creates per-peer tunnel interfaces and programs routes
-using standard kernel routing tables.
-
-**Advantages:** Simpler debugging with standard `ip route` tools.
+This design minimizes kernel objects at scale, shares tunnel interfaces, and
+provides efficient map-based lookups.
 
 ## How It Relates to unbounded-kube
 

--- a/docs/content/concepts/overview.md
+++ b/docs/content/concepts/overview.md
@@ -106,7 +106,7 @@ connectivity across sites by:
 - Grouping nodes into **Sites** based on their internal IPs.
 - Routing cross-site traffic through **Gateway** nodes using configurable
   tunnels (WireGuard, GENEVE, VXLAN, IPIP, or direct routing).
-- Running an eBPF or netlink dataplane on each node to program routes.
+- Running an eBPF dataplane on each node to program routes.
 
 See the [Networking concepts]({{< relref "concepts/networking" >}}) for an
 introduction and the

--- a/docs/content/reference/networking/architecture.md
+++ b/docs/content/reference/networking/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: "Architecture"
 weight: 1
-description: "Deep dive into unbounded-net system design, dataplanes, data flows, and security."
+description: "Deep dive into unbounded-net system design, dataplane, data flows, and security."
 ---
 
 This document provides a detailed overview of unbounded-net's architecture,
@@ -15,10 +15,8 @@ sites using encrypted (WireGuard) or unencrypted (GENEVE, VXLAN, IPIP) tunnels.
 The encapsulation type is selected per link scope and can be set explicitly or
 resolved automatically based on link characteristics.
 
-The data plane supports two modes: **eBPF** (default) and **netlink**. The eBPF
-dataplane uses a TC egress BPF program and LPM trie maps for tunnel endpoint
-resolution, while the netlink dataplane uses per-peer tunnel interfaces and
-kernel routing tables.
+The eBPF dataplane uses a TC egress BPF program and LPM trie maps for tunnel
+endpoint resolution.
 
 ### High-Level Architecture
 
@@ -73,7 +71,7 @@ The node agent runs as a DaemonSet on every node, including control plane nodes.
 It manages:
 
 - WireGuard interfaces and key management
-- Tunnel configuration (eBPF or netlink)
+- Tunnel configuration
 - eBPF program lifecycle and BPF map reconciliation
 - Route programming
 - CNI bridge configuration
@@ -186,9 +184,7 @@ the link uses WireGuard regardless of other scopes.
 See [Routing Flows]({{< relref "reference/networking/routing-flows" >}}) for
 the full protocol selection algorithm.
 
-## Tunnel Dataplane Modes
-
-### eBPF Dataplane (default)
+## Tunnel Dataplane
 
 Uses a single dummy device (`unbounded0`) as a routing anchor, a TC egress BPF
 program for tunnel endpoint resolution, and shared flow-based tunnel interfaces.
@@ -240,22 +236,9 @@ Entries are not applied incrementally. Each protocol appends entries to a
 pending map, then a single `Reconcile()` call atomically deletes stale entries
 and upserts desired entries, keeping IPv4 and IPv6 tries synchronized.
 
-### Netlink Dataplane (legacy)
-
-Creates per-peer tunnel interfaces and uses kernel routing tables:
-
-- Each GENEVE peer gets `gn<decimal_ip>` (fixed remote endpoint and VNI).
-- Each IPIP peer gets `ip<decimal_ip>`.
-- VXLAN uses a single shared `vxlan0` with lightweight tunnel encap metadata
-  on each route.
-- WireGuard works identically in both modes.
-
-The netlink dataplane is simpler but creates more kernel objects as the mesh
-grows.
-
 ## Data Flows
 
-### Same-Site Pod-to-Pod (eBPF, GENEVE)
+### Same-Site Pod-to-Pod (GENEVE)
 
 ![Same-site pod-to-pod flow: Pod A through cbr0, kernel routing, unbounded0, TC egress BPF with LPM lookup, GENEVE encap over LAN to Pod B](../../../img/networking-same-site-flow.svg)
 

--- a/docs/content/reference/networking/operations.md
+++ b/docs/content/reference/networking/operations.md
@@ -13,10 +13,10 @@ For configuration details, see
 ### Prerequisites
 
 1. **Kubernetes cluster** (1.24+)
-2. **WireGuard** kernel module on all nodes (for encrypted tunnels), or
-   eBPF/TC kernel support (for GENEVE/VXLAN/IPIP tunnels)
-3. Container runtime with CNI support
-4. Network connectivity between sites (UDP ports)
+2. eBPF/TC kernel support on all nodes
+3. **WireGuard** kernel module on nodes that use encrypted tunnels
+4. Container runtime with CNI support
+5. Network connectivity between sites (UDP ports)
 
 ### Verifying WireGuard Support
 
@@ -118,18 +118,18 @@ All pods carry `prometheus.io/*` annotations for automatic discovery.
 
 ### Viewing Tunnel Status
 
-**WireGuard mode:**
+**WireGuard status:**
 ```bash
 wg show all
 ```
 
-**eBPF mode -- verify BPF attachment:**
+**Verify BPF attachment:**
 ```bash
 tc filter show dev unbounded0 egress
 # Expected: bpf filter with "unbounded_encap direct-action"
 ```
 
-**eBPF mode -- dump BPF maps:**
+**Dump BPF maps:**
 ```bash
 bpftool map list | grep unbounded
 bpftool map dump name unb_endpts
@@ -201,7 +201,7 @@ procedure.
 
 ### Interface Verification
 
-**eBPF mode:**
+**Dataplane interfaces:**
 ```bash
 ip link show unbounded0       # Should have NOARP flag
 ip link show geneve0          # Flow-based GENEVE (if active)
@@ -210,7 +210,7 @@ ip link show ipip0            # Shared IPIP (if active)
 ip route show dev unbounded0  # Supernet routes (scope global)
 ```
 
-**WireGuard mode:**
+**WireGuard interfaces:**
 ```bash
 ip link show type wireguard
 ip route show dev wg51820

--- a/docs/content/reference/networking/routing-flows.md
+++ b/docs/content/reference/networking/routing-flows.md
@@ -1,14 +1,14 @@
 ---
 title: "Routing Flows"
 weight: 4
-description: "Packet-level routing flows for eBPF and netlink dataplanes, and protocol selection."
+description: "Packet-level routing flows for the eBPF dataplane and protocol selection."
 ---
 
-This document describes the detailed packet-level routing flows for both
-dataplane modes. For architecture context, see
+This document describes the detailed packet-level routing flows for the
+eBPF dataplane. For architecture context, see
 [Architecture]({{< relref "reference/networking/architecture" >}}).
 
-## eBPF Dataplane Mode (default)
+## eBPF Dataplane
 
 The eBPF dataplane uses a single TC egress BPF program (`unbounded_encap`)
 attached to the `unbounded0` dummy interface. All overlay traffic is attracted
@@ -121,38 +121,6 @@ cross-interface forwarding on gateway nodes.
 BPF map entries are accumulated in `pendingBPFEntries`, then a single
 `reconcilePendingBPFEntries()` call atomically deletes stale entries and
 upserts desired entries. This prevents partial/inconsistent state.
-
----
-
-## Netlink Dataplane Mode (legacy)
-
-The netlink dataplane creates per-peer tunnel interfaces and uses kernel
-routing tables.
-
-### Intra-Site Mesh (GENEVE)
-
-Each peer gets `gn<decimal_ip>` (uint32 of peer's underlay IPv4). The interface
-has a fixed remote endpoint and VNI; kernel routes for the peer's pod CIDRs
-point to it.
-
-### Per-Peer IPIP
-
-Each peer gets `ip<decimal_ip>`. Minimal overhead (20 bytes), no VNI
-multiplexing, no encryption.
-
-### Shared VXLAN
-
-A single `vxlan0` interface with per-peer routing via lightweight tunnel
-encap metadata:
-```
-ip route add <peer_cidr> encap ip src <local_ip> dst <peer_ip> dev vxlan0
-```
-
-### WireGuard in Netlink Mode
-
-Identical to eBPF mode. Kernel routes point directly to `wg<port>` interfaces.
-
----
 
 ## Protocol Selection
 

--- a/docs/net/architecture.md
+++ b/docs/net/architecture.md
@@ -6,7 +6,7 @@ This document provides a detailed overview of unbounded-net's architecture, comp
 
 ## System Overview
 
-unbounded-net is designed to provide seamless pod-to-pod networking across multiple Kubernetes sites using encrypted (WireGuard) or unencrypted (GENEVE, VXLAN, IPIP) tunnels. The encapsulation type is selected per link scope and can be set explicitly or resolved automatically based on link characteristics. The data plane supports two modes: **eBPF** (default) and **netlink**. The eBPF dataplane uses a TC egress BPF program and LPM trie maps for tunnel endpoint resolution, while the netlink dataplane uses per-peer tunnel interfaces and kernel routing tables.
+unbounded-net is designed to provide seamless pod-to-pod networking across multiple Kubernetes sites using encrypted (WireGuard) or unencrypted (GENEVE, VXLAN, IPIP) tunnels. The encapsulation type is selected per link scope and can be set explicitly or resolved automatically based on link characteristics. The eBPF dataplane uses a TC egress BPF program and LPM trie maps for tunnel endpoint resolution.
 
 ```mermaid
 graph TB
@@ -22,7 +22,7 @@ graph TB
         CTRL --> GC
     end
 
-    subgraph "Data Plane (eBPF mode)"
+    subgraph "Data Plane"
         subgraph "Node 1"
             NA1[Node Agent]
             UB1[unbounded0<br/>dummy NOARP]
@@ -271,9 +271,9 @@ Routes are programmed directly into the kernel via netlink using nexthop objects
 The node agent supports multiple encapsulation types for tunnel links:
 
 - **WireGuard**: Encrypted tunneling using the WireGuard protocol. Used by default for links that traverse untrusted networks (external/public IPs). Overhead: 80 bytes (IPv6 worst case).
-- **GENEVE**: Unencrypted Generic Network Virtualization Encapsulation. Used by default for links using only internal IPs (same-site, network-peered sites, internal gateway pools). Overhead: 58 bytes. A single `geneve0` interface with FDB entries handles all GENEVE peers for higher throughput on high-bandwidth links.
+- **GENEVE**: Unencrypted Generic Network Virtualization Encapsulation. Used by default for links using only internal IPs (same-site, network-peered sites, internal gateway pools). Overhead: 58 bytes. Uses the shared flow-based `geneve0` interface.
 - **VXLAN**: VXLAN encapsulation using a single external flow-based `vxlan0` interface. Similar overhead to GENEVE (~58 bytes). Useful when the underlying network has better VXLAN hardware offload support.
-- **IPIP**: IP-in-IP tunneling with minimal overhead (20 bytes). Uses per-peer tunnel interfaces. Best for environments where encryption is not needed and minimal encapsulation overhead is desired.
+- **IPIP**: IP-in-IP tunneling with minimal overhead (20 bytes). Uses the shared flow-based `ipip0` interface. Best for environments where encryption is not needed and minimal encapsulation overhead is desired.
 - **None**: Direct routing with no encapsulation. Requires L3 reachability between nodes. Zero overhead but no isolation.
 - **Auto**: System selects based on link characteristics. Links using external IPs resolve to WireGuard; links using only internal IPs resolve to GENEVE (configurable via `--preferred-private-encap` and `--preferred-public-encap` flags).
 
@@ -386,7 +386,7 @@ The node agent reconciles BPF map entries whenever the desired peer state change
 
 #### Shared Tunnel Interfaces
 
-In eBPF mode, tunnel interfaces are shared across all peers of the same type:
+Tunnel interfaces are shared across all peers of the same type:
 
 - **`geneve0`**: Flow-based GENEVE interface. BPF sets the remote endpoint and VNI via `bpf_skb_set_tunnel_key()`.
 - **`vxlan0`**: Flow-based VXLAN interface. Same metadata-driven approach as GENEVE.
@@ -426,7 +426,7 @@ The `unroute` tool (`cmd/unroute/main.go`) is a diagnostic utility for the eBPF 
 
 ## Data Flow
 
-### Pod-to-Pod Communication (Same Site, eBPF mode)
+### Pod-to-Pod Communication (Same Site)
 
 ```mermaid
 sequenceDiagram
@@ -750,7 +750,7 @@ flowchart LR
 | **Link Manager** | Network interfaces | Creates/updates interfaces; removes stale gateway interfaces |
 | **Masquerade Manager** | iptables NAT rules | Compares current vs desired rules; only adds/removes differences |
 | **ECMP Route Manager** | Multi-path routes | Adds/removes gateways from ECMP nexthop groups |
-| **BPF Map Reconciler** | LPM trie entries (eBPF mode) | Iterates existing map entries; deletes stale, upserts changed, keeps matching |
+| **BPF Map Reconciler** | LPM trie entries | Iterates existing map entries; deletes stale, upserts changed, keeps matching |
 
 This approach ensures:
 - No unnecessary interface flapping
@@ -766,7 +766,7 @@ Multiple gateway interfaces enable kernel-level ECMP load balancing via netlink 
 - Nexthop groups provide ECMP across multiple gateway interfaces
 - Kernel automatically distributes traffic per-flow (same flow = same path)
 
-In eBPF dataplane mode, BPF-level ECMP is also available. Each LPM trie entry
+BPF-level ECMP is also available. Each LPM trie entry
 supports up to 4 nexthops per CIDR prefix with **HRW (Highest Random Weight)**
 consistent hashing. HRW selects a nexthop per 5-tuple flow so that when a
 nexthop fails, only flows assigned to that nexthop are rehashed. Each nexthop

--- a/docs/net/operations.md
+++ b/docs/net/operations.md
@@ -9,11 +9,10 @@ This guide covers deployment, monitoring, troubleshooting, and operational proce
 ### Prerequisites
 
 1. **Kubernetes cluster** (1.24+)
-2. **Tunnel dataplane** -- one of:
-   - **WireGuard** kernel module on all nodes (encrypted tunnels)
-   - **eBPF** with GENEVE, VXLAN, or IPIP tunnels (requires kernel eBPF/TC support)
-3. **Container runtime** with CNI support
-4. **Network connectivity** between sites (UDP ports)
+2. **eBPF/TC** kernel support on all nodes
+3. **WireGuard** kernel module on nodes that use encrypted tunnels
+4. **Container runtime** with CNI support
+5. **Network connectivity** between sites (UDP ports)
 
 ### Verifying WireGuard Support
 
@@ -415,7 +414,7 @@ graph TD
 
 ### Viewing Tunnel Status
 
-#### WireGuard Mode
+#### WireGuard Status
 
 ```bash
 # On a node, show WireGuard status
@@ -455,9 +454,9 @@ ip route | grep 'wg'
 
 ### eBPF Dataplane Verification
 
-When using the eBPF dataplane (GENEVE, VXLAN, or IPIP tunnels), verification differs
-from WireGuard mode. Traffic is forwarded by a TC eBPF program attached to the
-`unbounded0` dummy interface rather than by per-peer kernel routes.
+Traffic is forwarded by a TC eBPF program attached to the `unbounded0` dummy
+interface. The following checks verify the dataplane independently of the
+selected tunnel protocol.
 
 #### Verifying BPF Program Attachment
 
@@ -525,7 +524,7 @@ The kubectl plugin supports viewing BPF entries for a node:
 # Show BPF map entries for a node
 kubectl unbounded net node show <node-name> bpf
 
-# Show routes for a node (supernet routes on unbounded0 in eBPF mode)
+# Show routes for a node (supernet routes on unbounded0)
 kubectl unbounded net node show <node-name> routes
 
 # Show full status JSON for a node
@@ -534,7 +533,7 @@ kubectl unbounded net node show <node-name> json
 
 ### Interface Verification
 
-#### WireGuard Mode
+#### WireGuard Interfaces
 
 ```bash
 # Check WireGuard interfaces
@@ -542,9 +541,9 @@ ip link show type wireguard
 wg show all
 ```
 
-#### eBPF Mode
+#### Dataplane Interfaces
 
-In eBPF mode, three types of interfaces are used:
+The dataplane uses the following interfaces:
 
 | Interface | Type | Purpose |
 |-----------|------|---------|
@@ -587,9 +586,7 @@ ip link show geneve0 | grep link/ether
 # The BPF program uses the same formula to set the source MAC on encapsulated packets
 ```
 
-### Route Verification (eBPF Mode)
-
-In eBPF mode, routes are configured differently from WireGuard mode:
+### Route Verification
 
 - **Supernet routes** are installed on `unbounded0` with `scope global` (not `scope link`).
   These attract pod traffic to the dummy interface, where the TC eBPF program handles
@@ -604,16 +601,14 @@ ip route show dev unbounded0
 # Expected: broad CIDR prefixes with scope global, e.g.:
 #   100.64.0.0/14 scope global
 
-# Confirm no per-peer routes on tunnel interfaces
-# (Unlike WireGuard mode, geneve0/vxlan0/ipip0 should have no routes)
+# Confirm no per-peer routes on flow-based tunnel interfaces
 ip route show dev geneve0 2>/dev/null
 ip route show dev vxlan0 2>/dev/null
 ip route show dev ipip0 2>/dev/null
 ```
 
-In WireGuard mode, per-peer routes are installed on `wg*` devices instead:
+For links that use WireGuard, inspect the corresponding `wg*` devices:
 ```bash
-# WireGuard mode routes (for comparison)
 ip route show dev wg51820
 ip route show dev wg51821
 ```
@@ -636,7 +631,7 @@ The node agent status server listens on port 9998 (configurable via `--health-po
 # Liveness check
 curl http://<node-agent-pod-ip>:9998/healthz
 
-# Full status JSON (includes BpfEntries when using eBPF dataplane)
+# Full status JSON (includes BpfEntries)
 curl http://<node-agent-pod-ip>:9998/status/json
 
 # Prometheus metrics
@@ -692,16 +687,14 @@ curl -s http://<controller-pod-ip>:9999/status/json | python3 -m json.tool | hea
 ### Unused Device Cleanup
 
 When the tunnel protocol changes for a peer (e.g., from GENEVE to VXLAN, or from
-WireGuard to eBPF), unused tunnel devices are automatically removed by the node agent
+WireGuard to GENEVE), unused tunnel devices are automatically removed by the node agent
 during reconciliation:
 
-- **eBPF mode**: `geneve0`, `vxlan0`, and `ipip0` are each removed if no active peer
+- `geneve0`, `vxlan0`, and `ipip0` are each removed if no active peer
   uses that protocol. For example, if all peers switch from GENEVE to VXLAN, the
   `geneve0` device is deleted.
-- **WireGuard mode**: If no WireGuard peers remain, the `wg*` mesh interface is deleted
+- If no WireGuard peers remain, the `wg*` mesh interface is deleted
   and routes are re-synced.
-- **Legacy cleanup**: Obsolete per-peer tunnel interfaces (e.g., `gn*`, `ip*` prefixed
-  links from older netlink-mode runs) are also removed.
 
 No manual intervention is needed -- the node agent handles cleanup automatically during
 each reconciliation cycle.
@@ -940,13 +933,13 @@ bpftool map list | grep unbounded
 # BPF entry dump (from node agent pod)
 # kubectl -n unbounded-system exec <node-agent-pod> -- unroute
 
-# Interfaces (eBPF mode)
+# Dataplane interfaces
 ip link show unbounded0
 ip link show geneve0 2>/dev/null
 ip link show vxlan0 2>/dev/null
 ip link show ipip0 2>/dev/null
 
-# Routes (eBPF mode -- supernet routes on unbounded0)
+# Dataplane routes (supernet routes on unbounded0)
 ip route show dev unbounded0
 
 # === Per-Node Diagnostics (Common) ===
@@ -959,7 +952,7 @@ ip addr show | grep -E 'wg|cbr|unbounded|geneve|vxlan|ipip'
 # CNI configuration
 cat /etc/cni/net.d/10-unbounded.conflist
 
-# WireGuard keys (WireGuard mode only)
+# WireGuard keys
 ls -la /etc/wireguard/
 
 # === Controller Diagnostics ===
@@ -980,7 +973,7 @@ kubectl unbounded net node list
 # Show node details
 kubectl unbounded net node show <node-name> json
 
-# Show BPF entries for a node (eBPF mode)
+# Show BPF entries for a node
 kubectl unbounded net node show <node-name> bpf
 
 # Show routes for a node
@@ -1246,7 +1239,9 @@ valid.
 
 ### Network Policies
 
-unbounded-system traffic can use WireGuard encryption (default for cross-site links), but internal links may use unencrypted tunneling (GENEVE, VXLAN, IPIP) in both WireGuard and eBPF dataplane modes. You may want additional network policies:
+unbounded-system traffic can use WireGuard encryption (default for cross-site
+links), while internal links may use unencrypted tunneling (GENEVE, VXLAN, or
+IPIP). You may want additional network policies:
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/docs/net/routing-flows.md
+++ b/docs/net/routing-flows.md
@@ -2,12 +2,11 @@
 
 # Routing Flows
 
-This document describes the detailed packet-level routing flows for both the
-eBPF dataplane (default) and the netlink dataplane (legacy). It covers
-intra-site mesh traffic, cross-site gateway transit, reply-path symmetry, and
-protocol selection.
+This document describes the detailed packet-level routing flows for the eBPF
+dataplane. It covers intra-site mesh traffic, cross-site gateway transit,
+reply-path symmetry, and protocol selection.
 
-## eBPF Dataplane Mode (default)
+## eBPF Dataplane
 
 The eBPF dataplane uses a single TC egress BPF program (`unbounded_encap`)
 attached to the `unbounded0` dummy interface. All overlay traffic is attracted
@@ -582,8 +581,6 @@ returns `WireGuard`.
 | BPF program              | `bpf/unbounded_encap.c`                                   |
 | BPF map management       | `internal/net/ebpf/tunnel_map.go`                                  |
 | eBPF tunnel setup        | `cmd/unbounded-net-node/ebpf_geneve_config.go`            |
-| Netlink GENEVE/IPIP      | `cmd/unbounded-net-node/geneve_config.go`                 |
-| Netlink VXLAN            | `cmd/unbounded-net-node/vxlan_config.go`                  |
 | WireGuard config         | `cmd/unbounded-net-node/wireguard_config.go`              |
 | Gateway policy routing   | `pkg/netlink/gateway_policy_manager.go`                   |
 | Route manager            | `pkg/netlink/route_manager.go`                            |

--- a/docs/net/troubleshooting.md
+++ b/docs/net/troubleshooting.md
@@ -80,9 +80,10 @@ Each node agent exposes status on port 9998:
 
 ### Route mismatch
 
-- In eBPF mode, routes should be on unbounded0 (scope global), not on per-peer tunnel interfaces
+- Routes should be on unbounded0 (scope global), not on per-peer tunnel interfaces
 - Check: `ip route show dev unbounded0` -- should show supernet routes
-- Phantom routes on wg*/geneve0/vxlan0 that are "expected but not present" are normal in eBPF mode and should be suppressed by the annotation system
+- Phantom routes on wg*/geneve0/vxlan0 that are "expected but not present" are
+  normal and should be suppressed by the annotation system
 
 ### Migrating a node from Cilium to unbounded-net
 


### PR DESCRIPTION
## Summary

- remove references to the unsupported legacy netlink dataplane
- document eBPF as the single networking dataplane
- distinguish WireGuard and other tunnel protocols from dataplane selection
- retain references to netlink where it describes Linux kernel API usage

## Validation

- built the Hugo documentation site
- confirmed the node agent has no dataplane mode selector and always configures the eBPF tunnel map and TC program