### PR TITLE
operator: own the unbounded-system namespace

### DIFF
--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -167,17 +167,18 @@ func run(ctx context.Context, cfg config) error {
 
 	cfg.apiServerEndpoint = apiServerEndpoint
 
-	// Install/upgrade the CRDs before starting the manager: the typed Site
-	// informer cannot sync until the Site CRD is served, and the operator owns
-	// CRD lifecycle so a cluster can be maintained by applying the operator
-	// manifests alone. This runs on every start and is idempotent.
+	// Install/upgrade the operator-owned resources before starting the manager:
+	// the shared system namespace (labels + Pod Security Admission) and the CRDs.
+	// The typed Site informer cannot sync until the Site CRD is served, and the
+	// operator owns this lifecycle so a cluster can be maintained by applying the
+	// operator manifests alone. This runs on every start and is idempotent.
 	bootstrapClient, err := client.New(restConfig, client.Options{Scheme: scheme})
 	if err != nil {
 		return fmt.Errorf("create bootstrap client: %w", err)
 	}
 
-	if err := operator.BootstrapCRDs(ctx, bootstrapClient); err != nil {
-		return fmt.Errorf("bootstrap CRDs: %w", err)
+	if err := operator.BootstrapAll(ctx, bootstrapClient, namespace); err != nil {
+		return fmt.Errorf("bootstrap operator resources: %w", err)
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
@@ -193,8 +194,8 @@ func run(ctx context.Context, cfg config) error {
 		return fmt.Errorf("create manager: %w", err)
 	}
 
-	if err := mgr.Add(&operator.CRDMaintainer{Client: bootstrapClient}); err != nil {
-		return fmt.Errorf("add CRD maintainer: %w", err)
+	if err := mgr.Add(&operator.BootstrapMaintainer{Client: bootstrapClient, Namespace: namespace}); err != nil {
+		return fmt.Errorf("add bootstrap maintainer: %w", err)
 	}
 
 	if err := (&operator.SiteReconciler{

--- a/deploy/gantry/00-namespace.yaml.tmpl
+++ b/deploy/gantry/00-namespace.yaml.tmpl
@@ -1,0 +1,15 @@
+# The shared system namespace for all unbounded components. It is owned at
+# runtime by the unbounded-operator (see BootstrapNamespace), which is its single
+# writer; components skip Namespace objects during reconcile. This document is
+# kept here for the standalone `kubectl apply -f deploy/gantry` path and must
+# stay identical to the Namespace shipped by the other components.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ default "unbounded-system" .Namespace }}
+  labels:
+    app.kubernetes.io/name: unbounded-cloud
+    app.kubernetes.io/managed-by: unbounded-operator
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/deploy/gantry/serviceaccount.yaml.tmpl
+++ b/deploy/gantry/serviceaccount.yaml.tmpl
@@ -5,13 +5,9 @@
 #   - pods (list/watch) in its own namespace, filtered by the
 #     gantry label selector.
 #   - nodes (list/watch) cluster-wide for the zone label.
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ default "unbounded-system" .Namespace }}
-  labels:
-    app.kubernetes.io/name: gantry
+#
+# The shared system Namespace is declared in 00-namespace.yaml so it is
+# uniform across components and is the operator's single owned object.
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/machina/01-namespace.yaml.tmpl
+++ b/deploy/machina/01-namespace.yaml.tmpl
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ default "unbounded-system" .Namespace }}
+  labels:
+    app.kubernetes.io/name: unbounded-cloud
+    app.kubernetes.io/managed-by: unbounded-operator
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/deploy/net/00-namespace.yaml.tmpl
+++ b/deploy/net/00-namespace.yaml.tmpl
@@ -7,4 +7,7 @@ kind: Namespace
 metadata:
   name: {{ default "unbounded-system" .Namespace }}
   labels:
-    app.kubernetes.io/name: unbounded-net
+    app.kubernetes.io/name: unbounded-cloud
+    app.kubernetes.io/managed-by: unbounded-operator
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/deploy/unbounded-operator/00-namespace.yaml.tmpl
+++ b/deploy/unbounded-operator/00-namespace.yaml.tmpl
@@ -7,4 +7,7 @@ kind: Namespace
 metadata:
   name: {{ default "unbounded-system" .Namespace }}
   labels:
-    app.kubernetes.io/name: unbounded-operator
+    app.kubernetes.io/name: unbounded-cloud
+    app.kubernetes.io/managed-by: unbounded-operator
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/deploy/unbounded-storage-supervisor/01-namespace.yaml.tmpl
+++ b/deploy/unbounded-storage-supervisor/01-namespace.yaml.tmpl
@@ -6,3 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ default "unbounded-system" .Namespace }}
+  labels:
+    app.kubernetes.io/name: unbounded-cloud
+    app.kubernetes.io/managed-by: unbounded-operator
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/e2e/operator/namespace_bootstrap_e2e_test.go
+++ b/e2e/operator/namespace_bootstrap_e2e_test.go
@@ -1,0 +1,199 @@
+//go:build e2e
+
+// This file holds the kind-based integration test for BootstrapNamespace. It
+// validates the server-side-apply preservation contract against a real API
+// server (real corev1 Namespace schema, real granular per-key field ownership),
+// which the fake-client unit tests can only approximate. See
+// internal/operator/namespace.go for the contract under test.
+//
+// Guarded by `//go:build e2e` like the rest of this package; run via
+// `go test -tags=e2e ./e2e/operator/...`.
+package operatore2e
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/unbounded/internal/operator"
+	"github.com/Azure/unbounded/internal/unbounded"
+)
+
+const namespaceClusterName = "operator-namespace-e2e"
+
+// TestBootstrapNamespacePreservationAgainstAPIServer is the real-apiserver
+// counterpart to the fake-client preservation unit test. It stages the shared
+// system namespace under a distinct field manager (a stand-in for an admin,
+// GitOps tool, or policy engine) that owns a foreign label, a foreign
+// annotation, and a deliberately tightened PSA level, then runs
+// BootstrapNamespace and asserts:
+//
+//   - the foreign label and annotation survive untouched (per-key ownership),
+//   - the operator reasserts its own keys, correcting the PSA level back to
+//     privileged, and
+//   - the operator's managed-field set is exactly its four label keys and no
+//     annotations, which is what makes the preservation guarantee hold.
+func TestBootstrapNamespacePreservationAgainstAPIServer(t *testing.T) {
+	requireBins(t, "kind", "docker")
+
+	kubeconfig := createClusterNamed(t, namespaceClusterName)
+	cli := newClient(t, kubeconfig)
+	ctx := context.Background()
+
+	const (
+		foreignManager    = "gitops-e2e"
+		foreignLabelKey   = "example.com/team"
+		foreignLabelValue = "platform"
+		foreignAnnoKey    = "argocd.argoproj.io/tracking-id"
+		foreignAnnoValue  = "unbounded:/Namespace:unbounded-system"
+		psaEnforceKey     = "pod-security.kubernetes.io/enforce"
+	)
+
+	namespace := unbounded.DefaultSystemNamespace
+
+	// A third-party manager creates the namespace with its own label + annotation
+	// and a tightened PSA level. Because it applies under its own field manager,
+	// the apiserver records it as the owner of these keys.
+	applyForeignNamespace(ctx, t, cli, foreignManager, namespace, map[string]string{
+		foreignLabelKey: foreignLabelValue,
+		psaEnforceKey:   "restricted",
+	}, map[string]string{
+		foreignAnnoKey: foreignAnnoValue,
+	})
+
+	if err := operator.BootstrapNamespace(ctx, cli, namespace); err != nil {
+		t.Fatalf("BootstrapNamespace: %v", err)
+	}
+
+	ns := &corev1.Namespace{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
+		t.Fatalf("get namespace %s: %v", namespace, err)
+	}
+
+	// The foreign label survives.
+	if got := ns.Labels[foreignLabelKey]; got != foreignLabelValue {
+		t.Fatalf("foreign label %q = %q, want %q (must be preserved)", foreignLabelKey, got, foreignLabelValue)
+	}
+
+	// The foreign annotation survives.
+	if got := ns.Annotations[foreignAnnoKey]; got != foreignAnnoValue {
+		t.Fatalf("foreign annotation %q = %q, want %q (must be preserved)", foreignAnnoKey, got, foreignAnnoValue)
+	}
+
+	// The operator reasserts its own keys, including correcting the PSA level
+	// back to privileged.
+	for key, want := range unbounded.SystemNamespaceLabels() {
+		if got := ns.Labels[key]; got != want {
+			t.Fatalf("operator label %q = %q, want %q (operator is authoritative on its own keys)", key, got, want)
+		}
+	}
+
+	assertOperatorManagesOnlyItsLabels(t, ns, foreignManager)
+}
+
+// applyForeignNamespace server-side applies the namespace's labels and
+// annotations under fieldManager, so the apiserver records those keys as owned
+// by a manager other than the operator.
+func applyForeignNamespace(ctx context.Context, t *testing.T, cli client.Client, fieldManager, namespace string, labels, annotations map[string]string) {
+	t.Helper()
+
+	meta := map[string]any{"name": namespace}
+	if len(labels) > 0 {
+		meta["labels"] = toAnyMap(labels)
+	}
+
+	if len(annotations) > 0 {
+		meta["annotations"] = toAnyMap(annotations)
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata":   meta,
+	}}
+
+	applyCfg := client.ApplyConfigurationFromUnstructured(obj)
+	if err := cli.Apply(ctx, applyCfg, client.FieldOwner(fieldManager), client.ForceOwnership); err != nil {
+		t.Fatalf("apply namespace as %q: %v", fieldManager, err)
+	}
+}
+
+// assertOperatorManagesOnlyItsLabels inspects metadata.managedFields and proves
+// the operator's ownership is scoped to exactly its label keys: it owns every
+// key in SystemNamespaceLabels, owns no annotations, and the foreign manager
+// still has an ownership entry. This is the apiserver-level evidence behind the
+// preservation contract.
+func assertOperatorManagesOnlyItsLabels(t *testing.T, ns *corev1.Namespace, foreignManager string) {
+	t.Helper()
+
+	var operatorFields, foreignFields *metav1.FieldsV1
+
+	for i := range ns.ManagedFields {
+		entry := ns.ManagedFields[i]
+		switch entry.Manager {
+		case operator.FieldOwner:
+			if entry.Operation == metav1.ManagedFieldsOperationApply {
+				operatorFields = entry.FieldsV1
+			}
+		case foreignManager:
+			foreignFields = entry.FieldsV1
+		}
+	}
+
+	if operatorFields == nil {
+		t.Fatalf("no Apply managed-fields entry for operator manager %q; managedFields=%+v", operator.FieldOwner, ns.ManagedFields)
+	}
+
+	if foreignFields == nil {
+		t.Fatalf("foreign manager %q lost its managed-fields entry; it must retain ownership of its own keys", foreignManager)
+	}
+
+	metaFields := managedMetadataFields(t, operatorFields)
+
+	labelFields, ok := metaFields["f:labels"].(map[string]any)
+	if !ok {
+		t.Fatalf("operator manages no labels; f:metadata=%v", metaFields)
+	}
+
+	for key := range unbounded.SystemNamespaceLabels() {
+		if _, owned := labelFields["f:"+key]; !owned {
+			t.Fatalf("operator does not own label %q; owned label fields=%v", key, labelFields)
+		}
+	}
+
+	if _, hasAnnotations := metaFields["f:annotations"]; hasAnnotations {
+		t.Fatalf("operator must not own any annotations; f:metadata=%v", metaFields)
+	}
+}
+
+// managedMetadataFields unmarshals a FieldsV1 blob and returns the f:metadata
+// sub-tree (the map of owned metadata field paths).
+func managedMetadataFields(t *testing.T, fields *metav1.FieldsV1) map[string]any {
+	t.Helper()
+
+	set := map[string]any{}
+	if err := json.Unmarshal(fields.GetRawBytes(), &set); err != nil {
+		t.Fatalf("unmarshal managed fields: %v", err)
+	}
+
+	meta, ok := set["f:metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("managed fields have no f:metadata sub-tree; set=%v", set)
+	}
+
+	return meta
+}
+
+func toAnyMap(in map[string]string) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}

--- a/internal/operator/bootstrap.go
+++ b/internal/operator/bootstrap.go
@@ -35,7 +35,7 @@ const (
 	// apply phase while CRDBootstrapTimeout bounds the complete operation.
 	crdEstablishedTimeout = 2 * time.Minute
 
-	defaultCRDMaintenanceInterval = time.Minute
+	defaultBootstrapMaintenanceInterval = time.Minute
 )
 
 // CRDBootstrapTimeout bounds the complete CRD bootstrap, including manifest
@@ -78,36 +78,52 @@ func BootstrapCRDs(ctx context.Context, c client.Client) error {
 	return bootstrapCRDs(ctx, c, CRDBootstrapTimeout)
 }
 
-// CRDMaintainer periodically reapplies the operator-owned CRDs using an
-// uncached client. Maintenance failures are logged and retried on the next
-// interval; they never stop the manager. CRDs that are already established stay
-// served by the apiserver regardless of the operator's liveness, so stopping on
-// maintenance failures would needlessly take down the Site reconciler and the
-// migration reaper for what is typically a transient apiserver blip.
-type CRDMaintainer struct {
+// BootstrapAll applies the operator-owned bootstrap resources in order: the
+// shared system namespace (canonical identity + Pod Security Admission labels)
+// followed by the CRDs. It is idempotent and is the single bootstrap entry point
+// shared by operator startup and the periodic BootstrapMaintainer.
+func BootstrapAll(ctx context.Context, c client.Client, namespace string) error {
+	if err := BootstrapNamespace(ctx, c, namespace); err != nil {
+		return fmt.Errorf("bootstrap namespace: %w", err)
+	}
+
+	return BootstrapCRDs(ctx, c)
+}
+
+// BootstrapMaintainer periodically reapplies the operator-owned bootstrap
+// resources (the shared system namespace and the CRDs) using an uncached client.
+// Maintenance failures are logged and retried on the next interval; they never
+// stop the manager. CRDs that are already established stay served by the
+// apiserver regardless of the operator's liveness, so stopping on maintenance
+// failures would needlessly take down the Site reconciler and the migration
+// reaper for what is typically a transient apiserver blip.
+type BootstrapMaintainer struct {
 	Client    client.Client
+	Namespace string
 	Interval  time.Duration
 	Bootstrap func(context.Context, client.Client) error
 }
 
-// NeedLeaderElection ensures only the elected operator replica maintains CRDs.
-func (*CRDMaintainer) NeedLeaderElection() bool { return true }
+// NeedLeaderElection ensures only the elected operator replica runs maintenance.
+func (*BootstrapMaintainer) NeedLeaderElection() bool { return true }
 
-// Start runs CRD maintenance until the manager stops (context cancellation).
-// Maintenance failures are logged and retried on the next interval; they do not
-// stop the manager.
-func (m *CRDMaintainer) Start(ctx context.Context) error {
+// Start runs bootstrap maintenance until the manager stops (context
+// cancellation). Maintenance failures are logged and retried on the next
+// interval; they do not stop the manager.
+func (m *BootstrapMaintainer) Start(ctx context.Context) error {
 	interval := m.Interval
 	if interval <= 0 {
-		interval = defaultCRDMaintenanceInterval
+		interval = defaultBootstrapMaintenanceInterval
 	}
 
 	bootstrap := m.Bootstrap
 	if bootstrap == nil {
-		bootstrap = BootstrapCRDs
+		bootstrap = func(ctx context.Context, c client.Client) error {
+			return BootstrapAll(ctx, c, m.Namespace)
+		}
 	}
 
-	logger := log.FromContext(ctx).WithName("crd-maintainer")
+	logger := log.FromContext(ctx).WithName("bootstrap-maintainer")
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -126,7 +142,7 @@ func (m *CRDMaintainer) Start(ctx context.Context) error {
 
 				failures++
 
-				logger.Error(err, "CRD maintenance failed; will retry on the next interval", "consecutiveFailures", failures)
+				logger.Error(err, "bootstrap maintenance failed; will retry on the next interval", "consecutiveFailures", failures)
 
 				continue
 			}

--- a/internal/operator/bootstrap_test.go
+++ b/internal/operator/bootstrap_test.go
@@ -19,18 +19,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
-func TestCRDMaintainerNeedsLeaderElection(t *testing.T) {
-	if !(&CRDMaintainer{}).NeedLeaderElection() {
-		t.Fatal("CRDMaintainer must require leader election")
+func TestBootstrapMaintainerNeedsLeaderElection(t *testing.T) {
+	if !(&BootstrapMaintainer{}).NeedLeaderElection() {
+		t.Fatal("BootstrapMaintainer must require leader election")
 	}
 }
 
-func TestCRDMaintainerInvokesBootstrap(t *testing.T) {
+func TestBootstrapMaintainerInvokesBootstrap(t *testing.T) {
 	cli := fake.NewClientBuilder().Build()
 	ctx, cancel := context.WithCancel(context.Background())
 	called := make(chan struct{})
 
-	maintainer := &CRDMaintainer{
+	maintainer := &BootstrapMaintainer{
 		Client:   cli,
 		Interval: time.Millisecond,
 		Bootstrap: func(_ context.Context, got client.Client) error {
@@ -52,16 +52,16 @@ func TestCRDMaintainerInvokesBootstrap(t *testing.T) {
 	select {
 	case <-called:
 	default:
-		t.Fatal("CRDMaintainer did not invoke Bootstrap")
+		t.Fatal("BootstrapMaintainer did not invoke Bootstrap")
 	}
 }
 
-func TestCRDMaintainerCancellation(t *testing.T) {
+func TestBootstrapMaintainerCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	called := false
-	maintainer := &CRDMaintainer{
+	maintainer := &BootstrapMaintainer{
 		Interval: time.Hour,
 		Bootstrap: func(context.Context, client.Client) error {
 			called = true
@@ -79,14 +79,14 @@ func TestCRDMaintainerCancellation(t *testing.T) {
 	}
 }
 
-func TestCRDMaintainerKeepsRetryingOnPersistentFailureWithoutStopping(t *testing.T) {
+func TestBootstrapMaintainerKeepsRetryingOnPersistentFailureWithoutStopping(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	wantErr := errors.New("apply failed")
 	calls := make(chan struct{}, 16)
 
-	maintainer := &CRDMaintainer{
+	maintainer := &BootstrapMaintainer{
 		Interval: time.Millisecond,
 		Bootstrap: func(context.Context, client.Client) error {
 			select {
@@ -119,7 +119,7 @@ func TestCRDMaintainerKeepsRetryingOnPersistentFailureWithoutStopping(t *testing
 	}
 }
 
-func TestCRDMaintainerRetriesTransientFailureWithoutCrashing(t *testing.T) {
+func TestBootstrapMaintainerRetriesTransientFailureWithoutCrashing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -127,7 +127,7 @@ func TestCRDMaintainerRetriesTransientFailureWithoutCrashing(t *testing.T) {
 	recovered := make(chan struct{})
 	calls := 0
 
-	maintainer := &CRDMaintainer{
+	maintainer := &BootstrapMaintainer{
 		Interval: time.Millisecond,
 		Bootstrap: func(context.Context, client.Client) error {
 			calls++

--- a/internal/operator/component/env.go
+++ b/internal/operator/component/env.go
@@ -36,6 +36,14 @@ const (
 	// them during reconcile.
 	CRDKind = "CustomResourceDefinition"
 
+	// NamespaceKind is the Kind of a Namespace object in the embedded manifests.
+	// The shared system namespace is owned by the operator's namespace bootstrap
+	// (see BootstrapNamespace), which is its single writer, so components skip
+	// any Namespace object during reconcile. The Namespace docs remain in the
+	// per-component templates for the standalone `kubectl apply -f deploy/<x>`
+	// path, exactly like CRDs.
+	NamespaceKind = "Namespace"
+
 	// SiteLabelKey is the canonical node label for site membership
 	// (unbounded-cloud.io/site). Per-site components node-select on it.
 	SiteLabelKey = unboundedv1alpha3.MachineSiteLabelKey
@@ -205,6 +213,13 @@ func (e *Env) applyManifestData(ctx context.Context, data []byte, mutate func(*u
 		}
 
 		if obj.Object == nil {
+			continue
+		}
+
+		// The shared system namespace is owned solely by the operator's
+		// namespace bootstrap. Skipping it here keeps components from
+		// re-applying (and clobbering the labels of) the one namespace object.
+		if obj.GetKind() == NamespaceKind {
 			continue
 		}
 

--- a/internal/operator/component/env.go
+++ b/internal/operator/component/env.go
@@ -37,11 +37,13 @@ const (
 	CRDKind = "CustomResourceDefinition"
 
 	// NamespaceKind is the Kind of a Namespace object in the embedded manifests.
-	// The shared system namespace is owned by the operator's namespace bootstrap
-	// (see BootstrapNamespace), which is its single writer, so components skip
-	// any Namespace object during reconcile. The Namespace docs remain in the
+	// The one shared system namespace is owned by the operator's namespace
+	// bootstrap (see BootstrapNamespace), which is its single writer, so
+	// components skip that specific Namespace (matched by name, see
+	// BuildDefaultNamespace) during reconcile. The Namespace docs remain in the
 	// per-component templates for the standalone `kubectl apply -f deploy/<x>`
-	// path, exactly like CRDs.
+	// path, exactly like CRDs. The skip is scoped by name rather than Kind so a
+	// component that ever needs a distinct namespace is not silently dropped.
 	NamespaceKind = "Namespace"
 
 	// SiteLabelKey is the canonical node label for site membership
@@ -216,10 +218,13 @@ func (e *Env) applyManifestData(ctx context.Context, data []byte, mutate func(*u
 			continue
 		}
 
-		// The shared system namespace is owned solely by the operator's
-		// namespace bootstrap. Skipping it here keeps components from
-		// re-applying (and clobbering the labels of) the one namespace object.
-		if obj.GetKind() == NamespaceKind {
+		// The one shared system namespace is owned solely by the operator's
+		// namespace bootstrap. Skipping it here keeps components from re-applying
+		// (and clobbering the labels of) that namespace object. This runs before
+		// RetargetNamespace, so the object still carries its build-time name; the
+		// skip is scoped to that name (not the Namespace Kind) so any other
+		// Namespace object is applied normally.
+		if obj.GetKind() == NamespaceKind && obj.GetName() == BuildDefaultNamespace {
 			continue
 		}
 

--- a/internal/operator/component/env_test.go
+++ b/internal/operator/component/env_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/fstest"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +26,52 @@ import (
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 )
+
+// TestApplyManifestFSSkipsNamespace asserts the operator apply path never writes
+// a Namespace object: the shared system namespace is owned solely by the
+// operator's namespace bootstrap, so components that ship a Namespace in their
+// manifests (for the standalone kubectl-apply path) must not clobber it.
+func TestApplyManifestFSSkipsNamespace(t *testing.T) {
+	manifests := fstest.MapFS{
+		"00-namespace.yaml": {Data: []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: unbounded-system\n")},
+		"10-configmap.yaml": {Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n  namespace: unbounded-system\n")},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+
+	applied := map[string]bool{}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+			o, ok := obj.(interface {
+				GetKind() string
+				GetName() string
+			})
+			if !ok {
+				t.Fatalf("unexpected apply type %T", obj)
+			}
+
+			applied[o.GetKind()+"/"+o.GetName()] = true
+
+			return nil
+		},
+	}).Build()
+
+	env := &Env{Client: cl, Scheme: scheme, Namespace: BuildDefaultNamespace}
+	if err := env.ApplyManifestFS(context.Background(), manifests, nil); err != nil {
+		t.Fatalf("ApplyManifestFS: %v", err)
+	}
+
+	if applied["Namespace/unbounded-system"] {
+		t.Fatal("Namespace object must be skipped by the operator apply path")
+	}
+
+	if !applied["ConfigMap/demo"] {
+		t.Fatalf("non-Namespace object should be applied; applied=%#v", applied)
+	}
+}
 
 func TestConfigImage(t *testing.T) {
 	cfg := Config{ImageRegistry: "registry.example.com/mirror/", ImageTag: "v1.2.3"}

--- a/internal/operator/component/env_test.go
+++ b/internal/operator/component/env_test.go
@@ -28,13 +28,15 @@ import (
 )
 
 // TestApplyManifestFSSkipsNamespace asserts the operator apply path never writes
-// a Namespace object: the shared system namespace is owned solely by the
-// operator's namespace bootstrap, so components that ship a Namespace in their
-// manifests (for the standalone kubectl-apply path) must not clobber it.
+// the shared system Namespace object: it is owned solely by the operator's
+// namespace bootstrap, so components that ship it in their manifests (for the
+// standalone kubectl-apply path) must not clobber it. The skip is scoped by
+// name, so any other Namespace object is still applied.
 func TestApplyManifestFSSkipsNamespace(t *testing.T) {
 	manifests := fstest.MapFS{
-		"00-namespace.yaml": {Data: []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: unbounded-system\n")},
-		"10-configmap.yaml": {Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n  namespace: unbounded-system\n")},
+		"00-namespace.yaml":       {Data: []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: unbounded-system\n")},
+		"05-other-namespace.yaml": {Data: []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: other-ns\n")},
+		"10-configmap.yaml":       {Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n  namespace: unbounded-system\n")},
 	}
 
 	scheme := runtime.NewScheme()
@@ -65,7 +67,14 @@ func TestApplyManifestFSSkipsNamespace(t *testing.T) {
 	}
 
 	if applied["Namespace/unbounded-system"] {
-		t.Fatal("Namespace object must be skipped by the operator apply path")
+		t.Fatal("shared system Namespace object must be skipped by the operator apply path")
+	}
+
+	// A Namespace that is not the shared system namespace must still be applied:
+	// the skip is scoped by name so a future component that needs a distinct
+	// namespace is not silently dropped.
+	if !applied["Namespace/other-ns"] {
+		t.Fatalf("non-system Namespace object should be applied; applied=%#v", applied)
 	}
 
 	if !applied["ConfigMap/demo"] {

--- a/internal/operator/components/gantry/gantry_test.go
+++ b/internal/operator/components/gantry/gantry_test.go
@@ -5,6 +5,7 @@ package gantry
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -278,6 +279,15 @@ func TestReconcileAppliesCoreManifestsAndSkipsExamples(t *testing.T) {
 	// The gantry ConfigMap is reconciled separately, not via the manifest apply.
 	if applied["ConfigMap/gantry-config"] {
 		t.Fatal("gantry-config ConfigMap should be reconciled separately, not applied")
+	}
+
+	// The shared system namespace is owned by the operator's namespace
+	// bootstrap; a component reconcile must never apply (and clobber) it, even
+	// though gantry ships a Namespace doc for the standalone kubectl-apply path.
+	for key := range applied {
+		if strings.HasPrefix(key, "Namespace/") {
+			t.Fatalf("component reconcile applied a Namespace object %q; it must be skipped", key)
+		}
 	}
 }
 

--- a/internal/operator/namespace.go
+++ b/internal/operator/namespace.go
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/Azure/unbounded/internal/operator/component"
+	"github.com/Azure/unbounded/internal/unbounded"
+)
+
+// BootstrapNamespace server-side applies the shared system namespace with its
+// canonical identity and Pod Security Admission labels
+// (unbounded.SystemNamespaceLabels). It is the single owner of that namespace
+// object: components skip Namespace objects during reconcile (see
+// component.NamespaceKind), so this is the only place the operator writes it.
+//
+// Preservation contract: the apply declares only the operator's own label keys
+// and no annotations. Server-side apply tracks ownership per map key for
+// metadata.labels and metadata.annotations, so labels and annotations placed on
+// the namespace by any other actor (an admin, a GitOps tool, a policy engine)
+// are left untouched. ForceOwnership only makes the operator authoritative for
+// the keys it declares; it reasserts those (for example pod-security enforce =
+// privileged, which the privileged/hostPath workloads here require) without
+// disturbing anything else.
+//
+// It creates the namespace if absent and is idempotent, so it is safe to run on
+// every operator start and on the BootstrapMaintainer interval.
+func BootstrapNamespace(ctx context.Context, c client.Client, namespace string) error {
+	if namespace == "" {
+		namespace = unbounded.SystemNamespace()
+	}
+
+	// Installing into a pre-consolidation namespace is unsafe: the migration
+	// reaper drains and deletes those. Refuse rather than stamp labels on a
+	// namespace that is about to be removed.
+	if unbounded.IsLegacyNamespace(namespace) {
+		return fmt.Errorf("refusing to bootstrap legacy namespace %q", namespace)
+	}
+
+	labels := make(map[string]any)
+	for key, value := range unbounded.SystemNamespaceLabels() {
+		labels[key] = value
+	}
+
+	// Build a minimal object: only name and the operator-owned labels. Declaring
+	// nothing else (no annotations, no spec/status) keeps the operator's managed
+	// field set to exactly these label keys, which is what preserves everyone
+	// else's labels and annotations under server-side apply.
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       component.NamespaceKind,
+		"metadata": map[string]any{
+			"name":   namespace,
+			"labels": labels,
+		},
+	}}
+
+	applyCfg := client.ApplyConfigurationFromUnstructured(obj)
+	if err := c.Apply(ctx, applyCfg, client.FieldOwner(FieldOwner), client.ForceOwnership); err != nil {
+		return fmt.Errorf("apply namespace %s: %w", namespace, err)
+	}
+
+	log.FromContext(ctx).WithName("namespace-bootstrap").Info("applied system namespace", "namespace", namespace)
+
+	return nil
+}

--- a/internal/operator/namespace_test.go
+++ b/internal/operator/namespace_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -73,25 +73,26 @@ func TestBootstrapNamespaceIsIdempotent(t *testing.T) {
 // TestBootstrapNamespacePreservesForeignLabelsAndAnnotations is the core
 // preservation guarantee: labels and annotations placed on the namespace by
 // another actor survive a bootstrap, while the operator reasserts its own keys.
+//
+// The foreign keys are applied under a distinct field manager (not seeded as
+// unowned metadata) so this exercises the real multi-manager server-side-apply
+// path: the operator's ForceOwnership apply must reassert only the keys it
+// declares and leave keys owned by another manager untouched.
 func TestBootstrapNamespacePreservesForeignLabelsAndAnnotations(t *testing.T) {
-	existing := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: unbounded.DefaultSystemNamespace,
-			Labels: map[string]string{
-				"example.com/team": "platform",
-				// A third party deliberately tightened PSA; the operator owns
-				// this key and must reassert privileged (the workloads here
-				// require it).
-				"pod-security.kubernetes.io/enforce": "restricted",
-			},
-			Annotations: map[string]string{
-				"kubectl.kubernetes.io/last-applied-configuration": "{}",
-				"argocd.argoproj.io/tracking-id":                   "unbounded:/Namespace:unbounded-system",
-			},
-		},
+	foreignAnnotations := map[string]string{
+		"kubectl.kubernetes.io/last-applied-configuration": "{}",
+		"argocd.argoproj.io/tracking-id":                   "unbounded:/Namespace:unbounded-system",
 	}
 
-	c := namespaceTestClient(t, existing)
+	c := namespaceTestClient(t)
+
+	// A third party (GitOps tool) owns example.com/team and deliberately
+	// tightened PSA to restricted; the operator owns the PSA key and must
+	// reassert privileged (the workloads here require it).
+	applyAsForeignManager(t, c, "gitops", unbounded.DefaultSystemNamespace, map[string]string{
+		"example.com/team":                   "platform",
+		"pod-security.kubernetes.io/enforce": "restricted",
+	}, foreignAnnotations)
 
 	if err := BootstrapNamespace(context.Background(), c, unbounded.DefaultSystemNamespace); err != nil {
 		t.Fatalf("BootstrapNamespace: %v", err)
@@ -105,7 +106,7 @@ func TestBootstrapNamespacePreservesForeignLabelsAndAnnotations(t *testing.T) {
 	}
 
 	// Every foreign annotation survives untouched.
-	for key, want := range existing.Annotations {
+	for key, want := range foreignAnnotations {
 		if got := ns.Annotations[key]; got != want {
 			t.Fatalf("annotation %q = %q, want %q (annotations must be preserved)", key, got, want)
 		}
@@ -117,6 +118,43 @@ func TestBootstrapNamespacePreservesForeignLabelsAndAnnotations(t *testing.T) {
 			t.Fatalf("operator label %q = %q, want %q (operator is authoritative on its own keys)", key, ns.Labels[key], want)
 		}
 	}
+}
+
+// applyAsForeignManager server-side applies the namespace's labels and
+// annotations under fieldManager, so those keys are genuinely owned by a manager
+// other than the operator. This models an admin, GitOps tool, or policy engine
+// that maintains its own keys on the shared namespace.
+func applyAsForeignManager(t *testing.T, c client.Client, fieldManager, namespace string, labels, annotations map[string]string) {
+	t.Helper()
+
+	meta := map[string]any{"name": namespace}
+	if len(labels) > 0 {
+		meta["labels"] = toAnyMap(labels)
+	}
+
+	if len(annotations) > 0 {
+		meta["annotations"] = toAnyMap(annotations)
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata":   meta,
+	}}
+
+	applyCfg := client.ApplyConfigurationFromUnstructured(obj)
+	if err := c.Apply(context.Background(), applyCfg, client.FieldOwner(fieldManager), client.ForceOwnership); err != nil {
+		t.Fatalf("apply namespace as %q: %v", fieldManager, err)
+	}
+}
+
+func toAnyMap(in map[string]string) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
 }
 
 func TestBootstrapNamespaceRefusesLegacyNamespace(t *testing.T) {

--- a/internal/operator/namespace_test.go
+++ b/internal/operator/namespace_test.go
@@ -166,12 +166,18 @@ func TestBootstrapNamespaceRefusesLegacyNamespace(t *testing.T) {
 }
 
 func TestBootstrapNamespaceDefaultsEmptyNamespace(t *testing.T) {
+	// Pin POD_NAMESPACE empty so the empty-namespace argument exercises the
+	// documented fallback to the build default rather than whatever namespace
+	// the test process happens to run in.
+	t.Setenv("POD_NAMESPACE", "")
+
 	c := namespaceTestClient(t)
 
 	if err := BootstrapNamespace(context.Background(), c, ""); err != nil {
 		t.Fatalf("BootstrapNamespace with empty namespace: %v", err)
 	}
 
-	// SystemNamespace() falls back to the default when POD_NAMESPACE is unset.
-	getNamespace(t, c, unbounded.SystemNamespace())
+	// With POD_NAMESPACE unset, an empty namespace falls back to the build
+	// default (DefaultSystemNamespace).
+	getNamespace(t, c, unbounded.DefaultSystemNamespace)
 }

--- a/internal/operator/namespace_test.go
+++ b/internal/operator/namespace_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package operator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/unbounded/internal/unbounded"
+)
+
+func namespaceTestClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func getNamespace(t *testing.T, c client.Client, name string) *corev1.Namespace {
+	t.Helper()
+
+	ns := &corev1.Namespace{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: name}, ns); err != nil {
+		t.Fatalf("get namespace %s: %v", name, err)
+	}
+
+	return ns
+}
+
+func TestBootstrapNamespaceStampsCanonicalLabels(t *testing.T) {
+	c := namespaceTestClient(t)
+
+	if err := BootstrapNamespace(context.Background(), c, unbounded.DefaultSystemNamespace); err != nil {
+		t.Fatalf("BootstrapNamespace: %v", err)
+	}
+
+	ns := getNamespace(t, c, unbounded.DefaultSystemNamespace)
+	for key, want := range unbounded.SystemNamespaceLabels() {
+		if ns.Labels[key] != want {
+			t.Fatalf("namespace label %q = %q, want %q", key, ns.Labels[key], want)
+		}
+	}
+}
+
+func TestBootstrapNamespaceIsIdempotent(t *testing.T) {
+	c := namespaceTestClient(t)
+
+	for i := 0; i < 2; i++ {
+		if err := BootstrapNamespace(context.Background(), c, unbounded.DefaultSystemNamespace); err != nil {
+			t.Fatalf("BootstrapNamespace pass %d: %v", i, err)
+		}
+	}
+
+	ns := getNamespace(t, c, unbounded.DefaultSystemNamespace)
+	for key, want := range unbounded.SystemNamespaceLabels() {
+		if ns.Labels[key] != want {
+			t.Fatalf("namespace label %q = %q, want %q", key, ns.Labels[key], want)
+		}
+	}
+}
+
+// TestBootstrapNamespacePreservesForeignLabelsAndAnnotations is the core
+// preservation guarantee: labels and annotations placed on the namespace by
+// another actor survive a bootstrap, while the operator reasserts its own keys.
+func TestBootstrapNamespacePreservesForeignLabelsAndAnnotations(t *testing.T) {
+	existing := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: unbounded.DefaultSystemNamespace,
+			Labels: map[string]string{
+				"example.com/team": "platform",
+				// A third party deliberately tightened PSA; the operator owns
+				// this key and must reassert privileged (the workloads here
+				// require it).
+				"pod-security.kubernetes.io/enforce": "restricted",
+			},
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": "{}",
+				"argocd.argoproj.io/tracking-id":                   "unbounded:/Namespace:unbounded-system",
+			},
+		},
+	}
+
+	c := namespaceTestClient(t, existing)
+
+	if err := BootstrapNamespace(context.Background(), c, unbounded.DefaultSystemNamespace); err != nil {
+		t.Fatalf("BootstrapNamespace: %v", err)
+	}
+
+	ns := getNamespace(t, c, unbounded.DefaultSystemNamespace)
+
+	// Foreign labels survive.
+	if got := ns.Labels["example.com/team"]; got != "platform" {
+		t.Fatalf("foreign label example.com/team = %q, want platform (must be preserved)", got)
+	}
+
+	// Every foreign annotation survives untouched.
+	for key, want := range existing.Annotations {
+		if got := ns.Annotations[key]; got != want {
+			t.Fatalf("annotation %q = %q, want %q (annotations must be preserved)", key, got, want)
+		}
+	}
+
+	// The operator reasserts its own keys, including correcting the PSA level.
+	for key, want := range unbounded.SystemNamespaceLabels() {
+		if ns.Labels[key] != want {
+			t.Fatalf("operator label %q = %q, want %q (operator is authoritative on its own keys)", key, ns.Labels[key], want)
+		}
+	}
+}
+
+func TestBootstrapNamespaceRefusesLegacyNamespace(t *testing.T) {
+	c := namespaceTestClient(t)
+
+	if err := BootstrapNamespace(context.Background(), c, unbounded.LegacyKubeNamespace); err == nil {
+		t.Fatal("BootstrapNamespace must refuse a legacy namespace")
+	}
+}
+
+func TestBootstrapNamespaceDefaultsEmptyNamespace(t *testing.T) {
+	c := namespaceTestClient(t)
+
+	if err := BootstrapNamespace(context.Background(), c, ""); err != nil {
+		t.Fatalf("BootstrapNamespace with empty namespace: %v", err)
+	}
+
+	// SystemNamespace() falls back to the default when POD_NAMESPACE is unset.
+	getNamespace(t, c, unbounded.SystemNamespace())
+}

--- a/internal/unbounded/namespace_drift_test.go
+++ b/internal/unbounded/namespace_drift_test.go
@@ -17,11 +17,16 @@ import (
 
 // namespaceTemplate names a component's manifest template directory and the
 // rendered file (relative to that directory) that declares its Namespace
-// resource.
+// resource. operatorManaged marks the components the unbounded-operator
+// reconciles into the shared system namespace; those must ship the canonical
+// label set (SystemNamespaceLabels) so the direct-apply path matches the
+// operator's BootstrapNamespace. Standalone deploy flows (machine-ops, orca,
+// inventory) are name-checked only.
 type namespaceTemplate struct {
-	component    string
-	templatesDir string
-	renderedFile string
+	component       string
+	templatesDir    string
+	renderedFile    string
+	operatorManaged bool
 }
 
 // TestSystemNamespace_MatchesTemplateDefaults is the drift guard between the
@@ -36,14 +41,14 @@ func TestSystemNamespace_MatchesTemplateDefaults(t *testing.T) {
 	root := repoRoot(t)
 
 	templates := []namespaceTemplate{
-		{"machina", filepath.Join("deploy", "machina"), "01-namespace.yaml"},
-		{"machine-ops", filepath.Join("deploy", "machine-ops"), "00-namespace.yaml"},
-		{"orca", filepath.Join("deploy", "orca"), "01-namespace.yaml"},
-		{"storage-supervisor", filepath.Join("deploy", "unbounded-storage-supervisor"), "01-namespace.yaml"},
-		{"unbounded-operator", filepath.Join("deploy", "unbounded-operator"), "00-namespace.yaml"},
-		{"net", filepath.Join("deploy", "net"), "00-namespace.yaml"},
-		{"gantry", filepath.Join("deploy", "gantry"), "serviceaccount.yaml"},
-		{"inventory", filepath.Join("deploy", "inventory"), filepath.Join("common", "01-namespace.yaml")},
+		{"machina", filepath.Join("deploy", "machina"), "01-namespace.yaml", true},
+		{"machine-ops", filepath.Join("deploy", "machine-ops"), "00-namespace.yaml", false},
+		{"orca", filepath.Join("deploy", "orca"), "01-namespace.yaml", false},
+		{"storage-supervisor", filepath.Join("deploy", "unbounded-storage-supervisor"), "01-namespace.yaml", true},
+		{"unbounded-operator", filepath.Join("deploy", "unbounded-operator"), "00-namespace.yaml", true},
+		{"net", filepath.Join("deploy", "net"), "00-namespace.yaml", true},
+		{"gantry", filepath.Join("deploy", "gantry"), "00-namespace.yaml", true},
+		{"inventory", filepath.Join("deploy", "inventory"), filepath.Join("common", "01-namespace.yaml"), false},
 	}
 
 	for _, tc := range templates {
@@ -62,24 +67,46 @@ func TestSystemNamespace_MatchesTemplateDefaults(t *testing.T) {
 				t.Fatalf("read rendered %s: %v", tc.renderedFile, err)
 			}
 
-			name := namespaceResourceName(t, raw)
+			name, labels := namespaceResource(t, raw)
 			if name != systemNamespace {
 				t.Fatalf("%s template default namespace %q does not match systemNamespace %q; keep the const and the manifest template defaults in sync",
 					tc.component, name, systemNamespace)
+			}
+
+			if !tc.operatorManaged {
+				return
+			}
+
+			// Operator-managed components must ship the canonical labels + PSA
+			// so a direct `kubectl apply` yields the same namespace posture the
+			// operator's BootstrapNamespace maintains.
+			want := SystemNamespaceLabels()
+			for key, wantValue := range want {
+				if labels[key] != wantValue {
+					t.Fatalf("%s namespace label %q = %q, want %q; keep the template labels in sync with SystemNamespaceLabels",
+						tc.component, key, labels[key], wantValue)
+				}
+			}
+
+			for key := range labels {
+				if _, ok := want[key]; !ok {
+					t.Fatalf("%s namespace carries unexpected label %q; the operator-managed namespace must ship exactly SystemNamespaceLabels", tc.component, key)
+				}
 			}
 		})
 	}
 }
 
-// namespaceResourceName extracts metadata.name from the `kind: Namespace`
-// document in a (possibly multi-document) rendered manifest.
-func namespaceResourceName(t *testing.T, manifest []byte) string {
+// namespaceResource extracts metadata.name and metadata.labels from the
+// `kind: Namespace` document in a (possibly multi-document) rendered manifest.
+func namespaceResource(t *testing.T, manifest []byte) (string, map[string]string) {
 	t.Helper()
 
 	type k8sObject struct {
 		Kind     string `json:"kind"`
 		Metadata struct {
-			Name string `json:"name"`
+			Name   string            `json:"name"`
+			Labels map[string]string `json:"labels"`
 		} `json:"metadata"`
 	}
 
@@ -95,13 +122,13 @@ func namespaceResourceName(t *testing.T, manifest []byte) string {
 		}
 
 		if obj.Kind == "Namespace" {
-			return obj.Metadata.Name
+			return obj.Metadata.Name, obj.Metadata.Labels
 		}
 	}
 
 	t.Fatal("no Namespace resource found in rendered manifest")
 
-	return ""
+	return "", nil
 }
 
 // repoRoot walks up from this test file's directory until it finds go.mod.

--- a/internal/unbounded/unbounded.go
+++ b/internal/unbounded/unbounded.go
@@ -54,3 +54,53 @@ const (
 func IsLegacyNamespace(ns string) bool {
 	return ns == LegacyKubeNamespace || ns == LegacyNetNamespace
 }
+
+const (
+	// SystemNamespaceAppName is the canonical value of the app.kubernetes.io/name
+	// label on the shared system namespace. Every component's manifest template
+	// declares this single value (rather than a per-component name) so the
+	// operator-owned namespace has one stable identity instead of a label that
+	// churns as each component reapplies it.
+	SystemNamespaceAppName = "unbounded-cloud"
+
+	// SystemNamespaceManagedBy is the value of the app.kubernetes.io/managed-by
+	// label on the shared system namespace.
+	SystemNamespaceManagedBy = "unbounded-operator"
+
+	// SystemNamespacePSAEnforce is the Pod Security Admission enforce level for
+	// the shared system namespace. The privileged workloads that run here
+	// (net-node hostNetwork, storage hostPath, gantry containerd socket and
+	// /etc/containerd/certs.d hostPath) require the privileged level; a stricter
+	// level would reject them at admission.
+	SystemNamespacePSAEnforce = "privileged"
+
+	// SystemNamespacePSAEnforceVersion pins the Pod Security Standard version the
+	// enforce level is evaluated against. "latest" tracks the cluster's current
+	// version; privileged is the most permissive level, so version drift is
+	// low-risk.
+	SystemNamespacePSAEnforceVersion = "latest"
+)
+
+// Well-known label keys stamped on the shared system namespace. They are the
+// only keys the operator manages on the namespace; see SystemNamespaceLabels.
+const (
+	appNameLabelKey           = "app.kubernetes.io/name"
+	appManagedByLabelKey      = "app.kubernetes.io/managed-by"
+	psaEnforceLabelKey        = "pod-security.kubernetes.io/enforce"
+	psaEnforceVersionLabelKey = "pod-security.kubernetes.io/enforce-version"
+)
+
+// SystemNamespaceLabels returns the canonical label set the operator stamps on
+// the shared system namespace. It is the single source of truth shared by the
+// operator's namespace bootstrap and the manifest-template drift guard, so the
+// Go-side owner and the rendered templates cannot diverge. The operator applies
+// these keys authoritatively (server-side apply, granular per-key ownership) and
+// leaves every other label and annotation on the namespace untouched.
+func SystemNamespaceLabels() map[string]string {
+	return map[string]string{
+		appNameLabelKey:           SystemNamespaceAppName,
+		appManagedByLabelKey:      SystemNamespaceManagedBy,
+		psaEnforceLabelKey:        SystemNamespacePSAEnforce,
+		psaEnforceVersionLabelKey: SystemNamespacePSAEnforceVersion,
+	}
+}


### PR DESCRIPTION
## Summary

Makes the unbounded-operator the sole owner of the shared `unbounded-system` Namespace object, fixing the multi-writer label churn and giving Pod Security Admission (PSA) labels a single home. Implements #529.

Previously net, machina, storage, and gantry each shipped their own `Namespace/unbounded-system` object, and the operator applied all of them under one server-side-apply field manager (`unbounded-operator`) with `ForceOwnership`. Because SSA replaces a manager's owned field set on each apply, the namespace was rewritten several times per reconcile pass and its `app.kubernetes.io/name` label churned between competing per-component values (`unbounded-net` -> stripped -> `gantry` -> ...). There was also no single owner for the PSA labels the privileged/hostPath workloads here require.

## What it does

- **`internal/unbounded`** - adds the canonical label set (`SystemNamespaceLabels`) as the single source of truth: `app.kubernetes.io/name=unbounded-cloud`, `app.kubernetes.io/managed-by=unbounded-operator`, and PSA `enforce=privileged` (version `latest`).
- **`component/env`** - adds `NamespaceKind` and skips `Namespace` objects centrally in `applyManifestData`, so no component (present or future) writes the namespace during reconcile.
- **`operator` (new `BootstrapNamespace`)** - server-side applies the namespace from a **minimal** object (name + the operator's own label keys only, no annotations). Granular per-key SSA ownership **preserves any labels and annotations placed by another actor** (admin, GitOps, policy engine) while the operator stays authoritative on its own keys (it reasserts `enforce=privileged`). Refuses legacy namespaces; creates the namespace if absent.
- **`operator`** - adds `BootstrapAll` (namespace then CRDs) and generalizes `CRDMaintainer` -> `BootstrapMaintainer` so the periodic maintainer reapplies the namespace alongside the CRDs. `main` wires both at startup + maintenance.
- **`deploy`** - unifies the `Namespace` doc across net/machina/storage/operator to the canonical labels + PSA, and splits gantry's Namespace out of `serviceaccount.yaml` into a standalone `00-namespace.yaml`. The docs stay in each component's manifests for the standalone `kubectl apply -f deploy/<x>` path, exactly like CRDs.

## Preservation contract

`BootstrapNamespace` is authoritative only for the keys it declares. All other labels and annotations on the namespace are preserved (per-key SSA ownership). `ForceOwnership` only makes the operator win on its own keys, e.g. correcting a third-party PSA downgrade back to `privileged`.

## Testing

- `BootstrapNamespace`: canonical labels, idempotency, legacy-namespace refusal, empty-namespace default, and the **third-party label + annotation preservation** guarantee (including reasserting a tampered PSA level).
- `applyManifestData`/`ApplyManifestFS` skips `Namespace`, applies everything else.
- Regression: a gantry reconcile pass applies no `Namespace`.
- The namespace drift guard now asserts the operator-managed templates carry exactly `SystemNamespaceLabels()`; gantry entry repointed to `00-namespace.yaml`.
- `make fmt`, `make lint` (0 issues), and `go test ./internal/operator/... ./internal/unbounded/... ./cmd/unbounded-operator/...` all pass.

## Note

The preservation guarantee relies on real apiserver SSA granular-map semantics. The fake-client tests pass (foreign keys preserved, operator keys reasserted), documenting intent, but this is worth a quick confirmation against a live cluster before merge.

Closes #529
