### PR TITLE
logging: route controller-runtime binaries through slog (retire zap)

### DIFF
--- a/cmd/machina/machina/controller/manager.go
+++ b/cmd/machina/machina/controller/manager.go
@@ -6,7 +6,9 @@ package controller
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
+	"github.com/go-logr/logr"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
@@ -35,7 +36,7 @@ func init() {
 
 // RunManager runs the controller manager.
 func RunManager(ctx context.Context, cfg Config) error {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/cmd/machine-ops-controller/main.go
+++ b/cmd/machine-ops-controller/main.go
@@ -9,18 +9,19 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
@@ -86,7 +87,7 @@ type config struct {
 }
 
 func run(ctx context.Context, cfg config) error {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
 
 	if (cfg.siteName == "") != (cfg.providerName == "") {
 		return errors.New(errSiteProviderPair)

--- a/cmd/playpen-operator/main.go
+++ b/cmd/playpen-operator/main.go
@@ -6,10 +6,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,7 +21,6 @@ import (
 	apiregclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/Azure/unbounded/internal/playpen/operator"
 	"github.com/Azure/unbounded/internal/version"
@@ -91,7 +92,7 @@ func main() {
 }
 
 func run(ctx context.Context, cfg operator.Config) error {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
 
 	scheme := runtimeScheme()
 	restConfig := ctrl.GetConfigOrDie()

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -6,11 +6,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strconv"
 	"syscall"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,7 +27,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
@@ -140,7 +141,11 @@ func resolveAPIServerEndpoint(ctx context.Context, override string, clientset ku
 }
 
 func run(ctx context.Context, cfg config) error {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	// Route controller-runtime's logr logging through slog, consistent with the
+	// rest of the repo (metalman, agent). slog.Default() is an Info-level
+	// handler, so logr V(1)+ maps to sub-Info slog levels and is suppressed by
+	// default.
+	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
 
 	scheme := runtimeScheme()
 

--- a/e2e/operator/reaper_e2e_test.go
+++ b/e2e/operator/reaper_e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
@@ -30,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -52,7 +54,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	netcontroller "github.com/Azure/unbounded/internal/net/controller"
@@ -128,7 +129,7 @@ func TestOperatorReaperMigration(t *testing.T) {
 	applyCRDs(t, kubeconfig, repoRoot)
 
 	cli := newClient(t, kubeconfig)
-	ctx := log.IntoContext(context.Background(), zap.New(zap.UseDevMode(true)))
+	ctx := log.IntoContext(context.Background(), logr.FromSlogHandler(slog.Default().Handler()))
 
 	stageNamespaces(ctx, t, cli)
 	stageLegacyWorkloads(ctx, t, cli)

--- a/e2e/operator/slice_window_e2e_test.go
+++ b/e2e/operator/slice_window_e2e_test.go
@@ -13,10 +13,12 @@ package operatore2e
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +27,6 @@ import (
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const sliceWindowClusterName = "operator-slice-window-e2e"
@@ -57,7 +58,7 @@ func TestSiteControllerPreservesSlicesDuringMigrationWindow(t *testing.T) {
 	applyCRDs(t, kubeconfig, repoRoot)
 
 	cli := newClient(t, kubeconfig)
-	ctx := log.IntoContext(context.Background(), zap.New(zap.UseDevMode(true)))
+	ctx := log.IntoContext(context.Background(), logr.FromSlogHandler(slog.Default().Handler()))
 
 	// The restricted SiteController identity's ServiceAccount lives in targetNS.
 	mustCreate(ctx, t, cli, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNS}})

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect


### PR DESCRIPTION
## Summary

Routes all controller-runtime binaries through `slog` instead of the kubebuilder-default zap backend, so the whole repo logs through `log/slog` (matching `metalman` and the `agent`). Each site swaps:

```go
// before
ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
// after
ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
```

controller-runtime's logging facade is `logr`, so a manager must set some `logr.Logger`; `logr.FromSlogHandler` adapts an slog handler to satisfy it (minimal form, mirroring `cmd/metalman/main.go`).

### Changed sites
- `cmd/unbounded-operator/main.go`
- `cmd/machina/machina/controller/manager.go`
- `cmd/machine-ops-controller/main.go`
- `cmd/playpen-operator/main.go`
- `e2e/operator/reaper_e2e_test.go`, `e2e/operator/slice_window_e2e_test.go` (`log.IntoContext`)

### Dependency cleanup
No source file imports `sigs.k8s.io/controller-runtime/pkg/log/zap` anymore, so `go mod tidy` drops `github.com/go-logr/zapr`. `go.uber.org/zap` remains only as a transitive dependency of `go-libp2p-kad-dht` (via `internal/gantry/discovery`), not of our logging.

## Behavior change

`slog.Default()` is an Info-level handler, and logr `V(n)` maps to slog level `-n`, so logr `V(1)+` logs (e.g. the migration reaper's routine `V(1)` lines) are now **suppressed by default** rather than printed. `zap.New(zap.UseDevMode(true))` previously pinned the level to Debug, which made `V`-level verbosity ineffective. With slog, `V(1)` becomes a real quiet lever - which also unblocks the fix in #533 (BootstrapMaintainer log churn).

## Testing

- `go build ./...`, `go vet -tags=e2e ./e2e/operator/...`, `make fmt`, `make lint` (0 issues), `go test ./cmd/... ./internal/operator/...` all pass.

Closes #534
Refs #533
