### PR TITLE
operator: bootstrap networking from host network

### DIFF
--- a/deploy/unbounded-operator/04-deployment.yaml.tmpl
+++ b/deploy/unbounded-operator/04-deployment.yaml.tmpl
@@ -34,7 +34,16 @@ spec:
         # Canonical JSON matches the `kubectl unbounded install` hash.
         unbounded-cloud.io/operator-config-hash: {{ dict "UNBOUNDED_API_SERVER_ENDPOINT" (default "" .APIServerEndpoint) "UNBOUNDED_IMAGE_REGISTRY" (default "ghcr.io" .ImageRegistry) "UNBOUNDED_REAP_LEGACY_RESOURCES" (default "true" .ReapLegacyResources) | toJson | sha256sum | quote }}
     spec:
+      # The operator installs the cluster CNI, so it must be able to reach the
+      # API server before pod networking or cluster DNS is available. Default
+      # DNS uses the node resolver for the AKS API FQDN annotation above.
+      hostNetwork: true
+      dnsPolicy: Default
       serviceAccountName: unbounded-operator
+      tolerations:
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: controller
           image: {{ .OperatorImage }}

--- a/deploy/unbounded-operator/render_test.go
+++ b/deploy/unbounded-operator/render_test.go
@@ -53,6 +53,7 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 	if got := cm.Data["UNBOUNDED_API_SERVER_ENDPOINT"]; got != endpoint {
 		t.Fatalf("configmap UNBOUNDED_API_SERVER_ENDPOINT = %q, want %q", got, endpoint)
 	}
+
 	if got := cm.Data["UNBOUNDED_IMAGE_REGISTRY"]; got != "registry.example.com/mirror" {
 		t.Fatalf("configmap UNBOUNDED_IMAGE_REGISTRY = %q", got)
 	}
@@ -68,6 +69,13 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 					Annotations map[string]string `yaml:"annotations"`
 				} `yaml:"metadata"`
 				Spec struct {
+					HostNetwork bool   `yaml:"hostNetwork"`
+					DNSPolicy   string `yaml:"dnsPolicy"`
+					Tolerations []struct {
+						Key      string `yaml:"key"`
+						Operator string `yaml:"operator"`
+						Effect   string `yaml:"effect"`
+					} `yaml:"tolerations"`
 					Containers []struct {
 						Name         string   `yaml:"name"`
 						Args         []string `yaml:"args"`
@@ -113,6 +121,28 @@ func TestOperatorConfigEndpointAndHashRender(t *testing.T) {
 	rollingUpdate, found := deploy.Spec.Strategy["rollingUpdate"]
 	if !found || rollingUpdate != nil {
 		t.Fatalf("deployment strategy rollingUpdate = %#v (present: %t), want explicit null", rollingUpdate, found)
+	}
+
+	if !deploy.Spec.Template.Spec.HostNetwork {
+		t.Fatal("deployment pod hostNetwork = false, want true so the operator can install CNI")
+	}
+
+	if got := deploy.Spec.Template.Spec.DNSPolicy; got != "Default" {
+		t.Fatalf("deployment pod dnsPolicy = %q, want Default for pre-CNI API FQDN resolution", got)
+	}
+
+	foundNotReadyToleration := false
+
+	for _, toleration := range deploy.Spec.Template.Spec.Tolerations {
+		if toleration.Key == "node.kubernetes.io/not-ready" && toleration.Operator == "Exists" && toleration.Effect == "NoSchedule" {
+			foundNotReadyToleration = true
+
+			break
+		}
+	}
+
+	if !foundNotReadyToleration {
+		t.Fatalf("deployment pod tolerations = %#v, want node.kubernetes.io/not-ready Exists NoSchedule", deploy.Spec.Template.Spec.Tolerations)
 	}
 
 	for _, container := range deploy.Spec.Template.Spec.Containers {
@@ -211,6 +241,7 @@ func TestOperatorConfigHashChangesWithEachConfigValue(t *testing.T) {
 	if got := renderHash("https://api.example.test:6443", "ghcr.io", "false"); got == baseline {
 		t.Fatal("changing UNBOUNDED_REAP_LEGACY_RESOURCES did not change the rendered config hash")
 	}
+
 	if got := renderHash("https://api.example.test:6443", "registry.example.com", "true"); got == baseline {
 		t.Fatal("changing UNBOUNDED_IMAGE_REGISTRY did not change the rendered config hash")
 	}


### PR DESCRIPTION
## Summary

- run the Unbounded operator pod on the host network so it can start before CNI is available
- use the node DNS resolver for the AKS API FQDN during pre-CNI startup
- tolerate the `node.kubernetes.io/not-ready` taint present while the network plugin is uninitialized
- assert all three bootstrap requirements in the rendered-manifest test

## Why

The operator installs and manages Unbounded-Net, but its Deployment currently requires pod networking. On an AKS cluster created with `--network-plugin none`, that creates a bootstrap cycle: the node remains NotReady until CNI is installed, while the operator cannot start to install CNI.

`dnsPolicy: Default` is intentional because CoreDNS cannot run before CNI; it lets the host-networked operator resolve the AKS API FQDN through the node resolver.

## Validation

- `GOTOOLCHAIN=auto go test ./cmd/unbounded-operator ./deploy/unbounded-operator ./cmd/kubectl-unbounded/app`
- `GOTOOLCHAIN=auto golangci-lint run ./deploy/unbounded-operator/... ./cmd/unbounded-operator/... ./cmd/kubectl-unbounded/app/...`
- `GOTOOLCHAIN=auto make unbounded-operator-manifests`
