### PR TITLE
fix: site init no longer installs or repoints the operator (#578)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -368,8 +368,8 @@ jobs:
   # the unbounded-system namespace. The reaper migrates any legacy split-namespace
   # state. We never render or apply component manifests directly here.
   #
-  #   MODE=init     -> 'install' then 'site init --skip-install' (creates the
-  #                    Site the operator reconciles). Used for the first bootstrap.
+  #   MODE=init     -> 'install' then 'site init' (creates the Site the operator
+  #                    reconciles). Used for the first bootstrap.
   #   MODE=upgrade  -> 'install' only; the operator reconciles the existing Site.
   #
   # The plugin is built from the snapshot checkout (no tarball download, no cosign
@@ -499,8 +499,7 @@ jobs:
             --cluster-pod-cidr  "${CLUSTER_POD_CIDR}" \
             --node-cidr         "${SITE_NODE_CIDR}" \
             --pod-cidr          "${SITE_POD_CIDR}" \
-            --manage-cni-plugin="${MANAGE_CNI_PLUGIN}" \
-            --skip-install
+            --manage-cni-plugin="${MANAGE_CNI_PLUGIN}"
 
       - name: Wait for rollouts
         run: |

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -370,8 +370,7 @@ jobs:
             --cluster-pod-cidr  "${CLUSTER_POD_CIDR}" \
             --node-cidr         "${SITE_NODE_CIDR}" \
             --pod-cidr          "${SITE_POD_CIDR}" \
-            --manage-cni-plugin="${MANAGE_CNI_PLUGIN}" \
-            --skip-install
+            --manage-cni-plugin="${MANAGE_CNI_PLUGIN}"
 
       - name: Sanity check tarball contents (upgrade)
         if: env.MODE == 'upgrade'

--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ chmod +x aks-quickstart.sh
     --remote-pod-cidr 10.245.0.0/16
 ```
 
-> The script creates an AKS cluster, adds a gateway node pool, and runs
-> `kubectl unbounded site init` to bootstrap the operator and request the
-> networking stack through the cluster Site.
+> The script creates an AKS cluster, adds a gateway node pool, runs
+> `kubectl unbounded install` to bootstrap the operator, then
+> `kubectl unbounded site init` to request the networking stack through the
+> cluster Site.
 
 ### 3. Add a remote node
 

--- a/cmd/kubectl-unbounded/app/site_init.go
+++ b/cmd/kubectl-unbounded/app/site_init.go
@@ -11,10 +11,13 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"strings"
 	"text/template"
-	"time"
 
 	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,6 +25,16 @@ import (
 	"github.com/Azure/unbounded/internal/kube"
 	"github.com/Azure/unbounded/internal/unbounded"
 )
+
+// siteRequiredCRDs are the CustomResourceDefinitions the site manifests apply.
+// The unbounded-operator owns CRD lifecycle and establishes these at startup, so
+// site init requires them to exist before it can create Site, GatewayPool, and
+// SiteGatewayPoolAssignment resources.
+var siteRequiredCRDs = []string{
+	"sites.unbounded-cloud.io",
+	"gatewaypools.net.unbounded-cloud.io",
+	"sitegatewaypoolassignments.net.unbounded-cloud.io",
+}
 
 //go:embed assets/unbounded-net-site/*.yaml
 var siteTemplates embed.FS
@@ -54,8 +67,6 @@ type siteInitHandler struct {
 	enableMachina  bool
 	enableMetalman bool
 	enableStorage  bool
-	skipInstall    bool
-	installTimeout time.Duration
 
 	// kubeCli is the kubernetes client interface.
 	kubeCli kubernetes.Interface
@@ -94,20 +105,8 @@ func (h *siteInitHandler) execute(ctx context.Context) error {
 	h.kubeResourcesCli = kubeResourcesCli
 	h.kubeConfig = kubeConfig
 
-	if !h.skipInstall {
-		installer := installHandler{
-			kubeconfigPath:   h.kubeconfigPath,
-			namespace:        unbounded.SystemNamespace(),
-			wait:             true,
-			timeout:          h.installTimeout,
-			kubeCli:          kubeCli,
-			kubeResourcesCli: kubeResourcesCli,
-			restConfig:       kubeConfig,
-			logger:           h.logger,
-		}
-		if err := installer.execute(ctx); err != nil {
-			return fmt.Errorf("bootstrapping unbounded-operator: %w", err)
-		}
+	if err := h.checkOperatorPrerequisites(ctx); err != nil {
+		return err
 	}
 
 	if err := h.ensureUnboundedSite(ctx, h.clusterSiteConfig()); err != nil {
@@ -123,6 +122,81 @@ func (h *siteInitHandler) execute(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// checkOperatorPrerequisites verifies the cluster is ready to accept Site
+// resources before site init creates them. The unbounded-operator owns CRD
+// lifecycle and reconciles Sites, so it must be installed first (via
+// `kubectl unbounded install`).
+//
+// Missing or unestablished CRDs are a hard error: the Site, GatewayPool, and
+// SiteGatewayPoolAssignment manifests cannot be applied without them. A missing
+// or not-yet-ready operator Deployment is only a warning, because the operator
+// reconciles the Site once it becomes ready.
+func (h *siteInitHandler) checkOperatorPrerequisites(ctx context.Context) error {
+	var missing []string
+
+	for _, name := range siteRequiredCRDs {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion("apiextensions.k8s.io/v1")
+		obj.SetKind("CustomResourceDefinition")
+
+		if err := h.kubeResourcesCli.Get(ctx, client.ObjectKey{Name: name}, obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				missing = append(missing, name)
+
+				continue
+			}
+
+			return fmt.Errorf("inspecting customresourcedefinition %s: %w", name, err)
+		}
+
+		if !crdEstablished(obj) {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"unbounded-operator is not installed: required CRDs are missing or not established (%s); run \"kubectl unbounded install\" first to bootstrap the unbounded-operator",
+			strings.Join(missing, ", "),
+		)
+	}
+
+	h.warnIfOperatorNotReady(ctx)
+
+	return nil
+}
+
+// warnIfOperatorNotReady logs a warning (never an error) when the
+// unbounded-operator Deployment is absent or not fully rolled out. The CRDs
+// checked by checkOperatorPrerequisites are enough to apply Site resources; a
+// not-yet-ready operator only delays reconciliation, so site init proceeds.
+func (h *siteInitHandler) warnIfOperatorNotReady(ctx context.Context) {
+	namespace := unbounded.SystemNamespace()
+	deploy := &appsv1.Deployment{}
+
+	if err := h.kubeResourcesCli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "unbounded-operator"}, deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			h.logger.Warn(
+				"unbounded-operator Deployment not found; the Site will not be reconciled until the operator is installed and ready",
+				"namespace", namespace,
+			)
+
+			return
+		}
+
+		h.logger.Warn("inspecting unbounded-operator Deployment", "namespace", namespace, "error", err)
+
+		return
+	}
+
+	if !deploymentRolloutComplete(deploy) {
+		h.logger.Warn(
+			"unbounded-operator Deployment is not fully rolled out; the Site will be reconciled once the operator is ready",
+			"namespace", namespace,
+		)
+	}
 }
 
 func (h *siteInitHandler) clusterSiteConfig() unboundedSiteConfig {
@@ -305,8 +379,6 @@ func siteInitCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&handler.enableMachina, "enable-machina", true, "Enable machina for the Site")
 	cmd.Flags().BoolVar(&handler.enableMetalman, "enable-metalman", false, "Enable metalman for the Site")
 	cmd.Flags().BoolVar(&handler.enableStorage, "enable-storage", false, "Enable unbounded-storage for the Site")
-	cmd.Flags().BoolVar(&handler.skipInstall, "skip-install", false, "Skip bootstrapping CRDs and unbounded-operator before creating site resources")
-	cmd.Flags().DurationVar(&handler.installTimeout, "install-timeout", defaultInstallTimeout, "Timeout while waiting for unbounded-operator bootstrap")
 
 	if err := cmd.MarkFlagRequired("name"); err != nil {
 		panic(err)

--- a/cmd/kubectl-unbounded/app/site_init.go
+++ b/cmd/kubectl-unbounded/app/site_init.go
@@ -9,15 +9,19 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"strings"
 	"text/template"
 
 	"github.com/spf13/cobra"
-	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,18 +30,11 @@ import (
 	"github.com/Azure/unbounded/internal/unbounded"
 )
 
-// siteRequiredCRDs are the CustomResourceDefinitions the site manifests apply.
-// The unbounded-operator owns CRD lifecycle and establishes these at startup, so
-// site init requires them to exist before it can create Site, GatewayPool, and
-// SiteGatewayPoolAssignment resources.
-var siteRequiredCRDs = []string{
-	"sites.unbounded-cloud.io",
-	"gatewaypools.net.unbounded-cloud.io",
-	"sitegatewaypoolassignments.net.unbounded-cloud.io",
-}
-
 //go:embed assets/unbounded-net-site/*.yaml
 var siteTemplates embed.FS
+
+// siteTemplateDir is the embedded directory holding the Site manifest templates.
+const siteTemplateDir = "assets/unbounded-net-site"
 
 // siteInitHandler creates declarative Site configuration and bootstrap credentials.
 // Component installation is reconciled by unbounded-operator from the Site spec.
@@ -124,41 +121,51 @@ func (h *siteInitHandler) execute(ctx context.Context) error {
 	return nil
 }
 
-// checkOperatorPrerequisites verifies the cluster is ready to accept Site
-// resources before site init creates them. The unbounded-operator owns CRD
+// checkOperatorPrerequisites verifies the cluster is ready to accept the Site
+// resources site init is about to create. The unbounded-operator owns CRD
 // lifecycle and reconciles Sites, so it must be installed first (via
 // `kubectl unbounded install`).
 //
-// Missing or unestablished CRDs are a hard error: the Site, GatewayPool, and
-// SiteGatewayPoolAssignment manifests cannot be applied without them. A missing
-// or not-yet-ready operator Deployment is only a warning, because the operator
-// reconciles the Site once it becomes ready.
+// The check uses API discovery to confirm the apiserver actually serves the
+// GroupVersionKinds site init applies (derived from the embedded manifests, so
+// the check tracks future API versions automatically). Discovery is used rather
+// than reading CustomResourceDefinition objects because it does not require
+// cluster-scoped CRD read permission and reflects the versions the apiserver
+// serves, not merely that a CRD is Established. A type that is not served is a
+// hard error; a missing or not-yet-ready operator Deployment is only a warning,
+// because the operator reconciles the Site once it becomes ready.
 func (h *siteInitHandler) checkOperatorPrerequisites(ctx context.Context) error {
+	required, err := requiredSiteAPIs()
+	if err != nil {
+		return fmt.Errorf("determining required Site API types: %w", err)
+	}
+
+	disco := h.kubeCli.Discovery()
+	servedKinds := map[schema.GroupVersion]map[string]bool{}
+
 	var missing []string
 
-	for _, name := range siteRequiredCRDs {
-		obj := &unstructured.Unstructured{}
-		obj.SetAPIVersion("apiextensions.k8s.io/v1")
-		obj.SetKind("CustomResourceDefinition")
+	for _, gvk := range required {
+		gv := gvk.GroupVersion()
 
-		if err := h.kubeResourcesCli.Get(ctx, client.ObjectKey{Name: name}, obj); err != nil {
-			if apierrors.IsNotFound(err) {
-				missing = append(missing, name)
-
-				continue
+		kinds, cached := servedKinds[gv]
+		if !cached {
+			kinds, err = servedKindsForGroupVersion(disco, gv)
+			if err != nil {
+				return fmt.Errorf("checking whether the cluster serves %s: %w", gv, err)
 			}
 
-			return fmt.Errorf("inspecting customresourcedefinition %s: %w", name, err)
+			servedKinds[gv] = kinds
 		}
 
-		if !crdEstablished(obj) {
-			missing = append(missing, name)
+		if !kinds[gvk.Kind] {
+			missing = append(missing, fmt.Sprintf("%s.%s", gvk.Kind, gv))
 		}
 	}
 
 	if len(missing) > 0 {
 		return fmt.Errorf(
-			"unbounded-operator is not installed: required CRDs are missing or not established (%s); run \"kubectl unbounded install\" first to bootstrap the unbounded-operator",
+			"unbounded-operator is not installed: the cluster is not serving required API types (%s); run \"kubectl unbounded install\" first to bootstrap the unbounded-operator",
 			strings.Join(missing, ", "),
 		)
 	}
@@ -168,25 +175,129 @@ func (h *siteInitHandler) checkOperatorPrerequisites(ctx context.Context) error 
 	return nil
 }
 
+// servedKindsForGroupVersion returns the set of Kinds the apiserver serves for
+// gv. A GroupVersion the apiserver does not serve yields an empty set (not an
+// error), so callers can treat "not served" uniformly with "kind absent".
+func servedKindsForGroupVersion(disco discovery.DiscoveryInterface, gv schema.GroupVersion) (map[string]bool, error) {
+	list, err := disco.ServerResourcesForGroupVersion(gv.String())
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return map[string]bool{}, nil
+		}
+
+		return nil, err
+	}
+
+	kinds := make(map[string]bool, len(list.APIResources))
+	for _, resource := range list.APIResources {
+		kinds[resource.Kind] = true
+	}
+
+	return kinds, nil
+}
+
+// requiredSiteAPIs returns the distinct GroupVersionKinds declared by the
+// embedded Site manifest templates. Deriving the set from the templates (instead
+// of a hard-coded list) keeps the preflight in lockstep with the versions site
+// init actually applies, including future API bumps.
+func requiredSiteAPIs() ([]schema.GroupVersionKind, error) {
+	entries, err := fs.ReadDir(siteTemplates, siteTemplateDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading site manifest templates: %w", err)
+	}
+
+	// Placeholder values so the templates render into valid YAML; only the
+	// static apiVersion/kind fields are read, which do not depend on the data.
+	data := unboundedSiteConfig{
+		SiteName:  "preflight",
+		NodeCIDRs: []string{"0.0.0.0/0"},
+		PodCIDRs:  []string{"0.0.0.0/0"},
+	}
+
+	seen := map[schema.GroupVersionKind]bool{}
+
+	var gvks []schema.GroupVersionKind
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+
+		content, err := fs.ReadFile(siteTemplates, siteTemplateDir+"/"+name)
+		if err != nil {
+			return nil, fmt.Errorf("reading site manifest template %s: %w", name, err)
+		}
+
+		tmpl, err := template.New(name).Parse(string(content))
+		if err != nil {
+			return nil, fmt.Errorf("parsing site manifest template %s: %w", name, err)
+		}
+
+		buf := &bytes.Buffer{}
+		if err := tmpl.Execute(buf, data); err != nil {
+			return nil, fmt.Errorf("rendering site manifest template %s: %w", name, err)
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(buf, 4096)
+
+		for {
+			obj := &unstructured.Unstructured{}
+
+			if err := decoder.Decode(obj); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, fmt.Errorf("decoding site manifest template %s: %w", name, err)
+			}
+
+			gvk := obj.GroupVersionKind()
+			if gvk.Empty() {
+				continue
+			}
+
+			if !seen[gvk] {
+				seen[gvk] = true
+
+				gvks = append(gvks, gvk)
+			}
+		}
+	}
+
+	return gvks, nil
+}
+
 // warnIfOperatorNotReady logs a warning (never an error) when the
-// unbounded-operator Deployment is absent or not fully rolled out. The CRDs
-// checked by checkOperatorPrerequisites are enough to apply Site resources; a
-// not-yet-ready operator only delays reconciliation, so site init proceeds.
+// unbounded-operator Deployment is absent or not fully rolled out. The served
+// API types checked by checkOperatorPrerequisites are enough to apply Site
+// resources; a not-yet-ready operator only delays reconciliation, so site init
+// proceeds. Permission errors are downgraded to a debug log so a caller that can
+// apply Sites but cannot read Deployments is not blocked or alarmed.
 func (h *siteInitHandler) warnIfOperatorNotReady(ctx context.Context) {
 	namespace := unbounded.SystemNamespace()
-	deploy := &appsv1.Deployment{}
 
-	if err := h.kubeResourcesCli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "unbounded-operator"}, deploy); err != nil {
-		if apierrors.IsNotFound(err) {
+	deploy, err := h.kubeCli.AppsV1().Deployments(namespace).Get(ctx, "unbounded-operator", metav1.GetOptions{})
+	if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
 			h.logger.Warn(
 				"unbounded-operator Deployment not found; the Site will not be reconciled until the operator is installed and ready",
 				"namespace", namespace,
 			)
-
-			return
+		case apierrors.IsForbidden(err):
+			h.logger.Debug(
+				"skipping unbounded-operator readiness check: not permitted to read Deployments",
+				"namespace", namespace,
+			)
+		default:
+			h.logger.Debug(
+				"could not inspect unbounded-operator Deployment",
+				"namespace", namespace,
+				"error", err,
+			)
 		}
-
-		h.logger.Warn("inspecting unbounded-operator Deployment", "namespace", namespace, "error", err)
 
 		return
 	}
@@ -303,10 +414,9 @@ func (h *siteInitHandler) ensureUnboundedSite(ctx context.Context, cfg unbounded
 	buf := &bytes.Buffer{}
 
 	templateFS := siteTemplates
-	templateDir := "assets/unbounded-net-site/"
 
 	for _, name := range cfg.Manifests {
-		path := templateDir + name
+		path := siteTemplateDir + "/" + name
 
 		content, err := fs.ReadFile(templateFS, path)
 		if err != nil {

--- a/cmd/kubectl-unbounded/app/site_init_test.go
+++ b/cmd/kubectl-unbounded/app/site_init_test.go
@@ -4,13 +4,17 @@
 package app
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"strings"
 	"testing"
 	"text/template"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -87,13 +91,11 @@ func TestSiteInitCommand_ComponentFlags(t *testing.T) {
 	require.NotNil(t, flag)
 	require.Equal(t, "false", flag.DefValue)
 
-	flag = cmd.Flags().Lookup("skip-install")
-	require.NotNil(t, flag)
-	require.Equal(t, "false", flag.DefValue)
-
-	flag = cmd.Flags().Lookup("install-timeout")
-	require.NotNil(t, flag)
-	require.Equal(t, defaultInstallTimeout.String(), flag.DefValue)
+	// site init no longer bootstraps the operator; the operator must be
+	// installed first via `kubectl unbounded install`. The install lifecycle
+	// flags were removed.
+	require.Nil(t, cmd.Flags().Lookup("skip-install"))
+	require.Nil(t, cmd.Flags().Lookup("install-timeout"))
 }
 
 func TestSiteInitCommand_ManageCniPluginFlag(t *testing.T) {
@@ -288,4 +290,113 @@ func TestSiteInitValidateClusterCIDRMessages(t *testing.T) {
 			require.EqualError(t, err, tc.wantErr)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// checkOperatorPrerequisites tests
+// ---------------------------------------------------------------------------
+
+// bufferLogger returns a slog.Logger that writes warn-level records to buf so
+// tests can assert on the operator-readiness warnings.
+func bufferLogger() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})), buf
+}
+
+// unestablishedCRD builds a CRD without the Established condition.
+func unestablishedCRD(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata":   map[string]any{"name": name},
+	}}
+}
+
+func establishedSiteCRDs() []client.Object {
+	objects := make([]client.Object, 0, len(siteRequiredCRDs))
+	for _, name := range siteRequiredCRDs {
+		objects = append(objects, establishedCRD(name))
+	}
+
+	return objects
+}
+
+func TestCheckOperatorPrerequisites_MissingCRDs(t *testing.T) {
+	cli := fakeclient.NewClientBuilder().Build()
+
+	logger, _ := bufferLogger()
+	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+
+	err := h.checkOperatorPrerequisites(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unbounded-operator is not installed")
+	require.Contains(t, err.Error(), "kubectl unbounded install")
+	require.Contains(t, err.Error(), "sites.unbounded-cloud.io")
+}
+
+func TestCheckOperatorPrerequisites_CRDsNotEstablished(t *testing.T) {
+	objects := make([]client.Object, 0, len(siteRequiredCRDs))
+	for _, name := range siteRequiredCRDs {
+		objects = append(objects, unestablishedCRD(name))
+	}
+
+	cli := fakeclient.NewClientBuilder().WithObjects(objects...).Build()
+
+	logger, _ := bufferLogger()
+	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+
+	err := h.checkOperatorPrerequisites(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not established")
+	require.Contains(t, err.Error(), "kubectl unbounded install")
+}
+
+func TestCheckOperatorPrerequisites_OperatorAbsentWarns(t *testing.T) {
+	cli := fakeclient.NewClientBuilder().WithObjects(establishedSiteCRDs()...).Build()
+
+	logger, logs := bufferLogger()
+	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+
+	// CRDs are established but the operator Deployment is absent: site init must
+	// proceed (no error) and only warn.
+	require.NoError(t, h.checkOperatorPrerequisites(context.Background()))
+	require.Contains(t, logs.String(), "unbounded-operator Deployment not found")
+}
+
+func TestCheckOperatorPrerequisites_OperatorNotRolledOutWarns(t *testing.T) {
+	objects := establishedSiteCRDs()
+	// Old pod Available while the new pod surges in: rollout is not complete.
+	objects = append(objects, operatorDeployment(appsv1.DeploymentStatus{
+		ObservedGeneration: 2,
+		Replicas:           2,
+		UpdatedReplicas:    1,
+		AvailableReplicas:  1,
+	}))
+
+	cli := fakeclient.NewClientBuilder().WithObjects(objects...).Build()
+
+	logger, logs := bufferLogger()
+	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+
+	require.NoError(t, h.checkOperatorPrerequisites(context.Background()))
+	require.Contains(t, logs.String(), "not fully rolled out")
+}
+
+func TestCheckOperatorPrerequisites_Ready(t *testing.T) {
+	objects := establishedSiteCRDs()
+	objects = append(objects, operatorDeployment(appsv1.DeploymentStatus{
+		ObservedGeneration: 2,
+		Replicas:           1,
+		UpdatedReplicas:    1,
+		AvailableReplicas:  1,
+	}))
+
+	cli := fakeclient.NewClientBuilder().WithObjects(objects...).Build()
+
+	logger, logs := bufferLogger()
+	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+
+	require.NoError(t, h.checkOperatorPrerequisites(context.Background()))
+	require.Empty(t, logs.String(), "a ready operator must not produce warnings")
 }

--- a/cmd/kubectl-unbounded/app/site_init_test.go
+++ b/cmd/kubectl-unbounded/app/site_init_test.go
@@ -6,6 +6,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -14,8 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -304,99 +309,136 @@ func bufferLogger() (*slog.Logger, *bytes.Buffer) {
 	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})), buf
 }
 
-// unestablishedCRD builds a CRD without the Established condition.
-func unestablishedCRD(name string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apiextensions.k8s.io/v1",
-		"kind":       "CustomResourceDefinition",
-		"metadata":   map[string]any{"name": name},
-	}}
-}
-
-func establishedSiteCRDs() []client.Object {
-	objects := make([]client.Object, 0, len(siteRequiredCRDs))
-	for _, name := range siteRequiredCRDs {
-		objects = append(objects, establishedCRD(name))
+// servedSiteAPIs returns the discovery resource lists for a cluster that serves
+// every API type site init applies. Individual tests drop entries to simulate an
+// operator that is not (yet) installed.
+func servedSiteAPIs() []*metav1.APIResourceList {
+	return []*metav1.APIResourceList{
+		{
+			GroupVersion: "unbounded-cloud.io/v1alpha3",
+			APIResources: []metav1.APIResource{
+				{Name: "sites", Kind: "Site"},
+			},
+		},
+		{
+			GroupVersion: "net.unbounded-cloud.io/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{Name: "gatewaypools", Kind: "GatewayPool"},
+				{Name: "sitegatewaypoolassignments", Kind: "SiteGatewayPoolAssignment"},
+			},
+		},
 	}
-
-	return objects
 }
 
-func TestCheckOperatorPrerequisites_MissingCRDs(t *testing.T) {
-	cli := fakeclient.NewClientBuilder().Build()
+// fakeClusterServing builds a fake clientset whose discovery serves the given
+// resource lists and whose objects seed the typed tracker.
+func fakeClusterServing(resources []*metav1.APIResourceList, objects ...runtime.Object) *k8sfake.Clientset {
+	cs := k8sfake.NewClientset(objects...)
+	cs.Resources = resources
+
+	return cs
+}
+
+func TestRequiredSiteAPIs(t *testing.T) {
+	gvks, err := requiredSiteAPIs()
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []schema.GroupVersionKind{
+		{Group: "unbounded-cloud.io", Version: "v1alpha3", Kind: "Site"},
+		{Group: "net.unbounded-cloud.io", Version: "v1alpha1", Kind: "GatewayPool"},
+		{Group: "net.unbounded-cloud.io", Version: "v1alpha1", Kind: "SiteGatewayPoolAssignment"},
+	}, gvks)
+}
+
+func TestCheckOperatorPrerequisites_APITypesNotServed(t *testing.T) {
+	cli := fakeClusterServing(nil)
 
 	logger, _ := bufferLogger()
-	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+	h := &siteInitHandler{kubeCli: cli, logger: logger}
 
 	err := h.checkOperatorPrerequisites(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unbounded-operator is not installed")
 	require.Contains(t, err.Error(), "kubectl unbounded install")
-	require.Contains(t, err.Error(), "sites.unbounded-cloud.io")
+	require.Contains(t, err.Error(), "Site.unbounded-cloud.io/v1alpha3")
 }
 
-func TestCheckOperatorPrerequisites_CRDsNotEstablished(t *testing.T) {
-	objects := make([]client.Object, 0, len(siteRequiredCRDs))
-	for _, name := range siteRequiredCRDs {
-		objects = append(objects, unestablishedCRD(name))
-	}
-
-	cli := fakeclient.NewClientBuilder().WithObjects(objects...).Build()
+func TestCheckOperatorPrerequisites_NetGroupNotServed(t *testing.T) {
+	// Only the machina (Site) group is served; the net types are still missing.
+	cli := fakeClusterServing([]*metav1.APIResourceList{servedSiteAPIs()[0]})
 
 	logger, _ := bufferLogger()
-	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+	h := &siteInitHandler{kubeCli: cli, logger: logger}
 
 	err := h.checkOperatorPrerequisites(context.Background())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not established")
-	require.Contains(t, err.Error(), "kubectl unbounded install")
+	require.Contains(t, err.Error(), "GatewayPool.net.unbounded-cloud.io/v1alpha1")
+	require.Contains(t, err.Error(), "SiteGatewayPoolAssignment.net.unbounded-cloud.io/v1alpha1")
+	require.NotContains(t, err.Error(), "Site.unbounded-cloud.io/v1alpha3")
 }
 
 func TestCheckOperatorPrerequisites_OperatorAbsentWarns(t *testing.T) {
-	cli := fakeclient.NewClientBuilder().WithObjects(establishedSiteCRDs()...).Build()
+	// All required types are served but the operator Deployment is absent: site
+	// init must proceed (no error) and only warn.
+	cli := fakeClusterServing(servedSiteAPIs())
 
 	logger, logs := bufferLogger()
-	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+	h := &siteInitHandler{kubeCli: cli, logger: logger}
 
-	// CRDs are established but the operator Deployment is absent: site init must
-	// proceed (no error) and only warn.
 	require.NoError(t, h.checkOperatorPrerequisites(context.Background()))
 	require.Contains(t, logs.String(), "unbounded-operator Deployment not found")
 }
 
 func TestCheckOperatorPrerequisites_OperatorNotRolledOutWarns(t *testing.T) {
-	objects := establishedSiteCRDs()
 	// Old pod Available while the new pod surges in: rollout is not complete.
-	objects = append(objects, operatorDeployment(appsv1.DeploymentStatus{
+	deploy := operatorDeployment(appsv1.DeploymentStatus{
 		ObservedGeneration: 2,
 		Replicas:           2,
 		UpdatedReplicas:    1,
 		AvailableReplicas:  1,
-	}))
-
-	cli := fakeclient.NewClientBuilder().WithObjects(objects...).Build()
+	})
+	cli := fakeClusterServing(servedSiteAPIs(), deploy)
 
 	logger, logs := bufferLogger()
-	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+	h := &siteInitHandler{kubeCli: cli, logger: logger}
 
 	require.NoError(t, h.checkOperatorPrerequisites(context.Background()))
 	require.Contains(t, logs.String(), "not fully rolled out")
 }
 
 func TestCheckOperatorPrerequisites_Ready(t *testing.T) {
-	objects := establishedSiteCRDs()
-	objects = append(objects, operatorDeployment(appsv1.DeploymentStatus{
+	deploy := operatorDeployment(appsv1.DeploymentStatus{
 		ObservedGeneration: 2,
 		Replicas:           1,
 		UpdatedReplicas:    1,
 		AvailableReplicas:  1,
-	}))
-
-	cli := fakeclient.NewClientBuilder().WithObjects(objects...).Build()
+	})
+	cli := fakeClusterServing(servedSiteAPIs(), deploy)
 
 	logger, logs := bufferLogger()
-	h := &siteInitHandler{kubeResourcesCli: cli, logger: logger}
+	h := &siteInitHandler{kubeCli: cli, logger: logger}
 
 	require.NoError(t, h.checkOperatorPrerequisites(context.Background()))
 	require.Empty(t, logs.String(), "a ready operator must not produce warnings")
+}
+
+// TestCheckOperatorPrerequisites_DeploymentForbiddenDoesNotFail proves that a
+// caller who may create Sites but cannot read Deployments is not blocked: the
+// served-API check passes and the forbidden Deployment read is downgraded to a
+// debug log (no warning, no error).
+func TestCheckOperatorPrerequisites_DeploymentForbiddenDoesNotFail(t *testing.T) {
+	cli := fakeClusterServing(servedSiteAPIs())
+	cli.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "apps", Resource: "deployments"},
+			"unbounded-operator",
+			errors.New("not allowed"),
+		)
+	})
+
+	logger, logs := bufferLogger()
+	h := &siteInitHandler{kubeCli: cli, logger: logger}
+
+	require.NoError(t, h.checkOperatorPrerequisites(context.Background()))
+	require.Empty(t, logs.String(), "a forbidden Deployment read must not warn or fail")
 }

--- a/demo/nebius-ssh/README.md
+++ b/demo/nebius-ssh/README.md
@@ -161,8 +161,7 @@ kubectl unbounded site init \
   --cluster-node-cidr <AKS_NODE_CIDR> \
   --cluster-pod-cidr <AKS_POD_CIDR> \
   --node-cidr 172.20.0.0/16 \
-  --pod-cidr 10.200.0.0/16 \
-  --skip-install
+  --pod-cidr 10.200.0.0/16
 ssh-keygen -t ed25519 -f ./unbounded_ed25519 -N ""
 ```
 

--- a/docs/content/concepts/networking.md
+++ b/docs/content/concepts/networking.md
@@ -169,9 +169,10 @@ system:
   traffic.
 
 They share the same API group prefix (`unbounded-cloud.io` / `net.unbounded-cloud.io`)
-and are designed to work together. When you run `kubectl unbounded site init`,
-it bootstraps `unbounded-operator`, creates Site resources, and lets the
-operator deploy machina and unbounded-net from `Site.spec.components`.
+and are designed to work together. After you bootstrap `unbounded-operator` with
+`kubectl unbounded install`, running `kubectl unbounded site init` creates Site
+resources and lets the operator deploy machina and unbounded-net from
+`Site.spec.components`.
 
 ## Next Steps
 

--- a/docs/content/concepts/overview.md
+++ b/docs/content/concepts/overview.md
@@ -55,8 +55,8 @@ over SSH. Given a `Machine` custom resource with SSH connection details, it:
    through its lifecycle phases.
 
 machina is deployed by `unbounded-operator` when it is enabled in
-`Site.spec.components`. `kubectl unbounded site init` bootstraps the operator by
-default.
+`Site.spec.components`. Install the operator first with
+`kubectl unbounded install`, then `kubectl unbounded site init` creates the Site.
 
 See the [SSH guide]({{< relref "guides/ssh" >}}) for a hands-on walkthrough
 and the [Architecture reference]({{< relref "reference/architecture" >}}) for
@@ -135,9 +135,9 @@ The flow varies by provisioning path, but all paths share the same final steps:
 
 **SSH path:**
 
-1. **`kubectl unbounded site init`** prepares the cluster: bootstraps
-   `unbounded-operator`, creates Site and GatewayPool resources, records enabled
-   components, and generates a bootstrap token.
+1. **`kubectl unbounded install`** bootstraps `unbounded-operator` and its CRDs,
+   then **`kubectl unbounded site init`** creates Site and GatewayPool resources,
+   records enabled components, and generates a bootstrap token.
 2. **`kubectl unbounded machine register`** creates a `Machine` resource with
    SSH connection details.
 3. **machina** SSHs into the host, runs the install script, and waits for the

--- a/docs/content/guides/existing-cluster.md
+++ b/docs/content/guides/existing-cluster.md
@@ -15,7 +15,7 @@ You'll label gateway nodes, initialize a site, and join remote machines.
 
 1. **[Install the prerequisites](#1-install-the-prerequisites)** -- kubectl and the unbounded plugin
 2. **[Prepare gateway nodes](#2-prepare-gateway-nodes)** -- label and open WireGuard ports
-3. **[Initialize a site](#3-initialize-a-site)** -- bootstrap the operator and create site resources
+3. **[Initialize a site](#3-initialize-a-site)** -- install the operator and create site resources
 4. **[Add machines](#4-add-machines)** -- register remote hosts for SSH provisioning
 5. **[Watch progress](#5-watch-progress)** -- monitor the provisioning lifecycle
 
@@ -75,11 +75,18 @@ kubectl label node <node-name> "unbounded-cloud.io/unbounded-net-gateway=true"
 
 ## 3. Initialize a Site
 
+First, bootstrap `unbounded-operator` on the cluster. This installs the CRDs and
+the operator that reconciles Unbounded components:
+
+```bash
+kubectl unbounded install
+```
+
 A **Site** represents a remote location where machines will run. The `site init`
-command bootstraps `unbounded-operator`, creates site resources, records the
-requested components in `Site.spec.components`, and generates a bootstrap token.
-The operator deploys unbounded-net, machina, and optional components from the
-Site specs.
+command requires the operator to already be installed (it errors otherwise). It
+creates site resources, records the requested components in
+`Site.spec.components`, and generates a bootstrap token. The operator deploys
+unbounded-net, machina, and optional components from the Site specs.
 
 ```bash
 kubectl unbounded site init \
@@ -108,7 +115,6 @@ kubectl unbounded site init \
 | `--enable-machina` | Enable machina on the cluster Site (default: `true`) |
 | `--enable-metalman` | Enable the metalman component in the Site spec |
 | `--enable-storage` | Enable the unbounded-storage component in the Site spec |
-| `--skip-install` | Skip operator bootstrap if you already ran `kubectl unbounded install` or applied the operator manifests |
 
 </details>
 

--- a/docs/content/guides/getting-started.md
+++ b/docs/content/guides/getting-started.md
@@ -75,9 +75,10 @@ chmod +x aks-quickstart.sh
     --remote-pod-cidr 10.245.0.0/16
 ```
 
-> The script creates an AKS cluster, adds a gateway node pool, and runs
-> `kubectl unbounded site init` to bootstrap the operator and request the
-> networking stack through the cluster Site.
+> The script creates an AKS cluster, adds a gateway node pool, runs
+> `kubectl unbounded install` to bootstrap the operator, then
+> `kubectl unbounded site init` to request the networking stack through the
+> cluster Site.
 
 | Flag | Description |
 |------|-------------|
@@ -197,6 +198,7 @@ WireGuard tunnels.
 ## What the Script Creates
 
 The quickstart script automates AKS infrastructure setup and then delegates to
+[`kubectl unbounded install`]({{< relref "reference/cli" >}}) and
 [`kubectl unbounded site init`]({{< relref "reference/cli" >}}) for the
 Kubernetes-level configuration. Here's what each piece does.
 

--- a/docs/content/guides/l3-connectivity.md
+++ b/docs/content/guides/l3-connectivity.md
@@ -337,10 +337,14 @@ kubectl get nodes -l unbounded-cloud.io/unbounded-net-gateway=true
 
 ## 6. Initialize the Site
 
-Run `kubectl unbounded site init` to bootstrap the operator and create site
-resources. The CIDRs must match the networks reachable over the VPN:
+Install `unbounded-operator` (if you haven't already), then run
+`kubectl unbounded site init` to create the site resources. `site init` requires
+the operator to be installed and errors otherwise. The CIDRs must match the
+networks reachable over the VPN:
 
 ```bash
+kubectl unbounded install
+
 kubectl unbounded site init \
     --name ubiquiti-site \
     --cluster-node-cidr 10.224.0.0/16 \

--- a/docs/content/guides/pxe.md
+++ b/docs/content/guides/pxe.md
@@ -35,10 +35,11 @@ setting the metalman entry in `Site.spec.components`:
 kubectl unbounded site init --name my-edge-site --enable-metalman
 ```
 
-`kubectl unbounded site init` also runs `install` by default, so a fresh site only
-needs the single command above. The operator then reconciles the `unbounded-system`
-namespace, ServiceAccounts (`metalman-controller`, `metalman-bootstrap`), RBAC roles,
-and a metalman Deployment for the Site.
+`kubectl unbounded site init` requires the operator to be installed first (the
+`kubectl unbounded install` step above), and errors otherwise. The operator then
+reconciles the `unbounded-system` namespace, ServiceAccounts
+(`metalman-controller`, `metalman-bootstrap`), RBAC roles, and a metalman
+Deployment for the Site.
 
 Key `serve-pxe` flags (baked into the operator-managed per-site Deployment; `--site`
 scoping is inherent to the per-site component):

--- a/docs/content/guides/ssh.md
+++ b/docs/content/guides/ssh.md
@@ -24,10 +24,16 @@ resulting Node.
 
 ## Cluster Setup
 
-Run `kubectl unbounded site init` to prepare the cluster and create a new site.
-This single command handles:
+First, bootstrap the Unbounded CRDs and `unbounded-operator`:
 
-- Bootstrapping the Unbounded CRDs and `unbounded-operator`
+```bash
+kubectl unbounded install
+```
+
+Then run `kubectl unbounded site init` to create a new site. It requires the
+operator to be installed (from the step above) and errors otherwise. This
+command handles:
+
 - Creating site resources for both the cluster and the new site
 - Recording requested components in `Site.spec.components`
 - Creating a **bootstrap token** Secret in `kube-system` (labeled `unbounded-cloud.io/site=<name>`)
@@ -51,7 +57,6 @@ All five flags above are required. Optional flags:
 | `--enable-machina` | Enable machina on the cluster Site (default: `true`) |
 | `--enable-metalman` | Enable the metalman component in the Site spec |
 | `--enable-storage` | Enable the unbounded-storage component in the Site spec |
-| `--skip-install` | Skip operator bootstrap if you already ran `kubectl unbounded install` or applied the operator manifests |
 
 ## Creating Machines
 

--- a/docs/content/reference/architecture.md
+++ b/docs/content/reference/architecture.md
@@ -70,7 +70,7 @@ Binary `cmd/kubectl-unbounded`. Provides subcommands:
 | Subcommand         | Purpose |
 |--------------------|---------|
 | `install`          | Bootstraps CRDs and `unbounded-operator`; component workloads are reconciled from `Site.spec.components`. |
-| `site init`        | Initializes a new site by bootstrapping Unbounded when needed, creating site resources, and creating the bootstrap token. |
+| `site init`        | Initializes a new site (requires `unbounded-operator` to be installed first): creates site resources and the bootstrap token. |
 | `machine register`   | Registers a machine to a site, creating a `Machine` CR with auto-discovery of SSH secrets and bootstrap tokens. |
 
 ### inventory -- Hardware Collector

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -86,10 +86,18 @@ compiled version.
 Initialize a new Unbounded site. This command:
 
 1. Validates inputs and kubeconfig access.
-2. Bootstraps CRDs and `unbounded-operator` unless `--skip-install` is set.
+2. Verifies `unbounded-operator` is installed: the required CRDs
+   (`sites.unbounded-cloud.io`, `gatewaypools.net.unbounded-cloud.io`,
+   `sitegatewaypoolassignments.net.unbounded-cloud.io`) must be established.
 3. Creates a cluster `Site`, a remote `Site`, and related net `GatewayPool` resources.
 4. Records component choices in `Site.spec.components` for `unbounded-operator`.
 5. Creates a bootstrap token for the remote site.
+
+> **Prerequisite:** `site init` no longer bootstraps `unbounded-operator`. Run
+> [`kubectl unbounded install`](#kubectl-unbounded-install) first. If the operator
+> CRDs are not present, `site init` fails with guidance to run `install`. If the
+> CRDs exist but the operator Deployment is missing or not yet rolled out,
+> `site init` warns and proceeds (the operator reconciles the Site once ready).
 
 Global components (`unbounded-net`, `machina`, and `unbounded-storage`) are
 enabled on the cluster Site. `metalman` is per-site and is enabled on the remote
@@ -114,17 +122,23 @@ Site when `--enable-metalman` is set.
 | `--enable-machina` | `bool` | `true` | Enable machina in `Site.spec.components` |
 | `--enable-metalman` | `bool` | `false` | Enable metalman in `Site.spec.components` |
 | `--enable-storage` | `bool` | `false` | Enable unbounded-storage in `Site.spec.components` |
-| `--skip-install` | `bool` | `false` | Skip bootstrapping CRDs and `unbounded-operator` |
-| `--install-timeout` | `duration` | `5m0s` | Timeout while waiting for operator bootstrap |
+
+> **Breaking change:** the `--skip-install` and `--install-timeout` flags have
+> been removed. `site init` no longer installs the operator, so there is nothing
+> to skip or time out. Run `kubectl unbounded install` first. Automation passing
+> `--skip-install` must drop it.
 
 #### Validation
 
 - All CIDR values must be valid IPv4 CIDR notation.
 - The kubeconfig must be readable.
+- `unbounded-operator` must be installed (its CRDs must be established).
 
 #### Example
 
 ```bash
+kubectl unbounded install
+
 kubectl unbounded site init \
   --name my-edge-site \
   --cluster-node-cidr 10.224.0.0/16 \

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -86,18 +86,20 @@ compiled version.
 Initialize a new Unbounded site. This command:
 
 1. Validates inputs and kubeconfig access.
-2. Verifies `unbounded-operator` is installed: the required CRDs
-   (`sites.unbounded-cloud.io`, `gatewaypools.net.unbounded-cloud.io`,
-   `sitegatewaypoolassignments.net.unbounded-cloud.io`) must be established.
+2. Verifies `unbounded-operator` is installed: the cluster must serve the API
+   types `site init` applies (`Site` in `unbounded-cloud.io/v1alpha3`;
+   `GatewayPool` and `SiteGatewayPoolAssignment` in
+   `net.unbounded-cloud.io/v1alpha1`). This is checked via API discovery.
 3. Creates a cluster `Site`, a remote `Site`, and related net `GatewayPool` resources.
 4. Records component choices in `Site.spec.components` for `unbounded-operator`.
 5. Creates a bootstrap token for the remote site.
 
 > **Prerequisite:** `site init` no longer bootstraps `unbounded-operator`. Run
-> [`kubectl unbounded install`](#kubectl-unbounded-install) first. If the operator
-> CRDs are not present, `site init` fails with guidance to run `install`. If the
-> CRDs exist but the operator Deployment is missing or not yet rolled out,
-> `site init` warns and proceeds (the operator reconciles the Site once ready).
+> [`kubectl unbounded install`](#kubectl-unbounded-install) first. If the cluster
+> is not serving the required API types, `site init` fails with guidance to run
+> `install`. If those types are served but the operator Deployment is missing or
+> not yet rolled out, `site init` warns and proceeds (the operator reconciles the
+> Site once ready).
 
 Global components (`unbounded-net`, `machina`, and `unbounded-storage`) are
 enabled on the cluster Site. `metalman` is per-site and is enabled on the remote
@@ -132,7 +134,7 @@ Site when `--enable-metalman` is set.
 
 - All CIDR values must be valid IPv4 CIDR notation.
 - The kubeconfig must be readable.
-- `unbounded-operator` must be installed (its CRDs must be established).
+- `unbounded-operator` must be installed (the cluster must serve the required API types).
 
 #### Example
 

--- a/docs/content/reference/networking/operations.md
+++ b/docs/content/reference/networking/operations.md
@@ -43,9 +43,9 @@ wg --version
    `kubectl label node <name> net.unbounded-cloud.io/gateway=true`
 6. **Verify Connectivity**: Test with pod-to-pod ping across sites.
 
-> **Note:** `kubectl unbounded site init` runs the bootstrap step by default,
-> creates the initial Site and gateway resources, and lets the operator deploy
-> controller and node workloads. See the
+> **Note:** After `kubectl unbounded install` bootstraps the operator,
+> `kubectl unbounded site init` creates the initial Site and gateway resources
+> (steps 2-4) and lets the operator deploy controller and node workloads. See the
 > [Getting Started guide]({{< relref "guides/getting-started" >}}).
 
 ---

--- a/hack/scripts/aks-quickstart.sh
+++ b/hack/scripts/aks-quickstart.sh
@@ -451,13 +451,18 @@ do_site_init() {
   local remote_node_cidr="$5"
   local remote_pod_cidr="$6"
 
-  log "Running kubectl unbounded site init..."
-
   local ctx_args=()
   if [[ ${#KUBECTL_CTX_ARGS[@]} -gt 0 ]]; then
     ctx_args=("${KUBECTL_CTX_ARGS[@]}")
   fi
 
+  # site init no longer bootstraps the unbounded-operator; it requires the
+  # operator (and its CRDs) to already be installed and errors otherwise. Run
+  # install first so the operator is present before creating Site resources.
+  log "Running kubectl unbounded install..."
+  kubectl "${ctx_args[@]}" unbounded install
+
+  log "Running kubectl unbounded site init..."
   kubectl "${ctx_args[@]}" unbounded site init \
     --name "$site_name" \
     --cluster-node-cidr "$cluster_node_cidr" \
@@ -642,7 +647,8 @@ cmd_create() {
   # Step 6: Detect cluster CIDRs.
   detect_cluster_cidrs
 
-  # Step 7: Run site init (installs CNI, creates site resources, deploys machina).
+  # Step 7: Install the operator, then run site init (creates site resources,
+  # deploys machina). do_site_init runs `kubectl unbounded install` first.
   do_site_init "$site_name" "$CLUSTER_NODE_CIDR" "$CLUSTER_POD_CIDR" "$CLUSTER_SERVICE_CIDR" "$remote_node_cidr" "$remote_pod_cidr"
 }
 
@@ -733,7 +739,8 @@ cmd_setup() {
   # Step 5: Detect cluster CIDRs.
   detect_cluster_cidrs
 
-  # Step 6: Run site init (installs CNI, creates site resources, deploys machina).
+  # Step 6: Install the operator, then run site init (creates site resources,
+  # deploys machina). do_site_init runs `kubectl unbounded install` first.
   do_site_init "$site_name" "$CLUSTER_NODE_CIDR" "$CLUSTER_POD_CIDR" "$CLUSTER_SERVICE_CIDR" "$remote_node_cidr" "$remote_pod_cidr"
 }
 

--- a/hack/scripts/get-aks-cluster-cidrs.sh
+++ b/hack/scripts/get-aks-cluster-cidrs.sh
@@ -232,6 +232,10 @@ echo
 echo "Run the following to initialize an unbounded site."
 echo "Edit <SITE-NAME>, <REMOTE-NODE-CIDR>, and <REMOTE-POD-CIDR> before running:"
 echo
+echo "  # Bootstrap the unbounded-operator first; 'site init' requires it and"
+echo "  # errors if it is not installed."
+echo "  kubectl unbounded install"
+echo
 echo "  kubectl unbounded site init \\"
 echo "    --name <SITE-NAME> \\"
 printf "    --cluster-node-cidr    %-20s\\\\\n" "$NODE_CIDR"


### PR DESCRIPTION
## Problem

`kubectl unbounded site init` implicitly bootstrapped `unbounded-operator` (unless `--skip-install` was passed) before creating Site resources. This coupling was introduced during the operator integration (#388), which folded operator lifecycle into the "create a site" command.

That side effect became actively harmful once #576 changed the operator's component registry to derive from the binary's embedded manifests instead of preserving the cluster's stored value. On a cluster whose operator had been customized, for example:

```
kubectl unbounded install \
  --operator-image registry.corp/unbounded-operator:v1 \
  --image-registry registry.corp/unbounded
```

a later flagless `site init` silently reinstalled the operator, **repointing both the operator Deployment image and `UNBOUNDED_IMAGE_REGISTRY` back to the stock `ghcr.io/azure` values**. The consequences:

- **Air-gapped / private clusters:** `ImagePullBackOff` after the registry is rewritten to an unreachable upstream.
- **Fork / mirror installs:** silently running upstream binaries where `ghcr.io` is reachable, a version-lockstep violation.
- **Surprising blast radius:** a site-creation command mutating cluster-wide operator configuration.

This is a regression: before the operator work, `site init` created site resources and did not perform operator lifecycle. #388 introduced the implicit install, and #576 turned it into a silent reconfiguration.

## Solution

`site init` no longer installs, upgrades, or reconfigures the operator. Operator bootstrap is now solely the responsibility of `kubectl unbounded install`. `site init` focuses on what it is named for: creating the cluster/remote `Site`, the net `GatewayPool` resources, and the bootstrap token.

The `--skip-install` and `--install-timeout` flags are removed, since there is no longer an install step to skip or wait on. Callers and docs are updated for the two-step `install` -> `site init` flow.

## Safeguards

Because the operator now must be installed first, `site init` preflights the cluster before touching anything and fails loudly with actionable guidance instead of producing a cryptic apply error deep in the run.

The preflight uses **API discovery** to confirm the apiserver actually serves the GroupVersionKinds `site init` is about to apply:

- `Site` in `unbounded-cloud.io/v1alpha3`
- `GatewayPool` and `SiteGatewayPoolAssignment` in `net.unbounded-cloud.io/v1alpha1`

Design choices that make the preflight robust:

- **Derived from the manifests, not hard-coded.** The required GroupVersionKinds are extracted from the embedded Site manifest templates, so the check automatically tracks future API version bumps (it always checks exactly what `site init` will apply).
- **Discovery, not CRD reads.** Discovery does not require cluster-scoped `customresourcedefinitions` read permission, so a caller who may create Sites but cannot read CRDs is not blocked. It also reflects the versions the apiserver actually serves, rather than merely that a CRD is `Established` (an Established CRD that does not serve the required version would otherwise pass and then fail the apply).
- **Hard error vs. warning.** A type that is not served is a hard error guiding the user to run `kubectl unbounded install` first. A missing or not-yet-ready operator Deployment is only a warning (the operator reconciles the Site once ready); a forbidden Deployment read is downgraded to a debug log so limited callers are neither blocked nor alarmed.

The net guarantee: a customized operator can never be repointed or downgraded by `site init`, and a fresh cluster gets a clear "install first" message rather than a confusing failure.

Closes #578.