### PR TITLE
Fix automatic fabric MTU reconciliation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -531,6 +531,14 @@ notices:
     license:
       - name: Apache License, Version 2.0
         link: https://github.com/vishvananda/netlink/blob/v1.3.1/LICENSE
+  - dependency: github.com/vishvananda/netns
+    ecosystem: go
+    copyright:
+      - Copyright 2014 Vishvananda Ishaya.
+      - Copyright 2014 Docker, Inc.
+    license:
+      - name: Apache License, Version 2.0
+        link: https://github.com/vishvananda/netns/blob/v0.0.5/LICENSE
   - dependency: golang.org/x/crypto
     ecosystem: go
     copyright:

--- a/cmd/unbounded-net-node/main.go
+++ b/cmd/unbounded-net-node/main.go
@@ -771,6 +771,10 @@ func run(cfg *config) error {
 	manageCniPlugin := getManageCniPluginFromCRDs(siteInformer, mySiteName)
 	siteTunnelMTU := getSiteTunnelMTUFromCRDs(siteInformer, mySiteName)
 	initialCNIConfigMTU := resolveInitialCNIConfigMTU(cfg.MTU, siteTunnelMTU, unboundednetnetlink.DetectDefaultRouteMTU())
+	if manageCniPlugin && initialCNIConfigMTU == 0 {
+		initialCNIConfigMTU = 1280
+		klog.Warning("Could not detect an initial route MTU; using safe CNI MTU 1280 until reconciliation resolves the fabric MTU")
+	}
 
 	var nodePodCIDRs []string
 

--- a/cmd/unbounded-net-node/main.go
+++ b/cmd/unbounded-net-node/main.go
@@ -198,7 +198,7 @@ func main() {
 		WireGuardDir:                  "/etc/wireguard",
 		WireGuardPort:                 51820,
 		EnablePolicyRouting:           false,
-		MTU:                           1280, // default WireGuard MTU (IPv6 minimum)
+		MTU:                           0,
 		HealthPort:                    9998,
 		InformerResyncPeriod:          600 * time.Second,
 		StatusPushEnabled:             true,             // Enabled by default
@@ -270,7 +270,7 @@ then annotates the node with the public key.`,
 	flags.StringVar(&cfg.CNIConfDir, "cni-conf-dir", "/etc/cni/net.d", "Directory to write CNI configuration")
 	flags.StringVar(&cfg.CNIConfFile, "cni-conf-file", "10-unbounded.conflist", "Name of the CNI configuration file")
 	flags.StringVar(&cfg.BridgeName, "bridge-name", "cbr0", "Name of the bridge interface")
-	flags.IntVar(&cfg.MTU, "mtu", 1280, "MTU for WireGuard and bridge interfaces (default 1280, the IPv6 minimum)")
+	flags.IntVar(&cfg.MTU, "mtu", 0, "Maximum MTU for tunnel and bridge interfaces (0 automatically derives MTU from each underlay route)")
 
 	// WireGuard configuration flags
 	flags.StringVar(&cfg.WireGuardDir, "wireguard-dir", "/etc/wireguard", "Directory to store WireGuard keys")
@@ -589,9 +589,8 @@ func applyNodeRuntimeConfig(cmd *cobra.Command, cfg *config) error {
 		return err
 	}
 
-	// Normalize MTU: treat 0 as 1280 (the IPv6 minimum, safe for all links).
-	if cfg.MTU == 0 {
-		cfg.MTU = 1280
+	if cfg.MTU < 0 {
+		return fmt.Errorf("node MTU must be >= 0")
 	}
 
 	// Apply common config.
@@ -770,17 +769,27 @@ func run(cfg *config) error {
 
 	// Check if this node's site has manageCniPlugin enabled using the informer cache
 	manageCniPlugin := getManageCniPluginFromCRDs(siteInformer, mySiteName)
+	siteTunnelMTU := getSiteTunnelMTUFromCRDs(siteInformer, mySiteName)
+	initialCNIConfigMTU := resolveInitialCNIConfigMTU(cfg.MTU, siteTunnelMTU, unboundednetnetlink.DetectDefaultRouteMTU())
 
 	var nodePodCIDRs []string
+
 	if manageCniPlugin {
 		// Wait for podCIDRs and configure CNI
-		nodePodCIDRs, err = waitForPodCIDRsAndConfigure(ctx, clientset, cfg, &cniConfigured)
+		cniCfg := *cfg
+		cniCfg.MTU = initialCNIConfigMTU
+
+		nodePodCIDRs, err = waitForPodCIDRsAndConfigure(ctx, clientset, &cniCfg, &cniConfigured)
 		if err != nil {
 			if err == context.Canceled {
 				return nil
 			}
 
 			return err
+		}
+
+		if err := ensureCNIBridgeMTUFunc(cfg.BridgeName, initialCNIConfigMTU, netlinkCache, true); err != nil {
+			return fmt.Errorf("reconcile MTU on CNI bridge %s: %w", cfg.BridgeName, err)
 		}
 	} else {
 		klog.Info("manageCniPlugin is false for this site - skipping CNI configuration")
@@ -798,5 +807,5 @@ func run(cfg *config) error {
 	// After CNI is configured (or skipped), watch Site CRD for WireGuard peers
 	// Pass the node's podCIDRs so routes can be configured with preferred source IPs
 	// Also pass the informers so they can be reused (already synced)
-	return watchSiteAndConfigureWireGuard(ctx, clientset, dynamicClient, cfg, pubKey, nodePodCIDRs, manageCniPlugin, healthState, netlinkCache, siteInformer, sliceInformer, gatewayPoolInformer, gatewayNodeInformer, sitePeeringInformer, assignmentInformer, poolPeeringInformer)
+	return watchSiteAndConfigureWireGuard(ctx, clientset, dynamicClient, cfg, pubKey, nodePodCIDRs, manageCniPlugin, initialCNIConfigMTU, healthState, netlinkCache, siteInformer, sliceInformer, gatewayPoolInformer, gatewayNodeInformer, sitePeeringInformer, assignmentInformer, poolPeeringInformer)
 }

--- a/cmd/unbounded-net-node/main.go
+++ b/cmd/unbounded-net-node/main.go
@@ -770,9 +770,11 @@ func run(cfg *config) error {
 	// Check if this node's site has manageCniPlugin enabled using the informer cache
 	manageCniPlugin := getManageCniPluginFromCRDs(siteInformer, mySiteName)
 	siteTunnelMTU := getSiteTunnelMTUFromCRDs(siteInformer, mySiteName)
+
 	initialCNIConfigMTU := resolveInitialCNIConfigMTU(cfg.MTU, siteTunnelMTU, unboundednetnetlink.DetectDefaultRouteMTU())
 	if manageCniPlugin && initialCNIConfigMTU == 0 {
 		initialCNIConfigMTU = 1280
+
 		klog.Warning("Could not detect an initial route MTU; using safe CNI MTU 1280 until reconciliation resolves the fabric MTU")
 	}
 

--- a/cmd/unbounded-net-node/mtu.go
+++ b/cmd/unbounded-net-node/mtu.go
@@ -1,0 +1,394 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/vishvananda/netlink"
+
+	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
+	unboundednetnetlink "github.com/Azure/unbounded/internal/net/netlink"
+)
+
+const hostProcDir = "/proc"
+
+type cniBridgeLinkManager interface {
+	Exists() bool
+	EnsureMTUWithCache(*unboundednetnetlink.NetlinkCache, int) error
+	EnsureBridgePortMTUs(int) error
+	EnsureBridgePodMTUs(string, int) error
+}
+
+var (
+	ensureCNIBridgeMTUFunc    = ensureCNIBridgeMTU
+	newCNIBridgeLinkManagerFn = func(bridgeName string) cniBridgeLinkManager {
+		return unboundednetnetlink.NewLinkManager(bridgeName)
+	}
+)
+
+func ensureCNIBridgeMTU(bridgeName string, mtu int, cache *unboundednetnetlink.NetlinkCache, reconcilePods bool) error {
+	if bridgeName == "" || mtu <= 0 {
+		return nil
+	}
+
+	linkManager := newCNIBridgeLinkManagerFn(bridgeName)
+	if !linkManager.Exists() {
+		return nil
+	}
+
+	if err := linkManager.EnsureMTUWithCache(cache, mtu); err != nil {
+		return err
+	}
+
+	if err := linkManager.EnsureBridgePortMTUs(mtu); err != nil {
+		return err
+	}
+
+	if !reconcilePods {
+		return nil
+	}
+
+	return linkManager.EnsureBridgePodMTUs(hostProcDir, mtu)
+}
+
+func verifyActiveTunnelMTUs(cfg *config, fabricMTU int, meshPeers []meshPeerInfo, gatewayPeers []gatewayPeerInfo) error {
+	if fabricMTU <= 0 {
+		return nil
+	}
+
+	required := make(map[string]bool)
+	if len(meshPeers) > 0 || len(gatewayPeers) > 0 {
+		required[unbounded0DeviceName] = true
+	}
+
+	needsGeneve, needsIPIP, needsVXLAN := neededTunnelProtocols(meshPeers, gatewayPeers)
+	if needsGeneve {
+		required[cfg.GeneveInterfaceName] = true
+	}
+
+	if needsIPIP {
+		required[cfg.IPIPInterfaceName] = true
+	}
+
+	if needsVXLAN {
+		required[cfg.VXLANInterfaceName] = true
+	}
+
+	wireGuardMesh := false
+	for _, peer := range meshPeers {
+		if unboundednetv1alpha1.TunnelProtocol(peer.TunnelProtocol) == unboundednetv1alpha1.TunnelProtocolWireGuard {
+			wireGuardMesh = true
+			break
+		}
+	}
+
+	if wireGuardMesh {
+		required[wireGuardInterfaceName(cfg, cfg.WireGuardPort)] = true
+	}
+
+	for _, peer := range gatewayPeers {
+		if unboundednetv1alpha1.TunnelProtocol(peer.TunnelProtocol) != unboundednetv1alpha1.TunnelProtocolWireGuard {
+			continue
+		}
+
+		if peer.GatewayWireguardPort == 0 {
+			return fmt.Errorf("WireGuard gateway peer %s has no interface port", peer.Name)
+		}
+
+		required[wireGuardInterfaceName(cfg, int(peer.GatewayWireguardPort))] = true
+	}
+
+	names := make([]string, 0, len(required))
+	for name := range required {
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+
+	sort.Strings(names)
+
+	for _, name := range names {
+		link, err := netlink.LinkByName(name)
+		if err != nil {
+			return fmt.Errorf("required tunnel interface %s is unavailable: %w", name, err)
+		}
+
+		if link.Attrs().MTU < fabricMTU {
+			return fmt.Errorf("tunnel interface %s MTU %d is below fabric MTU %d", name, link.Attrs().MTU, fabricMTU)
+		}
+	}
+
+	return nil
+}
+
+func resolveInitialCNIConfigMTU(configuredMTU, siteMTU, underlayMTU int) int {
+	autoMTU := 0
+	if underlayMTU > unboundednetnetlink.WireGuardMTUOverhead {
+		autoMTU = underlayMTU - unboundednetnetlink.WireGuardMTUOverhead
+	}
+
+	return resolveTunnelMTU(configuredMTU, siteMTU, autoMTU)
+}
+
+func resolveCNIConfigMTU(configuredMTU, siteMTU int, meshPeers []meshPeerInfo, gatewayPeers []gatewayPeerInfo, underlayMTU int) int {
+	values := []int{siteMTU}
+	for _, peer := range meshPeers {
+		values = append(values, peer.TunnelMTU)
+	}
+
+	for _, peer := range gatewayPeers {
+		values = append(values, peer.TunnelMTU)
+	}
+
+	mtu := resolveTunnelMTU(configuredMTU, values...)
+	if mtu > 0 {
+		return mtu
+	}
+
+	return resolveInitialCNIConfigMTU(configuredMTU, siteMTU, underlayMTU)
+}
+
+func resolvePeerTunnelMTUs(
+	cfg *config,
+	meshPeers []meshPeerInfo,
+	gatewayPeers []gatewayPeerInfo,
+	mySiteName string,
+	peeredSites, networkPeeredSites map[string]bool,
+	siteTunnelMTUs, peeringSiteTunnelMTUs, assignmentSiteTunnelMTUs,
+	assignmentPoolTunnelMTUs, poolTunnelMTUs map[string]int,
+	cache *unboundednetnetlink.NetlinkCache,
+) {
+	for i := range meshPeers {
+		underlayIP := selectUnderlayIP(meshPeers[i].InternalIPs, cfg.TunnelIPFamily)
+		autoMTU := detectEncapsulatedRouteMTU(cfg, underlayIP, meshPeers[i].TunnelProtocol, cache)
+		meshPeers[i].TunnelMTU = resolveTunnelMTU(cfg.MTU, autoMTU,
+			resolveMeshPeerTunnelMTU(0, meshPeers[i], mySiteName,
+				siteTunnelMTUs, peeringSiteTunnelMTUs, assignmentSiteTunnelMTUs))
+	}
+
+	for i := range gatewayPeers {
+		underlayIP := gatewayPeerUnderlayIP(gatewayPeers[i], mySiteName, networkPeeredSites, cfg.TunnelIPFamily)
+		if underlayIP == nil && peeredSites[gatewayPeers[i].SiteName] {
+			underlayIP = selectUnderlayIP(gatewayPeers[i].InternalIPs, cfg.TunnelIPFamily)
+		}
+
+		autoMTU := detectEncapsulatedRouteMTU(cfg, underlayIP, gatewayPeers[i].TunnelProtocol, cache)
+		gatewayPeers[i].TunnelMTU = resolveTunnelMTU(cfg.MTU, autoMTU,
+			resolveGatewayPeerTunnelMTU(0, mySiteName, gatewayPeers[i],
+				siteTunnelMTUs, assignmentPoolTunnelMTUs, poolTunnelMTUs))
+	}
+}
+
+func gatewayPeerUnderlayIP(peer gatewayPeerInfo, mySiteName string, networkPeeredSites map[string]bool, ipFamily string) net.IP {
+	if peer.SiteName == mySiteName || networkPeeredSites[peer.SiteName] || peer.PoolType != gatewayPoolTypeExternal {
+		return selectUnderlayIP(peer.InternalIPs, ipFamily)
+	}
+
+	for _, ipStr := range peer.ExternalIPs {
+		if ip := net.ParseIP(ipStr); ip != nil {
+			if ipFamily == "IPv4" && ip.To4() == nil {
+				continue
+			}
+
+			if ipFamily == "IPv6" && ip.To4() != nil {
+				continue
+			}
+
+			return ip
+		}
+	}
+
+	return nil
+}
+
+func detectEncapsulatedRouteMTU(cfg *config, underlayIP net.IP, protocol string, cache *unboundednetnetlink.NetlinkCache) int {
+	underlayMTU, ifaceName := unboundednetnetlink.DetectRouteMTUAndInterface(underlayIP, cache)
+	if isManagedTunnelInterface(cfg, ifaceName) {
+		underlayMTU = detectUnderlyingRouteMTU(cfg, underlayIP, cache)
+	}
+
+	if underlayMTU == 0 {
+		underlayMTU = unboundednetnetlink.DetectDefaultRouteMTUFromCache(cache)
+	}
+
+	overhead := tunnelProtocolMTUOverhead(protocol)
+	if underlayMTU <= overhead {
+		return 0
+	}
+
+	return underlayMTU - overhead
+}
+
+func detectUnderlyingRouteMTU(cfg *config, destination net.IP, cache *unboundednetnetlink.NetlinkCache) int {
+	if destination == nil {
+		return 0
+	}
+
+	family := netlink.FAMILY_V6
+	if destination.To4() != nil {
+		family = netlink.FAMILY_V4
+	}
+
+	var (
+		routes []netlink.Route
+		err    error
+	)
+	if cache != nil {
+		routes, err = cache.RouteList(nil, family)
+	} else {
+		routes, err = netlink.RouteList(nil, family)
+	}
+
+	if err != nil {
+		return 0
+	}
+
+	bestPrefix := -1
+	bestPriority := 0
+	bestMTU := 0
+
+	for _, route := range routes {
+		prefix := 0
+
+		if route.Dst != nil {
+			if !route.Dst.Contains(destination) {
+				continue
+			}
+
+			prefix, _ = route.Dst.Mask.Size()
+		}
+
+		var link netlink.Link
+		if cache != nil {
+			link, err = cache.LinkByIndex(route.LinkIndex)
+		} else {
+			link, err = netlink.LinkByIndex(route.LinkIndex)
+		}
+
+		if err != nil || link == nil || isManagedTunnelInterface(cfg, link.Attrs().Name) {
+			continue
+		}
+
+		if prefix < bestPrefix || (prefix == bestPrefix && bestPrefix >= 0 && route.Priority >= bestPriority) {
+			continue
+		}
+
+		mtu := link.Attrs().MTU
+		if route.MTU > 0 && (mtu == 0 || route.MTU < mtu) {
+			mtu = route.MTU
+		}
+
+		if mtu == 0 {
+			continue
+		}
+
+		bestPrefix = prefix
+		bestPriority = route.Priority
+		bestMTU = mtu
+	}
+
+	return bestMTU
+}
+
+func tunnelProtocolMTUOverhead(protocol string) int {
+	switch unboundednetv1alpha1.TunnelProtocol(protocol) {
+	case unboundednetv1alpha1.TunnelProtocolGENEVE:
+		return unboundednetnetlink.GeneveMTUOverhead
+	case unboundednetv1alpha1.TunnelProtocolVXLAN:
+		return unboundednetnetlink.VXLANMTUOverhead
+	case unboundednetv1alpha1.TunnelProtocolIPIP:
+		return unboundednetnetlink.IPIPMTUOverhead
+	case unboundednetv1alpha1.TunnelProtocolNone:
+		return 0
+	default:
+		return unboundednetnetlink.WireGuardMTUOverhead
+	}
+}
+
+func minimumPeerTunnelMTU(protocol string, meshPeers []meshPeerInfo, gatewayPeers []gatewayPeerInfo) int {
+	values := make([]int, 0, len(meshPeers)+len(gatewayPeers))
+	for _, peer := range meshPeers {
+		if peer.TunnelProtocol == protocol {
+			values = append(values, peer.TunnelMTU)
+		}
+	}
+
+	for _, peer := range gatewayPeers {
+		if peer.TunnelProtocol == protocol {
+			values = append(values, peer.TunnelMTU)
+		}
+	}
+
+	return resolveTunnelMTU(0, values...)
+}
+
+func protocolInterfaceMTU(configuredMTU, siteMTU, defaultUnderlayMTU int, protocol string, meshPeers []meshPeerInfo, gatewayPeers []gatewayPeerInfo) int {
+	mtu := minimumPeerTunnelMTU(protocol, meshPeers, gatewayPeers)
+	if mtu > 0 {
+		return mtu
+	}
+
+	var (
+		autoMTU  int
+		overhead = tunnelProtocolMTUOverhead(protocol)
+	)
+
+	if defaultUnderlayMTU > overhead {
+		autoMTU = defaultUnderlayMTU - overhead
+	}
+
+	return resolveTunnelMTU(configuredMTU, siteMTU, autoMTU)
+}
+
+func routeTunnelMTU(prefix *net.IPNet, meshPeers []meshPeerInfo, gatewayPeers []gatewayPeerInfo) int {
+	var values []int
+
+	addIfCovered := func(cidrStr string, mtu int) {
+		if mtu <= 0 {
+			return
+		}
+
+		_, cidr, err := net.ParseCIDR(cidrStr)
+		if err != nil {
+			return
+		}
+
+		if prefix.Contains(cidr.IP) || cidr.Contains(prefix.IP) {
+			values = append(values, mtu)
+		}
+	}
+
+	for _, peer := range meshPeers {
+		for _, cidr := range peer.PodCIDRs {
+			addIfCovered(cidr, peer.TunnelMTU)
+		}
+
+		for _, cidr := range ipsToHostCIDRs(peer.InternalIPs) {
+			addIfCovered(cidr, peer.TunnelMTU)
+		}
+	}
+
+	for _, peer := range gatewayPeers {
+		for _, cidr := range peer.PodCIDRs {
+			addIfCovered(cidr, peer.TunnelMTU)
+		}
+
+		for _, cidr := range peer.RoutedCidrs {
+			addIfCovered(cidr, peer.TunnelMTU)
+		}
+
+		for _, cidr := range ipsToHostCIDRs(peer.InternalIPs) {
+			addIfCovered(cidr, peer.TunnelMTU)
+		}
+	}
+
+	if mtu := resolveTunnelMTU(0, values...); mtu > 0 {
+		return mtu
+	}
+
+	return resolveCNIConfigMTU(0, 0, meshPeers, gatewayPeers, 0)
+}

--- a/cmd/unbounded-net-node/mtu.go
+++ b/cmd/unbounded-net-node/mtu.go
@@ -79,6 +79,7 @@ func verifyActiveTunnelMTUs(cfg *config, fabricMTU int, meshPeers []meshPeerInfo
 	}
 
 	wireGuardMesh := false
+
 	for _, peer := range meshPeers {
 		if unboundednetv1alpha1.TunnelProtocol(peer.TunnelProtocol) == unboundednetv1alpha1.TunnelProtocolWireGuard {
 			wireGuardMesh = true

--- a/cmd/unbounded-net-node/mtu_test.go
+++ b/cmd/unbounded-net-node/mtu_test.go
@@ -164,6 +164,10 @@ func TestResolveInitialCNIConfigMTU(t *testing.T) {
 	if got := resolveInitialCNIConfigMTU(1380, 1400, 1500); got != 1380 {
 		t.Fatalf("configured MTU = %d, want 1380", got)
 	}
+
+	if got := resolveInitialCNIConfigMTU(0, 0, 0); got != 0 {
+		t.Fatalf("unresolved MTU = %d, want 0 for caller fallback", got)
+	}
 }
 
 func TestResolveCNIConfigMTUUsesLowestPeer(t *testing.T) {

--- a/cmd/unbounded-net-node/mtu_test.go
+++ b/cmd/unbounded-net-node/mtu_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
+	unboundednetnetlink "github.com/Azure/unbounded/internal/net/netlink"
+)
+
+type fakeCNIBridgeLinkManager struct {
+	exists         bool
+	ensureErr      error
+	ensurePortsErr error
+	ensurePodsErr  error
+	ensureMTU      int
+	ensurePortsMTU int
+	ensurePodsMTU  int
+	netnsDir       string
+	cache          *unboundednetnetlink.NetlinkCache
+}
+
+func (f *fakeCNIBridgeLinkManager) Exists() bool {
+	return f.exists
+}
+
+func (f *fakeCNIBridgeLinkManager) EnsureMTUWithCache(cache *unboundednetnetlink.NetlinkCache, mtu int) error {
+	f.cache = cache
+	f.ensureMTU = mtu
+
+	return f.ensureErr
+}
+
+func (f *fakeCNIBridgeLinkManager) EnsureBridgePortMTUs(mtu int) error {
+	f.ensurePortsMTU = mtu
+
+	return f.ensurePortsErr
+}
+
+func (f *fakeCNIBridgeLinkManager) EnsureBridgePodMTUs(netnsDir string, mtu int) error {
+	f.netnsDir = netnsDir
+	f.ensurePodsMTU = mtu
+
+	return f.ensurePodsErr
+}
+
+func TestEnsureCNIBridgeMTU(t *testing.T) {
+	oldNewLinkManager := newCNIBridgeLinkManagerFn
+
+	t.Cleanup(func() {
+		newCNIBridgeLinkManagerFn = oldNewLinkManager
+	})
+
+	cache := &unboundednetnetlink.NetlinkCache{}
+
+	tests := []struct {
+		name       string
+		bridgeName string
+		mtu        int
+		exists     bool
+		ensureErr  error
+		portsErr   error
+		podsErr    error
+		wantCreate bool
+		wantEnsure bool
+		wantPorts  bool
+		wantPods   bool
+		wantErr    bool
+		reconcile  bool
+	}{
+		{name: "zero MTU", bridgeName: "cbr0", mtu: 0},
+		{name: "empty bridge name", mtu: 1420},
+		{name: "bridge not created yet", bridgeName: "cbr0", mtu: 1420, wantCreate: true},
+		{name: "existing bridge", bridgeName: "cbr0", mtu: 1420, exists: true, wantCreate: true, wantEnsure: true, wantPorts: true},
+		{name: "existing bridge and pods", bridgeName: "cbr0", mtu: 1420, exists: true, wantCreate: true, wantEnsure: true, wantPorts: true, wantPods: true, reconcile: true},
+		{name: "netlink error", bridgeName: "cbr0", mtu: 1420, exists: true, ensureErr: errors.New("set MTU"), wantCreate: true, wantEnsure: true, wantErr: true},
+		{name: "bridge port error", bridgeName: "cbr0", mtu: 1420, exists: true, portsErr: errors.New("set port MTU"), wantCreate: true, wantEnsure: true, wantPorts: true, wantErr: true},
+		{name: "pod interface error", bridgeName: "cbr0", mtu: 1420, exists: true, podsErr: errors.New("set pod MTU"), wantCreate: true, wantEnsure: true, wantPorts: true, wantPods: true, wantErr: true, reconcile: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &fakeCNIBridgeLinkManager{
+				exists:         tt.exists,
+				ensureErr:      tt.ensureErr,
+				ensurePortsErr: tt.portsErr,
+				ensurePodsErr:  tt.podsErr,
+			}
+			created := false
+			newCNIBridgeLinkManagerFn = func(bridgeName string) cniBridgeLinkManager {
+				created = true
+
+				if bridgeName != tt.bridgeName {
+					t.Fatalf("bridge name = %q, want %q", bridgeName, tt.bridgeName)
+				}
+
+				return manager
+			}
+
+			err := ensureCNIBridgeMTU(tt.bridgeName, tt.mtu, cache, tt.reconcile)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ensureCNIBridgeMTU() error = %v, want error %t", err, tt.wantErr)
+			}
+
+			if created != tt.wantCreate {
+				t.Fatalf("link manager created = %t, want %t", created, tt.wantCreate)
+			}
+
+			ensured := manager.ensureMTU != 0
+			if ensured != tt.wantEnsure {
+				t.Fatalf("MTU ensured = %t, want %t", ensured, tt.wantEnsure)
+			}
+
+			portsEnsured := manager.ensurePortsMTU != 0
+			if portsEnsured != tt.wantPorts {
+				t.Fatalf("bridge port MTUs ensured = %t, want %t", portsEnsured, tt.wantPorts)
+			}
+
+			podsEnsured := manager.ensurePodsMTU != 0
+			if podsEnsured != tt.wantPods {
+				t.Fatalf("pod interface MTUs ensured = %t, want %t", podsEnsured, tt.wantPods)
+			}
+
+			if tt.wantEnsure {
+				if manager.ensureMTU != tt.mtu {
+					t.Fatalf("ensured MTU = %d, want %d", manager.ensureMTU, tt.mtu)
+				}
+
+				if manager.cache != cache {
+					t.Fatal("netlink cache was not passed to link manager")
+				}
+			}
+
+			if tt.wantPorts && manager.ensurePortsMTU != tt.mtu {
+				t.Fatalf("ensured bridge port MTU = %d, want %d", manager.ensurePortsMTU, tt.mtu)
+			}
+
+			if tt.wantPods {
+				if manager.ensurePodsMTU != tt.mtu {
+					t.Fatalf("ensured pod interface MTU = %d, want %d", manager.ensurePodsMTU, tt.mtu)
+				}
+
+				if manager.netnsDir != hostProcDir {
+					t.Fatalf("proc directory = %q, want %q", manager.netnsDir, hostProcDir)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveInitialCNIConfigMTU(t *testing.T) {
+	if got := resolveInitialCNIConfigMTU(0, 0, 1500); got != 1420 {
+		t.Fatalf("auto MTU = %d, want 1420", got)
+	}
+
+	if got := resolveInitialCNIConfigMTU(0, 1400, 1500); got != 1400 {
+		t.Fatalf("site-limited MTU = %d, want 1400", got)
+	}
+
+	if got := resolveInitialCNIConfigMTU(1380, 1400, 1500); got != 1380 {
+		t.Fatalf("configured MTU = %d, want 1380", got)
+	}
+}
+
+func TestResolveCNIConfigMTUUsesLowestPeer(t *testing.T) {
+	meshPeers := []meshPeerInfo{{TunnelMTU: 1420}, {TunnelMTU: 1200}}
+	gatewayPeers := []gatewayPeerInfo{{TunnelMTU: 1350}}
+
+	if got := resolveCNIConfigMTU(0, 0, meshPeers, gatewayPeers, 1500); got != 1200 {
+		t.Fatalf("CNI MTU = %d, want 1200", got)
+	}
+}
+
+func TestTunnelProtocolMTUOverhead(t *testing.T) {
+	tests := map[string]int{
+		string(unboundednetv1alpha1.TunnelProtocolWireGuard): 80,
+		string(unboundednetv1alpha1.TunnelProtocolGENEVE):    58,
+		string(unboundednetv1alpha1.TunnelProtocolVXLAN):     50,
+		string(unboundednetv1alpha1.TunnelProtocolIPIP):      20,
+		string(unboundednetv1alpha1.TunnelProtocolNone):      0,
+	}
+
+	for protocol, want := range tests {
+		if got := tunnelProtocolMTUOverhead(protocol); got != want {
+			t.Fatalf("%s overhead = %d, want %d", protocol, got, want)
+		}
+	}
+}
+
+func TestRouteTunnelMTUUsesLowestMatchingPeer(t *testing.T) {
+	_, prefix, err := net.ParseCIDR("10.244.0.0/16")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	meshPeers := []meshPeerInfo{
+		{PodCIDRs: []string{"10.244.1.0/24"}, TunnelMTU: 1420},
+		{PodCIDRs: []string{"10.244.2.0/24"}, TunnelMTU: 1200},
+	}
+
+	if got := routeTunnelMTU(prefix, meshPeers, nil); got != 1200 {
+		t.Fatalf("route MTU = %d, want 1200", got)
+	}
+}
+
+func TestManagedTunnelInterfaceDetection(t *testing.T) {
+	cfg := &config{
+		WireGuardInterfacePrefix: "wg",
+		GeneveInterfaceName:      "geneve0",
+		VXLANInterfaceName:       "vxlan0",
+		IPIPInterfaceName:        "ipip0",
+	}
+
+	for _, iface := range []string{"unbounded0", "wg51820", "geneve0", "vxlan0", "ipip0"} {
+		if !isManagedTunnelInterface(cfg, iface) {
+			t.Fatalf("expected %s to be managed", iface)
+		}
+	}
+
+	if isManagedTunnelInterface(cfg, "tailscale0") {
+		t.Fatal("tailscale0 must be treated as an underlay route")
+	}
+}

--- a/cmd/unbounded-net-node/node_types.go
+++ b/cmd/unbounded-net-node/node_types.go
@@ -27,6 +27,8 @@ type wireGuardState struct {
 	nodeExternalIPs  []string // This node's external IPs (cached from node object)
 	siteName         string   // Site name this node belongs to
 	manageCniPlugin  bool     // Whether this node's site manages CNI plugin and full podCIDR mesh routes
+	cniMTU           int      // Last MTU written to the managed CNI configuration
+	cniConfigWritten bool     // Whether this process has written the managed CNI configuration
 	mu               sync.Mutex
 
 	// Kubernetes client for tainting nodes
@@ -100,7 +102,7 @@ type wireGuardState struct {
 	// Masquerade manager for iptables rules
 	masqueradeManager *unboundednetnetlink.MasqueradeManager
 
-	// MSS clamp manager for TCP MSS clamping on WireGuard interfaces
+	// MSS clamp manager for TCP MSS clamping across the unbounded fabric
 	mssClampManager *unboundednetnetlink.MSSClampManager
 
 	// Forward manager for tunnel-to-tunnel iptables FORWARD rules
@@ -189,6 +191,7 @@ type gatewayPeerInfo struct {
 	PodCIDRs               []string // Gateway node's podCIDRs for specific routing
 	SkipPodCIDRRoutes      bool     // Keep tunnel reachability host routes but skip explicit PodCIDR routes
 	TunnelProtocol         string   // Resolved tunnel protocol for this peer (WireGuard or GENEVE)
+	TunnelMTU              int      // Effective MTU after route, encapsulation, and CRD limits
 }
 
 // meshPeerInfo contains information about a peer on the main mesh interface.
@@ -204,6 +207,7 @@ type meshPeerInfo struct {
 	PodCIDRs               []string
 	SkipPodCIDRRoutes      bool   // Keep tunnel reachability host routes but skip explicit PodCIDR routes
 	TunnelProtocol         string // Resolved tunnel protocol for this peer (WireGuard or GENEVE)
+	TunnelMTU              int    // Effective MTU after route, encapsulation, and CRD limits
 }
 
 // Status types for /status and /status/json endpoints

--- a/cmd/unbounded-net-node/reconciliation_helpers.go
+++ b/cmd/unbounded-net-node/reconciliation_helpers.go
@@ -376,6 +376,7 @@ func resolveSiteTopologyTunnelMTU(
 
 	mySiteName = strings.TrimSpace(mySiteName)
 	start := sitePrefix + mySiteName
+
 	queue := make([]string, 0, 1+len(localGatewayPools))
 	if mySiteName != "" && adjacency[start] != nil {
 		queue = append(queue, start)
@@ -383,6 +384,7 @@ func resolveSiteTopologyTunnelMTU(
 
 	for _, poolName := range localGatewayPools {
 		poolName = strings.TrimSpace(poolName)
+
 		scope := poolPrefix + poolName
 		if poolName != "" && adjacency[scope] != nil {
 			queue = append(queue, scope)
@@ -399,6 +401,7 @@ func resolveSiteTopologyTunnelMTU(
 	for len(queue) > 0 {
 		scope := queue[0]
 		queue = queue[1:]
+
 		if visited[scope] {
 			continue
 		}

--- a/cmd/unbounded-net-node/reconciliation_helpers.go
+++ b/cmd/unbounded-net-node/reconciliation_helpers.go
@@ -255,13 +255,178 @@ func tunnelMTUFromSpec(mtu *int32) int {
 	return int(*mtu)
 }
 
+func mergeLowestTunnelMTU(tunnelMTUs map[string]int, scope string, mtu int) {
+	scope = strings.TrimSpace(scope)
+	if scope == "" || mtu <= 0 {
+		return
+	}
+
+	if current := tunnelMTUs[scope]; current == 0 || mtu < current {
+		tunnelMTUs[scope] = mtu
+	}
+}
+
+func mergeGatewayPoolPeeringTunnelMTU(tunnelMTUs map[string]int, peering unboundednetv1alpha1.GatewayPoolPeering) {
+	mtu := tunnelMTUFromSpec(peering.Spec.TunnelMTU)
+	for _, poolName := range peering.Spec.GatewayPools {
+		mergeLowestTunnelMTU(tunnelMTUs, poolName, mtu)
+	}
+}
+
+func resolveSiteTopologyTunnelMTU(
+	mySiteName string,
+	siteTunnelMTUs, poolTunnelMTUs map[string]int,
+	sitePeerings []unboundednetv1alpha1.SitePeering,
+	assignments []unboundednetv1alpha1.SiteGatewayPoolAssignment,
+	poolPeerings []unboundednetv1alpha1.GatewayPoolPeering,
+	localGatewayPools []string,
+) int {
+	const (
+		sitePrefix = "site/"
+		poolPrefix = "pool/"
+	)
+
+	adjacency := make(map[string]map[string]bool)
+	scopeTunnelMTUs := make(map[string]int)
+
+	addScope := func(scope string, mtu int) {
+		if scope == "" {
+			return
+		}
+
+		if adjacency[scope] == nil {
+			adjacency[scope] = make(map[string]bool)
+		}
+
+		mergeLowestTunnelMTU(scopeTunnelMTUs, scope, mtu)
+	}
+
+	connectScopes := func(scopes []string, mtu int) {
+		unique := make([]string, 0, len(scopes))
+		seen := make(map[string]bool, len(scopes))
+
+		for _, scope := range scopes {
+			scope = strings.TrimSpace(scope)
+			if scope == "" || seen[scope] {
+				continue
+			}
+
+			seen[scope] = true
+			unique = append(unique, scope)
+			addScope(scope, mtu)
+		}
+
+		if len(unique) < 2 {
+			return
+		}
+
+		first := unique[0]
+		for _, scope := range unique[1:] {
+			adjacency[first][scope] = true
+			adjacency[scope][first] = true
+		}
+	}
+
+	for siteName, mtu := range siteTunnelMTUs {
+		addScope(sitePrefix+siteName, mtu)
+	}
+
+	for poolName, mtu := range poolTunnelMTUs {
+		addScope(poolPrefix+poolName, mtu)
+	}
+
+	for _, peering := range sitePeerings {
+		scopes := make([]string, 0, len(peering.Spec.Sites))
+		for _, siteName := range peering.Spec.Sites {
+			if siteName = strings.TrimSpace(siteName); siteName != "" {
+				scopes = append(scopes, sitePrefix+siteName)
+			}
+		}
+
+		connectScopes(scopes, tunnelMTUFromSpec(peering.Spec.TunnelMTU))
+	}
+
+	for _, assignment := range assignments {
+		scopes := make([]string, 0, len(assignment.Spec.Sites)+len(assignment.Spec.GatewayPools))
+		for _, siteName := range assignment.Spec.Sites {
+			if siteName = strings.TrimSpace(siteName); siteName != "" {
+				scopes = append(scopes, sitePrefix+siteName)
+			}
+		}
+
+		for _, poolName := range assignment.Spec.GatewayPools {
+			if poolName = strings.TrimSpace(poolName); poolName != "" {
+				scopes = append(scopes, poolPrefix+poolName)
+			}
+		}
+
+		connectScopes(scopes, tunnelMTUFromSpec(assignment.Spec.TunnelMTU))
+	}
+
+	for _, peering := range poolPeerings {
+		scopes := make([]string, 0, len(peering.Spec.GatewayPools))
+		for _, poolName := range peering.Spec.GatewayPools {
+			if poolName = strings.TrimSpace(poolName); poolName != "" {
+				scopes = append(scopes, poolPrefix+poolName)
+			}
+		}
+
+		connectScopes(scopes, tunnelMTUFromSpec(peering.Spec.TunnelMTU))
+	}
+
+	mySiteName = strings.TrimSpace(mySiteName)
+	start := sitePrefix + mySiteName
+	queue := make([]string, 0, 1+len(localGatewayPools))
+	if mySiteName != "" && adjacency[start] != nil {
+		queue = append(queue, start)
+	}
+
+	for _, poolName := range localGatewayPools {
+		poolName = strings.TrimSpace(poolName)
+		scope := poolPrefix + poolName
+		if poolName != "" && adjacency[scope] != nil {
+			queue = append(queue, scope)
+		}
+	}
+
+	if len(queue) == 0 {
+		return 0
+	}
+
+	result := 0
+	visited := make(map[string]bool)
+
+	for len(queue) > 0 {
+		scope := queue[0]
+		queue = queue[1:]
+		if visited[scope] {
+			continue
+		}
+
+		visited[scope] = true
+		result = resolveTunnelMTU(result, scopeTunnelMTUs[scope])
+
+		for adjacent := range adjacency[scope] {
+			if !visited[adjacent] {
+				queue = append(queue, adjacent)
+			}
+		}
+	}
+
+	return result
+}
+
 // resolveTunnelMTU returns the effective tunnel MTU for a given scope,
 // taking the minimum of the global MTU and any CRD-specified MTU values.
 // Zero values in mtuValues are ignored (meaning "no override").
 func resolveTunnelMTU(globalMTU int, mtuValues ...int) int {
-	result := globalMTU
+	result := 0
+	if globalMTU > 0 {
+		result = globalMTU
+	}
+
 	for _, v := range mtuValues {
-		if v > 0 && v < result {
+		if v > 0 && (result == 0 || v < result) {
 			result = v
 		}
 	}
@@ -276,23 +441,15 @@ func resolveMeshPeerTunnelMTU(globalMTU int, peer meshPeerInfo, mySiteName strin
 	siteTunnelMTUs, peeringSiteTunnelMTUs map[string]int,
 	assignmentSiteTunnelMTUs map[string]int,
 ) int {
-	mtu := globalMTU
-	// Site MTU (from my site)
-	if v := siteTunnelMTUs[mySiteName]; v > 0 && v < mtu {
-		mtu = v
-	}
-	// If peer is in a different site, also consider the peering and assignment MTU
+	values := []int{siteTunnelMTUs[mySiteName]}
 	if peer.SiteName != mySiteName {
-		if v := peeringSiteTunnelMTUs[peer.SiteName]; v > 0 && v < mtu {
-			mtu = v
-		}
-
-		if v := assignmentSiteTunnelMTUs[peer.SiteName]; v > 0 && v < mtu {
-			mtu = v
-		}
+		values = append(values,
+			peeringSiteTunnelMTUs[peer.SiteName],
+			assignmentSiteTunnelMTUs[peer.SiteName],
+		)
 	}
 
-	return mtu
+	return resolveTunnelMTU(globalMTU, values...)
 }
 
 // resolveGatewayPeerTunnelMTU resolves the effective tunnel MTU for a gateway peer.
@@ -302,20 +459,11 @@ func resolveGatewayPeerTunnelMTU(globalMTU int, mySiteName string, peer gatewayP
 	siteTunnelMTUs, assignmentPoolTunnelMTUs map[string]int,
 	poolTunnelMTUs map[string]int,
 ) int {
-	mtu := globalMTU
-	if v := siteTunnelMTUs[mySiteName]; v > 0 && v < mtu {
-		mtu = v
-	}
-
-	if v := assignmentPoolTunnelMTUs[peer.PoolName]; v > 0 && v < mtu {
-		mtu = v
-	}
-
-	if v := poolTunnelMTUs[peer.PoolName]; v > 0 && v < mtu {
-		mtu = v
-	}
-
-	return mtu
+	return resolveTunnelMTU(globalMTU,
+		siteTunnelMTUs[mySiteName],
+		assignmentPoolTunnelMTUs[peer.PoolName],
+		poolTunnelMTUs[peer.PoolName],
+	)
 }
 
 func intOrStringMilliseconds(value *intstr.IntOrString, fieldRef string) (int, bool) {
@@ -471,7 +619,9 @@ func meshPeersEqual(a, b []meshPeerInfo) bool {
 			a[i].WireGuardPublicKey != b[i].WireGuardPublicKey ||
 			!strSliceEqual(a[i].InternalIPs, b[i].InternalIPs) ||
 			!strSliceEqual(a[i].PodCIDRs, b[i].PodCIDRs) ||
-			a[i].SkipPodCIDRRoutes != b[i].SkipPodCIDRRoutes {
+			a[i].SkipPodCIDRRoutes != b[i].SkipPodCIDRRoutes ||
+			a[i].TunnelProtocol != b[i].TunnelProtocol ||
+			a[i].TunnelMTU != b[i].TunnelMTU {
 			return false
 		}
 	}
@@ -499,7 +649,9 @@ func gatewayPeersEqual(a, b []gatewayPeerInfo) bool {
 			!strSliceEqual(a[i].RoutedCidrs, b[i].RoutedCidrs) ||
 			!intMapEqual(a[i].RouteDistances, b[i].RouteDistances) ||
 			!strSliceEqual(a[i].PodCIDRs, b[i].PodCIDRs) ||
-			a[i].SkipPodCIDRRoutes != b[i].SkipPodCIDRRoutes {
+			a[i].SkipPodCIDRRoutes != b[i].SkipPodCIDRRoutes ||
+			a[i].TunnelProtocol != b[i].TunnelProtocol ||
+			a[i].TunnelMTU != b[i].TunnelMTU {
 			return false
 		}
 	}

--- a/cmd/unbounded-net-node/reconciliation_helpers_test.go
+++ b/cmd/unbounded-net-node/reconciliation_helpers_test.go
@@ -226,6 +226,125 @@ func TestTunnelMTUFromSpec(t *testing.T) {
 	}
 }
 
+func TestMergeLowestTunnelMTU(t *testing.T) {
+	tunnelMTUs := map[string]int{"pool-a": 1400}
+
+	mergeLowestTunnelMTU(tunnelMTUs, "pool-a", 1450)
+	mergeLowestTunnelMTU(tunnelMTUs, "pool-a", 1280)
+	mergeLowestTunnelMTU(tunnelMTUs, " pool-b ", 1300)
+	mergeLowestTunnelMTU(tunnelMTUs, "", 1200)
+	mergeLowestTunnelMTU(tunnelMTUs, "pool-c", 0)
+
+	if got := tunnelMTUs["pool-a"]; got != 1280 {
+		t.Fatalf("pool-a MTU = %d, want 1280", got)
+	}
+
+	if got := tunnelMTUs["pool-b"]; got != 1300 {
+		t.Fatalf("pool-b MTU = %d, want 1300", got)
+	}
+
+	if _, exists := tunnelMTUs["pool-c"]; exists {
+		t.Fatal("zero MTU should not create a scope")
+	}
+}
+
+func TestMergeGatewayPoolPeeringTunnelMTU(t *testing.T) {
+	mtu := int32(1280)
+	peering := unboundednetv1alpha1.GatewayPoolPeering{
+		Spec: unboundednetv1alpha1.GatewayPoolPeeringSpec{
+			GatewayPools: []string{"pool-a", "pool-b"},
+			TunnelMTU:    &mtu,
+		},
+	}
+	tunnelMTUs := map[string]int{"pool-a": 1400, "pool-b": 1200}
+
+	mergeGatewayPoolPeeringTunnelMTU(tunnelMTUs, peering)
+
+	if got := tunnelMTUs["pool-a"]; got != 1280 {
+		t.Fatalf("pool-a MTU = %d, want 1280", got)
+	}
+
+	if got := tunnelMTUs["pool-b"]; got != 1200 {
+		t.Fatalf("pool-b MTU = %d, want existing lower value 1200", got)
+	}
+}
+
+func TestResolveSiteTopologyTunnelMTU(t *testing.T) {
+	siteMTUs := map[string]int{
+		"local":        1450,
+		"remote":       1250,
+		"disconnected": 576,
+	}
+	poolMTUs := map[string]int{
+		"local-pool":  1400,
+		"remote-pool": 1350,
+	}
+
+	sitePeerings := []unboundednetv1alpha1.SitePeering{{
+		Spec: unboundednetv1alpha1.SitePeeringSpec{
+			Sites:     []string{"local", "remote"},
+			TunnelMTU: ptrInt32(1300),
+		},
+	}}
+	assignments := []unboundednetv1alpha1.SiteGatewayPoolAssignment{
+		{
+			Spec: unboundednetv1alpha1.SiteGatewayPoolAssignmentSpec{
+				Sites:        []string{"local"},
+				GatewayPools: []string{"local-pool"},
+				TunnelMTU:    ptrInt32(1380),
+			},
+		},
+		{
+			Spec: unboundednetv1alpha1.SiteGatewayPoolAssignmentSpec{
+				Sites:        []string{"remote"},
+				GatewayPools: []string{"remote-pool"},
+			},
+		},
+	}
+	poolPeerings := []unboundednetv1alpha1.GatewayPoolPeering{{
+		Spec: unboundednetv1alpha1.GatewayPoolPeeringSpec{
+			GatewayPools: []string{"local-pool", "remote-pool"},
+			TunnelMTU:    ptrInt32(1280),
+		},
+	}}
+
+	if got := resolveSiteTopologyTunnelMTU(
+		"local",
+		siteMTUs,
+		poolMTUs,
+		sitePeerings,
+		assignments,
+		poolPeerings,
+		nil,
+	); got != 1250 {
+		t.Fatalf("local topology MTU = %d, want remote site minimum 1250", got)
+	}
+
+	if got := resolveSiteTopologyTunnelMTU(
+		"disconnected",
+		siteMTUs,
+		poolMTUs,
+		sitePeerings,
+		assignments,
+		poolPeerings,
+		nil,
+	); got != 576 {
+		t.Fatalf("disconnected topology MTU = %d, want 576", got)
+	}
+
+	if got := resolveSiteTopologyTunnelMTU(
+		"local",
+		map[string]int{"local": 1450},
+		map[string]int{"gateway-only": 1200},
+		nil,
+		nil,
+		nil,
+		[]string{"gateway-only"},
+	); got != 1200 {
+		t.Fatalf("gateway pool membership MTU = %d, want 1200", got)
+	}
+}
+
 // TestResolveTunnelMTU tests resolveTunnelMTU.
 func TestResolveTunnelMTU(t *testing.T) {
 	// No overrides -- global wins
@@ -243,6 +362,10 @@ func TestResolveTunnelMTU(t *testing.T) {
 	// Higher CRD value does not override global
 	if got := resolveTunnelMTU(1420, 1500); got != 1420 {
 		t.Fatalf("expected 1420, got %d", got)
+	}
+	// Zero global means automatic/unset, so a CRD value can establish the MTU.
+	if got := resolveTunnelMTU(0, 1420); got != 1420 {
+		t.Fatalf("expected 1420 with automatic global MTU, got %d", got)
 	}
 }
 

--- a/cmd/unbounded-net-node/site_watch_reconcile.go
+++ b/cmd/unbounded-net-node/site_watch_reconcile.go
@@ -35,7 +35,7 @@ import (
 // watchSitesAndConfigureWireGuard watches SiteNodeSlice objects and configures WireGuard peers for nodes in the same site
 // Gateway nodes can operate without being assigned to a site - they will still configure themselves to accept connections
 // The informers are passed in from run() and are already started and synced.
-func watchSiteAndConfigureWireGuard(ctx context.Context, clientset kubernetes.Interface, dynamicClient dynamic.Interface, cfg *config, myPubKey string, nodePodCIDRs []string, manageCniPlugin bool, healthState *nodeHealthState, netlinkCache *unboundednetnetlink.NetlinkCache, siteInformer, sliceInformer, gatewayPoolInformer, gatewayNodeInformer, sitePeeringInformer, assignmentInformer, poolPeeringInformer cache.SharedIndexInformer) error {
+func watchSiteAndConfigureWireGuard(ctx context.Context, clientset kubernetes.Interface, dynamicClient dynamic.Interface, cfg *config, myPubKey string, nodePodCIDRs []string, manageCniPlugin bool, initialCNIConfigMTU int, healthState *nodeHealthState, netlinkCache *unboundednetnetlink.NetlinkCache, siteInformer, sliceInformer, gatewayPoolInformer, gatewayNodeInformer, sitePeeringInformer, assignmentInformer, poolPeeringInformer cache.SharedIndexInformer) error {
 	klog.Info("Watching Site, SiteNodeSlice, GatewayPool, GatewayPoolNode, SitePeering, SiteGatewayPoolAssignment, and GatewayPoolPeering objects for changes")
 
 	// Read private key for WireGuard configuration
@@ -59,6 +59,8 @@ func watchSiteAndConfigureWireGuard(ctx context.Context, clientset kubernetes.In
 		linkManager:                   linkManager,
 		nodePodCIDRs:                  nodePodCIDRs, // Store node's podCIDRs for cbr0 gateway IP calculation
 		manageCniPlugin:               manageCniPlugin,
+		cniMTU:                        initialCNIConfigMTU,
+		cniConfigWritten:              manageCniPlugin,
 		clientset:                     clientset,    // Store clientset for tainting nodes
 		nodeName:                      cfg.NodeName, // Store node name for tainting
 		meshPeerHealthCheckEnabled:    make(map[string]bool),
@@ -163,16 +165,14 @@ func watchSiteAndConfigureWireGuard(ctx context.Context, clientset kubernetes.In
 		klog.Info("Masquerade manager initialized")
 	}
 
-	// Initialize MSS clamp manager for TCP MSS clamping on WireGuard interfaces.
-	// This prevents pods (with 1500-byte veth MTU) from advertising an MSS that
-	// exceeds the WireGuard tunnel MTU, which would cause silent drops of large
-	// TCP responses (e.g., TLS ServerHello) at gateway forwarding hops.
+	// Initialize MSS clamping for all forwarded traffic using the lowest
+	// calculated MTU for the unbounded fabric.
 	mssClampMgr, err := unboundednetnetlink.NewMSSClampManager(cfg.WireGuardInterfacePrefix)
 	if err != nil {
 		klog.Warningf("Failed to create MSS clamp manager (MSS clamping will be disabled): %v", err)
 	} else {
 		state.mssClampManager = mssClampMgr
-		if err := mssClampMgr.EnsureRules(); err != nil {
+		if err := mssClampMgr.EnsureRules(initialCNIConfigMTU); err != nil {
 			klog.Warningf("Failed to install MSS clamp rules: %v", err)
 		}
 	}
@@ -921,6 +921,30 @@ func getManageCniPluginFromCRDs(siteInformer cache.SharedIndexInformer, siteName
 	return true // Site not found, default to true
 }
 
+func getSiteTunnelMTUFromCRDs(siteInformer cache.SharedIndexInformer, siteName string) int {
+	if siteName == "" {
+		return 0
+	}
+
+	for _, item := range siteInformer.GetStore().List() {
+		unstr, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+
+		site, err := parseSite(unstr)
+		if err != nil {
+			continue
+		}
+
+		if site.Name == siteName {
+			return tunnelMTUFromSpec(site.Spec.TunnelMTU)
+		}
+	}
+
+	return 0
+}
+
 var configureWireGuardFunc = configureWireGuard
 
 // updateWireGuardFromSlices reads Site and SiteNodeSlices from the informer caches and configures WireGuard
@@ -1142,9 +1166,7 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 				}
 				// Collect peering-level tunnelMTU override for each remote site.
 				if v := tunnelMTUFromSpec(peering.Spec.TunnelMTU); v > 0 {
-					if _, exists := peeringSiteTunnelMTUs[siteName]; !exists {
-						peeringSiteTunnelMTUs[siteName] = v
-					}
+					mergeLowestTunnelMTU(peeringSiteTunnelMTUs, siteName, v)
 				}
 				// Collect peering-level tunnelProtocol override for each remote site.
 				if peering.Spec.TunnelProtocol != nil {
@@ -1204,9 +1226,7 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 					continue
 				}
 
-				if _, exists := assignmentSiteTunnelMTUs[siteName]; !exists {
-					assignmentSiteTunnelMTUs[siteName] = v
-				}
+				mergeLowestTunnelMTU(assignmentSiteTunnelMTUs, siteName, v)
 			}
 
 			for _, poolName := range assignment.Spec.GatewayPools {
@@ -1215,9 +1235,7 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 					continue
 				}
 
-				if _, exists := assignmentPoolTunnelMTUs[poolName]; !exists {
-					assignmentPoolTunnelMTUs[poolName] = v
-				}
+				mergeLowestTunnelMTU(assignmentPoolTunnelMTUs, poolName, v)
 			}
 		}
 
@@ -1291,12 +1309,19 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 		}
 		// Collect pool-level tunnelMTU override.
 		if v := tunnelMTUFromSpec(pool.Spec.TunnelMTU); v > 0 {
-			poolTunnelMTUs[pool.Name] = v
+			mergeLowestTunnelMTU(poolTunnelMTUs, pool.Name, v)
 		}
 		// Collect pool-level tunnelProtocol override.
 		if pool.Spec.TunnelProtocol != nil {
 			poolTunnelProtocols[pool.Name] = string(*pool.Spec.TunnelProtocol)
 		}
+	}
+
+	// A pool peering is a downstream transit path for every participating
+	// pool. Propagate its MTU cap to each pool so nodes assigned to that pool
+	// send packets small enough for the complete path, not only the first hop.
+	for _, peering := range poolPeerings {
+		mergeGatewayPoolPeeringTunnelMTU(poolTunnelMTUs, peering)
 	}
 
 	gatewayNodeMap := make(map[string]*unboundednetv1alpha1.GatewayPoolNode)
@@ -1483,9 +1508,7 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 						continue
 					}
 
-					if _, exists := assignmentSiteTunnelMTUs[siteName]; !exists {
-						assignmentSiteTunnelMTUs[siteName] = v
-					}
+					mergeLowestTunnelMTU(assignmentSiteTunnelMTUs, siteName, v)
 				}
 
 				for _, poolName := range assignment.Spec.GatewayPools {
@@ -1494,9 +1517,7 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 						continue
 					}
 
-					if _, exists := assignmentPoolTunnelMTUs[poolName]; !exists {
-						assignmentPoolTunnelMTUs[poolName] = v
-					}
+					mergeLowestTunnelMTU(assignmentPoolTunnelMTUs, poolName, v)
 				}
 			}
 
@@ -1544,6 +1565,17 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 			}
 		}
 	}
+
+	siteTopologyMTU := resolveSiteTopologyTunnelMTU(
+		mySiteName,
+		siteTunnelMTUs,
+		poolTunnelMTUs,
+		sitePeerings,
+		assignments,
+		poolPeerings,
+		localGatewayPools,
+	)
+	mergeLowestTunnelMTU(siteTunnelMTUs, mySiteName, siteTopologyMTU)
 
 	if klog.V(4).Enabled() {
 		profileNames := make([]string, 0, len(healthCheckProfiles))
@@ -1863,6 +1895,62 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 	nonMasqCIDRs = dedupeStrings(nonMasqCIDRs)
 	sitePodCIDRPools = dedupeStrings(sitePodCIDRPools)
 
+	// Resolve derived peer fields before differential comparison so the fresh
+	// peer set and the previously stored peer set have the same representation.
+	resolveTunnelProtocolsOnPeers(peers, gatewayPeers, mySiteName, peeredSites, networkPeeredSites,
+		isGatewayNode, hasExternalGatewayPool, localGatewayPools,
+		cfg.PreferredPrivateEncap, cfg.PreferredPublicEncap,
+		siteTunnelProtocols, peeringSiteTunnelProtocols,
+		assignmentPoolTunnelProtocols, poolTunnelProtocols)
+	resolvePeerTunnelMTUs(cfg, peers, gatewayPeers, mySiteName, peeredSites, networkPeeredSites,
+		siteTunnelMTUs, peeringSiteTunnelMTUs, assignmentSiteTunnelMTUs,
+		assignmentPoolTunnelMTUs, poolTunnelMTUs, state.netlinkCache)
+
+	fabricMTU := resolveCNIConfigMTU(cfg.MTU, siteTunnelMTUs[mySiteName], peers, gatewayPeers,
+		unboundednetnetlink.DetectDefaultRouteMTUFromCache(state.netlinkCache))
+	previousFabricMTU := state.cniMTU
+	fabricMTUChanged := fabricMTU > 0 && fabricMTU != previousFabricMTU
+	fabricMTUIncreased := fabricMTUChanged && previousFabricMTU > 0 && fabricMTU > previousFabricMTU
+
+	applyFabricMTU := func() error {
+		if manageCniPlugin && state.cniConfigWritten {
+			if fabricMTUChanged {
+				cniCfg := *cfg
+				cniCfg.MTU = fabricMTU
+
+				if err := writeCNIConfig(&cniCfg, state.nodePodCIDRs); err != nil {
+					return fmt.Errorf("update CNI config MTU to %d: %w", fabricMTU, err)
+				}
+			}
+
+			if err := ensureCNIBridgeMTUFunc(
+				cfg.BridgeName,
+				fabricMTU,
+				state.netlinkCache,
+				fabricMTUChanged,
+			); err != nil {
+				return fmt.Errorf("reconcile MTU on CNI bridge %s: %w", cfg.BridgeName, err)
+			}
+		}
+
+		if state.mssClampManager != nil {
+			if err := state.mssClampManager.EnsureRules(fabricMTU); err != nil {
+				return fmt.Errorf("reconcile MSS clamp rules for fabric MTU %d: %w", fabricMTU, err)
+			}
+		}
+
+		return nil
+	}
+
+	// Tighten the edge before lowering tunnels so no new flow can advertise an
+	// MSS larger than the pending fabric MTU during reconciliation. Unchanged
+	// MTUs are also checked so drift on an existing bridge is repaired.
+	if !fabricMTUIncreased {
+		if err := applyFabricMTU(); err != nil {
+			return err
+		}
+	}
+
 	// Phase 1: Read state and check for changes (under lock).
 	// Keep the lock scope narrow -- only hold it for the fast differential
 	// comparison and role-context update, then release before expensive
@@ -1896,7 +1984,8 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 		!stringMapEqual(state.peeringSiteTunnelProtocols, peeringSiteTunnelProtocols) ||
 		!stringMapEqual(state.assignmentSiteTunnelProtocols, assignmentSiteTunnelProtocols) ||
 		!stringMapEqual(state.assignmentPoolTunnelProtocols, assignmentPoolTunnelProtocols) ||
-		!stringMapEqual(state.poolTunnelProtocols, poolTunnelProtocols)
+		!stringMapEqual(state.poolTunnelProtocols, poolTunnelProtocols) ||
+		fabricMTUChanged
 
 	if !wgChanged {
 		klog.V(3).Info("State unchanged, skipping tunnel update")
@@ -1933,20 +2022,12 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 	// These are only written by this reconciliation goroutine (single writer),
 	// and getNodeStatus() does not read them, so lock-free access is safe.
 
-	// Resolve tunnel protocol on each peer, then split by tunnel protocol.
-	// Only split if GENEVE is actually configured (non-empty interface name);
-	// otherwise all peers flow through WireGuard.
-	resolveTunnelProtocolsOnPeers(peers, gatewayPeers, mySiteName, peeredSites, networkPeeredSites,
-		isGatewayNode, hasExternalGatewayPool, localGatewayPools,
-		cfg.PreferredPrivateEncap, cfg.PreferredPublicEncap,
-		siteTunnelProtocols, peeringSiteTunnelProtocols,
-		assignmentPoolTunnelProtocols, poolTunnelProtocols)
-
 	var (
-		wgMeshPeers    []meshPeerInfo
-		wgGatewayPeers []gatewayPeerInfo
-		tunnelRoutes   []unboundednetnetlink.DesiredRoute
-		tunnelHCPeers  map[string]bool
+		wgMeshPeers     []meshPeerInfo
+		wgGatewayPeers  []gatewayPeerInfo
+		tunnelRoutes    []unboundednetnetlink.DesiredRoute
+		tunnelHCPeers   map[string]bool
+		sharedTunnelErr error
 	)
 
 	// Swap health check enabled maps with fresh instances under the lock.
@@ -1975,17 +2056,24 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 
 		// Configure all shared-tunnel peers (GENEVE/VXLAN/IPIP/None) on
 		// their respective flow-based interfaces (geneve0/vxlan0/ipip0).
-		var tunnelErr error
-
-		tunnelRoutes, tunnelHCPeers, tunnelErr = configureTunnelPeers(ctx, cfg, tunnelMeshPeers, tunnelGatewayPeers,
+		tunnelRoutes, tunnelHCPeers, sharedTunnelErr = configureTunnelPeers(ctx, cfg, tunnelMeshPeers, tunnelGatewayPeers,
 			mySiteName, peeredSites, networkPeeredSites,
 			siteHealthCheckProfileNames, peeringSiteHealthCheckProfileNames,
 			assignmentSiteHealthCheckProfileNames, assignmentPoolHealthCheckProfileNames,
 			poolHealthCheckProfileNames,
 			siteTunnelMTUs, peeringSiteTunnelMTUs, assignmentSiteTunnelMTUs,
 			assignmentPoolTunnelMTUs, poolTunnelMTUs, state)
-		if tunnelErr != nil {
-			klog.Warningf("Tunnel configuration failed (WireGuard will still be configured): %v", tunnelErr)
+		if sharedTunnelErr != nil {
+			klog.Warningf("Tunnel configuration failed (WireGuard will still be configured): %v", sharedTunnelErr)
+		}
+
+		unboundedMTU := resolveCNIConfigMTU(cfg.MTU, siteTunnelMTUs[mySiteName], peers, gatewayPeers,
+			unboundednetnetlink.DetectDefaultRouteMTUFromCache(state.netlinkCache))
+		if unboundedMTU > 0 {
+			unboundedLinkManager := unboundednetnetlink.NewLinkManager(unbounded0DeviceName)
+			if err := unboundedLinkManager.EnsureMTUWithCache(state.netlinkCache, unboundedMTU); err != nil {
+				klog.Warningf("Failed to set MTU on %s: %v", unbounded0DeviceName, err)
+			}
 		}
 
 		// One unbounded0 supernet route per overlay CIDR, covering every peer
@@ -2032,6 +2120,27 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 		state.mu.Unlock()
 
 		return err
+	}
+
+	if sharedTunnelErr != nil && fabricMTUIncreased {
+		state.mu.Lock()
+		state.isGatewayNode = prevIsGatewayNode
+		state.myGatewayPort = prevMyGatewayPort
+		state.localGatewayPools = prevLocalGatewayPools
+		state.mu.Unlock()
+
+		return fmt.Errorf("cannot raise fabric MTU while tunnel reconciliation is incomplete: %w", sharedTunnelErr)
+	}
+
+	// Relax the edge only after every tunnel has accepted the larger MTU.
+	if fabricMTUIncreased {
+		if err := verifyActiveTunnelMTUs(cfg, fabricMTU, peers, gatewayPeers); err != nil {
+			return fmt.Errorf("cannot raise fabric MTU: %w", err)
+		}
+
+		if err := applyFabricMTU(); err != nil {
+			return err
+		}
 	}
 
 	addWireGuardPeersToBPFMap(cfg, state, wgMeshPeers, wgGatewayPeers)
@@ -2118,6 +2227,7 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 	state.assignmentSiteTunnelProtocols = copyStringMap(assignmentSiteTunnelProtocols)
 	state.assignmentPoolTunnelProtocols = copyStringMap(assignmentPoolTunnelProtocols)
 	state.poolTunnelProtocols = copyStringMap(poolTunnelProtocols)
+	state.cniMTU = fabricMTU
 	state.reconcileCount++
 	state.mu.Unlock()
 

--- a/cmd/unbounded-net-node/tunnel_config.go
+++ b/cmd/unbounded-net-node/tunnel_config.go
@@ -44,15 +44,6 @@ func buildSupernetRoutes(cfg *config, state *wireGuardState, meshPeers []meshPee
 		return nil
 	}
 
-	mtu := cfg.MTU
-
-	if defaultMTU := unboundednetnetlink.DetectDefaultRouteMTUFromCache(state.netlinkCache); defaultMTU > 0 {
-		detected := defaultMTU - unboundednetnetlink.GeneveMTUOverhead
-		if detected < mtu {
-			mtu = detected
-		}
-	}
-
 	supernets := collectSupernets(state, meshPeers, gatewayPeers, gatewayPeers)
 	for _, cidr := range extraSupernets {
 		supernets[cidr] = true
@@ -65,6 +56,7 @@ func buildSupernetRoutes(cfg *config, state *wireGuardState, meshPeers []meshPee
 			continue
 		}
 
+		mtu := routeTunnelMTU(cidr, meshPeers, gatewayPeers)
 		routes = append(routes, unboundednetnetlink.DesiredRoute{
 			Prefix: *cidr,
 			Nexthops: []unboundednetnetlink.DesiredNexthop{{
@@ -236,16 +228,9 @@ func configureTunnelPeers(
 	// interface churn and rp_filter resets.
 	needsGeneve, needsIPIP, needsVXLAN := neededTunnelProtocols(meshPeers, gatewayPeers)
 
-	// geneveMTU is used for supernet route MTU below. Initialize to the
-	// configured MTU and refine if geneve0 is created.
-	geneveMTU := cfg.MTU
-
-	if defaultMTU := unboundednetnetlink.DetectDefaultRouteMTUFromCache(nlCache); defaultMTU > 0 {
-		detected := defaultMTU - unboundednetnetlink.GeneveMTUOverhead
-		if detected < geneveMTU {
-			geneveMTU = detected
-		}
-	}
+	defaultUnderlayMTU := unboundednetnetlink.DetectDefaultRouteMTUFromCache(nlCache)
+	geneveMTU := protocolInterfaceMTU(cfg.MTU, siteTunnelMTUs[mySiteName], defaultUnderlayMTU,
+		string(unboundednetv1alpha1.TunnelProtocolGENEVE), meshPeers, gatewayPeers)
 
 	// Compute the deterministic MAC used for both shared GENEVE and VXLAN
 	// devices. It is set at create time via LinkAttrs.HardwareAddr so the
@@ -352,14 +337,8 @@ func configureTunnelPeers(
 				klog.Warningf("eBPF: failed to bring up %s: %v", ipipIfName, err)
 			}
 
-			ipipMTU := cfg.MTU
-
-			if defaultMTU := unboundednetnetlink.DetectDefaultRouteMTUFromCache(nlCache); defaultMTU > 0 {
-				detected := defaultMTU - unboundednetnetlink.IPIPMTUOverhead
-				if detected < ipipMTU {
-					ipipMTU = detected
-				}
-			}
+			ipipMTU := protocolInterfaceMTU(cfg.MTU, siteTunnelMTUs[mySiteName], defaultUnderlayMTU,
+				string(unboundednetv1alpha1.TunnelProtocolIPIP), meshPeers, gatewayPeers)
 
 			if err := ipipLM.EnsureMTUWithCache(nlCache, ipipMTU); err != nil {
 				klog.Warningf("eBPF: failed to set MTU on %s: %v", ipipIfName, err)
@@ -425,14 +404,8 @@ func configureTunnelPeers(
 			}
 		}
 
-		vxlanMTU := cfg.MTU
-
-		if defaultMTU := unboundednetnetlink.DetectDefaultRouteMTUFromCache(nlCache); defaultMTU > 0 {
-			detected := defaultMTU - unboundednetnetlink.VXLANMTUOverhead
-			if detected < vxlanMTU {
-				vxlanMTU = detected
-			}
-		}
+		vxlanMTU := protocolInterfaceMTU(cfg.MTU, siteTunnelMTUs[mySiteName], defaultUnderlayMTU,
+			string(unboundednetv1alpha1.TunnelProtocolVXLAN), meshPeers, gatewayPeers)
 
 		if err := vxlanLM.EnsureMTUWithCache(nlCache, vxlanMTU); err != nil {
 			klog.Warningf("eBPF: failed to set MTU on %s: %v", vxlanIfName, err)

--- a/cmd/unbounded-net-node/wireguard_config.go
+++ b/cmd/unbounded-net-node/wireguard_config.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
 	unboundednetnetlink "github.com/Azure/unbounded/internal/net/netlink"
 	"github.com/Azure/unbounded/internal/net/routeplan"
 )
@@ -44,13 +45,9 @@ func configureWireGuard(ctx context.Context, cfg *config, privKey string, peers 
 		detectedMTU = defaultMTU - unboundednetnetlink.WireGuardMTUOverhead
 	}
 
-	// The effective MTU is the lower of the configured value and the detected
-	// maximum. This ensures we never exceed the physical link capacity while
-	// still respecting an operator's deliberate lower setting.
-	tunnelMTU := cfg.MTU
-	if detectedMTU > 0 && detectedMTU < tunnelMTU {
-		tunnelMTU = detectedMTU
-	}
+	tunnelMTU := protocolInterfaceMTU(cfg.MTU, siteTunnelMTUs[mySiteName],
+		detectedMTU+unboundednetnetlink.WireGuardMTUOverhead,
+		string(unboundednetv1alpha1.TunnelProtocolWireGuard), peers, gatewayPeers)
 
 	// Warn if the configured MTU exceeds the detected maximum for this node.
 	if cfg.MTU > 0 && detectedMTU > 0 && cfg.MTU > detectedMTU {
@@ -182,9 +179,12 @@ func configureWireGuard(ctx context.Context, cfg *config, privKey string, peers 
 		}
 
 		var endpoint string
-		if peeredSites[peer.SiteName] && len(peer.InternalIPs) > 0 {
+
+		if peeredSites[peer.SiteName] {
 			// Same site or directly peered site -- use internal IP as endpoint
-			endpoint = net.JoinHostPort(peer.InternalIPs[0], fmt.Sprintf("%d", peerEndpointPort))
+			if endpointIP := selectUnderlayIP(peer.InternalIPs, cfg.TunnelIPFamily); endpointIP != nil {
+				endpoint = net.JoinHostPort(endpointIP.String(), fmt.Sprintf("%d", peerEndpointPort))
+			}
 		}
 		// Non-peered sites: no endpoint, WireGuard learns it from incoming packets
 
@@ -371,9 +371,13 @@ func configureWireGuard(ctx context.Context, cfg *config, privKey string, peers 
 			continue
 		}
 
-		// Apply the same tunnel MTU to gateway interfaces
-		if tunnelMTU > 0 {
-			if err := gwLinkManager.EnsureMTU(tunnelMTU); err != nil {
+		gatewayMTU := gwPeer.TunnelMTU
+		if gatewayMTU == 0 {
+			gatewayMTU = tunnelMTU
+		}
+
+		if gatewayMTU > 0 {
+			if err := gwLinkManager.EnsureMTU(gatewayMTU); err != nil {
 				klog.Warningf("Failed to set MTU on %s: %v", gwIfaceName, err)
 			}
 		}
@@ -416,18 +420,24 @@ func configureWireGuard(ctx context.Context, cfg *config, privKey string, peers 
 			endpointPort = int32(port)
 		}
 
-		if gwPeer.SiteName == mySiteName && len(gwPeer.InternalIPs) > 0 {
+		if gwPeer.SiteName == mySiteName {
 			// Same site -- always use internal IP regardless of pool type
-			endpoint = net.JoinHostPort(gwPeer.InternalIPs[0], fmt.Sprintf("%d", endpointPort))
-			klog.V(3).Infof("Gateway %s is in same site, using internal IP %s:%d", gwPeer.Name, gwPeer.InternalIPs[0], endpointPort)
-		} else if networkPeeredSites[gwPeer.SiteName] && len(gwPeer.InternalIPs) > 0 {
+			if endpointIP := selectUnderlayIP(gwPeer.InternalIPs, cfg.TunnelIPFamily); endpointIP != nil {
+				endpoint = net.JoinHostPort(endpointIP.String(), fmt.Sprintf("%d", endpointPort))
+				klog.V(3).Infof("Gateway %s is in same site, using internal IP %s:%d", gwPeer.Name, endpointIP, endpointPort)
+			}
+		} else if networkPeeredSites[gwPeer.SiteName] {
 			// Different site but network-peered -- use internal IP since sites can reach each other
-			endpoint = net.JoinHostPort(gwPeer.InternalIPs[0], fmt.Sprintf("%d", endpointPort))
-			klog.V(3).Infof("Gateway %s is in peered site (%s), using internal IP %s:%d", gwPeer.Name, gwPeer.SiteName, gwPeer.InternalIPs[0], endpointPort)
-		} else if gwPeer.PoolType == "External" && len(gwPeer.ExternalIPs) > 0 {
+			if endpointIP := selectUnderlayIP(gwPeer.InternalIPs, cfg.TunnelIPFamily); endpointIP != nil {
+				endpoint = net.JoinHostPort(endpointIP.String(), fmt.Sprintf("%d", endpointPort))
+				klog.V(3).Infof("Gateway %s is in peered site (%s), using internal IP %s:%d", gwPeer.Name, gwPeer.SiteName, endpointIP, endpointPort)
+			}
+		} else if gwPeer.PoolType == "External" {
 			// Different site, External pool, not peered -- use public IP
-			endpoint = net.JoinHostPort(gwPeer.ExternalIPs[0], fmt.Sprintf("%d", endpointPort))
-			klog.V(3).Infof("Gateway %s is in different site (%s), external pool, using public IP %s:%d", gwPeer.Name, gwPeer.SiteName, gwPeer.ExternalIPs[0], endpointPort)
+			if endpointIP := gatewayPeerUnderlayIP(gwPeer, mySiteName, networkPeeredSites, cfg.TunnelIPFamily); endpointIP != nil {
+				endpoint = net.JoinHostPort(endpointIP.String(), fmt.Sprintf("%d", endpointPort))
+				klog.V(3).Infof("Gateway %s is in different site (%s), external pool, using public IP %s:%d", gwPeer.Name, gwPeer.SiteName, endpointIP, endpointPort)
+			}
 		} else if gwPeer.PoolType == "Internal" {
 			// Different site, Internal pool -- no endpoint, WireGuard learns it
 			klog.V(3).Infof("Gateway %s is in different site (%s), internal pool, no endpoint (WireGuard learns)", gwPeer.Name, gwPeer.SiteName)

--- a/docs/content/reference/networking/configuration.md
+++ b/docs/content/reference/networking/configuration.md
@@ -46,7 +46,7 @@ node:
   bridgeName: cbr0
   wireGuardDir: /host/etc/wireguard
   wireGuardPort: 51820
-  mtu: 1280
+  mtu: 0
   healthPort: 9998
   tunnelDataplaneMapSize: 16384
   tunnelIPFamily: IPv4
@@ -131,31 +131,37 @@ to disable their creation.
 | `--cni-conf-dir` | `/etc/cni/net.d` | CNI configuration directory. |
 | `--cni-conf-file` | `10-unbounded.conflist` | CNI configuration file name. |
 | `--bridge-name` | `cbr0` | Bridge interface name. |
-| `--mtu` | `1280` | MTU for tunnel and bridge interfaces. |
+| `--mtu` | `0` | Optional MTU cap. Zero derives MTU from each peer's underlay route and encapsulation type. |
 
 ### MTU Guidance
 
-The `node.mtu` setting controls the MTU on tunnel and bridge interfaces.
+The `node.mtu` setting caps the automatically selected MTU on tunnel and bridge interfaces. Zero enables automatic selection.
 Encapsulation overhead:
 
 | Type | Overhead |
 |------|----------|
 | WireGuard | 80 bytes |
-| GENEVE / VXLAN | 58 bytes |
+| GENEVE | 58 bytes |
+| VXLAN | 50 bytes |
 | IPIP | 20 bytes |
 
-**Formula:** `node.mtu = <lowest physical-link MTU> - 80`
-
-Using 80 (the largest overhead) ensures the value is safe for all tunnel types.
-For standard 1500-byte links: `1500 - 80 = 1420`.
+The node agent resolves the route to each peer and subtracts the selected
+encapsulation overhead. For example, WireGuard over a 1500-byte route uses
+1420.
 
 **Behavior:**
-- Each node agent detects its default-route interface MTU and annotates itself
-  with `net.unbounded-cloud.io/tunnel-mtu`.
-- Effective MTU = `min(configured MTU, detected MTU)`.
-- If configured MTU exceeds detected, the node logs an error and surfaces an
-  `mtuMismatch` status error.
-- A value of `0` is normalized to `1280`.
+- Each peer's effective MTU is the lowest applicable configured cap, CRD
+  `tunnelMTU`, and route MTU after encapsulation overhead.
+- Sites and GatewayPools form a topology connected by SitePeerings,
+  SiteGatewayPoolAssignments, and GatewayPoolPeerings. The lowest `tunnelMTU`
+  in the local site's connected topology is applied site-wide, including
+  downstream multi-hop gateway paths.
+- The CNI MTU is the lowest effective peer or connected-topology MTU.
+- At startup and whenever the effective CNI MTU changes, the node agent updates
+  the CNI bridge and both endpoints of existing pod veth pairs.
+- Forwarded TCP SYN packets on every interface are MSS-clamped to the
+  site-wide fabric MTU (`MTU - 40` for IPv4 and `MTU - 60` for IPv6).
+- A value of `0` enables route-specific automatic MTU selection.
 
 ### WireGuard
 

--- a/docs/net/configuration.md
+++ b/docs/net/configuration.md
@@ -55,7 +55,7 @@ node:
   wireGuardDir: /host/etc/wireguard
   wireGuardPort: 51820
   enablePolicyRouting: false    # Deprecated -- PBR replaced by per-interface FORWARD ACCEPT rules
-  mtu: 1280
+  mtu: 0
   healthPort: 9998
   informerResyncPeriod: 3600s
   statusWebsocketEnabled: true
@@ -217,22 +217,23 @@ graph TD
 | `--cni-conf-dir` | string | `/etc/cni/net.d` | Directory to write CNI configuration. |
 | `--cni-conf-file` | string | `10-unbounded.conflist` | Name of the CNI configuration file. |
 | `--bridge-name` | string | `cbr0` | Name of the bridge interface. |
-| `--mtu` | int | `1280` | MTU for tunnel and bridge interfaces. Must be set to the lowest physical-link MTU of any node in the cluster minus the encapsulation overhead -- 80 bytes for WireGuard, 58 bytes for GENEVE/VXLAN, or 20 bytes for IPIP. The system auto-selects the correct overhead based on the encapsulation type for each link. The node agent clamps the effective MTU to `min(configured, detected)` so packets are never larger than the physical link can carry. A value of `0` is treated as `1280`. See [MTU Guidance](#mtu-guidance) below. |
+| `--mtu` | int | `0` | Optional maximum MTU for tunnel and bridge interfaces. With `0`, the node agent derives each route's MTU from the selected underlay route and encapsulation overhead. Positive values cap the automatically detected and CRD-configured MTU. |
 
 ### MTU Guidance
 
-The `node.mtu` setting controls the MTU used on tunnel interfaces (WireGuard,
-GENEVE, VXLAN, and IPIP) and the CNI bridge. WireGuard adds 80 bytes of
-encapsulation overhead, GENEVE and VXLAN add 58 bytes, and IPIP adds 20 bytes.
-The tunnel MTU must be lower than the underlying network interface MTU.
+The `node.mtu` setting is an optional upper bound for tunnel interfaces,
+per-destination routes, and the CNI bridge. WireGuard adds 80 bytes of
+encapsulation overhead, GENEVE adds 58 bytes, VXLAN adds 50 bytes, and IPIP
+adds 20 bytes. With the default value of `0`, the node agent looks up the
+actual route to each peer, subtracts the selected encapsulation overhead, and
+uses the lowest applicable Site, peering, assignment, or pool `tunnelMTU`.
+The node agent treats Sites and GatewayPools as a topology graph connected by
+SitePeerings, SiteGatewayPoolAssignments, and GatewayPoolPeerings. The lowest
+`tunnelMTU` anywhere in the local site's connected topology is applied
+site-wide, including downstream multi-hop gateway paths.
 
-**Formula:** `node.mtu = <lowest physical-link MTU of any node in the cluster> - 80`
-
-(Using 80, the largest overhead, ensures the value is safe for all tunnel types.)
-
-For example, if all nodes have a 1500-byte link MTU, set `node.mtu` to `1420`.
-If some nodes have jumbo frames (9000) but others have standard Ethernet (1500),
-the configured MTU must be based on the smallest value: `1500 - 80 = 1420`.
+For example, a WireGuard peer reached through a 1500-byte Ethernet route gets
+an automatic MTU of `1420`.
 
 **Behavior:**
 - Each node agent detects its default-route interface MTU at startup and on
@@ -246,7 +247,12 @@ the configured MTU must be based on the smallest value: `1500 - 80 = 1420`.
 - The controller reads `node.mtu` from the shared configmap and compares it
   against every node's `tunnel-mtu` annotation. Mismatches are reported as
   warnings on the status page and in the controller logs.
-- A value of `0` is normalized to `1280` (the IPv6 minimum MTU).
+- The CNI MTU is the lowest effective peer or connected-topology MTU. At
+  startup and whenever that value changes, the node agent updates the CNI
+  bridge and both endpoints of existing pod veth pairs.
+- Forwarded TCP SYN packets on every interface are MSS-clamped to the
+  site-wide fabric MTU (`MTU - 40` for IPv4 and `MTU - 60` for IPv6).
+- A value of `0` enables route-specific automatic MTU selection.
 
 ### WireGuard Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/vishvananda/netlink v1.3.1
+	github.com/vishvananda/netns v0.0.5
 	golang.org/x/crypto v0.54.0
 	golang.org/x/mod v0.38.0
 	golang.org/x/net v0.57.0
@@ -288,7 +289,6 @@ require (
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect
 	github.com/urfave/cli v1.22.16 // indirect
 	github.com/vbatts/go-mtree v0.6.1-0.20250911112631-8307d76bc1b9 // indirect
-	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/internal/net/netlink/link_manager.go
+++ b/internal/net/netlink/link_manager.go
@@ -4,11 +4,16 @@
 package netlink
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
 	"k8s.io/klog/v2"
 )
 
@@ -538,6 +543,289 @@ func (lm *LinkManager) EnsureMTU(mtu int) error {
 	return nil
 }
 
+// EnsureBridgePortMTUs sets the MTU on every veth interface enslaved to the
+// managed bridge. Links removed concurrently with pod teardown are ignored.
+func (lm *LinkManager) EnsureBridgePortMTUs(mtu int) error {
+	bridge, err := netlink.LinkByName(lm.ifaceName)
+	if err != nil {
+		return fmt.Errorf("failed to get bridge %s: %w", lm.ifaceName, err)
+	}
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("failed to list links for bridge %s: %w", lm.ifaceName, err)
+	}
+
+	var updateErrors []error
+
+	for _, link := range bridgeVethLinks(bridge.Attrs().Index, links) {
+		if link.Attrs().MTU == mtu {
+			continue
+		}
+
+		klog.Infof("Setting MTU on bridge port %s from %d to %d", link.Attrs().Name, link.Attrs().MTU, mtu)
+
+		if err := netlink.LinkSetMTU(link, mtu); err != nil {
+			if errors.Is(err, syscall.ENODEV) || errors.Is(err, syscall.ENOENT) {
+				continue
+			}
+
+			InterfaceOperationErrors.WithLabelValues("set_mtu").Inc()
+
+			updateErrors = append(updateErrors, fmt.Errorf("failed to set MTU on bridge port %s: %w", link.Attrs().Name, err))
+
+			continue
+		}
+
+		InterfaceOperations.WithLabelValues("set_mtu").Inc()
+	}
+
+	return errors.Join(updateErrors...)
+}
+
+// EnsureBridgePodMTUs sets the MTU on the pod-side peer of every veth
+// interface enslaved to the managed bridge.
+func (lm *LinkManager) EnsureBridgePodMTUs(procDir string, mtu int) error {
+	bridge, err := netlink.LinkByName(lm.ifaceName)
+	if err != nil {
+		return fmt.Errorf("failed to get bridge %s: %w", lm.ifaceName, err)
+	}
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("failed to list links for bridge %s: %w", lm.ifaceName, err)
+	}
+
+	hostPeers := make(map[int]int)
+
+	for _, link := range bridgeVethLinks(bridge.Attrs().Index, links) {
+		veth, ok := link.(*netlink.Veth)
+		if !ok {
+			continue
+		}
+
+		peerIndex, err := netlink.VethPeerIndex(veth)
+		if err != nil {
+			if isLinkGoneError(err) {
+				continue
+			}
+
+			return fmt.Errorf("get peer index for bridge port %s: %w", link.Attrs().Name, err)
+		}
+
+		hostPeers[link.Attrs().Index] = peerIndex
+	}
+
+	if len(hostPeers) == 0 {
+		return nil
+	}
+
+	netnsPaths, err := processNetworkNamespacePaths(procDir)
+	if err != nil {
+		return err
+	}
+
+	matchedHostPeers := make(map[int]bool, len(hostPeers))
+
+	var updateErrors []error
+
+	for _, nsPath := range netnsPaths {
+		nsHandle, err := netns.GetFromPath(nsPath)
+		if err != nil {
+			if !errors.Is(err, syscall.ENOENT) {
+				klog.V(4).Infof("Failed to open network namespace %s: %v", nsPath, err)
+			}
+
+			continue
+		}
+
+		handle, err := netlink.NewHandleAt(nsHandle)
+		if err != nil {
+			if closeErr := nsHandle.Close(); closeErr != nil {
+				klog.V(4).Infof("Failed to close network namespace %s: %v", nsPath, closeErr)
+			}
+
+			if !errors.Is(err, syscall.ENOENT) {
+				klog.V(4).Infof("Failed to create netlink handle for network namespace %s: %v", nsPath, err)
+			}
+
+			continue
+		}
+
+		nsLinks, listErr := handle.LinkList()
+		if listErr != nil {
+			if !isLinkGoneError(listErr) {
+				klog.V(4).Infof("Failed to list links in network namespace %s: %v", nsPath, listErr)
+			}
+		} else {
+			for _, podLink := range bridgePodVethLinks(hostPeers, nsLinks) {
+				hostIndex := podLink.Attrs().ParentIndex
+				matchedHostPeers[hostIndex] = true
+
+				if podLink.Attrs().MTU == mtu {
+					continue
+				}
+
+				klog.Infof("Setting MTU on pod interface %s in %s from %d to %d",
+					podLink.Attrs().Name, nsPath, podLink.Attrs().MTU, mtu)
+
+				if err := handle.LinkSetMTU(podLink, mtu); err != nil {
+					if isLinkGoneError(err) {
+						continue
+					}
+
+					InterfaceOperationErrors.WithLabelValues("set_mtu").Inc()
+
+					updateErrors = append(updateErrors,
+						fmt.Errorf("failed to set MTU on pod interface %s in %s: %w", podLink.Attrs().Name, nsPath, err))
+
+					continue
+				}
+
+				InterfaceOperations.WithLabelValues("set_mtu").Inc()
+			}
+		}
+
+		handle.Close()
+
+		if err := nsHandle.Close(); err != nil {
+			klog.V(4).Infof("Failed to close network namespace %s: %v", nsPath, err)
+		}
+	}
+
+	for hostIndex := range hostPeers {
+		if matchedHostPeers[hostIndex] {
+			continue
+		}
+
+		link, err := netlink.LinkByIndex(hostIndex)
+		if err != nil {
+			if !isLinkGoneError(err) {
+				klog.V(4).Infof("Failed to recheck bridge port index %d: %v", hostIndex, err)
+			}
+
+			continue
+		}
+
+		if link.Attrs().MasterIndex == bridge.Attrs().Index {
+			updateErrors = append(updateErrors,
+				fmt.Errorf("pod-side peer for bridge port %s was not found through %s", link.Attrs().Name, procDir))
+		}
+	}
+
+	return errors.Join(updateErrors...)
+}
+
+type networkNamespaceID struct {
+	device uint64
+	inode  uint64
+}
+
+func processNetworkNamespacePaths(procDir string) ([]string, error) {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil, fmt.Errorf("read process directory %s: %w", procDir, err)
+	}
+
+	selfID, err := networkNamespaceIDFromPath(filepath.Join(procDir, "self", "ns", "net"))
+	if err != nil {
+		return nil, fmt.Errorf("identify current network namespace: %w", err)
+	}
+
+	seen := map[networkNamespaceID]bool{selfID: true}
+	paths := make([]string, 0)
+
+	for _, entry := range entries {
+		if !isNumeric(entry.Name()) {
+			continue
+		}
+
+		nsPath := filepath.Join(procDir, entry.Name(), "ns", "net")
+
+		id, err := networkNamespaceIDFromPath(nsPath)
+		if err != nil {
+			if errors.Is(err, syscall.ENOENT) {
+				continue
+			}
+
+			klog.V(4).Infof("Failed to identify network namespace %s: %v", nsPath, err)
+
+			continue
+		}
+
+		if seen[id] {
+			continue
+		}
+
+		seen[id] = true
+
+		paths = append(paths, nsPath)
+	}
+
+	return paths, nil
+}
+
+func networkNamespaceIDFromPath(path string) (networkNamespaceID, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return networkNamespaceID{}, err
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return networkNamespaceID{}, fmt.Errorf("unexpected stat type for %s", path)
+	}
+
+	return networkNamespaceID{device: uint64(stat.Dev), inode: stat.Ino}, nil
+}
+
+func isNumeric(value string) bool {
+	if value == "" {
+		return false
+	}
+
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isLinkGoneError(err error) bool {
+	var linkNotFound netlink.LinkNotFoundError
+
+	return errors.As(err, &linkNotFound) ||
+		errors.Is(err, syscall.ENODEV) ||
+		errors.Is(err, syscall.ENOENT)
+}
+
+func bridgeVethLinks(bridgeIndex int, links []netlink.Link) []netlink.Link {
+	ports := make([]netlink.Link, 0)
+
+	for _, link := range links {
+		if link.Type() == "veth" && link.Attrs().MasterIndex == bridgeIndex {
+			ports = append(ports, link)
+		}
+	}
+
+	return ports
+}
+
+func bridgePodVethLinks(hostPeers map[int]int, links []netlink.Link) []netlink.Link {
+	peers := make([]netlink.Link, 0)
+
+	for _, link := range links {
+		expectedPeerIndex, ok := hostPeers[link.Attrs().ParentIndex]
+		if link.Type() == "veth" && ok && link.Attrs().Index == expectedPeerIndex {
+			peers = append(peers, link)
+		}
+	}
+
+	return peers
+}
+
 // WireGuardMTUOverhead is the number of bytes subtracted from the primary
 // interface MTU to derive the WireGuard tunnel MTU. This accounts for the
 // outer IP header, UDP header, and WireGuard encapsulation overhead.
@@ -573,6 +861,60 @@ func DetectDefaultRouteMTU() int {
 // to direct calls if the cache is nil.
 func DetectDefaultRouteMTUFromCache(cache *NetlinkCache) int {
 	return detectDefaultRouteMTUImpl(cache)
+}
+
+// DetectRouteMTU returns the MTU of the egress link selected for destination.
+// Returns 0 when the route or its link cannot be resolved.
+func DetectRouteMTU(destination net.IP, cache *NetlinkCache) int {
+	mtu, _ := DetectRouteMTUAndInterface(destination, cache)
+	return mtu
+}
+
+// DetectRouteMTUAndInterface returns the selected egress link MTU and interface
+// name for destination. Unlocked RouteGet MTUs are intentionally ignored
+// because Linux may report a transient destination-cache PMTU there; using it
+// as an underlay MTU would subtract tunnel overhead repeatedly after a tunnel
+// MTU change. Administratively locked route MTUs are still enforced.
+func DetectRouteMTUAndInterface(destination net.IP, cache *NetlinkCache) (int, string) {
+	if destination == nil {
+		return 0, ""
+	}
+
+	routes, err := netlink.RouteGet(destination)
+	if err != nil {
+		klog.V(3).Infof("Failed to resolve route MTU for %s: %v", destination, err)
+		return 0, ""
+	}
+
+	mtu := 0
+	ifaceName := ""
+
+	for _, route := range routes {
+		if route.MTULock && route.MTU > 0 && (mtu == 0 || route.MTU < mtu) {
+			mtu = route.MTU
+		}
+
+		if route.LinkIndex == 0 {
+			continue
+		}
+
+		link, linkErr := netlink.LinkByIndex(route.LinkIndex)
+		if linkErr != nil && cache != nil {
+			link, linkErr = cache.LinkByIndex(route.LinkIndex)
+		}
+
+		if linkErr != nil {
+			klog.V(3).Infof("Failed to get route link %d for %s: %v", route.LinkIndex, destination, linkErr)
+			continue
+		}
+
+		ifaceName = link.Attrs().Name
+		if linkMTU := link.Attrs().MTU; linkMTU > 0 && (mtu == 0 || linkMTU < mtu) {
+			mtu = linkMTU
+		}
+	}
+
+	return mtu, ifaceName
 }
 
 func detectDefaultRouteMTUImpl(cache *NetlinkCache) int {

--- a/internal/net/netlink/link_manager.go
+++ b/internal/net/netlink/link_manager.go
@@ -566,7 +566,7 @@ func (lm *LinkManager) EnsureBridgePortMTUs(mtu int) error {
 		klog.Infof("Setting MTU on bridge port %s from %d to %d", link.Attrs().Name, link.Attrs().MTU, mtu)
 
 		if err := netlink.LinkSetMTU(link, mtu); err != nil {
-			if errors.Is(err, syscall.ENODEV) || errors.Is(err, syscall.ENOENT) {
+			if isLinkGoneError(err) {
 				continue
 			}
 

--- a/internal/net/netlink/mss_clamp_manager.go
+++ b/internal/net/netlink/mss_clamp_manager.go
@@ -118,6 +118,10 @@ func (m *MSSClampManager) EnsureRules(fabricMTU int) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if fabricMTU <= 0 {
+		return nil
+	}
+
 	if fabricMTU <= 60 {
 		return fmt.Errorf("fabric MTU %d is too small for TCP MSS clamping", fabricMTU)
 	}

--- a/internal/net/netlink/mss_clamp_manager.go
+++ b/internal/net/netlink/mss_clamp_manager.go
@@ -63,10 +63,12 @@ func NewMSSClampManager(wgPrefix string) (*MSSClampManager, error) {
 	if ipt6 != nil {
 		if err := m.ensureChain(ipt6, "IPv6"); err != nil {
 			klog.Warningf("Failed to create IPv6 MSS clamp chain: %v", err)
+
 			ipt6 = nil
 			m.ipt6 = nil
 		} else if err := ipt6.ClearChain("mangle", mssClampChain); err != nil {
 			klog.Warningf("Failed to clear stale IPv6 MSS clamp rules: %v", err)
+
 			ipt6 = nil
 			m.ipt6 = nil
 		}

--- a/internal/net/netlink/mss_clamp_manager.go
+++ b/internal/net/netlink/mss_clamp_manager.go
@@ -5,6 +5,7 @@ package netlink
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -15,25 +16,22 @@ const (
 	// mssClampChain is the custom chain for MSS clamping rules.
 	mssClampChain = "UNBOUNDED-MSS-CLAMP"
 	// mssClampComment identifies rules created by this manager.
-	mssClampComment = "unbounded-net: clamp TCP MSS to PMTU on WireGuard interfaces"
+	mssClampComment = "unbounded-net: clamp TCP MSS to fabric MTU"
+	// legacyMSSClampComment identifies the previous WireGuard-only rules.
+	legacyMSSClampComment = "unbounded-net: clamp TCP MSS to PMTU on WireGuard interfaces"
 )
 
 // MSSClampManager installs iptables mangle rules that clamp TCP MSS on SYN
-// packets transiting WireGuard interfaces. This prevents pods (whose network
-// namespace sees a 1500-byte veth MTU) from advertising an MSS too large for
-// the WireGuard tunnel, which would cause silent drops of large TLS responses
-// at gateway forwarding hops.
+// packets forwarded through the node. The explicit MSS is derived from the
+// lowest calculated MTU for the unbounded fabric.
 type MSSClampManager struct {
 	ipt4 *iptables.IPTables
 	ipt6 *iptables.IPTables
 	mu   sync.Mutex
-	// wgPrefix is the configured WireGuard interface prefix (e.g. "wg").
-	// The mangle rule matches the iptables interface-name pattern
-	// "<wgPrefix>+" so all per-port WG devices created with that prefix
-	// are covered.
-	wgPrefix string
-	// installed tracks whether rules have been applied.
-	installed bool
+	// legacyWGPrefix is retained to remove rules created by older versions.
+	legacyWGPrefix string
+	// installedMTU is the fabric MTU represented by the current rules.
+	installedMTU int
 }
 
 // NewMSSClampManager creates a manager and ensures the mangle chain exists.
@@ -52,15 +50,25 @@ func NewMSSClampManager(wgPrefix string) (*MSSClampManager, error) {
 		ipt6 = nil
 	}
 
-	m := &MSSClampManager{ipt4: ipt4, ipt6: ipt6, wgPrefix: wgPrefix}
+	m := &MSSClampManager{ipt4: ipt4, ipt6: ipt6, legacyWGPrefix: wgPrefix}
 
 	if err := m.ensureChain(ipt4, "IPv4"); err != nil {
 		return nil, fmt.Errorf("failed to create IPv4 MSS clamp chain: %w", err)
 	}
 
+	if err := ipt4.ClearChain("mangle", mssClampChain); err != nil {
+		return nil, fmt.Errorf("failed to clear stale IPv4 MSS clamp rules: %w", err)
+	}
+
 	if ipt6 != nil {
 		if err := m.ensureChain(ipt6, "IPv6"); err != nil {
 			klog.Warningf("Failed to create IPv6 MSS clamp chain: %v", err)
+			ipt6 = nil
+			m.ipt6 = nil
+		} else if err := ipt6.ClearChain("mangle", mssClampChain); err != nil {
+			klog.Warningf("Failed to clear stale IPv6 MSS clamp rules: %v", err)
+			ipt6 = nil
+			m.ipt6 = nil
 		}
 	}
 
@@ -82,6 +90,11 @@ func (m *MSSClampManager) ensureChain(ipt *iptables.IPTables, family string) err
 		klog.V(2).Infof("Created %s chain %s in mangle table", family, mssClampChain)
 	}
 
+	legacyJumpRule := []string{"-m", "comment", "--comment", legacyMSSClampComment, "-j", mssClampChain}
+	if err := ipt.DeleteIfExists("mangle", "FORWARD", legacyJumpRule...); err != nil {
+		return fmt.Errorf("failed to remove legacy jump rule: %w", err)
+	}
+
 	jumpRule := []string{"-m", "comment", "--comment", mssClampComment, "-j", mssClampChain}
 
 	exists, err = ipt.Exists("mangle", "FORWARD", jumpRule...)
@@ -100,46 +113,47 @@ func (m *MSSClampManager) ensureChain(ipt *iptables.IPTables, family string) err
 	return nil
 }
 
-// EnsureRules installs the TCPMSS clamp rules if not already present.
-// Safe to call on every reconciliation loop.
-func (m *MSSClampManager) EnsureRules() error {
+// EnsureRules reconciles TCPMSS rules to the current fabric MTU.
+func (m *MSSClampManager) EnsureRules(fabricMTU int) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.installed {
+	if fabricMTU <= 60 {
+		return fmt.Errorf("fabric MTU %d is too small for TCP MSS clamping", fabricMTU)
+	}
+
+	if m.installedMTU == fabricMTU {
 		return nil
 	}
 
-	if err := m.ensureRulesForFamily(m.ipt4, "IPv4"); err != nil {
+	if err := m.ensureRulesForFamily(m.ipt4, "IPv4", fabricMTU, m.installedMTU, false); err != nil {
 		return fmt.Errorf("failed to ensure IPv4 MSS clamp rules: %w", err)
 	}
 
 	if m.ipt6 != nil {
-		if err := m.ensureRulesForFamily(m.ipt6, "IPv6"); err != nil {
-			klog.Warningf("Failed to ensure IPv6 MSS clamp rules: %v", err)
+		if err := m.ensureRulesForFamily(m.ipt6, "IPv6", fabricMTU, m.installedMTU, true); err != nil {
+			return fmt.Errorf("failed to ensure IPv6 MSS clamp rules: %w", err)
 		}
 	}
 
-	m.installed = true
+	m.installedMTU = fabricMTU
 
-	klog.V(2).Info("MSS clamp rules installed on WireGuard interfaces")
+	klog.V(2).Infof("MSS clamp rules reconciled for fabric MTU %d", fabricMTU)
 
 	return nil
 }
 
-// ensureRulesForFamily adds the TCPMSS --clamp-mss-to-pmtu rule for a single
-// address family, matching SYN packets leaving via any wg+ interface.
-func (m *MSSClampManager) ensureRulesForFamily(ipt *iptables.IPTables, family string) error {
+func (m *MSSClampManager) ensureRulesForFamily(
+	ipt *iptables.IPTables,
+	family string,
+	fabricMTU, previousMTU int,
+	ipv6 bool,
+) error {
 	if ipt == nil {
 		return nil
 	}
 
-	rule := []string{
-		"-o", m.wgPrefix + "+",
-		"-p", "tcp", "--tcp-flags", "SYN,RST", "SYN",
-		"-m", "comment", "--comment", mssClampComment,
-		"-j", "TCPMSS", "--clamp-mss-to-pmtu",
-	}
+	rule := mssClampRule(fabricMTU, ipv6)
 
 	exists, err := ipt.Exists("mangle", mssClampChain, rule...)
 	if err != nil {
@@ -150,11 +164,46 @@ func (m *MSSClampManager) ensureRulesForFamily(ipt *iptables.IPTables, family st
 		if err := ipt.Append("mangle", mssClampChain, rule...); err != nil {
 			return fmt.Errorf("failed to add %s MSS clamp rule: %w", family, err)
 		}
+	}
 
-		klog.V(2).Infof("Added %s MSS clamp rule for %s+ interfaces", family, m.wgPrefix)
+	if previousMTU > 0 && previousMTU != fabricMTU {
+		if err := ipt.DeleteIfExists("mangle", mssClampChain, mssClampRule(previousMTU, ipv6)...); err != nil {
+			return fmt.Errorf("failed to remove previous %s MSS clamp rule: %w", family, err)
+		}
+	}
+
+	if m.legacyWGPrefix != "" {
+		if err := ipt.DeleteIfExists("mangle", mssClampChain, legacyMSSClampRule(m.legacyWGPrefix)...); err != nil {
+			return fmt.Errorf("failed to remove legacy %s MSS clamp rule: %w", family, err)
+		}
 	}
 
 	return nil
+}
+
+func mssClampRule(fabricMTU int, ipv6 bool) []string {
+	headerSize := 40
+	if ipv6 {
+		headerSize = 60
+	}
+
+	mss := fabricMTU - headerSize
+
+	return []string{
+		"-p", "tcp", "--tcp-flags", "SYN,RST", "SYN",
+		"-m", "tcpmss", "--mss", strconv.Itoa(mss+1) + ":65535",
+		"-m", "comment", "--comment", mssClampComment,
+		"-j", "TCPMSS", "--set-mss", strconv.Itoa(mss),
+	}
+}
+
+func legacyMSSClampRule(wgPrefix string) []string {
+	return []string{
+		"-o", wgPrefix + "+",
+		"-p", "tcp", "--tcp-flags", "SYN,RST", "SYN",
+		"-m", "comment", "--comment", legacyMSSClampComment,
+		"-j", "TCPMSS", "--clamp-mss-to-pmtu",
+	}
 }
 
 // Cleanup removes all MSS clamping rules installed by this manager.
@@ -173,7 +222,7 @@ func (m *MSSClampManager) Cleanup() error {
 		}
 	}
 
-	m.installed = false
+	m.installedMTU = 0
 
 	if len(errs) > 0 {
 		return fmt.Errorf("MSS clamp cleanup errors: %v", errs)
@@ -193,6 +242,11 @@ func (m *MSSClampManager) cleanupFamily(ipt *iptables.IPTables, family string) e
 	jumpRule := []string{"-m", "comment", "--comment", mssClampComment, "-j", mssClampChain}
 	if err := ipt.DeleteIfExists("mangle", "FORWARD", jumpRule...); err != nil {
 		klog.Warningf("Failed to remove %s MSS clamp jump rule: %v", family, err)
+	}
+
+	legacyJumpRule := []string{"-m", "comment", "--comment", legacyMSSClampComment, "-j", mssClampChain}
+	if err := ipt.DeleteIfExists("mangle", "FORWARD", legacyJumpRule...); err != nil {
+		klog.Warningf("Failed to remove legacy %s MSS clamp jump rule: %v", family, err)
 	}
 
 	exists, err := ipt.ChainExists("mangle", mssClampChain)

--- a/internal/net/netlink/mss_clamp_manager_test.go
+++ b/internal/net/netlink/mss_clamp_manager_test.go
@@ -38,3 +38,11 @@ func TestMSSClampRule(t *testing.T) {
 		})
 	}
 }
+
+func TestMSSClampManagerIgnoresUnknownMTU(t *testing.T) {
+	manager := &MSSClampManager{}
+
+	if err := manager.EnsureRules(0); err != nil {
+		t.Fatalf("EnsureRules(0) returned error: %v", err)
+	}
+}

--- a/internal/net/netlink/mss_clamp_manager_test.go
+++ b/internal/net/netlink/mss_clamp_manager_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package netlink
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestMSSClampRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		fabricMTU int
+		ipv6      bool
+		wantMSS   string
+		wantRange string
+	}{
+		{name: "IPv4", fabricMTU: 1280, wantMSS: "1240", wantRange: "1241:65535"},
+		{name: "IPv6", fabricMTU: 1280, ipv6: true, wantMSS: "1220", wantRange: "1221:65535"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := mssClampRule(tt.fabricMTU, tt.ipv6)
+
+			if !slices.Contains(rule, tt.wantMSS) {
+				t.Fatalf("rule %v does not set MSS %s", rule, tt.wantMSS)
+			}
+
+			if !slices.Contains(rule, tt.wantRange) {
+				t.Fatalf("rule %v does not match MSS range %s", rule, tt.wantRange)
+			}
+
+			if slices.Contains(rule, "-i") || slices.Contains(rule, "-o") {
+				t.Fatalf("rule %v should apply across all forwarded interfaces", rule)
+			}
+		})
+	}
+}

--- a/internal/net/netlink/netlink_test.go
+++ b/internal/net/netlink/netlink_test.go
@@ -5,7 +5,11 @@ package netlink
 
 import (
 	"net/netip"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 // Note: Most netlink operations require root privileges and actual network interfaces.
@@ -118,6 +122,89 @@ func TestLinkManager_EnsureMTU_NonExistentInterface(t *testing.T) {
 	err := lm.EnsureMTU(1420)
 	if err == nil {
 		t.Error("expected error for non-existent interface, got nil")
+	}
+}
+
+func TestBridgeVethLinks(t *testing.T) {
+	links := []netlink.Link{
+		&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth-cbr0", MasterIndex: 10}},
+		&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth-other", MasterIndex: 20}},
+		&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "dummy-cbr0", MasterIndex: 10}},
+	}
+
+	got := bridgeVethLinks(10, links)
+	if len(got) != 1 {
+		t.Fatalf("bridgeVethLinks() returned %d links, want 1", len(got))
+	}
+
+	if got[0].Attrs().Name != "veth-cbr0" {
+		t.Fatalf("bridgeVethLinks() returned %q, want veth-cbr0", got[0].Attrs().Name)
+	}
+}
+
+func TestBridgePodVethLinks(t *testing.T) {
+	hostPeers := map[int]int{
+		100: 2,
+		200: 3,
+	}
+	links := []netlink.Link{
+		&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "eth0", Index: 2, ParentIndex: 100}},
+		&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "net1", Index: 3, ParentIndex: 999}},
+		&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "wrong-index", Index: 4, ParentIndex: 200}},
+		&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "dummy", Index: 3, ParentIndex: 200}},
+	}
+
+	got := bridgePodVethLinks(hostPeers, links)
+	if len(got) != 1 {
+		t.Fatalf("bridgePodVethLinks() returned %d links, want 1", len(got))
+	}
+
+	if got[0].Attrs().Name != "eth0" {
+		t.Fatalf("bridgePodVethLinks() returned %q, want eth0", got[0].Attrs().Name)
+	}
+}
+
+func TestProcessNetworkNamespacePaths(t *testing.T) {
+	procDir := t.TempDir()
+
+	selfPath := filepath.Join(procDir, "self", "ns", "net")
+	if err := os.MkdirAll(filepath.Dir(selfPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(selfPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	duplicatePath := filepath.Join(procDir, "1", "ns", "net")
+	if err := os.MkdirAll(filepath.Dir(duplicatePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Link(selfPath, duplicatePath); err != nil {
+		t.Fatal(err)
+	}
+
+	distinctPath := filepath.Join(procDir, "2", "ns", "net")
+	if err := os.MkdirAll(filepath.Dir(distinctPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(distinctPath, []byte("distinct"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(procDir, "not-a-pid", "ns"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := processNetworkNamespacePaths(procDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 1 || got[0] != distinctPath {
+		t.Fatalf("processNetworkNamespacePaths() = %v, want [%s]", got, distinctPath)
 	}
 }
 


### PR DESCRIPTION
Summary: Derive peer MTUs from underlay routes and encapsulation overhead; propagate the lowest tunnelMTU across each site's complete Site and GatewayPool topology; reconcile CNI, tunnels, unbounded0, cbr0, host veths, and pod veths; and clamp forwarded TCP MSS across all interfaces. Validation: targeted Go tests and node build; five-node AKS decrease, increase, and automatic-mode testing; GENEVE 1442, WireGuard 1420, and VXLAN 1450; all 20 cross-node DF ping and 4 MiB TCP paths; every tunnelMTU CRD scope; nested pod WireGuard at MTU 1280; and dynamic IPv4 and IPv6 MSS clamping.