### PR TITLE
Move unbounded-net over to build as an OCI image.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -446,7 +446,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/unbounded-net-controller:ci-${{ matrix.arch }}
           cache-from: type=gha,scope=build-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
-          push: false
+          outputs: type=oci,dest=${{ runner.temp }}/net-controller.oci.tar,oci-mediatypes=true
           provenance: false
 
       - name: Build node image
@@ -463,8 +463,41 @@ jobs:
           tags: ${{ env.REGISTRY }}/unbounded-net-node:ci-${{ matrix.arch }}
           cache-from: type=gha,scope=build-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
-          push: false
+          outputs: type=oci,dest=${{ runner.temp }}/net-node.oci.tar,oci-mediatypes=true
           provenance: false
+
+      - name: Verify OCI image layouts
+        run: |
+          set -euo pipefail
+
+          validate_layout() {
+            local name="$1"
+            local archive="${RUNNER_TEMP}/net-${name}.oci.tar"
+            local index
+            index="$(tar -xOf "$archive" index.json)"
+
+            jq -e '
+              .schemaVersion == 2 and
+              .mediaType == "application/vnd.oci.image.index.v1+json" and
+              (.manifests | length > 0) and
+              all(.manifests[]; .mediaType == "application/vnd.oci.image.manifest.v1+json")
+            ' <<<"$index"
+
+            while IFS= read -r digest; do
+              local algorithm="${digest%%:*}"
+              local encoded="${digest#*:}"
+              local manifest="blobs/$algorithm/$encoded"
+              tar -xOf "$archive" "$manifest" | jq -e '
+                .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                .config.mediaType == "application/vnd.oci.image.config.v1+json" and
+                all(.layers[];
+                  .mediaType | test("^application/vnd\\.oci\\.image\\.layer\\.v1\\.tar(\\+(gzip|zstd))?$"))
+              '
+            done < <(jq -r '.manifests[].digest' <<<"$index")
+          }
+
+          validate_layout controller
+          validate_layout node
 
   # ---------- Publish Orca image (main only) ----------
   # Publishes a dev Orca image to ghcr on every merge to main so the

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -201,13 +201,14 @@ jobs:
         run: echo "go_version=$(awk '/^go /{split($2,v,"."); print v[1]"."v[2]}' go.mod)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push controller image
+        id: push_controller
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: images/net/Containerfile
           target: controller
           platforms: linux/amd64
-          push: true
+          outputs: type=image,push=true,oci-mediatypes=true
           provenance: false
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.go_version }}
@@ -219,13 +220,14 @@ jobs:
           cache-to: type=gha,scope=nightly-net-controller,mode=max
 
       - name: Build and push node image
+        id: push_node
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: images/net/Containerfile
           target: node
           platforms: linux/amd64
-          push: true
+          outputs: type=image,push=true,oci-mediatypes=true
           provenance: false
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.go_version }}
@@ -235,6 +237,27 @@ jobs:
           tags: ${{ env.REGISTRY }}/unbounded-net-node:${{ env.TAG }}
           cache-from: type=gha,scope=nightly-net-node
           cache-to: type=gha,scope=nightly-net-node,mode=max
+
+      - name: Verify OCI image media types
+        env:
+          CONTROLLER_DIGEST: ${{ steps.push_controller.outputs.digest }}
+          NODE_DIGEST: ${{ steps.push_node.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for image in controller node; do
+            if [[ "$image" == "controller" ]]; then
+              digest="$CONTROLLER_DIGEST"
+            else
+              digest="$NODE_DIGEST"
+            fi
+            ref="${REGISTRY}/unbounded-net-${image}@${digest}"
+            docker buildx imagetools inspect --raw "$ref" | jq -e '
+              .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+              .config.mediaType == "application/vnd.oci.image.config.v1+json" and
+              all(.layers[];
+                .mediaType | test("^application/vnd\\.oci\\.image\\.layer\\.v1\\.tar(\\+(gzip|zstd))?$"))
+            '
+          done
 
   # ---------------------------------------------------------------------------
   # Build and push the remaining images the deploy needs (amd64).

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -342,7 +342,7 @@ jobs:
           file: images/net/Containerfile
           target: controller
           platforms: ${{ matrix.platform }}
-          push: true
+          outputs: type=image,push=true,oci-mediatypes=true
           provenance: false
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.go_version }}
@@ -361,7 +361,7 @@ jobs:
           file: images/net/Containerfile
           target: node
           platforms: ${{ matrix.platform }}
-          push: true
+          outputs: type=image,push=true,oci-mediatypes=true
           provenance: false
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.go_version }}
@@ -371,6 +371,27 @@ jobs:
           tags: ${{ env.REGISTRY }}/unbounded-net-node:${{ needs.version.outputs.tag }}-${{ matrix.arch }}
           cache-from: type=gha,scope=net-node-${{ matrix.arch }}
           cache-to: type=gha,scope=net-node-${{ matrix.arch }},mode=max
+
+      - name: Verify OCI image media types
+        env:
+          CONTROLLER_DIGEST: ${{ steps.push_controller.outputs.digest }}
+          NODE_DIGEST: ${{ steps.push_node.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for image in controller node; do
+            if [[ "$image" == "controller" ]]; then
+              digest="$CONTROLLER_DIGEST"
+            else
+              digest="$NODE_DIGEST"
+            fi
+            ref="${REGISTRY}/unbounded-net-${image}@${digest}"
+            docker buildx imagetools inspect --raw "$ref" | jq -e '
+              .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+              .config.mediaType == "application/vnd.oci.image.config.v1+json" and
+              all(.layers[];
+                .mediaType | test("^application/vnd\\.oci\\.image\\.layer\\.v1\\.tar(\\+(gzip|zstd))?$"))
+            '
+          done
 
       - name: Sign per-arch net images
         run: |
@@ -439,12 +460,23 @@ jobs:
           for image in controller node; do
             SRC="${{ env.REGISTRY }}/unbounded-net-${image}"
             echo "Creating manifest ${SRC}:${TAG}..."
+            metadata="$(mktemp)"
             docker buildx imagetools create \
               --tag "${SRC}:${TAG}" \
+              --metadata-file "$metadata" \
               "${SRC}:${TAG}-amd64" \
               "${SRC}:${TAG}-arm64"
 
-            digest="$(docker buildx imagetools inspect "${SRC}:${TAG}" | awk '$1 == "Digest:" {print $2; exit}')"
+            jq -e '
+              .["containerimage.descriptor"].mediaType == "application/vnd.oci.image.index.v1+json"
+            ' "$metadata"
+            docker buildx imagetools inspect --raw "${SRC}:${TAG}" | jq -e '
+              .mediaType == "application/vnd.oci.image.index.v1+json" and
+              all(.manifests[]; .mediaType == "application/vnd.oci.image.manifest.v1+json")
+            '
+
+            digest="$(jq -r '.["containerimage.descriptor"].digest // empty' "$metadata")"
+            rm -f "$metadata"
             if [[ -z "$digest" ]]; then
               echo "could not resolve digest for ${SRC}:${TAG}" >&2
               exit 1


### PR DESCRIPTION
Move unbounded-net over to build as an OCI image.