### PR TITLE
fix(operator): skip Gantry node config

### DIFF
--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -413,7 +413,6 @@ jobs:
             "deploy unbounded-net-controller" \
             "ds unbounded-net-node" \
             "deploy machina-controller" \
-            "ds gantry-containerd-config" \
             "ds gantry"; do
             set -- $target
             wait_exists "$1" "$2"
@@ -444,7 +443,7 @@ jobs:
           kubectl -n "$NS" get deploy,ds,pods -o wide 2>&1
           echo "::endgroup::"
           echo "::group::Applied component images"
-          for kn in "deploy/unbounded-operator" "deploy/unbounded-net-controller" "ds/unbounded-net-node" "deploy/machina-controller" "ds/gantry-containerd-config" "ds/gantry"; do
+          for kn in "deploy/unbounded-operator" "deploy/unbounded-net-controller" "ds/unbounded-net-node" "deploy/machina-controller" "ds/gantry"; do
             img=$(kubectl -n "$NS" get "$kn" -o jsonpath='{.spec.template.spec.containers[*].image}' 2>/dev/null)
             printf '%s image=[%s]\n' "$kn" "$img"
           done

--- a/internal/operator/components/gantry/gantry.go
+++ b/internal/operator/components/gantry/gantry.go
@@ -7,9 +7,8 @@
 // components it defaults to enabled: it is deployed unless every Site explicitly
 // opts out via spec.components.gantry.enabled=false.
 //
-// The component also manages the per-node containerd wiring: a helper DaemonSet
-// writes /etc/containerd/certs.d/_default/hosts.toml so pulls use the node-local
-// gantry agent as their default mirror.
+// The unbounded agent manages the per-node containerd wiring, so the operator
+// installs only the Gantry workload and its Kubernetes configuration.
 package gantry
 
 import (
@@ -20,6 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,19 +41,15 @@ const (
 
 	// agentContainerName is the gantry agent's main container. Only this
 	// container carries the operator-managed image; the DaemonSet's busybox
-	// init container (and the busybox node-config DaemonSet) keep their pinned
-	// public images.
+	// init container keeps its pinned public image.
 	agentContainerName = "gantry"
 
-	// nodeConfigName and nodeConfigDaemonSetName are the operator-managed
-	// containerd node-wiring objects: a ConfigMap carrying the certs.d
-	// hosts.toml and the DaemonSet that installs it into
-	// /etc/containerd/certs.d/_default on every node.
-	nodeConfigName          = "gantry-containerd-hosts"
-	nodeConfigDaemonSetName = "gantry-containerd-config"
+	// legacyNodeConfigName and legacyNodeConfigDaemonSetName were installed by
+	// older operator versions. The unbounded agent owns this host configuration.
+	legacyNodeConfigName          = "gantry-containerd-hosts"
+	legacyNodeConfigDaemonSetName = "gantry-containerd-config"
 
-	configHashAnnotation     = "unbounded-cloud.io/gantry-config-hash"
-	nodeConfigHashAnnotation = "unbounded-cloud.io/gantry-node-config-hash"
+	configHashAnnotation = "unbounded-cloud.io/gantry-config-hash"
 )
 
 // Component reconciles the gantry cluster singleton.
@@ -83,6 +79,10 @@ func EnabledFor(site *unboundedv1alpha3.Site) bool {
 // not opt out and keeps an existing installation reconciled when every Site opts
 // out.
 func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unboundedv1alpha3.Site) component.Result {
+	if err := cleanupLegacyNodeConfig(ctx, env); err != nil {
+		return component.Failed(err)
+	}
+
 	enabled := false
 
 	for i := range sites {
@@ -111,34 +111,24 @@ func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unbo
 		return component.Failed(err)
 	}
 
-	// The node-config ConfigMap is operator-owned static content (the certs.d
-	// hosts.toml), applied directly from the embedded manifests. Hash it so a
-	// content change rolls the writer DaemonSet, which otherwise writes once and
-	// sleeps.
-	nodeConfigHash, err := nodeConfigPayloadHash(env)
-	if err != nil {
-		return component.Failed(err)
-	}
-
-	if err := applyManifests(ctx, env, applyMutator(env.Config.Image(imageRepository), configHash, nodeConfigHash)); err != nil {
+	if err := applyManifests(ctx, env, applyMutator(env.Config.Image(imageRepository), configHash)); err != nil {
 		return component.Failed(err)
 	}
 
 	return component.Reconciled()
 }
 
-// SetupWatches reconciles gantry on changes to its config payloads and on
-// create/delete/generation changes of its agent and node-config DaemonSets.
+// SetupWatches reconciles Gantry on changes to its active resources and when
+// legacy node-config resources appear so they can be removed.
 func (Component) SetupWatches(b *builder.Builder, env *component.Env) {
 	b.Watches(&corev1.ConfigMap{}, env.RequestSingletonAndAllSites(),
-		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceNamed(configName, nodeConfigName))))
+		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceNamed(configName, legacyNodeConfigName))))
 	b.Watches(&appsv1.DaemonSet{}, env.RequestSingleton(),
-		builder.WithPredicates(env.ManagedWorkloadPredicate(env.InNamespaceNamed(daemonSetName, nodeConfigDaemonSetName))))
+		builder.WithPredicates(env.ManagedWorkloadPredicate(env.InNamespaceNamed(daemonSetName, legacyNodeConfigDaemonSetName))))
 }
 
-// applyManifests applies gantry's top-level manifests. The examples/ subtree in
-// the embedded manifests (optional NetworkPolicy hardening and a sample registry
-// Secret) is intentionally excluded from the default install.
+// applyManifests applies Gantry's operator-managed top-level manifests. The
+// standalone node configurator and examples subtree are intentionally excluded.
 func applyManifests(ctx context.Context, env *component.Env, mutate func(*unstructured.Unstructured) error) error {
 	files, err := component.YamlFiles(gantrymanifests.Manifests)
 	if err != nil {
@@ -148,8 +138,8 @@ func applyManifests(ctx context.Context, env *component.Env, mutate func(*unstru
 	topLevel := make([]string, 0, len(files))
 
 	for _, file := range files {
-		if strings.Contains(file, "/") {
-			continue // skip examples/ and any other subdirectory
+		if file == "node-config.yaml" || strings.Contains(file, "/") {
+			continue
 		}
 
 		topLevel = append(topLevel, file)
@@ -165,8 +155,6 @@ func resourcesExist(ctx context.Context, env *component.Env) (bool, error) {
 	}{
 		{name: configName, object: &corev1.ConfigMap{}},
 		{name: daemonSetName, object: &appsv1.DaemonSet{}},
-		{name: nodeConfigName, object: &corev1.ConfigMap{}},
-		{name: nodeConfigDaemonSetName, object: &appsv1.DaemonSet{}},
 	} {
 		key := client.ObjectKey{Namespace: env.Namespace, Name: resource.name}
 		if err := env.Client.Get(ctx, key, resource.object); err == nil {
@@ -179,13 +167,24 @@ func resourcesExist(ctx context.Context, env *component.Env) (bool, error) {
 	return false, nil
 }
 
+func cleanupLegacyNodeConfig(ctx context.Context, env *component.Env) error {
+	for _, obj := range []client.Object{
+		&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: env.Namespace, Name: legacyNodeConfigDaemonSetName}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: env.Namespace, Name: legacyNodeConfigName}},
+	} {
+		if err := env.DeleteIfExists(ctx, obj); err != nil {
+			return fmt.Errorf("remove legacy Gantry node config: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // applyMutator skips CRDs and the separately reconciled gantry-config ConfigMap,
 // stamps the operator-derived agent image onto the agent DaemonSet, and stamps
-// the config payload hashes on the workloads they belong to so a config change
-// rolls the corresponding DaemonSet. Only the agent's own container is
-// re-imaged; the busybox init and the busybox node-config DaemonSet keep their
-// pinned public images.
-func applyMutator(agentImage, configHash, nodeConfigHash string) func(*unstructured.Unstructured) error {
+// the config payload hash on its pod template so a config change rolls the
+// DaemonSet. Only the agent's own container is re-imaged.
+func applyMutator(agentImage, configHash string) func(*unstructured.Unstructured) error {
 	return func(obj *unstructured.Unstructured) error {
 		if obj.GetKind() == component.CRDKind {
 			obj.Object = nil
@@ -199,18 +198,15 @@ func applyMutator(agentImage, configHash, nodeConfigHash string) func(*unstructu
 			return nil
 		}
 
-		switch {
-		case obj.GetKind() == "DaemonSet" && obj.GetName() == daemonSetName:
+		if obj.GetKind() == "DaemonSet" && obj.GetName() == daemonSetName {
 			if err := component.SetNamedContainerImage(obj, agentContainerName, agentImage); err != nil {
 				return fmt.Errorf("set gantry agent image: %w", err)
 			}
 
 			return stampConfigHash(obj, configHashAnnotation, configHash)
-		case obj.GetKind() == "DaemonSet" && obj.GetName() == nodeConfigDaemonSetName:
-			return stampConfigHash(obj, nodeConfigHashAnnotation, nodeConfigHash)
-		default:
-			return nil
 		}
+
+		return nil
 	}
 }
 
@@ -232,17 +228,6 @@ func stampConfigHash(obj *unstructured.Unstructured, annotation, hash string) er
 	}
 
 	return nil
-}
-
-// nodeConfigPayloadHash returns the payload hash of the embedded node-config
-// hosts ConfigMap so the writer DaemonSet can be rolled when it changes.
-func nodeConfigPayloadHash(env *component.Env) (string, error) {
-	cm, err := env.DefaultConfigMap(gantrymanifests.Manifests, nodeConfigName, "gantry node-config")
-	if err != nil {
-		return "", err
-	}
-
-	return component.ConfigMapPayloadHash(cm), nil
 }
 
 // ensureConfig creates the embedded default only when no config exists. An

--- a/internal/operator/components/gantry/gantry_test.go
+++ b/internal/operator/components/gantry/gantry_test.go
@@ -5,12 +5,14 @@ package gantry
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -158,7 +160,7 @@ func TestApplyMutatorStampsDaemonSetAndSkipsConfig(t *testing.T) {
 		}},
 	}}
 
-	if err := applyMutator("ghcr.io/azure/gantry:test", "gantry-hash", "node-hash")(ds); err != nil {
+	if err := applyMutator("ghcr.io/azure/gantry:test", "gantry-hash")(ds); err != nil {
 		t.Fatalf("applyMutator: %v", err)
 	}
 
@@ -167,34 +169,17 @@ func TestApplyMutatorStampsDaemonSetAndSkipsConfig(t *testing.T) {
 		t.Fatalf("pod template annotations = %#v", annotations)
 	}
 
-	nodeDS := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apps/v1",
-		"kind":       "DaemonSet",
-		"metadata":   map[string]any{"name": nodeConfigDaemonSetName},
-		"spec":       map[string]any{"template": map[string]any{"metadata": map[string]any{}}},
-	}}
-
-	if err := applyMutator("ghcr.io/azure/gantry:test", "gantry-hash", "node-hash")(nodeDS); err != nil {
-		t.Fatalf("applyMutator node-config: %v", err)
-	}
-
-	nodeAnnotations, _, _ := unstructured.NestedStringMap(nodeDS.Object, "spec", "template", "metadata", "annotations")
-	if nodeAnnotations[nodeConfigHashAnnotation] != "node-hash" {
-		t.Fatalf("node-config pod template annotations = %#v", nodeAnnotations)
-	}
-
 	config := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": configName},
 	}}
-	if err := applyMutator("ghcr.io/azure/gantry:test", "gantry-hash", "node-hash")(config); err != nil || config.Object != nil {
+	if err := applyMutator("ghcr.io/azure/gantry:test", "gantry-hash")(config); err != nil || config.Object != nil {
 		t.Fatalf("gantry ConfigMap was not skipped: err=%v object=%#v", err, config.Object)
 	}
 }
 
 // TestApplyMutatorImagesOnlyAgentContainer asserts the operator-derived image is
 // stamped only on the gantry agent's own container, leaving the busybox init
-// container (and, on the node-config DaemonSet, the busybox worker) with their
-// pinned public images.
+// container with its pinned public image.
 func TestApplyMutatorImagesOnlyAgentContainer(t *testing.T) {
 	const derived = "ghcr.io/azure/gantry:v1.2.3"
 
@@ -215,7 +200,7 @@ func TestApplyMutatorImagesOnlyAgentContainer(t *testing.T) {
 		}},
 	}}
 
-	if err := applyMutator(derived, "h", "n")(agent); err != nil {
+	if err := applyMutator(derived, "h")(agent); err != nil {
 		t.Fatalf("applyMutator: %v", err)
 	}
 
@@ -227,11 +212,11 @@ func TestApplyMutatorImagesOnlyAgentContainer(t *testing.T) {
 		t.Fatalf("agent container image = %q, want derived %q", agentImg, derived)
 	}
 
-	// The node-config DaemonSet is entirely busybox and must not be re-imaged.
+	// The standalone node-config DaemonSet is not an operator-managed workload.
 	nodeDS := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
 		"kind":       "DaemonSet",
-		"metadata":   map[string]any{"name": nodeConfigDaemonSetName},
+		"metadata":   map[string]any{"name": legacyNodeConfigDaemonSetName},
 		"spec": map[string]any{"template": map[string]any{
 			"metadata": map[string]any{},
 			"spec": map[string]any{
@@ -242,7 +227,7 @@ func TestApplyMutatorImagesOnlyAgentContainer(t *testing.T) {
 		}},
 	}}
 
-	if err := applyMutator(derived, "h", "n")(nodeDS); err != nil {
+	if err := applyMutator(derived, "h")(nodeDS); err != nil {
 		t.Fatalf("applyMutator node-config: %v", err)
 	}
 
@@ -274,34 +259,76 @@ func containerImage(t *testing.T, obj *unstructured.Unstructured, field, name st
 }
 
 func TestReconcileAppliesCoreManifestsAndSkipsExamples(t *testing.T) {
-	env, applied := reconcilerEnv(t)
+	legacyConfig := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: legacyNodeConfigName}}
+	legacyDaemonSet := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: legacyNodeConfigDaemonSetName}}
+	env, applied := reconcilerEnv(t, legacyConfig, legacyDaemonSet)
 
 	res := Component{}.Reconcile(t.Context(), env, []unboundedv1alpha3.Site{*siteWithGantry("edge", nil)})
 	if !res.Ready || res.Err != nil {
 		t.Fatalf("Reconcile = %+v, want ready", res)
 	}
 
-	// Core install objects are applied, including the node-config objects that
-	// wire node containerd through the mirror.
+	// Core Gantry objects are applied, while host configuration remains owned by
+	// unbounded-agent.
 	for _, want := range []string{
 		"ServiceAccount/gantry", "DaemonSet/gantry", "PriorityClass/gantry-low", "ClusterRole/gantry-agent",
-		"ConfigMap/gantry-containerd-hosts", "DaemonSet/gantry-containerd-config",
 	} {
 		if !applied[want] {
 			t.Fatalf("expected %s to be applied; applied=%#v", want, applied)
 		}
 	}
 
-	// The optional examples (NetworkPolicy, sample Secret) must NOT be applied.
+	// The standalone node configurator and optional examples must not be applied.
 	for key := range applied {
-		if key == "NetworkPolicy/gantry" || key == "Secret/gantry-registry-credentials" {
-			t.Fatalf("example object %s was applied by the default install", key)
+		if key == "ConfigMap/"+legacyNodeConfigName || key == "DaemonSet/"+legacyNodeConfigDaemonSetName ||
+			key == "NetworkPolicy/gantry" || key == "Secret/gantry-registry-credentials" {
+			t.Fatalf("excluded object %s was applied by the operator", key)
+		}
+	}
+
+	var config corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: configName}, &config); err != nil {
+		t.Fatalf("get operator-managed gantry config: %v", err)
+	}
+
+	for _, obj := range []client.Object{legacyConfig, legacyDaemonSet} {
+		if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(obj), obj); !apierrors.IsNotFound(err) {
+			t.Fatalf("legacy node-config object %T was not deleted: %v", obj, err)
 		}
 	}
 
 	// The gantry ConfigMap is reconciled separately, not via the manifest apply.
 	if applied["ConfigMap/gantry-config"] {
 		t.Fatal("gantry-config ConfigMap should be reconciled separately, not applied")
+	}
+}
+
+func TestReconcileFailsWhenLegacyNodeConfigCleanupFails(t *testing.T) {
+	wantErr := errors.New("delete denied")
+	scheme := testScheme(t)
+	applied := false
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+				return wantErr
+			},
+			Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				applied = true
+
+				return nil
+			},
+		}).
+		Build()
+	env := &component.Env{Client: cl, Scheme: scheme, Namespace: component.DefaultNamespace}
+
+	res := Component{}.Reconcile(t.Context(), env, []unboundedv1alpha3.Site{*siteWithGantry("edge", nil)})
+	if res.Ready || !errors.Is(res.Err, wantErr) {
+		t.Fatalf("Reconcile = %+v, want failure wrapping %v", res, wantErr)
+	}
+
+	if applied {
+		t.Fatal("manifests were applied after legacy node-config cleanup failed")
 	}
 }
 
@@ -332,8 +359,8 @@ func TestReconcileRetainsExistingWhenAllSitesOptOut(t *testing.T) {
 	}{
 		{name: "agent config", existing: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: configName}}},
 		{name: "agent DaemonSet", existing: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: daemonSetName}}},
-		{name: "node config", existing: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: nodeConfigName}}},
-		{name: "node-config DaemonSet", existing: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: nodeConfigDaemonSetName}}},
+		{name: "legacy node config", existing: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: legacyNodeConfigName}}},
+		{name: "legacy node-config DaemonSet", existing: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: legacyNodeConfigDaemonSetName}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			env, applied := reconcilerEnv(t, tc.existing)
@@ -343,10 +370,21 @@ func TestReconcileRetainsExistingWhenAllSitesOptOut(t *testing.T) {
 				t.Fatalf("Reconcile = %+v, want ready", res)
 			}
 
-			for _, want := range []string{"DaemonSet/gantry", "DaemonSet/gantry-containerd-config"} {
-				if !applied[want] {
-					t.Fatalf("retained gantry install did not reconcile %s; applied=%#v", want, applied)
+			legacy := tc.existing.GetName() == legacyNodeConfigName || tc.existing.GetName() == legacyNodeConfigDaemonSetName
+			if legacy {
+				if res.Reason != component.ReasonDisabled || len(applied) != 0 {
+					t.Fatalf("legacy-only install was retained: result=%+v applied=%#v", res, applied)
 				}
+
+				if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(tc.existing), tc.existing); !apierrors.IsNotFound(err) {
+					t.Fatalf("legacy-only object %T was not deleted: %v", tc.existing, err)
+				}
+
+				return
+			}
+
+			if !applied["DaemonSet/gantry"] {
+				t.Fatalf("retained gantry install did not reconcile DaemonSet/gantry; applied=%#v", applied)
 			}
 		})
 	}
@@ -393,18 +431,19 @@ func TestResourcesExist(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		existing client.Object
+		want     bool
 	}{
-		{name: "agent config", existing: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: configName}}},
-		{name: "agent DaemonSet", existing: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: daemonSetName}}},
-		{name: "node config", existing: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: nodeConfigName}}},
-		{name: "node-config DaemonSet", existing: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: nodeConfigDaemonSetName}}},
+		{name: "agent config", existing: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: configName}}, want: true},
+		{name: "agent DaemonSet", existing: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: daemonSetName}}, want: true},
+		{name: "legacy node config", existing: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: legacyNodeConfigName}}},
+		{name: "legacy node-config DaemonSet", existing: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: legacyNodeConfigDaemonSetName}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			env := testEnv(t, tc.existing)
 
 			got, err := resourcesExist(t.Context(), env)
-			if err != nil || !got {
-				t.Fatalf("resourcesExist = %t, %v", got, err)
+			if err != nil || got != tc.want {
+				t.Fatalf("resourcesExist = %t, %v; want %t", got, err, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- keep the operator-managed `gantry-config` ConfigMap while excluding standalone `node-config.yaml` resources
- remove `gantry-containerd-config` and `gantry-containerd-hosts` left by older operator versions
- stop the release-upgrade workflow from waiting on the removed DaemonSet

## Testing

- `go test -count=1 ./internal/operator/...`
- repository-pinned `gofumpt` and `golangci-lint -E wsl_v5` on the changed Go package
- `git diff --check`