### PR TITLE
ci: mark CodeQL merge_group runs as continue-on-error to fix flaky SARIF upload

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -30,6 +30,14 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    # In merge_group runs, GitHub's merge queue can complete and delete the
+    # temporary gh-readonly-queue ref before this job finishes uploading its
+    # SARIF results (Go analysis in particular can take 10+ minutes), which
+    # makes the upload step fail with a spurious "ref not found" error even
+    # though the merge itself already succeeded. Don't let that false
+    # failure block/redden the check; the same commit is also analyzed via
+    # the pull_request trigger before it ever enters the queue.
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The `Analyze (go)` CodeQL job fails intermittently when run for a `merge_group` event:

```
##[error]ref 'refs/heads/gh-readonly-queue/main/pr-558-...' not found in this repository
```

Reference: https://github.com/Azure/unbounded/actions/runs/30668066925/job/91279593342

Go CodeQL analysis (autobuild + full dependency extraction) takes on the order of 10+ minutes. The merge queue's other required checks can pass and the queue can complete/merge before this job finishes, which deletes the temporary `gh-readonly-queue/...` ref. When the CodeQL job later tries to upload its SARIF results, the ref is already gone and the upload step fails with a "ref not found" error, even though the merge itself already succeeded and nothing was actually blocked.

## Fix

Rather than dropping the `merge_group` trigger entirely (which would stop CodeQL from ever scanning merge-queue-specific commits, e.g. when multiple PRs are batched together via the `ALLGREEN` grouping strategy), mark the `analyze` job as `continue-on-error` only when triggered by `merge_group`. This preserves real CodeQL coverage and results for merge-queue commits while not letting this known, benign race condition surface as a failed/red check after the merge has already gone through.

A follow-up could look at reducing Go analysis time (build-mode tuning, dependency caching) to make this race less likely to occur in the first place, but that's independent of this fix.