### PR TITLE
Fix MTU route selection and MSS cleanup

### DIFF
--- a/internal/net/netlink/link_manager.go
+++ b/internal/net/netlink/link_manager.go
@@ -890,11 +890,11 @@ func DetectRouteMTUAndInterface(destination net.IP, cache *NetlinkCache) (int, s
 	ifaceName := ""
 
 	for _, route := range routes {
-		if route.MTULock && route.MTU > 0 && (mtu == 0 || route.MTU < mtu) {
-			mtu = route.MTU
-		}
-
 		if route.LinkIndex == 0 {
+			if route.MTULock {
+				mtu, ifaceName = selectLowerMTU(mtu, ifaceName, route.MTU, "")
+			}
+
 			continue
 		}
 
@@ -905,16 +905,31 @@ func DetectRouteMTUAndInterface(destination net.IP, cache *NetlinkCache) (int, s
 
 		if linkErr != nil {
 			klog.V(3).Infof("Failed to get route link %d for %s: %v", route.LinkIndex, destination, linkErr)
+
+			if route.MTULock {
+				mtu, ifaceName = selectLowerMTU(mtu, ifaceName, route.MTU, "")
+			}
+
 			continue
 		}
 
-		ifaceName = link.Attrs().Name
-		if linkMTU := link.Attrs().MTU; linkMTU > 0 && (mtu == 0 || linkMTU < mtu) {
-			mtu = linkMTU
+		routeIfaceName := link.Attrs().Name
+		if route.MTULock {
+			mtu, ifaceName = selectLowerMTU(mtu, ifaceName, route.MTU, routeIfaceName)
 		}
+
+		mtu, ifaceName = selectLowerMTU(mtu, ifaceName, link.Attrs().MTU, routeIfaceName)
 	}
 
 	return mtu, ifaceName
+}
+
+func selectLowerMTU(currentMTU int, currentIface string, candidateMTU int, candidateIface string) (int, string) {
+	if candidateMTU <= 0 || (currentMTU > 0 && candidateMTU >= currentMTU) {
+		return currentMTU, currentIface
+	}
+
+	return candidateMTU, candidateIface
 }
 
 func detectDefaultRouteMTUImpl(cache *NetlinkCache) int {

--- a/internal/net/netlink/mss_clamp_manager.go
+++ b/internal/net/netlink/mss_clamp_manager.go
@@ -25,13 +25,23 @@ const (
 // packets forwarded through the node. The explicit MSS is derived from the
 // lowest calculated MTU for the unbounded fabric.
 type MSSClampManager struct {
-	ipt4 *iptables.IPTables
-	ipt6 *iptables.IPTables
+	ipt4 iptablesClient
+	ipt6 iptablesClient
 	mu   sync.Mutex
 	// legacyWGPrefix is retained to remove rules created by older versions.
 	legacyWGPrefix string
 	// installedMTU is the fabric MTU represented by the current rules.
 	installedMTU int
+}
+
+type iptablesClient interface {
+	Append(table, chain string, rulespec ...string) error
+	ChainExists(table, chain string) (bool, error)
+	ClearChain(table, chain string) error
+	DeleteChain(table, chain string) error
+	DeleteIfExists(table, chain string, rulespec ...string) error
+	Exists(table, chain string, rulespec ...string) (bool, error)
+	NewChain(table, chain string) error
 }
 
 // NewMSSClampManager creates a manager and ensures the mangle chain exists.
@@ -47,9 +57,13 @@ func NewMSSClampManager(wgPrefix string) (*MSSClampManager, error) {
 	if err != nil {
 		klog.Warningf("Failed to initialize IPv6 iptables (IPv6 MSS clamping will be disabled): %v", err)
 
-		ipt6 = nil
+		return newMSSClampManager(wgPrefix, ipt4, nil)
 	}
 
+	return newMSSClampManager(wgPrefix, ipt4, ipt6)
+}
+
+func newMSSClampManager(wgPrefix string, ipt4, ipt6 iptablesClient) (*MSSClampManager, error) {
 	m := &MSSClampManager{ipt4: ipt4, ipt6: ipt6, legacyWGPrefix: wgPrefix}
 
 	if err := m.ensureChain(ipt4, "IPv4"); err != nil {
@@ -69,7 +83,13 @@ func NewMSSClampManager(wgPrefix string) (*MSSClampManager, error) {
 		} else if err := ipt6.ClearChain("mangle", mssClampChain); err != nil {
 			klog.Warningf("Failed to clear stale IPv6 MSS clamp rules: %v", err)
 
-			ipt6 = nil
+			if detachErr := m.detachChain(ipt6, "IPv6"); detachErr != nil {
+				return nil, fmt.Errorf(
+					"failed to disable IPv6 MSS clamping after clearing stale rules: %w",
+					detachErr,
+				)
+			}
+
 			m.ipt6 = nil
 		}
 	}
@@ -78,7 +98,7 @@ func NewMSSClampManager(wgPrefix string) (*MSSClampManager, error) {
 }
 
 // ensureChain creates the custom chain and adds a jump from FORWARD.
-func (m *MSSClampManager) ensureChain(ipt *iptables.IPTables, family string) error {
+func (m *MSSClampManager) ensureChain(ipt iptablesClient, family string) error {
 	exists, err := ipt.ChainExists("mangle", mssClampChain)
 	if err != nil {
 		return fmt.Errorf("failed to check if chain exists: %w", err)
@@ -110,6 +130,20 @@ func (m *MSSClampManager) ensureChain(ipt *iptables.IPTables, family string) err
 		}
 
 		klog.V(2).Infof("Added %s jump from FORWARD to %s", family, mssClampChain)
+	}
+
+	return nil
+}
+
+func (m *MSSClampManager) detachChain(ipt iptablesClient, family string) error {
+	jumpRule := []string{"-m", "comment", "--comment", mssClampComment, "-j", mssClampChain}
+	if err := ipt.DeleteIfExists("mangle", "FORWARD", jumpRule...); err != nil {
+		return fmt.Errorf("failed to remove %s MSS clamp jump rule: %w", family, err)
+	}
+
+	legacyJumpRule := []string{"-m", "comment", "--comment", legacyMSSClampComment, "-j", mssClampChain}
+	if err := ipt.DeleteIfExists("mangle", "FORWARD", legacyJumpRule...); err != nil {
+		return fmt.Errorf("failed to remove legacy %s MSS clamp jump rule: %w", family, err)
 	}
 
 	return nil
@@ -150,7 +184,7 @@ func (m *MSSClampManager) EnsureRules(fabricMTU int) error {
 }
 
 func (m *MSSClampManager) ensureRulesForFamily(
-	ipt *iptables.IPTables,
+	ipt iptablesClient,
 	family string,
 	fabricMTU, previousMTU int,
 	ipv6 bool,
@@ -240,7 +274,7 @@ func (m *MSSClampManager) Cleanup() error {
 }
 
 // cleanupFamily removes the jump and chain for one address family.
-func (m *MSSClampManager) cleanupFamily(ipt *iptables.IPTables, family string) error {
+func (m *MSSClampManager) cleanupFamily(ipt iptablesClient, family string) error {
 	if ipt == nil {
 		return nil
 	}

--- a/internal/net/netlink/mss_clamp_manager_test.go
+++ b/internal/net/netlink/mss_clamp_manager_test.go
@@ -4,9 +4,55 @@
 package netlink
 
 import (
+	"errors"
 	"slices"
 	"testing"
 )
+
+type fakeIPTables struct {
+	clearChainErr      error
+	deleteJumpErr      error
+	deletedCurrentJump bool
+	deletedLegacyJump  bool
+}
+
+func (f *fakeIPTables) Append(_, _ string, _ ...string) error {
+	return nil
+}
+
+func (f *fakeIPTables) ChainExists(_, _ string) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeIPTables) ClearChain(_, _ string) error {
+	return f.clearChainErr
+}
+
+func (f *fakeIPTables) DeleteChain(_, _ string) error {
+	return nil
+}
+
+func (f *fakeIPTables) DeleteIfExists(_, _ string, rulespec ...string) error {
+	if slices.Contains(rulespec, mssClampComment) {
+		f.deletedCurrentJump = true
+
+		return f.deleteJumpErr
+	}
+
+	if slices.Contains(rulespec, legacyMSSClampComment) {
+		f.deletedLegacyJump = true
+	}
+
+	return nil
+}
+
+func (f *fakeIPTables) Exists(_, _ string, _ ...string) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeIPTables) NewChain(_, _ string) error {
+	return nil
+}
 
 func TestMSSClampRule(t *testing.T) {
 	tests := []struct {
@@ -44,5 +90,35 @@ func TestMSSClampManagerIgnoresUnknownMTU(t *testing.T) {
 
 	if err := manager.EnsureRules(0); err != nil {
 		t.Fatalf("EnsureRules(0) returned error: %v", err)
+	}
+}
+
+func TestNewMSSClampManagerDetachesIPv6JumpWhenClearFails(t *testing.T) {
+	ipt4 := &fakeIPTables{}
+	ipt6 := &fakeIPTables{clearChainErr: errors.New("clear failed")}
+
+	manager, err := newMSSClampManager("wg", ipt4, ipt6)
+	if err != nil {
+		t.Fatalf("newMSSClampManager() returned error: %v", err)
+	}
+
+	if manager.ipt6 != nil {
+		t.Fatal("newMSSClampManager() left IPv6 reconciliation enabled")
+	}
+
+	if !ipt6.deletedCurrentJump || !ipt6.deletedLegacyJump {
+		t.Fatal("newMSSClampManager() did not detach IPv6 MSS clamp jumps")
+	}
+}
+
+func TestNewMSSClampManagerFailsIfIPv6JumpCannotBeDetached(t *testing.T) {
+	ipt4 := &fakeIPTables{}
+	ipt6 := &fakeIPTables{
+		clearChainErr: errors.New("clear failed"),
+		deleteJumpErr: errors.New("delete failed"),
+	}
+
+	if _, err := newMSSClampManager("wg", ipt4, ipt6); err == nil {
+		t.Fatal("newMSSClampManager() returned nil error when IPv6 jump remained active")
 	}
 }

--- a/internal/net/netlink/netlink_test.go
+++ b/internal/net/netlink/netlink_test.go
@@ -114,6 +114,24 @@ func TestGeneveMTUOverhead(t *testing.T) {
 	}
 }
 
+func TestSelectLowerMTUTracksSelectedInterface(t *testing.T) {
+	mtu, ifaceName := selectLowerMTU(0, "", 1400, "eth0")
+	mtu, ifaceName = selectLowerMTU(mtu, ifaceName, 1500, "eth1")
+
+	if mtu != 1400 {
+		t.Fatalf("selectLowerMTU() MTU = %d, want 1400", mtu)
+	}
+
+	if ifaceName != "eth0" {
+		t.Fatalf("selectLowerMTU() interface = %q, want %q", ifaceName, "eth0")
+	}
+
+	mtu, ifaceName = selectLowerMTU(mtu, ifaceName, 1300, "eth2")
+	if mtu != 1300 || ifaceName != "eth2" {
+		t.Fatalf("selectLowerMTU() = (%d, %q), want (1300, %q)", mtu, ifaceName, "eth2")
+	}
+}
+
 // TestLinkManager_EnsureMTU_NonExistentInterface verifies EnsureMTU returns an
 // error for a non-existent interface.
 func TestLinkManager_EnsureMTU_NonExistentInterface(t *testing.T) {


### PR DESCRIPTION
## Summary

- retain the interface associated with the lowest selected route MTU
- detach IPv6 MSS clamp jumps when stale-chain clearing fails
- add regression coverage for both failure modes

## Context

This addresses the two findings listed as suppressed comments in the final Copilot review on PR #568:

- `internal/net/netlink/link_manager.go:915`: route MTU selection could return an interface unrelated to the selected MTU
- `internal/net/netlink/mss_clamp_manager.go:74`: failed IPv6 chain clearing could leave active but unmanaged MSS clamping

Review: https://github.com/Azure/unbounded/pull/568#pullrequestreview-4850015237