### PR TITLE
release: complete operator-managed artifacts

### DIFF
--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -282,8 +282,12 @@ jobs:
           mkdir -p dist/manifests
           tar -xzf "dist/unbounded-manifests-${TAG}.tar.gz" -C dist/manifests
           MANIFESTS_DIR="dist/manifests/unbounded-manifests-${TAG}"
-          if [[ ! -d "${MANIFESTS_DIR}/net" || ! -d "${MANIFESTS_DIR}/machina" || ! -d "${MANIFESTS_DIR}/unbounded-operator" ]]; then
-            echo "::error::Tarball is missing expected net/, machina/, or unbounded-operator/ subdir"
+          if [[ ! -d "${MANIFESTS_DIR}/net" ||
+                ! -d "${MANIFESTS_DIR}/machina" ||
+                ! -d "${MANIFESTS_DIR}/gantry" ||
+                ! -d "${MANIFESTS_DIR}/unbounded-storage-supervisor" ||
+                ! -d "${MANIFESTS_DIR}/unbounded-operator" ]]; then
+            echo "::error::Tarball is missing an expected component manifest directory"
             ls -la "${MANIFESTS_DIR}" || true
             exit 1
           fi
@@ -389,7 +393,9 @@ jobs:
             "deploy unbounded-operator" \
             "deploy unbounded-net-controller" \
             "ds unbounded-net-node" \
-            "deploy machina-controller"; do
+            "deploy machina-controller" \
+            "ds gantry-containerd-config" \
+            "ds gantry"; do
             set -- $target
             wait_exists "$1" "$2"
             kubectl -n "$NS" rollout status "$1/$2" --timeout=5m
@@ -419,7 +425,7 @@ jobs:
           kubectl -n "$NS" get deploy,ds,pods -o wide 2>&1
           echo "::endgroup::"
           echo "::group::Applied component images"
-          for kn in "deploy/unbounded-operator" "deploy/unbounded-net-controller" "ds/unbounded-net-node" "deploy/machina-controller"; do
+          for kn in "deploy/unbounded-operator" "deploy/unbounded-net-controller" "ds/unbounded-net-node" "deploy/machina-controller" "ds/gantry-containerd-config" "ds/gantry"; do
             img=$(kubectl -n "$NS" get "$kn" -o jsonpath='{.spec.template.spec.containers[*].image}' 2>/dev/null)
             printf '%s image=[%s]\n' "$kn" "$img"
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,8 @@ name: unbounded release
 #         -> net-images-manifest (multi-arch tag stitch + sign + SBOM attest)
 #     -> netboot-image     (PXE boot artifact image)
 #         -> metalman-image (stamped with the matching default netboot image)
-#     -> component-images  (matrix: machina, machine-ops-controller, orca, gantry, host-ubuntu2404)
+#     -> component-images  (matrix: machina, machine-ops-controller, unbounded-operator,
+#                           orca, gantry, unbounded-storage-supervisor, host-ubuntu2404)
 #     -> manifests-tarball (make release-manifests + cosign sign)
 #     -> storage-binaries  (matrix: amd64, arm64; binary + bundled libfabric)
 #     -> finalize          (attach extras + krew manifest)
@@ -629,6 +630,10 @@ jobs:
             file: images/gantry/Containerfile
             platforms: linux/amd64,linux/arm64
             trivy: true
+          - name: unbounded-storage-supervisor
+            file: images/unbounded-storage-supervisor/Containerfile
+            platforms: linux/amd64,linux/arm64
+            trivy: true
           - name: host-ubuntu2404
             file: images/host-ubuntu2404/Containerfile
             platforms: linux/amd64,linux/arm64
@@ -744,7 +749,9 @@ jobs:
           TAG="${{ needs.version.outputs.tag }}"
           make release-manifests unbounded-operator-release-manifest \
             VERSION="${TAG}" \
-            CONTAINER_REGISTRY="${{ env.REGISTRY }}"
+            CONTAINER_REGISTRY="${{ env.REGISTRY }}" \
+            NET_APISERVER_URL="" \
+            UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT=""
 
       - name: Sign manifests tarball with cosign (keyless)
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1316,7 +1316,7 @@ images-net-all: image-net-controller-local image-net-node-local ## Build all unb
 
 images-net-all-push: image-net-controller-push image-net-node-push ## Build and push all unbounded-net container images
 
-images-local: image-machina-local image-machine-ops-controller-local image-metalman-local image-unbounded-operator-local image-net-controller-local image-net-node-local ## Build all container images locally
+images-local: image-machina-local image-machine-ops-controller-local image-metalman-local image-unbounded-storage-supervisor-local image-unbounded-operator-local image-net-controller-local image-net-node-local image-gantry-local ## Build all container images locally
 
 ##@ Net Frontend
 
@@ -1388,21 +1388,26 @@ RELEASE_MANIFESTS_STAGE_DIR := build/release-manifests
 RELEASE_MANIFESTS_NAME      := unbounded-manifests-$(VERSION)
 UNBOUNDED_OPERATOR_RELEASE_MANIFEST := build/unbounded-operator-$(VERSION).yaml
 
+unbounded-operator-release-manifest: UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT :=
 unbounded-operator-release-manifest: unbounded-operator-manifests ## Build a versioned, directly applicable operator manifest under build/
 	@mkdir -p build
 	@cat $$(ls -1 "$(UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR)"/*.yaml | LC_ALL=C sort) > "$(UNBOUNDED_OPERATOR_RELEASE_MANIFEST)"
 	@echo "Operator release manifest: $(UNBOUNDED_OPERATOR_RELEASE_MANIFEST)"
 
-release-manifests: machina-manifests machine-ops-manifests net-manifests unbounded-storage-supervisor-manifests unbounded-operator-manifests ## Build stamped combined manifest tarball under build/
+release-manifests: NET_APISERVER_URL :=
+release-manifests: UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT :=
+release-manifests: machina-manifests machine-ops-manifests net-manifests gantry-manifests unbounded-storage-supervisor-manifests unbounded-operator-manifests ## Build stamped combined manifest tarball under build/
 	@rm -rf $(RELEASE_MANIFESTS_STAGE_DIR)
 	@mkdir -p $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/machina
 	@mkdir -p $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/machine-ops
 	@mkdir -p $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/net
+	@mkdir -p $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/gantry
 	@mkdir -p $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/unbounded-storage-supervisor
 	@mkdir -p $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/unbounded-operator
 	@cp -R $(MACHINA_MANIFEST_RENDERED_DIR)/. $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/machina/
 	@cp -R $(MACHINE_OPS_MANIFEST_RENDERED_DIR)/. $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/machine-ops/
 	@cp -R $(NET_MANIFEST_RENDERED_DIR)/.     $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/net/
+	@cp -R $(GANTRY_MANIFEST_RENDERED_DIR)/. $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/gantry/
 	@cp -R $(UNBOUNDED_STORAGE_SUPERVISOR_MANIFEST_RENDERED_DIR)/. $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/unbounded-storage-supervisor/
 	@cp -R $(UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR)/. $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/unbounded-operator/
 	@echo "$(VERSION)" > $(RELEASE_MANIFESTS_STAGE_DIR)/$(RELEASE_MANIFESTS_NAME)/VERSION

--- a/deploy/gantry/node-config.yaml.tmpl
+++ b/deploy/gantry/node-config.yaml.tmpl
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/component: node-config
 data:
   hosts.toml: |
-    # Managed by the Gantry node-config DaemonSet.
+    # Managed by unbounded-agent for Gantry.
     [host."http://127.0.0.1:5000"]
       capabilities = ["pull", "resolve"]
       dial_timeout = "200ms"
@@ -58,11 +58,13 @@ spec:
               target_dir=/host-certs/_default
               target_file="$target_dir/hosts.toml"
               source_file=/config/hosts.toml
-              managed_marker='# Managed by the Gantry node-config DaemonSet.'
+              managed_marker='# Managed by unbounded-agent for Gantry.'
+              legacy_managed_marker='# Managed by the Gantry node-config DaemonSet.'
 
               mkdir -p "$target_dir"
               if [ -e "$target_file" ] && \
-                 ! grep -Fqx "$managed_marker" "$target_file"; then
+                 ! grep -Fqx "$managed_marker" "$target_file" && \
+                 ! grep -Fqx "$legacy_managed_marker" "$target_file"; then
                 echo "refusing to overwrite unmanaged $target_file" >&2
                 exit 1
               fi

--- a/internal/operator/components/gantry/gantry_test.go
+++ b/internal/operator/components/gantry/gantry_test.go
@@ -5,6 +5,8 @@ package gantry
 
 import (
 	"context"
+	"io/fs"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -17,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	gantrymanifests "github.com/Azure/unbounded/deploy/gantry"
 	"github.com/Azure/unbounded/internal/operator/component"
 )
 
@@ -118,6 +121,27 @@ func TestEnsureConfigPreservesExistingPayload(t *testing.T) {
 
 	if hash != component.ConfigMapPayloadHash(&got) {
 		t.Fatalf("hash = %q, want exact payload hash", hash)
+	}
+}
+
+func TestNodeConfigUsesAgentMarkerAndAcceptsLegacyMarker(t *testing.T) {
+	manifest, err := fs.ReadFile(gantrymanifests.Manifests, "node-config.yaml")
+	if err != nil {
+		t.Fatalf("read node-config manifest: %v", err)
+	}
+
+	const (
+		agentMarker  = "# Managed by unbounded-agent for Gantry."
+		legacyMarker = "# Managed by the Gantry node-config DaemonSet."
+	)
+
+	content := string(manifest)
+	if strings.Count(content, agentMarker) < 2 {
+		t.Fatalf("node-config manifest does not write and recognize agent marker %q", agentMarker)
+	}
+
+	if !strings.Contains(content, legacyMarker) {
+		t.Fatalf("node-config manifest does not recognize legacy marker %q", legacyMarker)
 	}
 }
 


### PR DESCRIPTION
Summary: package Gantry manifests; publish storage supervisor image; make release manifests endpoint-neutral; make Gantry mirror marker compatible with unbounded-agent and legacy node-config; wait for Gantry in release upgrade.

Validation: focused operator/Gantry tests pass; first-party `go test ./api/... ./cmd/... ./hack/... ./internal/... ./pkg/...` passes; candidate v0.1.24-rc.8 archive has all six component directories and version-matched images; lint 0 issues.

Note: local `make test` traverses ignored tmp/hugo-modcache in this long-lived checkout, while all first-party packages pass and clean CI does not contain that scratch tree.