### PR TITLE
operator: resolve component images from a full registry prefix (#574)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,6 +179,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Normalize container registry to lowercase
+        run: echo "REGISTRY=${REGISTRY,,}" >> "$GITHUB_ENV"
+
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
@@ -196,6 +199,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ needs.version.outputs.tag }}
+          # The GoReleaser before-hook renders the operator manifests embedded in
+          # kubectl-unbounded. Pass the (lowercased) release registry so a fork's
+          # binary embeds its own registry/org instead of the ghcr.io/azure
+          # Makefile default. REGISTRY is normalized to lowercase above because
+          # ghcr rejects uppercase repository names (owner "Azure" -> "azure").
+          CONTAINER_REGISTRY: ${{ env.REGISTRY }}
 
       - name: Upload dist artifact for downstream jobs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,9 +121,11 @@ changelog:
       - "^chore:"
 
 release:
-  github:
-    owner: Azure
-    name: unbounded
+  # owner/name are intentionally omitted so GoReleaser targets the repository the
+  # workflow runs in (detected from the git remote). The Actions GITHUB_TOKEN is
+  # scoped to that repository, so a release can only ever be created where the
+  # workflow runs; hardcoding Azure/unbounded only broke fork releases without
+  # adding any guard.
   # Always create as draft. The release workflow attaches additional
   # artifacts (manifests tarball, krew manifest, image signatures) before
   # a human flips the release to published.

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,11 @@ UNBOUNDED_OPERATOR_CMD=./cmd/unbounded-operator
 UNBOUNDED_OPERATOR_IMAGE ?= $(CONTAINER_REGISTRY)/unbounded-operator:$(VERSION_TAG)
 UNBOUNDED_OPERATOR_NAMESPACE ?= $(UNBOUNDED_NAMESPACE)
 UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT ?=
-UNBOUNDED_OPERATOR_IMAGE_REGISTRY ?= ghcr.io
+# Full image-repository prefix the operator resolves component images under. It
+# derives from CONTAINER_REGISTRY so it cannot drift from the operator's own
+# image: overriding CONTAINER_REGISTRY (as the release workflow does per fork)
+# points components at the same registry/org as the operator.
+UNBOUNDED_OPERATOR_IMAGE_REGISTRY ?= $(CONTAINER_REGISTRY)
 UNBOUNDED_OPERATOR_REAP_LEGACY_RESOURCES ?= true
 export UNBOUNDED_OPERATOR_API_SERVER_ENDPOINT
 UNBOUNDED_OPERATOR_MANIFEST_TEMPLATES_DIR := deploy/unbounded-operator

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -99,7 +99,7 @@ func addInstallFlags(cmd *cobra.Command, handler *installHandler) {
 	cmd.Flags().StringVar(&handler.kubeconfigPath, "kubeconfig", "", "Path to kubeconfig file")
 	cmd.Flags().StringVar(&handler.namespace, "namespace", unbounded.SystemNamespace(), "Namespace for unbounded-operator and default components")
 	cmd.Flags().StringVar(&handler.operatorImage, "operator-image", "", "unbounded-operator image override")
-	cmd.Flags().StringVar(&handler.imageRegistry, "image-registry", "", "Registry for operator-managed component images")
+	cmd.Flags().StringVar(&handler.imageRegistry, "image-registry", "", "Full image-repository prefix (registry host plus org/namespace) for operator-managed component images; defaults to the registry the binary was built with")
 	cmd.Flags().StringVar(&handler.apiServerEndpoint, "api-server-endpoint", "", "Override the Kubernetes API server endpoint advertised to provisioned machines; by default the operator auto-discovers it from kube-public/cluster-info, or the KUBERNETES_SERVICE_HOST FQDN on clusters (e.g. AKS) that do not publish cluster-info")
 	cmd.Flags().BoolVar(&handler.wait, "wait", true, "Wait for unbounded-operator rollout")
 	cmd.Flags().DurationVar(&handler.timeout, "timeout", defaultInstallTimeout, "Timeout for rollout waits")
@@ -382,6 +382,12 @@ func (h *installHandler) manifests() fs.FS {
 // set, a missing unbounded-operator-config ConfigMap, or an empty registry value
 // is an error rather than a silent fallback to the upstream default, so a
 // malformed build cannot quietly install upstream components.
+//
+// This walks the embedded manifests directly rather than reusing
+// component.DefaultConfigMap: that helper is a method on *Env (it retargets the
+// namespace and returns a typed ConfigMap) and does not enforce the fail-closed
+// empty-value check, so a self-contained lookup keeps the install command
+// decoupled from the operator's internals.
 func (h *installHandler) embeddedImageRegistry() (string, error) {
 	files, err := yamlFiles(h.manifests())
 	if err != nil {

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -62,6 +62,11 @@ type installHandler struct {
 	// operatormanifests.Manifests; tests inject a fork-rendered set.
 	operatorManifests fs.FS
 
+	// resolvedOperatorImage is the operator Deployment image install stamps,
+	// computed by resolveImages as <registry>/<name:tag> so it always shares the
+	// component registry.
+	resolvedOperatorImage string
+
 	wait    bool
 	timeout time.Duration
 
@@ -98,8 +103,8 @@ Sites are created or updated.`,
 func addInstallFlags(cmd *cobra.Command, handler *installHandler) {
 	cmd.Flags().StringVar(&handler.kubeconfigPath, "kubeconfig", "", "Path to kubeconfig file")
 	cmd.Flags().StringVar(&handler.namespace, "namespace", unbounded.SystemNamespace(), "Namespace for unbounded-operator and default components")
-	cmd.Flags().StringVar(&handler.operatorImage, "operator-image", "", "unbounded-operator image override")
-	cmd.Flags().StringVar(&handler.imageRegistry, "image-registry", "", "Full image-repository prefix (registry host plus org/namespace) for operator-managed component images; defaults to the registry the binary was built with")
+	cmd.Flags().StringVar(&handler.operatorImage, "operator-image", "", "unbounded-operator image name and tag without a registry (e.g. unbounded-operator:v1); the registry comes from --image-registry")
+	cmd.Flags().StringVar(&handler.imageRegistry, "image-registry", "", "Full image-repository prefix (registry host plus org/namespace) all unbounded images are pulled from; defaults to the registry the binary was built with")
 	cmd.Flags().StringVar(&handler.apiServerEndpoint, "api-server-endpoint", "", "Override the Kubernetes API server endpoint advertised to provisioned machines; by default the operator auto-discovers it from kube-public/cluster-info, or the KUBERNETES_SERVICE_HOST FQDN on clusters (e.g. AKS) that do not publish cluster-info")
 	cmd.Flags().BoolVar(&handler.wait, "wait", true, "Wait for unbounded-operator rollout")
 	cmd.Flags().DurationVar(&handler.timeout, "timeout", defaultInstallTimeout, "Timeout for rollout waits")
@@ -238,7 +243,7 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 	}
 
 	if obj.GetKind() == "Deployment" && obj.GetName() == "unbounded-operator" {
-		if err := setContainerImage(obj, "controller", h.operatorImage); err != nil {
+		if err := setContainerImage(obj, "controller", h.resolvedOperatorImage); err != nil {
 			return err
 		}
 
@@ -294,23 +299,20 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 	// override is preserved across reinstalls (like the reaper flag) rather than
 	// being cleared or replaced with the kubeconfig host.
 	endpoint := ""
-	// The component registry tracks the registry baked into the embedded operator
-	// manifests, which is rendered from the same CONTAINER_REGISTRY as the
-	// operator image this binary deploys. Deriving it from the build (rather than
-	// preserving a stored cluster value) keeps it in lockstep with the operator
-	// image, which install also re-derives from the binary on every run, and
-	// avoids the #574 drift where the two could diverge. An explicit
-	// --image-registry wins; otherwise the build-derived value is required. A
-	// stored value from an older install is simply overwritten.
-	imageRegistry := h.imageRegistry
-	if imageRegistry == "" {
-		embedded, err := h.embeddedImageRegistry()
-		if err != nil {
-			return fmt.Errorf("determine component image registry from the embedded operator manifests: %w; pass --image-registry to set it explicitly", err)
-		}
-
-		imageRegistry = embedded
+	// The operator image and the component registry must stay in lockstep (the
+	// operator resolves components at its own version from this registry), so a
+	// single value drives both: the registry comes from --image-registry (or the
+	// registry baked into the embedded manifests at build time), and the operator
+	// Deployment image is that registry plus the operator's name:tag. Because
+	// --operator-image cannot carry a registry of its own, the two cannot diverge
+	// (the #574 drift). The registry is not preserved from cluster state; a stored
+	// value from an older install is simply overwritten.
+	resolvedOperatorImage, imageRegistry, err := h.resolveImages()
+	if err != nil {
+		return err
 	}
+
+	h.resolvedOperatorImage = resolvedOperatorImage
 
 	reapLegacyResources := true
 	previousImageRegistry := ""
@@ -373,6 +375,113 @@ func (h *installHandler) manifests() fs.FS {
 	}
 
 	return operatormanifests.Manifests
+}
+
+// resolveImages determines the operator Deployment image and the component
+// registry, keeping them in lockstep. The registry is the single source: it comes
+// from --image-registry, or the registry baked into the embedded manifests at
+// build time. The operator image is that registry plus the operator's name:tag,
+// taken from --operator-image (which must be a name:tag with no registry) or the
+// embedded operator image. Because the registry is never taken from
+// --operator-image, the operator and its components cannot come from different
+// registries. Both defaults fail closed rather than falling back to the upstream
+// registry.
+func (h *installHandler) resolveImages() (operatorImage, registry string, err error) {
+	embeddedRegistry, embeddedRegistryErr := h.embeddedImageRegistry()
+
+	registry = h.imageRegistry
+	if registry == "" {
+		if embeddedRegistryErr != nil {
+			return "", "", fmt.Errorf("determine component image registry from the embedded operator manifests: %w; pass --image-registry to set it explicitly", embeddedRegistryErr)
+		}
+
+		registry = embeddedRegistry
+	}
+
+	registry = strings.TrimRight(registry, "/")
+
+	nameTag := h.operatorImage
+	if nameTag != "" {
+		if strings.Contains(nameTag, "/") {
+			return "", "", fmt.Errorf("--operator-image %q must be an image name and tag with no registry (for example unbounded-operator:v1); set the registry with --image-registry", nameTag)
+		}
+	} else {
+		// Default the operator name:tag from the embedded operator image, stripped
+		// of the registry it was rendered with, so a bare --image-registry still
+		// yields <registry>/unbounded-operator:<embedded-tag>.
+		embeddedOperator, embeddedOperatorErr := h.embeddedOperatorImage()
+		if embeddedOperatorErr != nil {
+			return "", "", fmt.Errorf("determine operator image from the embedded manifests: %w; pass --operator-image to set it explicitly", embeddedOperatorErr)
+		}
+
+		if embeddedRegistryErr != nil {
+			return "", "", fmt.Errorf("determine operator image from the embedded manifests: %w; pass --operator-image to set it explicitly", embeddedRegistryErr)
+		}
+
+		prefix := strings.TrimRight(embeddedRegistry, "/") + "/"
+		if !strings.HasPrefix(embeddedOperator, prefix) {
+			return "", "", fmt.Errorf("cannot derive the operator image name from the embedded manifests (%q is not under %q); pass --operator-image", embeddedOperator, embeddedRegistry)
+		}
+
+		nameTag = strings.TrimPrefix(embeddedOperator, prefix)
+	}
+
+	return registry + "/" + nameTag, registry, nil
+}
+
+// embeddedOperatorImage returns the controller image baked into the embedded
+// operator Deployment at build time. It fails closed on an unreadable manifest
+// set, a missing unbounded-operator Deployment, or an empty image.
+func (h *installHandler) embeddedOperatorImage() (string, error) {
+	files, err := yamlFiles(h.manifests())
+	if err != nil {
+		return "", fmt.Errorf("list embedded operator manifests: %w", err)
+	}
+
+	for _, file := range files {
+		data, err := fs.ReadFile(h.manifests(), file)
+		if err != nil {
+			return "", fmt.Errorf("read embedded operator manifest %s: %w", file, err)
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+		for {
+			obj := &unstructured.Unstructured{}
+			if err := decoder.Decode(obj); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return "", fmt.Errorf("decode embedded operator manifest %s: %w", file, err)
+			}
+
+			if obj.Object == nil || obj.GetKind() != "Deployment" || obj.GetName() != "unbounded-operator" {
+				continue
+			}
+
+			containers, _, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+			if err != nil {
+				return "", fmt.Errorf("read embedded operator Deployment containers: %w", err)
+			}
+
+			for _, c := range containers {
+				container, ok := c.(map[string]any)
+				if !ok || container["name"] != "controller" {
+					continue
+				}
+
+				image, ok := container["image"].(string)
+				if ok && image != "" {
+					return image, nil
+				}
+
+				return "", fmt.Errorf("embedded operator Deployment controller container has no image")
+			}
+		}
+	}
+
+	return "", fmt.Errorf("embedded operator manifests contain no unbounded-operator Deployment")
 }
 
 // embeddedImageRegistry returns the UNBOUNDED_IMAGE_REGISTRY baked into the

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -47,15 +47,6 @@ const (
 	// CRD bootstrap needs to repair a missing or unestablished CRD.
 	operatorCRDRepairAnnotation = "unbounded-cloud.io/operator-crd-repair-token"
 
-	// imageRegistrySchemaAnnotation records, on the unbounded-operator-config
-	// ConfigMap, the semantics version of its UNBOUNDED_IMAGE_REGISTRY value. An
-	// absent annotation means the value predates #574, when the operator appended
-	// an implicit "/azure/" segment, so the stored value was the prefix before it.
-	// imageRegistrySchemaCurrent means the value is already a full
-	// image-repository prefix. install migrates an unmarked value exactly once.
-	imageRegistrySchemaAnnotation = "unbounded-cloud.io/image-registry-schema"
-	imageRegistrySchemaCurrent    = "2"
-
 	// fallbackImageRegistry is used only when the embedded operator ConfigMap
 	// cannot be read; normal builds render it with the build-time CONTAINER_REGISTRY.
 	fallbackImageRegistry = "ghcr.io/azure"
@@ -247,15 +238,6 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 		}
 
 		h.operatorConfigData = data
-
-		// Stamp the schema marker so a later reinstall recognizes this value as a
-		// full prefix and does not migrate it again. Stamping here (not only in
-		// the template) keeps migration once-only even if the embedded manifest
-		// predates the marker. The annotation is not ConfigMap data, so it stays
-		// out of the operator's envFrom and the config-hash.
-		if err := unstructured.SetNestedField(obj.Object, imageRegistrySchemaCurrent, "metadata", "annotations", imageRegistrySchemaAnnotation); err != nil {
-			return fmt.Errorf("set image registry schema annotation: %w", err)
-		}
 	}
 
 	if obj.GetKind() == "Deployment" && obj.GetName() == "unbounded-operator" {
@@ -315,13 +297,16 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 	// override is preserved across reinstalls (like the reaper flag) rather than
 	// being cleared or replaced with the kubeconfig host.
 	endpoint := ""
-	// The fresh-install default tracks the registry baked into the embedded
-	// operator manifests, which is rendered from the same CONTAINER_REGISTRY as
-	// the operator image this binary deploys. Hardcoding it here would make a
-	// fork build (operator image ghcr.io/myorg) configure components from
-	// ghcr.io/azure, the exact drift #574 removed.
+	// The component registry tracks the registry baked into the embedded operator
+	// manifests, which is rendered from the same CONTAINER_REGISTRY as the
+	// operator image this binary deploys. Deriving it from the build (rather than
+	// preserving a stored cluster value) keeps it in lockstep with the operator
+	// image, which install also re-derives from the binary on every run, and
+	// avoids the #574 drift where the two could diverge. A stored value from an
+	// older install is simply overwritten.
 	imageRegistry := h.embeddedImageRegistry()
 	reapLegacyResources := true
+	previousImageRegistry := ""
 	configMap := &unstructured.Unstructured{}
 	configMap.SetAPIVersion("v1")
 	configMap.SetKind("ConfigMap")
@@ -337,22 +322,10 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 			return fmt.Errorf("get existing unbounded-operator-config data: %w", err)
 		}
 
-		annotations, _, err := unstructured.NestedStringMap(configMap.Object, "metadata", "annotations")
-		if err != nil {
-			return fmt.Errorf("get existing unbounded-operator-config annotations: %w", err)
-		}
-
+		// The endpoint and reaper flag are cluster policy and are preserved across
+		// reinstalls; the image registry is a build-artifact locator and is not.
 		endpoint = data["UNBOUNDED_API_SERVER_ENDPOINT"]
-		if value := data["UNBOUNDED_IMAGE_REGISTRY"]; value != "" {
-			// A ConfigMap written before the schema marker existed stored the
-			// prefix the operator appended "/azure/" to, so migrate it once;
-			// a marked value is already a full prefix and is preserved verbatim.
-			if annotations[imageRegistrySchemaAnnotation] == imageRegistrySchemaCurrent {
-				imageRegistry = value
-			} else {
-				imageRegistry = migrateLegacyImageRegistry(value)
-			}
-		}
+		previousImageRegistry = data["UNBOUNDED_IMAGE_REGISTRY"]
 
 		if value, found := data["UNBOUNDED_REAP_LEGACY_RESOURCES"]; found {
 			parsed, err := strconv.ParseBool(value)
@@ -370,6 +343,14 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 
 	if h.imageRegistry != "" {
 		imageRegistry = h.imageRegistry
+	}
+
+	// Surface a registry change so repointing components is not silent (the main
+	// concern in #574): an upgrade of an existing cluster rewrites a pre-#574
+	// bare "ghcr.io" to the resolved full prefix.
+	if previousImageRegistry != "" && previousImageRegistry != imageRegistry {
+		h.logger.Info("updating component image registry",
+			"from", previousImageRegistry, "to", imageRegistry)
 	}
 
 	h.operatorConfigData = map[string]string{
@@ -392,10 +373,10 @@ func (h *installHandler) manifests() fs.FS {
 }
 
 // embeddedImageRegistry returns the UNBOUNDED_IMAGE_REGISTRY baked into the
-// embedded operator ConfigMap at build time. Tying the fresh-install default to
-// the build keeps the configured component registry in lockstep with the
-// operator image the binary deploys, so fork and mirror builds work without a
-// flag. It falls back to the release default only if the manifest is unreadable.
+// embedded operator ConfigMap at build time. Tying the component registry to the
+// build keeps it in lockstep with the operator image the binary deploys, so fork
+// and mirror builds work without a flag. It falls back to the release default
+// only if the manifest is unreadable.
 func (h *installHandler) embeddedImageRegistry() string {
 	files, err := yamlFiles(h.manifests())
 	if err != nil {
@@ -428,22 +409,6 @@ func (h *installHandler) embeddedImageRegistry() string {
 	}
 
 	return fallbackImageRegistry
-}
-
-// migrateLegacyImageRegistry upgrades a pre-#574 UNBOUNDED_IMAGE_REGISTRY value
-// (identified by the absence of the schema-marker annotation) to the current
-// full-prefix semantics. The operator used to append a hardcoded "/azure/"
-// segment, so the stored value was the prefix before it; appending "/azure"
-// reproduces the same images for every legacy value, bare host or path-based
-// mirror alike. The schema marker install stamps on write prevents this from
-// running twice.
-func migrateLegacyImageRegistry(registry string) string {
-	trimmed := strings.TrimRight(registry, "/")
-	if trimmed == "" {
-		return registry
-	}
-
-	return trimmed + "/azure"
 }
 
 func (h *installHandler) prepareOperatorRepair(ctx context.Context) error {

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -112,9 +112,11 @@ func addInstallFlags(cmd *cobra.Command, handler *installHandler) {
 
 func (h *installHandler) execute(ctx context.Context) error {
 	// execute can be called repeatedly in tests and by command embedders. Do not
-	// carry values derived from the previous cluster state into this run.
+	// carry values derived from a previous run (from cluster state or the embedded
+	// manifests) into this one.
 	h.operatorConfigData = nil
 	h.operatorRepairToken = ""
+	h.resolvedOperatorImage = ""
 
 	if h.logger == nil {
 		h.logger = slog.Default()
@@ -410,12 +412,8 @@ func (h *installHandler) resolveImages() (operatorImage, registry string, err er
 		// of the registry it was rendered with, so a bare --image-registry still
 		// yields <registry>/unbounded-operator:<embedded-tag>.
 		embeddedOperator, embeddedOperatorErr := h.embeddedOperatorImage()
-		if embeddedOperatorErr != nil {
-			return "", "", fmt.Errorf("determine operator image from the embedded manifests: %w; pass --operator-image to set it explicitly", embeddedOperatorErr)
-		}
-
-		if embeddedRegistryErr != nil {
-			return "", "", fmt.Errorf("determine operator image from the embedded manifests: %w; pass --operator-image to set it explicitly", embeddedRegistryErr)
+		if err := errors.Join(embeddedOperatorErr, embeddedRegistryErr); err != nil {
+			return "", "", fmt.Errorf("determine the operator image name and tag from the embedded manifests: %w; pass --operator-image (e.g. unbounded-operator:v1) to set it explicitly", err)
 		}
 
 		prefix := strings.TrimRight(embeddedRegistry, "/") + "/"
@@ -424,15 +422,24 @@ func (h *installHandler) resolveImages() (operatorImage, registry string, err er
 		}
 
 		nameTag = strings.TrimPrefix(embeddedOperator, prefix)
+
+		// The embedded operator image must be a direct child of the registry
+		// (<registry>/unbounded-operator:<tag>) so it can be re-expressed as a
+		// name:tag under a different --image-registry. The render pipeline
+		// guarantees this; guard against a hand-edited manifest.
+		if strings.Contains(nameTag, "/") {
+			return "", "", fmt.Errorf("embedded operator image %q is nested below its registry %q; pass --operator-image", embeddedOperator, embeddedRegistry)
+		}
 	}
 
 	return registry + "/" + nameTag, registry, nil
 }
 
-// embeddedOperatorImage returns the controller image baked into the embedded
-// operator Deployment at build time. It fails closed on an unreadable manifest
-// set, a missing unbounded-operator Deployment, or an empty image.
-func (h *installHandler) embeddedOperatorImage() (string, error) {
+// embeddedManifestValue walks the embedded operator manifests and returns the
+// value extract produces from the first object matching kind and name. desc names
+// the object in the not-found error. It fails closed on an unreadable manifest
+// set or a missing object.
+func (h *installHandler) embeddedManifestValue(kind, name, desc string, extract func(*unstructured.Unstructured) (string, error)) (string, error) {
 	files, err := yamlFiles(h.manifests())
 	if err != nil {
 		return "", fmt.Errorf("list embedded operator manifests: %w", err)
@@ -456,32 +463,43 @@ func (h *installHandler) embeddedOperatorImage() (string, error) {
 				return "", fmt.Errorf("decode embedded operator manifest %s: %w", file, err)
 			}
 
-			if obj.Object == nil || obj.GetKind() != "Deployment" || obj.GetName() != "unbounded-operator" {
+			if obj.Object == nil || obj.GetKind() != kind || obj.GetName() != name {
 				continue
 			}
 
-			containers, _, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
-			if err != nil {
-				return "", fmt.Errorf("read embedded operator Deployment containers: %w", err)
-			}
-
-			for _, c := range containers {
-				container, ok := c.(map[string]any)
-				if !ok || container["name"] != "controller" {
-					continue
-				}
-
-				image, ok := container["image"].(string)
-				if ok && image != "" {
-					return image, nil
-				}
-
-				return "", fmt.Errorf("embedded operator Deployment controller container has no image")
-			}
+			return extract(obj)
 		}
 	}
 
-	return "", fmt.Errorf("embedded operator manifests contain no unbounded-operator Deployment")
+	return "", fmt.Errorf("embedded operator manifests contain no %s", desc)
+}
+
+// embeddedOperatorImage returns the controller image baked into the embedded
+// operator Deployment at build time. It fails closed on an unreadable manifest
+// set, a missing unbounded-operator Deployment, or an empty image.
+func (h *installHandler) embeddedOperatorImage() (string, error) {
+	return h.embeddedManifestValue("Deployment", "unbounded-operator", "unbounded-operator Deployment", func(obj *unstructured.Unstructured) (string, error) {
+		containers, _, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+		if err != nil {
+			return "", fmt.Errorf("read embedded operator Deployment containers: %w", err)
+		}
+
+		for _, c := range containers {
+			container, ok := c.(map[string]any)
+			if !ok || container["name"] != "controller" {
+				continue
+			}
+
+			image, ok := container["image"].(string)
+			if ok && image != "" {
+				return image, nil
+			}
+
+			return "", fmt.Errorf("embedded operator Deployment controller container has no image")
+		}
+
+		return "", fmt.Errorf("embedded operator Deployment has no controller container")
+	})
 }
 
 // embeddedImageRegistry returns the UNBOUNDED_IMAGE_REGISTRY baked into the
@@ -492,53 +510,24 @@ func (h *installHandler) embeddedOperatorImage() (string, error) {
 // is an error rather than a silent fallback to the upstream default, so a
 // malformed build cannot quietly install upstream components.
 //
-// This walks the embedded manifests directly rather than reusing
+// It walks the embedded manifests directly rather than reusing
 // component.DefaultConfigMap: that helper is a method on *Env (it retargets the
 // namespace and returns a typed ConfigMap) and does not enforce the fail-closed
 // empty-value check, so a self-contained lookup keeps the install command
 // decoupled from the operator's internals.
 func (h *installHandler) embeddedImageRegistry() (string, error) {
-	files, err := yamlFiles(h.manifests())
-	if err != nil {
-		return "", fmt.Errorf("list embedded operator manifests: %w", err)
-	}
-
-	for _, file := range files {
-		data, err := fs.ReadFile(h.manifests(), file)
+	return h.embeddedManifestValue("ConfigMap", "unbounded-operator-config", "unbounded-operator-config ConfigMap", func(obj *unstructured.Unstructured) (string, error) {
+		value, _, err := unstructured.NestedString(obj.Object, "data", "UNBOUNDED_IMAGE_REGISTRY")
 		if err != nil {
-			return "", fmt.Errorf("read embedded operator manifest %s: %w", file, err)
+			return "", fmt.Errorf("read UNBOUNDED_IMAGE_REGISTRY from embedded unbounded-operator-config: %w", err)
 		}
 
-		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
-
-		for {
-			obj := &unstructured.Unstructured{}
-			if err := decoder.Decode(obj); err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-
-				return "", fmt.Errorf("decode embedded operator manifest %s: %w", file, err)
-			}
-
-			if obj.Object == nil || obj.GetKind() != "ConfigMap" || obj.GetName() != "unbounded-operator-config" {
-				continue
-			}
-
-			value, _, err := unstructured.NestedString(obj.Object, "data", "UNBOUNDED_IMAGE_REGISTRY")
-			if err != nil {
-				return "", fmt.Errorf("read UNBOUNDED_IMAGE_REGISTRY from embedded unbounded-operator-config: %w", err)
-			}
-
-			if value == "" {
-				return "", fmt.Errorf("embedded unbounded-operator-config has an empty UNBOUNDED_IMAGE_REGISTRY")
-			}
-
-			return value, nil
+		if value == "" {
+			return "", fmt.Errorf("embedded unbounded-operator-config has an empty UNBOUNDED_IMAGE_REGISTRY")
 		}
-	}
 
-	return "", fmt.Errorf("embedded operator manifests contain no unbounded-operator-config ConfigMap")
+		return value, nil
+	})
 }
 
 func (h *installHandler) prepareOperatorRepair(ctx context.Context) error {

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -46,6 +46,19 @@ const (
 	// operatorCRDRepairAnnotation restarts an existing operator when its startup
 	// CRD bootstrap needs to repair a missing or unestablished CRD.
 	operatorCRDRepairAnnotation = "unbounded-cloud.io/operator-crd-repair-token"
+
+	// imageRegistrySchemaAnnotation records, on the unbounded-operator-config
+	// ConfigMap, the semantics version of its UNBOUNDED_IMAGE_REGISTRY value. An
+	// absent annotation means the value predates #574, when the operator appended
+	// an implicit "/azure/" segment, so the stored value was the prefix before it.
+	// imageRegistrySchemaCurrent means the value is already a full
+	// image-repository prefix. install migrates an unmarked value exactly once.
+	imageRegistrySchemaAnnotation = "unbounded-cloud.io/image-registry-schema"
+	imageRegistrySchemaCurrent    = "2"
+
+	// fallbackImageRegistry is used only when the embedded operator ConfigMap
+	// cannot be read; normal builds render it with the build-time CONTAINER_REGISTRY.
+	fallbackImageRegistry = "ghcr.io/azure"
 )
 
 type installHandler struct {
@@ -55,6 +68,11 @@ type installHandler struct {
 	operatorImage     string
 	imageRegistry     string
 	apiServerEndpoint string
+
+	// operatorManifests is the embedded operator manifest filesystem install
+	// applies and reads its build-time defaults from. It defaults to
+	// operatormanifests.Manifests; tests inject a fork-rendered set.
+	operatorManifests fs.FS
 
 	wait    bool
 	timeout time.Duration
@@ -145,7 +163,7 @@ func (h *installHandler) execute(ctx context.Context) error {
 		return err
 	}
 
-	if err := applyManifestFS(ctx, h.logger, h.kubeResourcesCli, operatormanifests.Manifests, fieldManagerID, h.mutateOperatorObject); err != nil {
+	if err := applyManifestFS(ctx, h.logger, h.kubeResourcesCli, h.manifests(), fieldManagerID, h.mutateOperatorObject); err != nil {
 		return fmt.Errorf("applying unbounded-operator manifests: %w", err)
 	}
 
@@ -229,6 +247,15 @@ func (h *installHandler) mutateOperatorObject(obj *unstructured.Unstructured) er
 		}
 
 		h.operatorConfigData = data
+
+		// Stamp the schema marker so a later reinstall recognizes this value as a
+		// full prefix and does not migrate it again. Stamping here (not only in
+		// the template) keeps migration once-only even if the embedded manifest
+		// predates the marker. The annotation is not ConfigMap data, so it stays
+		// out of the operator's envFrom and the config-hash.
+		if err := unstructured.SetNestedField(obj.Object, imageRegistrySchemaCurrent, "metadata", "annotations", imageRegistrySchemaAnnotation); err != nil {
+			return fmt.Errorf("set image registry schema annotation: %w", err)
+		}
 	}
 
 	if obj.GetKind() == "Deployment" && obj.GetName() == "unbounded-operator" {
@@ -288,7 +315,12 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 	// override is preserved across reinstalls (like the reaper flag) rather than
 	// being cleared or replaced with the kubeconfig host.
 	endpoint := ""
-	imageRegistry := "ghcr.io/azure"
+	// The fresh-install default tracks the registry baked into the embedded
+	// operator manifests, which is rendered from the same CONTAINER_REGISTRY as
+	// the operator image this binary deploys. Hardcoding it here would make a
+	// fork build (operator image ghcr.io/myorg) configure components from
+	// ghcr.io/azure, the exact drift #574 removed.
+	imageRegistry := h.embeddedImageRegistry()
 	reapLegacyResources := true
 	configMap := &unstructured.Unstructured{}
 	configMap.SetAPIVersion("v1")
@@ -305,9 +337,21 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 			return fmt.Errorf("get existing unbounded-operator-config data: %w", err)
 		}
 
+		annotations, _, err := unstructured.NestedStringMap(configMap.Object, "metadata", "annotations")
+		if err != nil {
+			return fmt.Errorf("get existing unbounded-operator-config annotations: %w", err)
+		}
+
 		endpoint = data["UNBOUNDED_API_SERVER_ENDPOINT"]
 		if value := data["UNBOUNDED_IMAGE_REGISTRY"]; value != "" {
-			imageRegistry = migrateLegacyImageRegistry(value)
+			// A ConfigMap written before the schema marker existed stored the
+			// prefix the operator appended "/azure/" to, so migrate it once;
+			// a marked value is already a full prefix and is preserved verbatim.
+			if annotations[imageRegistrySchemaAnnotation] == imageRegistrySchemaCurrent {
+				imageRegistry = value
+			} else {
+				imageRegistry = migrateLegacyImageRegistry(value)
+			}
 		}
 
 		if value, found := data["UNBOUNDED_REAP_LEGACY_RESOURCES"]; found {
@@ -337,16 +381,65 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 	return nil
 }
 
-// migrateLegacyImageRegistry upgrades a preserved UNBOUNDED_IMAGE_REGISTRY value
-// from the pre-#574 semantics (where the operator appended a hardcoded /azure/
-// segment) to the current full-prefix semantics. A bare host with no path
-// segment (the released default "ghcr.io", or any custom bare host) gains an
-// "/azure" suffix so it keeps resolving to the same images after upgrade. Values
-// that already carry a path segment are assumed to be current full prefixes and
-// are left untouched, which also makes the rewrite idempotent across reinstalls.
+// manifests returns the operator manifest filesystem, defaulting to the embedded
+// set when a test has not injected one.
+func (h *installHandler) manifests() fs.FS {
+	if h.operatorManifests != nil {
+		return h.operatorManifests
+	}
+
+	return operatormanifests.Manifests
+}
+
+// embeddedImageRegistry returns the UNBOUNDED_IMAGE_REGISTRY baked into the
+// embedded operator ConfigMap at build time. Tying the fresh-install default to
+// the build keeps the configured component registry in lockstep with the
+// operator image the binary deploys, so fork and mirror builds work without a
+// flag. It falls back to the release default only if the manifest is unreadable.
+func (h *installHandler) embeddedImageRegistry() string {
+	files, err := yamlFiles(h.manifests())
+	if err != nil {
+		return fallbackImageRegistry
+	}
+
+	for _, file := range files {
+		data, err := fs.ReadFile(h.manifests(), file)
+		if err != nil {
+			continue
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+		for {
+			obj := &unstructured.Unstructured{}
+			if err := decoder.Decode(obj); err != nil {
+				break
+			}
+
+			if obj.Object == nil || obj.GetKind() != "ConfigMap" || obj.GetName() != "unbounded-operator-config" {
+				continue
+			}
+
+			value, _, err := unstructured.NestedString(obj.Object, "data", "UNBOUNDED_IMAGE_REGISTRY")
+			if err == nil && value != "" {
+				return value
+			}
+		}
+	}
+
+	return fallbackImageRegistry
+}
+
+// migrateLegacyImageRegistry upgrades a pre-#574 UNBOUNDED_IMAGE_REGISTRY value
+// (identified by the absence of the schema-marker annotation) to the current
+// full-prefix semantics. The operator used to append a hardcoded "/azure/"
+// segment, so the stored value was the prefix before it; appending "/azure"
+// reproduces the same images for every legacy value, bare host or path-based
+// mirror alike. The schema marker install stamps on write prevents this from
+// running twice.
 func migrateLegacyImageRegistry(registry string) string {
 	trimmed := strings.TrimRight(registry, "/")
-	if trimmed == "" || strings.Contains(trimmed, "/") {
+	if trimmed == "" {
 		return registry
 	}
 

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -46,10 +47,6 @@ const (
 	// operatorCRDRepairAnnotation restarts an existing operator when its startup
 	// CRD bootstrap needs to repair a missing or unestablished CRD.
 	operatorCRDRepairAnnotation = "unbounded-cloud.io/operator-crd-repair-token"
-
-	// fallbackImageRegistry is used only when the embedded operator ConfigMap
-	// cannot be read; normal builds render it with the build-time CONTAINER_REGISTRY.
-	fallbackImageRegistry = "ghcr.io/azure"
 )
 
 type installHandler struct {
@@ -302,9 +299,19 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 	// operator image this binary deploys. Deriving it from the build (rather than
 	// preserving a stored cluster value) keeps it in lockstep with the operator
 	// image, which install also re-derives from the binary on every run, and
-	// avoids the #574 drift where the two could diverge. A stored value from an
-	// older install is simply overwritten.
-	imageRegistry := h.embeddedImageRegistry()
+	// avoids the #574 drift where the two could diverge. An explicit
+	// --image-registry wins; otherwise the build-derived value is required. A
+	// stored value from an older install is simply overwritten.
+	imageRegistry := h.imageRegistry
+	if imageRegistry == "" {
+		embedded, err := h.embeddedImageRegistry()
+		if err != nil {
+			return fmt.Errorf("determine component image registry from the embedded operator manifests: %w; pass --image-registry to set it explicitly", err)
+		}
+
+		imageRegistry = embedded
+	}
+
 	reapLegacyResources := true
 	previousImageRegistry := ""
 	configMap := &unstructured.Unstructured{}
@@ -341,10 +348,6 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 		endpoint = h.apiServerEndpoint
 	}
 
-	if h.imageRegistry != "" {
-		imageRegistry = h.imageRegistry
-	}
-
 	// Surface a registry change so repointing components is not silent (the main
 	// concern in #574): an upgrade of an existing cluster rewrites a pre-#574
 	// bare "ghcr.io" to the resolved full prefix.
@@ -375,18 +378,20 @@ func (h *installHandler) manifests() fs.FS {
 // embeddedImageRegistry returns the UNBOUNDED_IMAGE_REGISTRY baked into the
 // embedded operator ConfigMap at build time. Tying the component registry to the
 // build keeps it in lockstep with the operator image the binary deploys, so fork
-// and mirror builds work without a flag. It falls back to the release default
-// only if the manifest is unreadable.
-func (h *installHandler) embeddedImageRegistry() string {
+// and mirror builds work without a flag. It fails closed: an unreadable manifest
+// set, a missing unbounded-operator-config ConfigMap, or an empty registry value
+// is an error rather than a silent fallback to the upstream default, so a
+// malformed build cannot quietly install upstream components.
+func (h *installHandler) embeddedImageRegistry() (string, error) {
 	files, err := yamlFiles(h.manifests())
 	if err != nil {
-		return fallbackImageRegistry
+		return "", fmt.Errorf("list embedded operator manifests: %w", err)
 	}
 
 	for _, file := range files {
 		data, err := fs.ReadFile(h.manifests(), file)
 		if err != nil {
-			continue
+			return "", fmt.Errorf("read embedded operator manifest %s: %w", file, err)
 		}
 
 		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
@@ -394,7 +399,11 @@ func (h *installHandler) embeddedImageRegistry() string {
 		for {
 			obj := &unstructured.Unstructured{}
 			if err := decoder.Decode(obj); err != nil {
-				break
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return "", fmt.Errorf("decode embedded operator manifest %s: %w", file, err)
 			}
 
 			if obj.Object == nil || obj.GetKind() != "ConfigMap" || obj.GetName() != "unbounded-operator-config" {
@@ -402,13 +411,19 @@ func (h *installHandler) embeddedImageRegistry() string {
 			}
 
 			value, _, err := unstructured.NestedString(obj.Object, "data", "UNBOUNDED_IMAGE_REGISTRY")
-			if err == nil && value != "" {
-				return value
+			if err != nil {
+				return "", fmt.Errorf("read UNBOUNDED_IMAGE_REGISTRY from embedded unbounded-operator-config: %w", err)
 			}
+
+			if value == "" {
+				return "", fmt.Errorf("embedded unbounded-operator-config has an empty UNBOUNDED_IMAGE_REGISTRY")
+			}
+
+			return value, nil
 		}
 	}
 
-	return fallbackImageRegistry
+	return "", fmt.Errorf("embedded operator manifests contain no unbounded-operator-config ConfigMap")
 }
 
 func (h *installHandler) prepareOperatorRepair(ctx context.Context) error {

--- a/cmd/kubectl-unbounded/app/install.go
+++ b/cmd/kubectl-unbounded/app/install.go
@@ -288,7 +288,7 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 	// override is preserved across reinstalls (like the reaper flag) rather than
 	// being cleared or replaced with the kubeconfig host.
 	endpoint := ""
-	imageRegistry := "ghcr.io"
+	imageRegistry := "ghcr.io/azure"
 	reapLegacyResources := true
 	configMap := &unstructured.Unstructured{}
 	configMap.SetAPIVersion("v1")
@@ -307,7 +307,7 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 
 		endpoint = data["UNBOUNDED_API_SERVER_ENDPOINT"]
 		if value := data["UNBOUNDED_IMAGE_REGISTRY"]; value != "" {
-			imageRegistry = value
+			imageRegistry = migrateLegacyImageRegistry(value)
 		}
 
 		if value, found := data["UNBOUNDED_REAP_LEGACY_RESOURCES"]; found {
@@ -335,6 +335,22 @@ func (h *installHandler) prepareOperatorConfig(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// migrateLegacyImageRegistry upgrades a preserved UNBOUNDED_IMAGE_REGISTRY value
+// from the pre-#574 semantics (where the operator appended a hardcoded /azure/
+// segment) to the current full-prefix semantics. A bare host with no path
+// segment (the released default "ghcr.io", or any custom bare host) gains an
+// "/azure" suffix so it keeps resolving to the same images after upgrade. Values
+// that already carry a path segment are assumed to be current full prefixes and
+// are left untouched, which also makes the rewrite idempotent across reinstalls.
+func migrateLegacyImageRegistry(registry string) string {
+	trimmed := strings.TrimRight(registry, "/")
+	if trimmed == "" || strings.Contains(trimmed, "/") {
+		return registry
+	}
+
+	return trimmed + "/azure"
 }
 
 func (h *installHandler) prepareOperatorRepair(ctx context.Context) error {

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -288,74 +288,34 @@ func TestInstallMergesLiveReaperConfig(t *testing.T) {
 	}
 }
 
-func TestMigrateLegacyImageRegistry(t *testing.T) {
+// TestInstallReinstallDerivesRegistryFromBuild asserts the component registry is
+// re-derived from the binary's embedded manifests on every install, not
+// preserved from cluster state. An older cluster storing the pre-#574 bare
+// "ghcr.io" (or any custom value) is overwritten with the embedded default, so
+// the registry cannot drift from the operator image install also re-derives.
+func TestInstallReinstallDerivesRegistryFromBuild(t *testing.T) {
 	t.Parallel()
 
-	// migrateLegacyImageRegistry runs only on unmarked (pre-#574) values, which
-	// were the prefix the operator appended "/azure/" to, so every non-empty
-	// value gains "/azure" - bare host and path-based mirror alike.
 	cases := []struct {
-		name     string
-		registry string
-		want     string
+		name  string
+		value string
 	}{
-		{name: "released default bare host", registry: "ghcr.io", want: "ghcr.io/azure"},
-		{name: "fork org", registry: "ghcr.io/myorg", want: "ghcr.io/myorg/azure"},
-		{name: "custom bare host", registry: "registry.corp.internal", want: "registry.corp.internal/azure"},
-		{name: "path-based mirror", registry: "registry.corp.internal/unbounded", want: "registry.corp.internal/unbounded/azure"},
-		{name: "trailing slash", registry: "ghcr.io/", want: "ghcr.io/azure"},
-		{name: "empty unchanged", registry: "", want: ""},
+		{name: "legacy bare host overwritten", value: "ghcr.io"},
+		{name: "stale custom mirror overwritten", value: "registry.old/mirror"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			if got := migrateLegacyImageRegistry(tc.registry); got != tc.want {
-				t.Fatalf("migrateLegacyImageRegistry(%q) = %q, want %q", tc.registry, got, tc.want)
-			}
-		})
-	}
-}
-
-// TestInstallImageRegistryMigration covers the schema-marker migration end to
-// end: an unmarked (legacy) value is rewritten to a full prefix and the marker
-// is stamped, while a marked value is preserved verbatim so the migration never
-// runs twice.
-func TestInstallImageRegistryMigration(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name   string
-		value  string
-		schema string // schema annotation on the existing ConfigMap ("" = absent)
-		want   string
-	}{
-		{name: "legacy bare host migrates", value: "ghcr.io", schema: "", want: "ghcr.io/azure"},
-		{name: "legacy path mirror migrates", value: "registry.corp/unbounded", schema: "", want: "registry.corp/unbounded/azure"},
-		{name: "marked default preserved", value: "ghcr.io/azure", schema: "2", want: "ghcr.io/azure"},
-		{name: "marked bare host preserved", value: "registry.internal", schema: "2", want: "registry.internal"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			metadata := map[string]any{
-				"name":      "unbounded-operator-config",
-				"namespace": "unbounded-system",
-			}
-			if tc.schema != "" {
-				metadata["annotations"] = map[string]any{
-					"unbounded-cloud.io/image-registry-schema": tc.schema,
-				}
-			}
 
 			existing := &unstructured.Unstructured{Object: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
-				"metadata":   metadata,
-				"data":       map[string]any{"UNBOUNDED_IMAGE_REGISTRY": tc.value},
+				"metadata": map[string]any{
+					"name":      "unbounded-operator-config",
+					"namespace": "unbounded-system",
+				},
+				"data": map[string]any{"UNBOUNDED_IMAGE_REGISTRY": tc.value},
 			}}
 			cli, captured := newCapturingInstallClient(existing)
 			h := installHandler{
@@ -369,22 +329,38 @@ func TestInstallImageRegistryMigration(t *testing.T) {
 
 			data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
 			require.NoError(t, err)
-			require.Equal(t, tc.want, data["UNBOUNDED_IMAGE_REGISTRY"])
-
-			// Every applied ConfigMap carries the current schema marker, so a
-			// subsequent reinstall treats the value as a full prefix.
-			schema, _, err := unstructured.NestedString(captured.configMap.Object, "metadata", "annotations", "unbounded-cloud.io/image-registry-schema")
-			require.NoError(t, err)
-			require.Equal(t, "2", schema)
+			// The real embedded manifest renders ghcr.io/azure at build time.
+			require.Equal(t, "ghcr.io/azure", data["UNBOUNDED_IMAGE_REGISTRY"])
 		})
 	}
 }
 
-// TestInstallForkBuildPreservesEmbeddedRegistry asserts a fork build (whose
+// TestInstallImageRegistryFlagOverridesEmbedded asserts an explicit
+// --image-registry wins over the embedded default.
+func TestInstallImageRegistryFlagOverridesEmbedded(t *testing.T) {
+	t.Parallel()
+
+	cli, captured := newCapturingInstallClient()
+	h := installHandler{
+		namespace:        "unbounded-system",
+		kubeResourcesCli: cli,
+		imageRegistry:    "registry.corp/unbounded",
+		logger:           discardLogger(),
+	}
+
+	require.NoError(t, h.execute(context.Background()))
+	require.NotNil(t, captured.configMap)
+
+	data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
+	require.NoError(t, err)
+	require.Equal(t, "registry.corp/unbounded", data["UNBOUNDED_IMAGE_REGISTRY"])
+}
+
+// TestInstallForkBuildDerivesEmbeddedRegistry asserts a fork build (whose
 // embedded manifests were rendered with CONTAINER_REGISTRY=ghcr.io/myorg)
 // installs its own operator image and configures components from its own
 // registry, rather than discarding the embedded value for ghcr.io/azure.
-func TestInstallForkBuildPreservesEmbeddedRegistry(t *testing.T) {
+func TestInstallForkBuildDerivesEmbeddedRegistry(t *testing.T) {
 	t.Parallel()
 
 	forkManifests := fstest.MapFS{
@@ -393,8 +369,6 @@ kind: ConfigMap
 metadata:
   name: unbounded-operator-config
   namespace: unbounded-system
-  annotations:
-    unbounded-cloud.io/image-registry-schema: "2"
 data:
   UNBOUNDED_API_SERVER_ENDPOINT: ""
   UNBOUNDED_IMAGE_REGISTRY: "ghcr.io/myorg"

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -411,6 +411,123 @@ spec:
 	require.Equal(t, "ghcr.io/myorg/unbounded-operator:v1.2.3", containers[0].(map[string]any)["image"])
 }
 
+// TestEmbeddedImageRegistryFailsClosed asserts the build-derived registry lookup
+// returns an error (rather than silently falling back to ghcr.io/azure) when the
+// embedded manifests are missing the ConfigMap, carry an empty value, or are
+// malformed, so a broken build cannot quietly install upstream components.
+func TestEmbeddedImageRegistryFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		manifests fstest.MapFS
+		want      string // "" means expect an error
+	}{
+		{
+			name: "valid",
+			manifests: fstest.MapFS{"03-configmap.yaml": &fstest.MapFile{Data: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbounded-operator-config
+data:
+  UNBOUNDED_IMAGE_REGISTRY: "ghcr.io/myorg"
+`)}},
+			want: "ghcr.io/myorg",
+		},
+		{
+			name:      "no configmap",
+			manifests: fstest.MapFS{"04-deployment.yaml": &fstest.MapFile{Data: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: unbounded-operator\n")}},
+		},
+		{
+			name: "empty value",
+			manifests: fstest.MapFS{"03-configmap.yaml": &fstest.MapFile{Data: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbounded-operator-config
+data:
+  UNBOUNDED_IMAGE_REGISTRY: ""
+`)}},
+		},
+		{
+			name:      "malformed yaml",
+			manifests: fstest.MapFS{"03-configmap.yaml": &fstest.MapFile{Data: []byte("this: [is: not: valid: yaml")}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := installHandler{operatorManifests: tc.manifests}
+
+			got, err := h.embeddedImageRegistry()
+			if tc.want == "" {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestInstallFailsClosedOnUnresolvableRegistry asserts install errors (rather
+// than defaulting to ghcr.io/azure) when the embedded registry cannot be
+// resolved and no --image-registry is given, and that --image-registry overrides
+// an unresolvable embedded value.
+func TestInstallFailsClosedOnUnresolvableRegistry(t *testing.T) {
+	t.Parallel()
+
+	brokenManifests := fstest.MapFS{
+		"03-configmap.yaml": &fstest.MapFile{Data: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbounded-operator-config
+data:
+  UNBOUNDED_IMAGE_REGISTRY: ""
+`)},
+	}
+
+	t.Run("errors without a flag", func(t *testing.T) {
+		t.Parallel()
+
+		cli, captured := newCapturingInstallClient()
+		h := installHandler{
+			namespace:         "unbounded-system",
+			kubeResourcesCli:  cli,
+			operatorManifests: brokenManifests,
+			logger:            discardLogger(),
+		}
+
+		err := h.execute(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "--image-registry")
+		require.Zero(t, captured.applyCount)
+	})
+
+	t.Run("flag overrides unresolvable embedded value", func(t *testing.T) {
+		t.Parallel()
+
+		cli, captured := newCapturingInstallClient()
+		h := installHandler{
+			namespace:         "unbounded-system",
+			kubeResourcesCli:  cli,
+			operatorManifests: brokenManifests,
+			imageRegistry:     "registry.corp/unbounded",
+			logger:            discardLogger(),
+		}
+
+		require.NoError(t, h.execute(context.Background()))
+		require.NotNil(t, captured.configMap)
+
+		data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
+		require.NoError(t, err)
+		require.Equal(t, "registry.corp/unbounded", data["UNBOUNDED_IMAGE_REGISTRY"])
+	})
+}
+
 func TestInstallRejectsInvalidLiveReaperConfigBeforeApply(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -423,6 +423,23 @@ func TestInstallRejectsRegistryQualifiedOperatorImage(t *testing.T) {
 	require.Zero(t, captured.applyCount)
 }
 
+// TestResolveImagesRejectsNestedEmbeddedOperatorImage guards the derived
+// name:tag: if the embedded operator image sits below its registry (so it cannot
+// be re-expressed as a name:tag under another registry), install fails closed and
+// points at --operator-image. The render pipeline never produces this; it guards
+// a hand-edited manifest.
+func TestResolveImagesRejectsNestedEmbeddedOperatorImage(t *testing.T) {
+	t.Parallel()
+
+	h := installHandler{
+		operatorManifests: operatorManifestsFS("ghcr.io/azure", "ghcr.io/azure/sub/unbounded-operator:v1"),
+	}
+
+	_, _, err := h.resolveImages()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--operator-image")
+}
+
 // TestInstallForkBuildDerivesEmbeddedRegistry asserts a fork build (whose
 // embedded manifests were rendered with CONTAINER_REGISTRY=ghcr.io/myorg)
 // installs its own operator image and configures components from its own

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -264,9 +264,15 @@ func TestInstallMergesLiveReaperConfig(t *testing.T) {
 			data, found, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
 			require.NoError(t, err)
 			require.True(t, found)
+
+			// The registry is derived from the embedded manifest, which the make
+			// render stamps from CONTAINER_REGISTRY; read it rather than hardcode
+			// so a fork build (non-default CONTAINER_REGISTRY) still passes.
+			wantRegistry, err := (&installHandler{}).embeddedImageRegistry()
+			require.NoError(t, err)
 			require.Equal(t, map[string]string{
 				"UNBOUNDED_API_SERVER_ENDPOINT":   "https://api.example.test:6443",
-				"UNBOUNDED_IMAGE_REGISTRY":        "ghcr.io/azure",
+				"UNBOUNDED_IMAGE_REGISTRY":        wantRegistry,
 				"UNBOUNDED_REAP_LEGACY_RESOURCES": tt.wantReaper,
 			}, data)
 
@@ -291,10 +297,14 @@ func TestInstallMergesLiveReaperConfig(t *testing.T) {
 // TestInstallReinstallDerivesRegistryFromBuild asserts the component registry is
 // re-derived from the binary's embedded manifests on every install, not
 // preserved from cluster state. An older cluster storing the pre-#574 bare
-// "ghcr.io" (or any custom value) is overwritten with the embedded default, so
-// the registry cannot drift from the operator image install also re-derives.
+// "ghcr.io" (or any custom value) is overwritten with the embedded registry, so
+// it cannot drift from the operator image install also re-derives. The embedded
+// registry is injected (rather than read from the make-rendered manifests) so the
+// assertion does not depend on the build-time CONTAINER_REGISTRY.
 func TestInstallReinstallDerivesRegistryFromBuild(t *testing.T) {
 	t.Parallel()
+
+	const embeddedRegistry = "registry.test/unbounded"
 
 	cases := []struct {
 		name  string
@@ -319,9 +329,10 @@ func TestInstallReinstallDerivesRegistryFromBuild(t *testing.T) {
 			}}
 			cli, captured := newCapturingInstallClient(existing)
 			h := installHandler{
-				namespace:        "unbounded-system",
-				kubeResourcesCli: cli,
-				logger:           discardLogger(),
+				namespace:         "unbounded-system",
+				kubeResourcesCli:  cli,
+				operatorManifests: operatorManifestsFS(embeddedRegistry, embeddedRegistry+"/unbounded-operator:v1"),
+				logger:            discardLogger(),
 			}
 
 			require.NoError(t, h.execute(context.Background()))
@@ -329,8 +340,7 @@ func TestInstallReinstallDerivesRegistryFromBuild(t *testing.T) {
 
 			data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
 			require.NoError(t, err)
-			// The real embedded manifest renders ghcr.io/azure at build time.
-			require.Equal(t, "ghcr.io/azure", data["UNBOUNDED_IMAGE_REGISTRY"])
+			require.Equal(t, embeddedRegistry, data["UNBOUNDED_IMAGE_REGISTRY"])
 		})
 	}
 }
@@ -363,38 +373,16 @@ func TestInstallImageRegistryFlagOverridesEmbedded(t *testing.T) {
 func TestInstallForkBuildDerivesEmbeddedRegistry(t *testing.T) {
 	t.Parallel()
 
-	forkManifests := fstest.MapFS{
-		"03-configmap.yaml": &fstest.MapFile{Data: []byte(`apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: unbounded-operator-config
-  namespace: unbounded-system
-data:
-  UNBOUNDED_API_SERVER_ENDPOINT: ""
-  UNBOUNDED_IMAGE_REGISTRY: "ghcr.io/myorg"
-  UNBOUNDED_REAP_LEGACY_RESOURCES: "true"
-`)},
-		"04-deployment.yaml": &fstest.MapFile{Data: []byte(`apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: unbounded-operator
-  namespace: unbounded-system
-spec:
-  template:
-    spec:
-      containers:
-        - name: controller
-          image: ghcr.io/myorg/unbounded-operator:v1.2.3
-          args:
-            - --namespace=unbounded-system
-`)},
-	}
+	const (
+		registry      = "ghcr.io/myorg"
+		operatorImage = "ghcr.io/myorg/unbounded-operator:v1.2.3"
+	)
 
 	cli, captured := newCapturingInstallClient()
 	h := installHandler{
 		namespace:         "unbounded-system",
 		kubeResourcesCli:  cli,
-		operatorManifests: forkManifests,
+		operatorManifests: operatorManifestsFS(registry, operatorImage),
 		logger:            discardLogger(),
 	}
 
@@ -404,11 +392,49 @@ spec:
 
 	data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
 	require.NoError(t, err)
-	require.Equal(t, "ghcr.io/myorg", data["UNBOUNDED_IMAGE_REGISTRY"])
+	require.Equal(t, registry, data["UNBOUNDED_IMAGE_REGISTRY"])
 
 	containers, _, err := unstructured.NestedSlice(captured.deployment.Object, "spec", "template", "spec", "containers")
 	require.NoError(t, err)
-	require.Equal(t, "ghcr.io/myorg/unbounded-operator:v1.2.3", containers[0].(map[string]any)["image"])
+	require.Equal(t, operatorImage, containers[0].(map[string]any)["image"])
+}
+
+// operatorManifestsFS builds a minimal embedded operator manifest set (the
+// unbounded-operator-config ConfigMap and the operator Deployment) with a chosen
+// component registry and operator image. Injecting it lets a test assert the
+// build-derived registry/image without depending on the make-rendered manifests
+// or the build-time CONTAINER_REGISTRY.
+func operatorManifestsFS(registry, operatorImage string) fstest.MapFS {
+	configMap := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbounded-operator-config
+  namespace: unbounded-system
+data:
+  UNBOUNDED_API_SERVER_ENDPOINT: ""
+  UNBOUNDED_IMAGE_REGISTRY: %q
+  UNBOUNDED_REAP_LEGACY_RESOURCES: "true"
+`, registry)
+
+	deployment := fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unbounded-operator
+  namespace: unbounded-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: controller
+          image: %q
+          args:
+            - --namespace=unbounded-system
+`, operatorImage)
+
+	return fstest.MapFS{
+		"03-configmap.yaml":  &fstest.MapFile{Data: []byte(configMap)},
+		"04-deployment.yaml": &fstest.MapFile{Data: []byte(deployment)},
+	}
 }
 
 // TestEmbeddedImageRegistryFailsClosed asserts the build-derived registry lookup

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -290,18 +291,20 @@ func TestInstallMergesLiveReaperConfig(t *testing.T) {
 func TestMigrateLegacyImageRegistry(t *testing.T) {
 	t.Parallel()
 
+	// migrateLegacyImageRegistry runs only on unmarked (pre-#574) values, which
+	// were the prefix the operator appended "/azure/" to, so every non-empty
+	// value gains "/azure" - bare host and path-based mirror alike.
 	cases := []struct {
 		name     string
 		registry string
 		want     string
 	}{
 		{name: "released default bare host", registry: "ghcr.io", want: "ghcr.io/azure"},
-		{name: "already migrated default", registry: "ghcr.io/azure", want: "ghcr.io/azure"},
-		{name: "fork org left untouched", registry: "ghcr.io/myorg", want: "ghcr.io/myorg"},
+		{name: "fork org", registry: "ghcr.io/myorg", want: "ghcr.io/myorg/azure"},
 		{name: "custom bare host", registry: "registry.corp.internal", want: "registry.corp.internal/azure"},
-		{name: "custom mirror with path untouched", registry: "registry.corp.internal/unbounded", want: "registry.corp.internal/unbounded"},
-		{name: "trailing slash bare host", registry: "ghcr.io/", want: "ghcr.io/azure"},
-		{name: "empty preserved unchanged", registry: "", want: ""},
+		{name: "path-based mirror", registry: "registry.corp.internal/unbounded", want: "registry.corp.internal/unbounded/azure"},
+		{name: "trailing slash", registry: "ghcr.io/", want: "ghcr.io/azure"},
+		{name: "empty unchanged", registry: "", want: ""},
 	}
 
 	for _, tc := range cases {
@@ -315,35 +318,123 @@ func TestMigrateLegacyImageRegistry(t *testing.T) {
 	}
 }
 
-// TestInstallMigratesPreservedBareImageRegistry asserts that reinstalling onto a
-// cluster whose stored UNBOUNDED_IMAGE_REGISTRY is the pre-#574 bare "ghcr.io"
-// rewrites it to the full-prefix "ghcr.io/azure", so operator-managed components
-// keep resolving to the correct upstream images after upgrade.
-func TestInstallMigratesPreservedBareImageRegistry(t *testing.T) {
+// TestInstallImageRegistryMigration covers the schema-marker migration end to
+// end: an unmarked (legacy) value is rewritten to a full prefix and the marker
+// is stamped, while a marked value is preserved verbatim so the migration never
+// runs twice.
+func TestInstallImageRegistryMigration(t *testing.T) {
 	t.Parallel()
 
-	existing := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "v1",
-		"kind":       "ConfigMap",
-		"metadata": map[string]any{
-			"name":      "unbounded-operator-config",
-			"namespace": "unbounded-system",
-		},
-		"data": map[string]any{"UNBOUNDED_IMAGE_REGISTRY": "ghcr.io"},
-	}}
-	cli, captured := newCapturingInstallClient(existing)
+	cases := []struct {
+		name   string
+		value  string
+		schema string // schema annotation on the existing ConfigMap ("" = absent)
+		want   string
+	}{
+		{name: "legacy bare host migrates", value: "ghcr.io", schema: "", want: "ghcr.io/azure"},
+		{name: "legacy path mirror migrates", value: "registry.corp/unbounded", schema: "", want: "registry.corp/unbounded/azure"},
+		{name: "marked default preserved", value: "ghcr.io/azure", schema: "2", want: "ghcr.io/azure"},
+		{name: "marked bare host preserved", value: "registry.internal", schema: "2", want: "registry.internal"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			metadata := map[string]any{
+				"name":      "unbounded-operator-config",
+				"namespace": "unbounded-system",
+			}
+			if tc.schema != "" {
+				metadata["annotations"] = map[string]any{
+					"unbounded-cloud.io/image-registry-schema": tc.schema,
+				}
+			}
+
+			existing := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   metadata,
+				"data":       map[string]any{"UNBOUNDED_IMAGE_REGISTRY": tc.value},
+			}}
+			cli, captured := newCapturingInstallClient(existing)
+			h := installHandler{
+				namespace:        "unbounded-system",
+				kubeResourcesCli: cli,
+				logger:           discardLogger(),
+			}
+
+			require.NoError(t, h.execute(context.Background()))
+			require.NotNil(t, captured.configMap)
+
+			data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, data["UNBOUNDED_IMAGE_REGISTRY"])
+
+			// Every applied ConfigMap carries the current schema marker, so a
+			// subsequent reinstall treats the value as a full prefix.
+			schema, _, err := unstructured.NestedString(captured.configMap.Object, "metadata", "annotations", "unbounded-cloud.io/image-registry-schema")
+			require.NoError(t, err)
+			require.Equal(t, "2", schema)
+		})
+	}
+}
+
+// TestInstallForkBuildPreservesEmbeddedRegistry asserts a fork build (whose
+// embedded manifests were rendered with CONTAINER_REGISTRY=ghcr.io/myorg)
+// installs its own operator image and configures components from its own
+// registry, rather than discarding the embedded value for ghcr.io/azure.
+func TestInstallForkBuildPreservesEmbeddedRegistry(t *testing.T) {
+	t.Parallel()
+
+	forkManifests := fstest.MapFS{
+		"03-configmap.yaml": &fstest.MapFile{Data: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbounded-operator-config
+  namespace: unbounded-system
+  annotations:
+    unbounded-cloud.io/image-registry-schema: "2"
+data:
+  UNBOUNDED_API_SERVER_ENDPOINT: ""
+  UNBOUNDED_IMAGE_REGISTRY: "ghcr.io/myorg"
+  UNBOUNDED_REAP_LEGACY_RESOURCES: "true"
+`)},
+		"04-deployment.yaml": &fstest.MapFile{Data: []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unbounded-operator
+  namespace: unbounded-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: controller
+          image: ghcr.io/myorg/unbounded-operator:v1.2.3
+          args:
+            - --namespace=unbounded-system
+`)},
+	}
+
+	cli, captured := newCapturingInstallClient()
 	h := installHandler{
-		namespace:        "unbounded-system",
-		kubeResourcesCli: cli,
-		logger:           discardLogger(),
+		namespace:         "unbounded-system",
+		kubeResourcesCli:  cli,
+		operatorManifests: forkManifests,
+		logger:            discardLogger(),
 	}
 
 	require.NoError(t, h.execute(context.Background()))
 	require.NotNil(t, captured.configMap)
+	require.NotNil(t, captured.deployment)
 
 	data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
 	require.NoError(t, err)
-	require.Equal(t, "ghcr.io/azure", data["UNBOUNDED_IMAGE_REGISTRY"])
+	require.Equal(t, "ghcr.io/myorg", data["UNBOUNDED_IMAGE_REGISTRY"])
+
+	containers, _, err := unstructured.NestedSlice(captured.deployment.Object, "spec", "template", "spec", "containers")
+	require.NoError(t, err)
+	require.Equal(t, "ghcr.io/myorg/unbounded-operator:v1.2.3", containers[0].(map[string]any)["image"])
 }
 
 func TestInstallRejectsInvalidLiveReaperConfigBeforeApply(t *testing.T) {

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -95,7 +95,8 @@ func TestInstallHandlerApplyBootstrapManifests(t *testing.T) {
 
 	h := installHandler{
 		namespace:         "custom-system",
-		operatorImage:     "operator:test",
+		operatorImage:     "unbounded-operator:test",
+		imageRegistry:     "registry.example.com",
 		apiServerEndpoint: "https://api.example.test:6443",
 		wait:              false,
 		kubeResourcesCli:  cli,
@@ -345,9 +346,10 @@ func TestInstallReinstallDerivesRegistryFromBuild(t *testing.T) {
 	}
 }
 
-// TestInstallImageRegistryFlagOverridesEmbedded asserts an explicit
-// --image-registry wins over the embedded default.
-func TestInstallImageRegistryFlagOverridesEmbedded(t *testing.T) {
+// TestInstallImageRegistryDrivesBothImages asserts --image-registry sets the
+// component registry and the operator Deployment image shares it: with a
+// name:tag --operator-image the operator image is <registry>/<name:tag>.
+func TestInstallImageRegistryDrivesBothImages(t *testing.T) {
 	t.Parallel()
 
 	cli, captured := newCapturingInstallClient()
@@ -355,15 +357,70 @@ func TestInstallImageRegistryFlagOverridesEmbedded(t *testing.T) {
 		namespace:        "unbounded-system",
 		kubeResourcesCli: cli,
 		imageRegistry:    "registry.corp/unbounded",
+		operatorImage:    "unbounded-operator:v9",
 		logger:           discardLogger(),
 	}
 
 	require.NoError(t, h.execute(context.Background()))
 	require.NotNil(t, captured.configMap)
+	require.NotNil(t, captured.deployment)
 
 	data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
 	require.NoError(t, err)
 	require.Equal(t, "registry.corp/unbounded", data["UNBOUNDED_IMAGE_REGISTRY"])
+
+	containers, _, err := unstructured.NestedSlice(captured.deployment.Object, "spec", "template", "spec", "containers")
+	require.NoError(t, err)
+	require.Equal(t, "registry.corp/unbounded/unbounded-operator:v9", containers[0].(map[string]any)["image"])
+}
+
+// TestInstallImageRegistryReconstructsOperatorImage asserts that --image-registry
+// alone (no --operator-image) rewrites the operator image's registry to match, so
+// the operator does not run from the embedded registry while components come from
+// --image-registry. The operator's name:tag is taken from the embedded image.
+func TestInstallImageRegistryReconstructsOperatorImage(t *testing.T) {
+	t.Parallel()
+
+	cli, captured := newCapturingInstallClient()
+	h := installHandler{
+		namespace:         "unbounded-system",
+		kubeResourcesCli:  cli,
+		operatorManifests: operatorManifestsFS("ghcr.io/azure", "ghcr.io/azure/unbounded-operator:v9"),
+		imageRegistry:     "registry.corp/mirror",
+		logger:            discardLogger(),
+	}
+
+	require.NoError(t, h.execute(context.Background()))
+	require.NotNil(t, captured.configMap)
+	require.NotNil(t, captured.deployment)
+
+	data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
+	require.NoError(t, err)
+	require.Equal(t, "registry.corp/mirror", data["UNBOUNDED_IMAGE_REGISTRY"])
+
+	containers, _, err := unstructured.NestedSlice(captured.deployment.Object, "spec", "template", "spec", "containers")
+	require.NoError(t, err)
+	require.Equal(t, "registry.corp/mirror/unbounded-operator:v9", containers[0].(map[string]any)["image"])
+}
+
+// TestInstallRejectsRegistryQualifiedOperatorImage asserts --operator-image must
+// be a name:tag with no registry, so it can never contradict --image-registry.
+func TestInstallRejectsRegistryQualifiedOperatorImage(t *testing.T) {
+	t.Parallel()
+
+	cli, captured := newCapturingInstallClient()
+	h := installHandler{
+		namespace:        "unbounded-system",
+		kubeResourcesCli: cli,
+		operatorImage:    "ghcr.io/foo/unbounded-operator:v1",
+		logger:           discardLogger(),
+	}
+
+	err := h.execute(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--operator-image")
+	require.Contains(t, err.Error(), "--image-registry")
+	require.Zero(t, captured.applyCount)
 }
 
 // TestInstallForkBuildDerivesEmbeddedRegistry asserts a fork build (whose
@@ -500,9 +557,9 @@ data:
 }
 
 // TestInstallFailsClosedOnUnresolvableRegistry asserts install errors (rather
-// than defaulting to ghcr.io/azure) when the embedded registry cannot be
-// resolved and no --image-registry is given, and that --image-registry overrides
-// an unresolvable embedded value.
+// than defaulting to ghcr.io/azure) when the embedded registry cannot be resolved
+// and no --image-registry is given, and that supplying the flags lets install
+// proceed without reading the embedded manifests.
 func TestInstallFailsClosedOnUnresolvableRegistry(t *testing.T) {
 	t.Parallel()
 
@@ -516,7 +573,7 @@ data:
 `)},
 	}
 
-	t.Run("errors without a flag", func(t *testing.T) {
+	t.Run("errors without --image-registry", func(t *testing.T) {
 		t.Parallel()
 
 		cli, captured := newCapturingInstallClient()
@@ -533,7 +590,7 @@ data:
 		require.Zero(t, captured.applyCount)
 	})
 
-	t.Run("flag overrides unresolvable embedded value", func(t *testing.T) {
+	t.Run("flags let install proceed despite unresolvable embedded value", func(t *testing.T) {
 		t.Parallel()
 
 		cli, captured := newCapturingInstallClient()
@@ -542,6 +599,7 @@ data:
 			kubeResourcesCli:  cli,
 			operatorManifests: brokenManifests,
 			imageRegistry:     "registry.corp/unbounded",
+			operatorImage:     "unbounded-operator:v1",
 			logger:            discardLogger(),
 		}
 

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -265,7 +265,7 @@ func TestInstallMergesLiveReaperConfig(t *testing.T) {
 			require.True(t, found)
 			require.Equal(t, map[string]string{
 				"UNBOUNDED_API_SERVER_ENDPOINT":   "https://api.example.test:6443",
-				"UNBOUNDED_IMAGE_REGISTRY":        "ghcr.io",
+				"UNBOUNDED_IMAGE_REGISTRY":        "ghcr.io/azure",
 				"UNBOUNDED_REAP_LEGACY_RESOURCES": tt.wantReaper,
 			}, data)
 
@@ -285,6 +285,65 @@ func TestInstallMergesLiveReaperConfig(t *testing.T) {
 			require.Nil(t, rollingUpdate)
 		})
 	}
+}
+
+func TestMigrateLegacyImageRegistry(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		registry string
+		want     string
+	}{
+		{name: "released default bare host", registry: "ghcr.io", want: "ghcr.io/azure"},
+		{name: "already migrated default", registry: "ghcr.io/azure", want: "ghcr.io/azure"},
+		{name: "fork org left untouched", registry: "ghcr.io/myorg", want: "ghcr.io/myorg"},
+		{name: "custom bare host", registry: "registry.corp.internal", want: "registry.corp.internal/azure"},
+		{name: "custom mirror with path untouched", registry: "registry.corp.internal/unbounded", want: "registry.corp.internal/unbounded"},
+		{name: "trailing slash bare host", registry: "ghcr.io/", want: "ghcr.io/azure"},
+		{name: "empty preserved unchanged", registry: "", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := migrateLegacyImageRegistry(tc.registry); got != tc.want {
+				t.Fatalf("migrateLegacyImageRegistry(%q) = %q, want %q", tc.registry, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInstallMigratesPreservedBareImageRegistry asserts that reinstalling onto a
+// cluster whose stored UNBOUNDED_IMAGE_REGISTRY is the pre-#574 bare "ghcr.io"
+// rewrites it to the full-prefix "ghcr.io/azure", so operator-managed components
+// keep resolving to the correct upstream images after upgrade.
+func TestInstallMigratesPreservedBareImageRegistry(t *testing.T) {
+	t.Parallel()
+
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      "unbounded-operator-config",
+			"namespace": "unbounded-system",
+		},
+		"data": map[string]any{"UNBOUNDED_IMAGE_REGISTRY": "ghcr.io"},
+	}}
+	cli, captured := newCapturingInstallClient(existing)
+	h := installHandler{
+		namespace:        "unbounded-system",
+		kubeResourcesCli: cli,
+		logger:           discardLogger(),
+	}
+
+	require.NoError(t, h.execute(context.Background()))
+	require.NotNil(t, captured.configMap)
+
+	data, _, err := unstructured.NestedStringMap(captured.configMap.Object, "data")
+	require.NoError(t, err)
+	require.Equal(t, "ghcr.io/azure", data["UNBOUNDED_IMAGE_REGISTRY"])
 }
 
 func TestInstallRejectsInvalidLiveReaperConfigBeforeApply(t *testing.T) {

--- a/cmd/unbounded-operator/main.go
+++ b/cmd/unbounded-operator/main.go
@@ -73,7 +73,7 @@ func newCommand(runFn func(context.Context, config) error) *cobra.Command {
 	cmd.Flags().BoolVar(&cfg.leaderElection, "leader-elect", true, "Enable leader election")
 	cmd.Flags().StringVar(&cfg.leaderElectionNamespace, "leader-elect-namespace", unbounded.SystemNamespace(), "Namespace for the leader election lease")
 	cmd.Flags().StringVar(&cfg.namespace, "namespace", unbounded.SystemNamespace(), "Namespace the operator reconciles components into and migrates legacy state to")
-	cmd.Flags().StringVar(&cfg.imageRegistry, "image-registry", envStringDefault("UNBOUNDED_IMAGE_REGISTRY", "ghcr.io"), "Registry for operator-managed component images (defaults to $UNBOUNDED_IMAGE_REGISTRY or ghcr.io)")
+	cmd.Flags().StringVar(&cfg.imageRegistry, "image-registry", envStringDefault("UNBOUNDED_IMAGE_REGISTRY", "ghcr.io/azure"), "Full image-repository prefix (registry host plus org/namespace) for operator-managed component images (defaults to $UNBOUNDED_IMAGE_REGISTRY or ghcr.io/azure)")
 	cmd.Flags().StringVar(&cfg.apiServerEndpoint, "api-server-endpoint", os.Getenv("UNBOUNDED_API_SERVER_ENDPOINT"), "Kubernetes API server endpoint advertised by machina; overrides auto-discovery from kube-public/cluster-info or the KUBERNETES_SERVICE_HOST FQDN (defaults to $UNBOUNDED_API_SERVER_ENDPOINT)")
 	cmd.Flags().BoolVar(&cfg.reapLegacyResources, "reap-legacy-resources", true, "Translate legacy net-group Sites, migrate state into unbounded-system, and reap the pre-consolidation namespaces (defaults to $UNBOUNDED_REAP_LEGACY_RESOURCES or true)")
 	cmd.CompletionOptions.DisableDefaultCmd = true

--- a/cmd/unbounded-operator/main_test.go
+++ b/cmd/unbounded-operator/main_test.go
@@ -96,7 +96,7 @@ func TestImageRegistryConfiguration(t *testing.T) {
 		args []string
 		want string
 	}{
-		{name: "default", want: "ghcr.io"},
+		{name: "default", want: "ghcr.io/azure"},
 		{name: "environment", env: "mirror.example.com", want: "mirror.example.com"},
 		{name: "flag overrides environment", env: "mirror.example.com", args: []string{"--image-registry=registry.example.com"}, want: "registry.example.com"},
 	}

--- a/deploy/unbounded-operator/03-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/03-configmap.yaml.tmpl
@@ -19,12 +19,6 @@ metadata:
   labels:
     app.kubernetes.io/name: unbounded-operator
     app.kubernetes.io/component: controller
-  annotations:
-    # Semantics version of UNBOUNDED_IMAGE_REGISTRY. "2" means the value is a
-    # full image-repository prefix (post-#574). kubectl unbounded install reads
-    # this to decide whether a preserved value predates the change and needs
-    # migrating. Not a data key, so it stays out of the operator's envFrom.
-    unbounded-cloud.io/image-registry-schema: "2"
 data:
   # Full image-repository prefix (registry host plus org/namespace) for all
   # operator-managed first-party component images. The flat component name and

--- a/deploy/unbounded-operator/03-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/03-configmap.yaml.tmpl
@@ -19,6 +19,12 @@ metadata:
   labels:
     app.kubernetes.io/name: unbounded-operator
     app.kubernetes.io/component: controller
+  annotations:
+    # Semantics version of UNBOUNDED_IMAGE_REGISTRY. "2" means the value is a
+    # full image-repository prefix (post-#574). kubectl unbounded install reads
+    # this to decide whether a preserved value predates the change and needs
+    # migrating. Not a data key, so it stays out of the operator's envFrom.
+    unbounded-cloud.io/image-registry-schema: "2"
 data:
   # Full image-repository prefix (registry host plus org/namespace) for all
   # operator-managed first-party component images. The flat component name and

--- a/deploy/unbounded-operator/03-configmap.yaml.tmpl
+++ b/deploy/unbounded-operator/03-configmap.yaml.tmpl
@@ -20,8 +20,10 @@ metadata:
     app.kubernetes.io/name: unbounded-operator
     app.kubernetes.io/component: controller
 data:
-  # Registry prefix for all operator-managed first-party component images.
-  UNBOUNDED_IMAGE_REGISTRY: {{ default "ghcr.io" .ImageRegistry | quote }}
+  # Full image-repository prefix (registry host plus org/namespace) for all
+  # operator-managed first-party component images. The flat component name and
+  # operator version are appended, so ghcr.io/azure yields ghcr.io/azure/machina.
+  UNBOUNDED_IMAGE_REGISTRY: {{ default "ghcr.io/azure" .ImageRegistry | quote }}
   # External Kubernetes API endpoint advertised to provisioned machines. Remote
   # nodes dial this to join, so it must be reachable from outside the cluster.
   # Leave empty to let the operator auto-discover it: it prefers the standard

--- a/deploy/unbounded-operator/04-deployment.yaml.tmpl
+++ b/deploy/unbounded-operator/04-deployment.yaml.tmpl
@@ -32,7 +32,7 @@ spec:
         kubernetes.azure.com/set-kube-service-host-fqdn: "true"
         # Rolls the operator when any ConfigMap data changes at render time.
         # Canonical JSON matches the `kubectl unbounded install` hash.
-        unbounded-cloud.io/operator-config-hash: {{ dict "UNBOUNDED_API_SERVER_ENDPOINT" (default "" .APIServerEndpoint) "UNBOUNDED_IMAGE_REGISTRY" (default "ghcr.io" .ImageRegistry) "UNBOUNDED_REAP_LEGACY_RESOURCES" (default "true" .ReapLegacyResources) | toJson | sha256sum | quote }}
+        unbounded-cloud.io/operator-config-hash: {{ dict "UNBOUNDED_API_SERVER_ENDPOINT" (default "" .APIServerEndpoint) "UNBOUNDED_IMAGE_REGISTRY" (default "ghcr.io/azure" .ImageRegistry) "UNBOUNDED_REAP_LEGACY_RESOURCES" (default "true" .ReapLegacyResources) | toJson | sha256sum | quote }}
     spec:
       # The operator installs the cluster CNI, so it must be able to reach the
       # API server before pod networking or cluster DNS is available. Default

--- a/deploy/unbounded-operator/render_test.go
+++ b/deploy/unbounded-operator/render_test.go
@@ -329,9 +329,6 @@ func TestOperatorImageAndComponentRegistryShareRegistry(t *testing.T) {
 	}
 
 	var cm struct {
-		Metadata struct {
-			Annotations map[string]string `yaml:"annotations"`
-		} `yaml:"metadata"`
 		Data map[string]string `yaml:"data"`
 	}
 	readYAML(t, filepath.Join(outputDir, "03-configmap.yaml"), &cm)
@@ -346,13 +343,6 @@ func TestOperatorImageAndComponentRegistryShareRegistry(t *testing.T) {
 	// feeding the raw github.repository_owner (e.g. "Azure") without lowercasing.
 	if registry != strings.ToLower(registry) {
 		t.Fatalf("configmap UNBOUNDED_IMAGE_REGISTRY %q is not lowercase; OCI repository names must be lowercase", registry)
-	}
-
-	// The ConfigMap must carry the image-registry schema marker so kubectl
-	// unbounded install recognizes a directly-applied config as already using the
-	// full-prefix semantics and never migrates it.
-	if got := cm.Metadata.Annotations["unbounded-cloud.io/image-registry-schema"]; got != "2" {
-		t.Fatalf("configmap image-registry-schema annotation = %q, want \"2\"", got)
 	}
 
 	var deploy struct {

--- a/deploy/unbounded-operator/render_test.go
+++ b/deploy/unbounded-operator/render_test.go
@@ -301,6 +301,79 @@ func TestOperatorRBACIncludesCachedReadKinds(t *testing.T) {
 	t.Fatal("events.k8s.io Event writer RBAC rule not found")
 }
 
+// TestOperatorImageAndComponentRegistryShareRegistry guards against the #574
+// regression where the operator's own image and the component image-registry
+// came from two unrelated defaults that only agreed because the org was literally
+// "azure". The operator resolves component images as
+// <UNBOUNDED_IMAGE_REGISTRY>/<component>:<tag>, so the rendered operator image
+// must be exactly <UNBOUNDED_IMAGE_REGISTRY>/unbounded-operator:<tag>. Rendering
+// with the template's default ImageRegistry (OperatorImage supplied as the
+// make/release path does) asserts the two share a registry and cannot drift.
+func TestOperatorImageAndComponentRegistryShareRegistry(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tag           = "v1.2.3"
+		operatorImage = "ghcr.io/azure/unbounded-operator:" + tag
+	)
+
+	outputDir := t.TempDir()
+	// Omit ImageRegistry so the ConfigMap default is exercised; supply
+	// OperatorImage as the make/release render path does.
+	if err := render.Render(filepath.Join(repoRoot(t), "deploy", "unbounded-operator"), outputDir, map[string]string{
+		"Namespace":     "unbounded-system",
+		"OperatorImage": operatorImage,
+	}); err != nil {
+		t.Fatalf("render.Render: %v", err)
+	}
+
+	var cm struct {
+		Data map[string]string `yaml:"data"`
+	}
+	readYAML(t, filepath.Join(outputDir, "03-configmap.yaml"), &cm)
+
+	registry := cm.Data["UNBOUNDED_IMAGE_REGISTRY"]
+	if registry == "" {
+		t.Fatal("configmap UNBOUNDED_IMAGE_REGISTRY is empty")
+	}
+
+	var deploy struct {
+		Spec struct {
+			Template struct {
+				Spec struct {
+					Containers []struct {
+						Name  string `yaml:"name"`
+						Image string `yaml:"image"`
+					} `yaml:"containers"`
+				} `yaml:"spec"`
+			} `yaml:"template"`
+		} `yaml:"spec"`
+	}
+	readYAML(t, filepath.Join(outputDir, "04-deployment.yaml"), &deploy)
+
+	var image string
+
+	for _, c := range deploy.Spec.Template.Spec.Containers {
+		if c.Name == "controller" {
+			image = c.Image
+
+			break
+		}
+	}
+
+	if image == "" {
+		t.Fatal("controller container image not found")
+	}
+
+	// The operator appends "/<component>:<tag>" to the registry, so its own image
+	// must share that exact registry prefix or it would deploy components from a
+	// different registry than itself.
+	want := registry + "/unbounded-operator:" + tag
+	if image != want {
+		t.Fatalf("operator image %q does not match component registry %q (want %q)", image, registry, want)
+	}
+}
+
 func readYAML(t *testing.T, path string, out any) {
 	t.Helper()
 

--- a/deploy/unbounded-operator/render_test.go
+++ b/deploy/unbounded-operator/render_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -328,6 +329,9 @@ func TestOperatorImageAndComponentRegistryShareRegistry(t *testing.T) {
 	}
 
 	var cm struct {
+		Metadata struct {
+			Annotations map[string]string `yaml:"annotations"`
+		} `yaml:"metadata"`
 		Data map[string]string `yaml:"data"`
 	}
 	readYAML(t, filepath.Join(outputDir, "03-configmap.yaml"), &cm)
@@ -335,6 +339,20 @@ func TestOperatorImageAndComponentRegistryShareRegistry(t *testing.T) {
 	registry := cm.Data["UNBOUNDED_IMAGE_REGISTRY"]
 	if registry == "" {
 		t.Fatal("configmap UNBOUNDED_IMAGE_REGISTRY is empty")
+	}
+
+	// ghcr (and OCI generally) reject uppercase repository names, so the resolved
+	// registry must be lowercase. This is cheap insurance against a release job
+	// feeding the raw github.repository_owner (e.g. "Azure") without lowercasing.
+	if registry != strings.ToLower(registry) {
+		t.Fatalf("configmap UNBOUNDED_IMAGE_REGISTRY %q is not lowercase; OCI repository names must be lowercase", registry)
+	}
+
+	// The ConfigMap must carry the image-registry schema marker so kubectl
+	// unbounded install recognizes a directly-applied config as already using the
+	// full-prefix semantics and never migrates it.
+	if got := cm.Metadata.Annotations["unbounded-cloud.io/image-registry-schema"]; got != "2" {
+		t.Fatalf("configmap image-registry-schema annotation = %q, want \"2\"", got)
 	}
 
 	var deploy struct {

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -79,16 +79,21 @@ Optional flags:
 image-repository prefix (registry host plus org/namespace, e.g. `ghcr.io/azure`,
 `ghcr.io/myorg`, or `registry.corp.internal/unbounded`) that components are
 resolved under; their flat repository name and image tag (always the operator's
-compiled version) are appended to it. Left unset, a fresh install inherits the
-registry the binary was built with (the same one as its operator image), so fork
-and mirror builds work without a flag.
+compiled version) are appended to it.
 
-Reinstalling a cluster whose stored registry predates this change is migrated
-automatically: the old value was the prefix the operator appended an implicit
-`/azure/` to, so `ghcr.io` becomes `ghcr.io/azure` and a mirror `registry.corp/unbounded`
-becomes `registry.corp/unbounded/azure`, preserving the images it already pulled.
-A schema marker on the operator ConfigMap makes this run exactly once, so a value
-you set intentionally is never rewritten again.
+Unset, the registry is derived from the one the binary was built with (the same
+source as its operator image), so fork and mirror builds work without a flag. It
+is re-derived on every install, not preserved from cluster state, so it stays in
+lockstep with the operator image (which install also re-derives). Upgrading a
+cluster that stored the pre-change bare `ghcr.io` therefore rewrites it to
+`ghcr.io/azure` automatically; install logs the change. A stock binary pointed at
+a private registry must pass `--image-registry` (and `--operator-image`) on each
+install, or use a build whose `CONTAINER_REGISTRY` bakes them in.
+
+`install` is the only command that bootstraps `unbounded-operator`
+([`site init`](#kubectl-unbounded-site-init) requires it to be installed
+already), so a private or air-gapped setup sets `--image-registry` and
+`--operator-image` here, then runs `site init`.
 
 > **Breaking change:** `--image-registry` is now a full prefix. Automation that
 > passed the old bare `ghcr.io` must pass `ghcr.io/azure` (or its own equivalent),

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -79,9 +79,20 @@ Optional flags:
 image-repository prefix (registry host plus org/namespace, e.g. `ghcr.io/azure`,
 `ghcr.io/myorg`, or `registry.corp.internal/unbounded`) that components are
 resolved under; their flat repository name and image tag (always the operator's
-compiled version) are appended to it. Reinstalling a cluster whose stored value
-predates this change (a bare host such as `ghcr.io`) migrates it to the
-equivalent `ghcr.io/azure` prefix automatically.
+compiled version) are appended to it. Left unset, a fresh install inherits the
+registry the binary was built with (the same one as its operator image), so fork
+and mirror builds work without a flag.
+
+Reinstalling a cluster whose stored registry predates this change is migrated
+automatically: the old value was the prefix the operator appended an implicit
+`/azure/` to, so `ghcr.io` becomes `ghcr.io/azure` and a mirror `registry.corp/unbounded`
+becomes `registry.corp/unbounded/azure`, preserving the images it already pulled.
+A schema marker on the operator ConfigMap makes this run exactly once, so a value
+you set intentionally is never rewritten again.
+
+> **Breaking change:** `--image-registry` is now a full prefix. Automation that
+> passed the old bare `ghcr.io` must pass `ghcr.io/azure` (or its own equivalent),
+> otherwise components resolve to `ghcr.io/<component>`.
 
 ---
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -69,35 +69,41 @@ Optional flags:
 | `--wait` | `bool` | `true` | Wait for the operator rollout and CRD establishment |
 | `--timeout` | `duration` | `5m0s` | Timeout for rollout waits |
 | `--api-server-endpoint` | `string` | auto-discovered | Override the API server endpoint advertised to provisioned machines; by default the operator discovers it from `kube-public/cluster-info`, or the `KUBERNETES_SERVICE_HOST` FQDN on clusters (e.g. AKS) that do not publish cluster-info |
-| `--image-registry` | `string` | `ghcr.io/azure` | Full image-repository prefix (registry host plus org/namespace) the operator resolves version-matched first-party component images under |
+| `--image-registry` | `string` | build default | Full image-repository prefix (registry host plus org/namespace) all unbounded images are pulled from |
+| `--operator-image` | `string` | build default | `unbounded-operator` image name and tag, **without** a registry (e.g. `unbounded-operator:v1`); the registry comes from `--image-registry` |
 
 > **Breaking change:** the `--skip-crds` flag has been removed. CRDs are now owned
 > and installed by the operator at startup (`operator.BootstrapCRDs`), so there is
 > nothing for `install` to skip. Automation passing `--skip-crds` must drop it.
 
-`--operator-image` overrides the operator image. `--image-registry` is the full
-image-repository prefix (registry host plus org/namespace, e.g. `ghcr.io/azure`,
-`ghcr.io/myorg`, or `registry.corp.internal/unbounded`) that components are
-resolved under; their flat repository name and image tag (always the operator's
-compiled version) are appended to it.
+`--image-registry` is the single knob for where **all** unbounded images come
+from. It is written to `UNBOUNDED_IMAGE_REGISTRY`; the operator resolves each
+component as `<registry>/<component>:<operator-version>`, and the operator's own
+Deployment image is `<registry>/<operator-name:tag>`. Because both the operator
+and its components take the registry from this one value, they can never come from
+different registries. `--operator-image` overrides only the operator's `name:tag`
+(it must not include a registry); it is rarely needed. The component image tag is
+always the operator's compiled version.
 
-Unset, the registry is derived from the one the binary was built with (the same
-source as its operator image), so fork and mirror builds work without a flag. It
-is re-derived on every install, not preserved from cluster state, so it stays in
-lockstep with the operator image (which install also re-derives). Upgrading a
-cluster that stored the pre-change bare `ghcr.io` therefore rewrites it to
-`ghcr.io/azure` automatically; install logs the change. A stock binary pointed at
-a private registry must pass `--image-registry` (and `--operator-image`) on each
-install, or use a build whose `CONTAINER_REGISTRY` bakes them in.
+Unset, both the registry and the operator `name:tag` come from the manifests baked
+into the binary at build time (rendered from `CONTAINER_REGISTRY`), so fork and
+mirror builds work without any flag. The registry is applied on every install, not
+preserved from cluster state, so it cannot drift; upgrading a cluster that stored a
+pre-change bare `ghcr.io` rewrites it to the full prefix and install logs the
+change. A private or air-gapped install sets `--image-registry` (e.g.
+`--image-registry registry.corp/unbounded`); the operator image follows.
 
 `install` is the only command that bootstraps `unbounded-operator`
 ([`site init`](#kubectl-unbounded-site-init) requires it to be installed
-already), so a private or air-gapped setup sets `--image-registry` and
-`--operator-image` here, then runs `site init`.
+already), so a private or air-gapped setup runs `install --image-registry ...`
+first, then `site init`.
 
-> **Breaking change:** `--image-registry` is now a full prefix. Automation that
-> passed the old bare `ghcr.io` must pass `ghcr.io/azure` (or its own equivalent),
-> otherwise components resolve to `ghcr.io/<component>`.
+> **Breaking change:** `--image-registry` is now a full image-repository prefix
+> (registry host plus org/namespace), not a bare host the operator appends
+> `/azure/` to. `--operator-image` is now a `name:tag` with no registry (the
+> registry comes from `--image-registry`); a registry-qualified value is rejected.
+> Automation passing a bare `ghcr.io` to `--image-registry`, or a fully-qualified
+> image to `--operator-image`, must update.
 
 ---
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -69,15 +69,19 @@ Optional flags:
 | `--wait` | `bool` | `true` | Wait for the operator rollout and CRD establishment |
 | `--timeout` | `duration` | `5m0s` | Timeout for rollout waits |
 | `--api-server-endpoint` | `string` | auto-discovered | Override the API server endpoint advertised to provisioned machines; by default the operator discovers it from `kube-public/cluster-info`, or the `KUBERNETES_SERVICE_HOST` FQDN on clusters (e.g. AKS) that do not publish cluster-info |
-| `--image-registry` | `string` | `ghcr.io` | Registry prefix used by the operator for version-matched first-party component images |
+| `--image-registry` | `string` | `ghcr.io/azure` | Full image-repository prefix (registry host plus org/namespace) the operator resolves version-matched first-party component images under |
 
 > **Breaking change:** the `--skip-crds` flag has been removed. CRDs are now owned
 > and installed by the operator at startup (`operator.BootstrapCRDs`), so there is
 > nothing for `install` to skip. Automation passing `--skip-crds` must drop it.
 
-`--operator-image` overrides the operator image. `--image-registry` configures
-the registry for components; their image tag always matches the operator's
-compiled version.
+`--operator-image` overrides the operator image. `--image-registry` is the full
+image-repository prefix (registry host plus org/namespace, e.g. `ghcr.io/azure`,
+`ghcr.io/myorg`, or `registry.corp.internal/unbounded`) that components are
+resolved under; their flat repository name and image tag (always the operator's
+compiled version) are appended to it. Reinstalling a cluster whose stored value
+predates this change (a bare host such as `ghcr.io`) migrates it to the
+equivalent `ghcr.io/azure` prefix automatically.
 
 ---
 

--- a/internal/operator/component/env.go
+++ b/internal/operator/component/env.go
@@ -62,6 +62,12 @@ var DefaultNamespace = unbounded.SystemNamespace()
 
 // Config carries operator-level settings components read while reconciling.
 type Config struct {
+	// ImageRegistry is the full image-repository prefix (registry host plus any
+	// org/namespace path) that operator-managed component images live under. The
+	// component's flat repository name and the operator's image tag are appended
+	// to it, so ImageRegistry=ghcr.io/azure yields ghcr.io/azure/machina:<tag>.
+	// It carries no implicit path segment: forks and mirrors set it to their own
+	// prefix (for example ghcr.io/myorg or registry.corp.internal/unbounded).
 	ImageRegistry string
 	ImageTag      string
 
@@ -70,9 +76,11 @@ type Config struct {
 	APIServerEndpoint string
 }
 
-// Image returns the operator-managed image for repository.
+// Image returns the operator-managed image for repository. ImageRegistry is a
+// full repository prefix, so repository is appended directly with no implicit
+// org/namespace segment.
 func (c Config) Image(repository string) string {
-	return strings.TrimRight(c.ImageRegistry, "/") + "/azure/" + repository + ":" + c.ImageTag
+	return strings.TrimRight(c.ImageRegistry, "/") + "/" + repository + ":" + c.ImageTag
 }
 
 // SetPodSpecImages replaces every init and main container image in a workload.

--- a/internal/operator/component/env_test.go
+++ b/internal/operator/component/env_test.go
@@ -27,9 +27,25 @@ import (
 )
 
 func TestConfigImage(t *testing.T) {
-	cfg := Config{ImageRegistry: "registry.example.com/mirror/", ImageTag: "v1.2.3"}
-	if got := cfg.Image("machina"); got != "registry.example.com/mirror/azure/machina:v1.2.3" {
-		t.Fatalf("Image = %q", got)
+	cases := []struct {
+		name     string
+		registry string
+		want     string
+	}{
+		{name: "bare host", registry: "ghcr.io", want: "ghcr.io/machina:v1.2.3"},
+		{name: "host and org", registry: "ghcr.io/azure", want: "ghcr.io/azure/machina:v1.2.3"},
+		{name: "fork org", registry: "ghcr.io/myorg", want: "ghcr.io/myorg/machina:v1.2.3"},
+		{name: "host and multi-segment path", registry: "registry.corp.internal/unbounded/mirror", want: "registry.corp.internal/unbounded/mirror/machina:v1.2.3"},
+		{name: "trailing slash", registry: "registry.example.com/mirror/", want: "registry.example.com/mirror/machina:v1.2.3"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{ImageRegistry: tc.registry, ImageTag: "v1.2.3"}
+			if got := cfg.Image("machina"); got != tc.want {
+				t.Fatalf("Image = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/operator/components/machina/machina_test.go
+++ b/internal/operator/components/machina/machina_test.go
@@ -169,7 +169,7 @@ func TestApplyMutatorStampsConfigHash(t *testing.T) {
 	containers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
 	image := containers[0].(map[string]any)["image"].(string)
 
-	if image != "registry.example.com/azure/machina:v1.2.3" {
+	if image != "registry.example.com/machina:v1.2.3" {
 		t.Fatalf("image = %q", image)
 	}
 }

--- a/internal/operator/components/metalman/metalman_test.go
+++ b/internal/operator/components/metalman/metalman_test.go
@@ -98,7 +98,7 @@ func TestDeployment(t *testing.T) {
 	}
 
 	container := d.Spec.Template.Spec.Containers[0]
-	if container.Image != "registry.example.com/azure/metalman:v1.2.3" {
+	if container.Image != "registry.example.com/metalman:v1.2.3" {
 		t.Fatalf("image = %q", container.Image)
 	}
 

--- a/internal/operator/components/net/net_test.go
+++ b/internal/operator/components/net/net_test.go
@@ -121,7 +121,7 @@ func TestApplyMutatorStampsBothWorkloads(t *testing.T) {
 
 			for _, field := range []string{"initContainers", "containers"} {
 				containers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", field)
-				if got := containers[0].(map[string]any)["image"]; got != "registry.example.com/azure/"+wantRepository+":v1.2.3" {
+				if got := containers[0].(map[string]any)["image"]; got != "registry.example.com/"+wantRepository+":v1.2.3" {
 					t.Fatalf("%s image = %q", field, got)
 				}
 			}

--- a/internal/operator/components/storage/storage_test.go
+++ b/internal/operator/components/storage/storage_test.go
@@ -111,7 +111,7 @@ func TestMutateObjectScopesDaemonSetToSite(t *testing.T) {
 
 	for _, field := range []string{"initContainers", "containers"} {
 		containers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", field)
-		if got := containers[0].(map[string]any)["image"]; got != "registry.example.com/azure/unbounded-storage-supervisor:v1.2.3" {
+		if got := containers[0].(map[string]any)["image"]; got != "registry.example.com/unbounded-storage-supervisor:v1.2.3" {
 			t.Fatalf("%s image = %q", field, got)
 		}
 	}


### PR DESCRIPTION
## Problem

Fixes #574.

The operator resolved every component image by appending a hardcoded `/azure/`
segment to a registry setting:

```go
func (c Config) Image(repository string) string {
    return strings.TrimRight(c.ImageRegistry, "/") + "/azure/" + repository + ":" + c.ImageTag
}
```

But release images are published **flat** at `<registry>/<component>`, where
`<registry> = ghcr.io/${{ github.repository_owner }}` and the `azure` segment is
just the org. The literal and the org only agreed because the GitHub org is
literally named `azure`, so:

- **No value worked for a fork/mirror.** The setting defaulted to `ghcr.io`, and
  the operator's own image came from an unrelated variable (`CONTAINER_REGISTRY`,
  default `ghcr.io/azure`). Setting the registry to `ghcr.io/myorg` produced a
  phantom `ghcr.io/myorg/azure/machina`; leaving it default produced upstream
  `ghcr.io/azure/machina`.
- **Silent wrong-image pull.** A fork's operator started healthy (its own image
  was correct) and then deployed components from `ghcr.io/azure`, violating the
  version-lockstep invariant. If the tag existed upstream the pull *succeeded* on
  the wrong binaries.
- **Air-gapped mirrors needed an undocumented `/azure/` directory**, blocking
  offline install (#461).

The root cause was two independent paths for the operator image and the component
registry that were only kept in sync by the org name.

## Fix

**1. Full-prefix semantics.** `Config.Image` now treats `ImageRegistry` as a
complete image-repository prefix (registry host plus org/namespace) and appends
the flat component name directly, with no implicit segment. Defaults move to
`ghcr.io/azure` across the operator flag, the operator ConfigMap and Deployment
templates.

**2. Remove the drift at its source.** `UNBOUNDED_OPERATOR_IMAGE_REGISTRY` now
derives from `CONTAINER_REGISTRY` in the Makefile, so the component registry
cannot diverge from the operator image, and a fork that overrides
`CONTAINER_REGISTRY` gets both pointed at its own org.

**3. `kubectl unbounded install` single-sources the registry.** `--image-registry`
is the one knob for where **all** unbounded images come from (written verbatim to
`UNBOUNDED_IMAGE_REGISTRY`); `--operator-image` is only the operator's `name:tag`
(a registry-qualified value is rejected). install stamps the operator Deployment
image as `<registry>/<name:tag>`, so the operator and the components it deploys
always share the registry and cannot diverge. Unset, the registry and the operator
name:tag both come from the manifests embedded at build time (rendered from
`CONTAINER_REGISTRY`), so fork/mirror builds work with no flag. When
`--image-registry` is set without `--operator-image`, install rewrites the embedded
operator image's registry to match (preventing the reverse drift). Both defaults
fail closed rather than defaulting to the upstream registry; a stale stored value
is overwritten and the change is logged. The operator's runtime mechanism is
unchanged (it reads `UNBOUNDED_IMAGE_REGISTRY`; the component tag is always the
operator's compiled version). No new dependency is needed - extracting the registry
is a known-prefix strip, not image-reference parsing.

**4. Release pipeline renders fork-correct binaries.** The GoReleaser before-hook
renders the operator manifests embedded in `kubectl-unbounded`. The `binaries`
job now normalizes `REGISTRY` to lowercase (ghcr rejects uppercase repository
names, so owner `Azure` -> `azure`) and passes `CONTAINER_REGISTRY` to GoReleaser,
so a fork's released binary embeds its own registry instead of `ghcr.io/azure`.

## Behavior changes

- **Breaking:** the operator's `UNBOUNDED_IMAGE_REGISTRY` / install `--image-registry`
  is now a full image-repository prefix (registry host plus org/namespace), not a
  bare host the operator appends `/azure/` to. Automation passing a bare `ghcr.io`
  must pass `ghcr.io/azure` (or its own equivalent).
- **Breaking:** `--operator-image` is now the operator's `name:tag` with **no**
  registry (the registry comes from `--image-registry`); a registry-qualified value
  is rejected. Automation passing a fully-qualified `--operator-image` must move the
  registry to `--image-registry`.
- The component registry is **applied on every install, not preserved** across
  reinstalls (it tracks the operator image). A private/air-gapped install sets
  `--image-registry` (e.g. `registry.corp/unbounded`), or uses a build whose
  `CONTAINER_REGISTRY` bakes it in; the operator image follows.

## Upgrade / migration

- A cluster storing the pre-change bare `ghcr.io` is rewritten to the full prefix
  (`ghcr.io/azure` on a stock binary) on the next `kubectl unbounded install`;
  install logs `updating component image registry from ... to ...` so the repoint
  is not silent.
- Direct `kubectl apply` / GitOps upgrades migrate via the new rendered ConfigMap
  default (`ghcr.io/azure`).

## Tests

- `Config.Image` table test (bare host, host+org, fork org, multi-segment path,
  trailing slash) plus updated component image assertions (net, machina, storage,
  metalman).
- install: `--image-registry` drives both the component registry and the operator
  Deployment image (`<registry>/<name:tag>`); a bare `--image-registry` (no
  `--operator-image`) reconstructs the operator image's registry; a
  registry-qualified `--operator-image` is rejected; fail-closed when neither the
  flags nor the embedded value yield a registry; fork build (injected embedded
  manifests) derives its own registry and keeps its own operator image;
  endpoint/reaper flag remain preserved.
- Render guard asserts the rendered operator image and component registry share a
  prefix (`<registry>/unbounded-operator:<tag>`) and that the registry is
  lowercase, so the two paths and the ghcr casing requirement cannot regress.

## Out of scope

- The raw-`kubectl apply` UX gap (`kubectl unbounded install --dry-run -o yaml`),
  noted in #574, is filed separately.
- Legacy air-gapped mirrors that used the old phantom `<prefix>/azure/` layout are
  not auto-rewritten; re-specify the registry (or re-mirror without the phantom
  directory) on upgrade.


