### PR TITLE
release: sign and inventory release artifacts

### DIFF
--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -261,20 +261,39 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --pattern 'unbounded-manifests-*.tar.gz' \
             --pattern 'unbounded-manifests-*.tar.gz.bundle.json' \
+            --pattern 'unbounded-operator-*.yaml' \
+            --pattern 'unbounded-operator-*.yaml.bundle.json' \
+            --pattern "unbounded-release-bom-${TAG}.json" \
+            --pattern "unbounded-release-bom-${TAG}.json.bundle.json" \
             --pattern 'kubectl-unbounded-linux-amd64.tar.gz' \
             --dir dist/
           ls -la dist/
 
-      - name: Verify cosign signature on manifests tarball
+      - name: Verify release signatures and BOM
         run: |
           set -euo pipefail
+          IDENTITY="^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yaml@refs/tags/${TAG}$"
           ARCHIVE="dist/unbounded-manifests-${TAG}.tar.gz"
-          BUNDLE="${ARCHIVE}.bundle.json"
-          cosign verify-blob \
-            --bundle "${BUNDLE}" \
-            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yaml@refs/tags/${TAG}$" \
-            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            "${ARCHIVE}"
+          OPERATOR_MANIFEST="dist/unbounded-operator-${TAG}.yaml"
+          BOM="dist/unbounded-release-bom-${TAG}.json"
+
+          for artifact in "${ARCHIVE}" "${OPERATOR_MANIFEST}" "${BOM}"; do
+            cosign verify-blob \
+              --bundle "${artifact}.bundle.json" \
+              --certificate-identity-regexp "${IDENTITY}" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "${artifact}"
+          done
+
+          test "$(jq -r '.release.tag' "${BOM}")" = "${TAG}"
+          test "$(jq -r '.release.gitCommit' "${BOM}")" = "$(git rev-parse HEAD)"
+
+          jq -r '.images[] | .reference + "@" + .digest' "${BOM}" | while IFS= read -r image; do
+            cosign verify \
+              --certificate-identity-regexp "${IDENTITY}" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "${image}" >/dev/null
+          done
 
       - name: Extract manifests
         run: |

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -288,7 +288,7 @@ jobs:
           test "$(jq -r '.release.tag' "${BOM}")" = "${TAG}"
           test "$(jq -r '.release.gitCommit' "${BOM}")" = "$(git rev-parse HEAD)"
 
-          jq -r '.images[] | .reference + "@" + .digest' "${BOM}" | while IFS= read -r image; do
+          jq -r '.images[] | (.reference | sub(":[^/]+$"; "")) + "@" + .digest' "${BOM}" | while IFS= read -r image; do
             cosign verify \
               --certificate-identity-regexp "${IDENTITY}" \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -412,7 +412,7 @@ jobs:
             "${{ env.REGISTRY }}/unbounded-net-node@${{ steps.push_node.outputs.digest }}"
 
   # ---------------------------------------------------------------------------
-  # Stitch per-arch net image tags into multi-arch manifests for :TAG.
+  # Stitch per-arch net image tags into signed multi-arch manifests for :TAG.
   # ---------------------------------------------------------------------------
   net-images-manifest:
     needs: [version, net-images]
@@ -422,6 +422,9 @@ jobs:
         run: echo "REGISTRY=${REGISTRY,,}" >> "$GITHUB_ENV"
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Log in to ghcr.io
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -440,6 +443,13 @@ jobs:
               --tag "${SRC}:${TAG}" \
               "${SRC}:${TAG}-amd64" \
               "${SRC}:${TAG}-arm64"
+
+            digest="$(docker buildx imagetools inspect "${SRC}:${TAG}" | awk '$1 == "Digest:" {print $2; exit}')"
+            if [[ -z "$digest" ]]; then
+              echo "could not resolve digest for ${SRC}:${TAG}" >&2
+              exit 1
+            fi
+            cosign sign --yes "${SRC}@${digest}"
           done
 
   # ---------------------------------------------------------------------------
@@ -753,13 +763,17 @@ jobs:
             NET_APISERVER_URL="" \
             UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT=""
 
-      - name: Sign manifests tarball with cosign (keyless)
+      - name: Sign release manifests with cosign (keyless)
         run: |
           TAG="${{ needs.version.outputs.tag }}"
           ARCHIVE="build/unbounded-manifests-${TAG}.tar.gz"
+          OPERATOR_MANIFEST="build/unbounded-operator-${TAG}.yaml"
           cosign sign-blob --yes \
             --bundle="${ARCHIVE}.bundle.json" \
             "${ARCHIVE}"
+          cosign sign-blob --yes \
+            --bundle="${OPERATOR_MANIFEST}.bundle.json" \
+            "${OPERATOR_MANIFEST}"
 
       - name: Upload manifests artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -768,6 +782,7 @@ jobs:
           path: |
             build/unbounded-manifests-*
             build/unbounded-operator-*.yaml
+            build/unbounded-operator-*.yaml.bundle.json
           retention-days: 1
 
   # ---------------------------------------------------------------------------
@@ -907,6 +922,16 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Normalize container registry to lowercase
+        run: echo "REGISTRY=${REGISTRY,,}" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Download goreleaser dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
@@ -936,6 +961,19 @@ jobs:
           export SHA_DARWIN_ARM64=$(sha256sum dist/kubectl-unbounded-darwin-arm64.tar.gz | awk '{print $1}')
           envsubst < hack/krew-manifest.yaml > dist/unbounded.yaml
 
+      - name: Generate and sign release BOM
+        run: |
+          TAG="${{ needs.version.outputs.tag }}"
+          BOM="dist/unbounded-release-bom-${TAG}.json"
+          make release-bom \
+            VERSION="${TAG}" \
+            GIT_COMMIT="${GITHUB_SHA}" \
+            CONTAINER_REGISTRY="${{ env.REGISTRY }}" \
+            RELEASE_BOM_OUTPUT="${BOM}"
+          cosign sign-blob --yes \
+            --bundle="${BOM}.bundle.json" \
+            "${BOM}"
+
       - name: Attach extras to release and set notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -948,6 +986,9 @@ jobs:
             dist/unbounded-manifests-*.tar.gz \
             dist/unbounded-manifests-*.tar.gz.bundle.json \
             dist/unbounded-operator-*.yaml \
+            dist/unbounded-operator-*.yaml.bundle.json \
+            "dist/unbounded-release-bom-${TAG}.json" \
+            "dist/unbounded-release-bom-${TAG}.json.bundle.json" \
             dist/unbounded-storage-linux-*.tar.gz \
             dist/unbounded-storage-linux-*.tar.gz.sha256 \
             dist/unbounded-storage-linux-*.tar.gz.spdx.json \

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ NET_FRONTEND_CACHE_FILE    := $(NET_FRONTEND_DIST_DIR)/.frontend-build-key
 REACT_DEV ?= false
 
 .PHONY: all help fmt lint test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build install-tools install-protoc generate kubectl-unbounded forge agent-artifacts-builder agent-artifacts-builder-build orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push unbounded-operator unbounded-operator-build unbounded-operator-manifests playpen-manifests e2e-playpen gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build gantry-manifests inventory-manifests
-.PHONY: net-frontend net-frontend-clean net-ebpf-build net-ebpf-generate net-ebpf-verify net-manifests release-manifests unbounded-operator-release-manifest
+.PHONY: net-frontend net-frontend-clean net-ebpf-build net-ebpf-generate net-ebpf-verify net-manifests release-bom release-manifests unbounded-operator-release-manifest
 .PHONY: image-machina-local image-machine-ops-controller-local image-metalman-local image-unbounded-operator-local image-unbounded-operator-push image-playpen-local image-net-controller-local image-net-node-local image-gantry-local image-gantry-push images-local
 .PHONY: image-net-controller-push image-net-node-push images-net-all images-net-all-push
 .PHONY: unbounded-storage unbounded-storage-build unbounded-storage-smoke unbounded-storage-tarball unbounded-storage-push bench unbounded-storage-test unbounded-storage-check unbounded-storage-model-check libfabric openssl
@@ -1387,6 +1387,15 @@ net-manifests: ## Render net manifests into $(NET_MANIFEST_RENDERED_DIR)
 RELEASE_MANIFESTS_STAGE_DIR := build/release-manifests
 RELEASE_MANIFESTS_NAME      := unbounded-manifests-$(VERSION)
 UNBOUNDED_OPERATOR_RELEASE_MANIFEST := build/unbounded-operator-$(VERSION).yaml
+RELEASE_BOM_OUTPUT ?= build/unbounded-release-bom-$(VERSION).json
+
+release-bom: ## Generate a digest-pinned release bill of materials
+	$(GOCMD) run ./hack/cmd/release-bom \
+		--tag "$(VERSION)" \
+		--commit "$(GIT_COMMIT)" \
+		--registry "$(CONTAINER_REGISTRY)" \
+		--net-cni-version "$(CNI_PLUGINS_VERSION)" \
+		--output "$(RELEASE_BOM_OUTPUT)"
 
 unbounded-operator-release-manifest: UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT :=
 unbounded-operator-release-manifest: unbounded-operator-manifests ## Build a versioned, directly applicable operator manifest under build/

--- a/hack/cmd/release-bom/main.go
+++ b/hack/cmd/release-bom/main.go
@@ -1,0 +1,313 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// release-bom generates a machine-readable inventory of release images and
+// node bootstrap dependencies. Image tags are resolved to immutable digests so
+// downstream automation can verify exactly what a release is expected to use.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
+)
+
+const bomSchemaVersion = 1
+
+var releaseImageNames = []string{
+	"gantry",
+	"host-ubuntu2404",
+	"machina",
+	"machine-ops-controller",
+	"metalman",
+	"netboot",
+	"orca",
+	"unbounded-net-controller",
+	"unbounded-net-node",
+	"unbounded-operator",
+	"unbounded-storage-supervisor",
+}
+
+type options struct {
+	tag           string
+	commit        string
+	registry      string
+	netCNIVersion string
+	output        string
+}
+
+type releaseBOM struct {
+	SchemaVersion int                  `json:"schemaVersion"`
+	Release       releaseInfo          `json:"release"`
+	Artifacts     []releaseArtifact    `json:"artifacts"`
+	Images        []resolvedImage      `json:"images"`
+	NodeBootstrap nodeBootstrapProfile `json:"nodeBootstrap"`
+}
+
+type releaseInfo struct {
+	Tag       string `json:"tag"`
+	GitCommit string `json:"gitCommit"`
+}
+
+type releaseArtifact struct {
+	Name            string `json:"name"`
+	Integrity       string `json:"integrity"`
+	SignatureBundle string `json:"signatureBundle,omitempty"`
+}
+
+type resolvedImage struct {
+	Name      string   `json:"name"`
+	Reference string   `json:"reference"`
+	Digest    string   `json:"digest"`
+	MediaType string   `json:"mediaType"`
+	Platforms []string `json:"platforms,omitempty"`
+}
+
+type nodeBootstrapProfile struct {
+	KubernetesVersionSource string          `json:"kubernetesVersionSource"`
+	ContainerdVersion       string          `json:"containerdVersion"`
+	RuncVersion             string          `json:"runcVersion"`
+	CNIPluginVersion        string          `json:"cniPluginVersion"`
+	NetCNIPluginVersion     string          `json:"netCniPluginVersion"`
+	CrictlVersionSource     string          `json:"crictlVersionSource"`
+	SandboxImage            resolvedImage   `json:"sandboxImage"`
+	KubeProxyImageTemplate  string          `json:"kubeProxyImageTemplate"`
+	RootFSImages            []resolvedImage `json:"rootfsImages"`
+}
+
+type imageResolver func(context.Context, string, string) (resolvedImage, error)
+
+func main() {
+	var opts options
+
+	flag.StringVar(&opts.tag, "tag", "", "Release tag")
+	flag.StringVar(&opts.commit, "commit", "", "Release git commit")
+	flag.StringVar(&opts.registry, "registry", "ghcr.io/azure", "Container registry and repository prefix")
+	flag.StringVar(&opts.netCNIVersion, "net-cni-version", "", "CNI plugin bundle version in the unbounded-net node image")
+	flag.StringVar(&opts.output, "output", "", "Output JSON file")
+	flag.Parse()
+
+	if err := opts.validate(); err != nil {
+		exitWithError(err)
+	}
+
+	bom, err := buildBOM(context.Background(), opts, resolveImage)
+	if err != nil {
+		exitWithError(err)
+	}
+
+	if err := writeBOM(opts.output, bom); err != nil {
+		exitWithError(err)
+	}
+}
+
+func (o options) validate() error {
+	switch {
+	case strings.TrimSpace(o.tag) == "":
+		return fmt.Errorf("--tag is required")
+	case strings.TrimSpace(o.commit) == "":
+		return fmt.Errorf("--commit is required")
+	case strings.TrimSpace(o.registry) == "":
+		return fmt.Errorf("--registry is required")
+	case strings.TrimSpace(o.netCNIVersion) == "":
+		return fmt.Errorf("--net-cni-version is required")
+	case strings.TrimSpace(o.output) == "":
+		return fmt.Errorf("--output is required")
+	default:
+		return nil
+	}
+}
+
+func buildBOM(ctx context.Context, opts options, resolve imageResolver) (*releaseBOM, error) {
+	images := make([]resolvedImage, 0, len(releaseImageNames))
+	for _, name := range releaseImageNames {
+		ref := strings.TrimRight(opts.registry, "/") + "/" + name + ":" + opts.tag
+
+		image, err := resolve(ctx, name, ref)
+		if err != nil {
+			return nil, fmt.Errorf("resolve release image %s: %w", name, err)
+		}
+
+		images = append(images, image)
+	}
+
+	rootFSRefs := map[string]string{
+		"azurelinux3":        goalstates.DefaultAzureLinux3OCIImage,
+		"azurelinux3-nvidia": goalstates.DefaultAzureLinux3NvidiaOCIImage,
+		"ubuntu2404":         goalstates.DefaultOCIImage,
+		"ubuntu2404-nvidia":  goalstates.DefaultNvidiaOCIImage,
+		"ubuntu2604":         goalstates.DefaultUbuntu2604OCIImage,
+		"ubuntu2604-nvidia":  goalstates.DefaultUbuntu2604NvidiaOCIImage,
+	}
+
+	rootFSNames := make([]string, 0, len(rootFSRefs))
+	for name := range rootFSRefs {
+		rootFSNames = append(rootFSNames, name)
+	}
+
+	sort.Strings(rootFSNames)
+
+	rootFSImages := make([]resolvedImage, 0, len(rootFSNames))
+	for _, name := range rootFSNames {
+		image, err := resolve(ctx, name, rootFSRefs[name])
+		if err != nil {
+			return nil, fmt.Errorf("resolve rootfs image %s: %w", name, err)
+		}
+
+		rootFSImages = append(rootFSImages, image)
+	}
+
+	sandboxImage, err := resolve(ctx, "sandbox", goalstates.SandboxImage)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox image: %w", err)
+	}
+
+	return &releaseBOM{
+		SchemaVersion: bomSchemaVersion,
+		Release: releaseInfo{
+			Tag:       opts.tag,
+			GitCommit: opts.commit,
+		},
+		Artifacts: releaseArtifacts(opts.tag),
+		Images:    images,
+		NodeBootstrap: nodeBootstrapProfile{
+			KubernetesVersionSource: "cluster control plane version",
+			ContainerdVersion:       goalstates.ContainerdVersion,
+			RuncVersion:             goalstates.RunCVersion,
+			CNIPluginVersion:        goalstates.CNIPluginVersion,
+			NetCNIPluginVersion:     opts.netCNIVersion,
+			CrictlVersionSource:     "Kubernetes major.minor.0",
+			SandboxImage:            sandboxImage,
+			KubeProxyImageTemplate:  goalstates.KubeProxyImageRepository + ":v{KUBERNETES_VERSION}",
+			RootFSImages:            rootFSImages,
+		},
+	}, nil
+}
+
+func releaseArtifacts(tag string) []releaseArtifact {
+	return []releaseArtifact{
+		{Name: "checksums.txt", Integrity: "cosign-bundle", SignatureBundle: "checksums.txt.bundle.json"},
+		{Name: "unbounded-manifests-" + tag + ".tar.gz", Integrity: "cosign-bundle", SignatureBundle: "unbounded-manifests-" + tag + ".tar.gz.bundle.json"},
+		{Name: "unbounded-operator-" + tag + ".yaml", Integrity: "cosign-bundle", SignatureBundle: "unbounded-operator-" + tag + ".yaml.bundle.json"},
+		{Name: "unbounded-storage-linux-amd64.tar.gz", Integrity: "sha256-and-cosign-bundle", SignatureBundle: "unbounded-storage-linux-amd64.tar.gz.bundle.json"},
+		{Name: "unbounded-storage-linux-arm64.tar.gz", Integrity: "sha256-and-cosign-bundle", SignatureBundle: "unbounded-storage-linux-arm64.tar.gz.bundle.json"},
+		{Name: "unbounded.yaml", Integrity: "contains-archive-sha256"},
+	}
+}
+
+func resolveImage(ctx context.Context, name, ref string) (resolvedImage, error) {
+	repo, err := remote.NewRepository(ref)
+	if err != nil {
+		return resolvedImage{}, fmt.Errorf("parse image reference %q: %w", ref, err)
+	}
+
+	repo.Client = &auth.Client{Client: retry.DefaultClient, Cache: auth.DefaultCache}
+
+	desc, err := repo.Resolve(ctx, repo.Reference.Reference)
+	if err != nil {
+		return resolvedImage{}, fmt.Errorf("resolve image reference %q: %w", ref, err)
+	}
+
+	image := resolvedImage{
+		Name:      name,
+		Reference: ref,
+		Digest:    desc.Digest.String(),
+		MediaType: desc.MediaType,
+	}
+
+	if desc.MediaType != ocispec.MediaTypeImageIndex && desc.MediaType != "application/vnd.docker.distribution.manifest.list.v2+json" {
+		return image, nil
+	}
+
+	content, err := repo.Fetch(ctx, desc)
+	if err != nil {
+		return resolvedImage{}, fmt.Errorf("fetch image index %q: %w", ref, err)
+	}
+	defer content.Close() //nolint:errcheck // best effort close
+
+	var index ocispec.Index
+	if err := json.NewDecoder(content).Decode(&index); err != nil {
+		return resolvedImage{}, fmt.Errorf("decode image index %q: %w", ref, err)
+	}
+
+	var platforms []string
+
+	for _, manifest := range index.Manifests {
+		if manifest.Platform == nil || manifest.Platform.OS == "" || manifest.Platform.Architecture == "" || manifest.Platform.OS == "unknown" || manifest.Platform.Architecture == "unknown" {
+			continue
+		}
+
+		platform := manifest.Platform.OS + "/" + manifest.Platform.Architecture
+		if manifest.Platform.Variant != "" {
+			platform += "/" + manifest.Platform.Variant
+		}
+
+		platforms = append(platforms, platform)
+	}
+
+	image.Platforms = uniqueSortedStrings(platforms)
+
+	return image, nil
+}
+
+func uniqueSortedStrings(values []string) []string {
+	unique := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		unique[value] = struct{}{}
+	}
+
+	result := make([]string, 0, len(unique))
+	for value := range unique {
+		result = append(result, value)
+	}
+
+	sort.Strings(result)
+
+	return result
+}
+
+func writeBOM(path string, bom *releaseBOM) error {
+	var output io.Writer = os.Stdout
+
+	if path != "-" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("create BOM output directory: %w", err)
+		}
+
+		file, err := os.Create(path)
+		if err != nil {
+			return fmt.Errorf("create BOM %q: %w", path, err)
+		}
+		defer file.Close() //nolint:errcheck // best effort close
+
+		output = file
+	}
+
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(bom); err != nil {
+		return fmt.Errorf("encode BOM: %w", err)
+	}
+
+	return nil
+}
+
+func exitWithError(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/hack/cmd/release-bom/main_test.go
+++ b/hack/cmd/release-bom/main_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
+)
+
+func TestBuildBOM(t *testing.T) {
+	opts := options{
+		tag:           "v1.2.3",
+		commit:        "abcdef123456",
+		registry:      "registry.example.com/project",
+		netCNIVersion: "v9.8.7",
+		output:        "ignored.json",
+	}
+
+	resolver := func(_ context.Context, name, ref string) (resolvedImage, error) {
+		digest := fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(ref)))
+
+		return resolvedImage{
+			Name:      name,
+			Reference: ref,
+			Digest:    digest,
+			MediaType: "application/vnd.oci.image.index.v1+json",
+			Platforms: []string{"linux/amd64", "linux/arm64"},
+		}, nil
+	}
+
+	bom, err := buildBOM(t.Context(), opts, resolver)
+	if err != nil {
+		t.Fatalf("buildBOM: %v", err)
+	}
+
+	if bom.SchemaVersion != bomSchemaVersion || bom.Release.Tag != opts.tag || bom.Release.GitCommit != opts.commit {
+		t.Fatalf("release metadata = %#v", bom.Release)
+	}
+
+	if len(bom.Images) != len(releaseImageNames) {
+		t.Fatalf("release image count = %d, want %d", len(bom.Images), len(releaseImageNames))
+	}
+
+	if got, want := bom.Images[0].Reference, "registry.example.com/project/gantry:v1.2.3"; got != want {
+		t.Fatalf("first image reference = %q, want %q", got, want)
+	}
+
+	if bom.NodeBootstrap.ContainerdVersion != goalstates.ContainerdVersion ||
+		bom.NodeBootstrap.RuncVersion != goalstates.RunCVersion ||
+		bom.NodeBootstrap.CNIPluginVersion != goalstates.CNIPluginVersion ||
+		bom.NodeBootstrap.NetCNIPluginVersion != opts.netCNIVersion {
+		t.Fatalf("node bootstrap versions = %#v", bom.NodeBootstrap)
+	}
+
+	if len(bom.NodeBootstrap.RootFSImages) != 6 {
+		t.Fatalf("rootfs image count = %d, want 6", len(bom.NodeBootstrap.RootFSImages))
+	}
+
+	if bom.NodeBootstrap.SandboxImage.Reference != goalstates.SandboxImage {
+		t.Fatalf("sandbox image = %q, want %q", bom.NodeBootstrap.SandboxImage.Reference, goalstates.SandboxImage)
+	}
+
+	foundOperatorManifest := false
+
+	for _, artifact := range bom.Artifacts {
+		if artifact.Name == "unbounded-operator-v1.2.3.yaml" && artifact.SignatureBundle == "unbounded-operator-v1.2.3.yaml.bundle.json" {
+			foundOperatorManifest = true
+		}
+	}
+
+	if !foundOperatorManifest {
+		t.Fatal("signed operator manifest is missing from BOM artifacts")
+	}
+}
+
+func TestOptionsValidate(t *testing.T) {
+	valid := options{tag: "v1", commit: "abc", registry: "registry.example", netCNIVersion: "v1", output: "bom.json"}
+	if err := valid.validate(); err != nil {
+		t.Fatalf("valid options: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*options)
+	}{
+		{name: "tag", mutate: func(o *options) { o.tag = "" }},
+		{name: "commit", mutate: func(o *options) { o.commit = "" }},
+		{name: "registry", mutate: func(o *options) { o.registry = "" }},
+		{name: "net CNI version", mutate: func(o *options) { o.netCNIVersion = "" }},
+		{name: "output", mutate: func(o *options) { o.output = "" }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := valid
+			test.mutate(&opts)
+
+			if err := opts.validate(); err == nil {
+				t.Fatal("validate returned nil")
+			}
+		})
+	}
+}
+
+func TestResolvedImagePlatformsAreStable(t *testing.T) {
+	platforms := uniqueSortedStrings([]string{"linux/arm64", "linux/amd64", "linux/arm64"})
+
+	if got, want := fmt.Sprint(platforms), "[linux/amd64 linux/arm64]"; got != want {
+		t.Fatalf("platforms = %q, want %q", got, want)
+	}
+}
+
+func TestWriteBOMCreatesOutputDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "release-bom.json")
+	want := &releaseBOM{SchemaVersion: bomSchemaVersion, Release: releaseInfo{Tag: "v1.2.3", GitCommit: "abc"}}
+
+	if err := writeBOM(path, want); err != nil {
+		t.Fatalf("writeBOM: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read BOM: %v", err)
+	}
+
+	var got releaseBOM
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal BOM: %v", err)
+	}
+
+	if got.SchemaVersion != want.SchemaVersion || got.Release != want.Release {
+		t.Fatalf("BOM = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
Summary:
- sign stitched multi-arch unbounded-net indexes and the standalone operator manifest
- generate and sign a digest-pinned release BOM covering all release images, rootfs variants, sandbox image, and node runtime versions
- make release-upgrade verify the BOM, blob signatures, and every release image signature before deployment
Validation:
- `make fmt`
- `make lint` (0 issues)
- `go test ./api/... ./cmd/... ./hack/... ./internal/... ./pkg/...`
- live BOM generation against v0.1.24-rc.8 resolved all 11 release images, six rootfs images, and sandbox image
- parsed both workflow YAML files and `bash -n` checked all 62 run blocks
