### PR TITLE
kubectl: route command output through an injected writer

### DIFF
--- a/cmd/kubectl-unbounded/app/config_assign.go
+++ b/cmd/kubectl-unbounded/app/config_assign.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 	"k8s.io/utils/ptr"
@@ -46,7 +47,7 @@ Example:
 				versionPtr = ptr.To(version)
 			}
 
-			return runConfigAssign(ctx, c, configName, args[0], versionPtr)
+			return runConfigAssign(ctx, c, configName, args[0], versionPtr, cmd.OutOrStdout())
 		},
 	}
 
@@ -57,7 +58,7 @@ Example:
 	return cmd
 }
 
-func runConfigAssign(ctx context.Context, c client.WithWatch, configName, machineName string, version *int32) error {
+func runConfigAssign(ctx context.Context, c client.WithWatch, configName, machineName string, version *int32, out io.Writer) error {
 	// Verify the MachineConfiguration exists.
 	mc := &v1alpha3.MachineConfiguration{}
 	if err := c.Get(ctx, client.ObjectKey{Name: configName}, mc); err != nil {
@@ -90,16 +91,16 @@ func runConfigAssign(ctx context.Context, c client.WithWatch, configName, machin
 		return fmt.Errorf("updating Machine: %w", err)
 	}
 
-	printStep(fmt.Sprintf("Assigned %s to Machine %s", configName, machineName))
-	printConfig("configuration", configName)
+	printStep(out, fmt.Sprintf("Assigned %s to Machine %s", configName, machineName))
+	printConfig(out, "configuration", configName)
 
 	if version != nil {
-		printConfig("version", fmt.Sprintf("%d", *version))
+		printConfig(out, "version", fmt.Sprintf("%d", *version))
 	} else {
-		printConfig("version", "(controller will select latest)")
+		printConfig(out, "version", "(controller will select latest)")
 	}
 
-	fmt.Println()
+	fprintln(out)
 
 	return nil
 }

--- a/cmd/kubectl-unbounded/app/config_create.go
+++ b/cmd/kubectl-unbounded/app/config_create.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +57,7 @@ Example:
 				taints:            taints,
 				updateStrategy:    updateStrategy,
 				priority:          priority,
-			})
+			}, cmd.OutOrStdout())
 		},
 	}
 
@@ -79,7 +80,7 @@ type configCreateOpts struct {
 	priority          int32
 }
 
-func runConfigCreate(ctx context.Context, c client.WithWatch, name string, opts configCreateOpts) error {
+func runConfigCreate(ctx context.Context, c client.WithWatch, name string, opts configCreateOpts, out io.Writer) error {
 	mc := &v1alpha3.MachineConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -127,29 +128,29 @@ func runConfigCreate(ctx context.Context, c client.WithWatch, name string, opts 
 		return fmt.Errorf("creating MachineConfiguration: %w", err)
 	}
 
-	printStep(fmt.Sprintf("Created MachineConfiguration %s", name))
+	printStep(out, fmt.Sprintf("Created MachineConfiguration %s", name))
 
 	if opts.kubernetesVersion != "" {
-		printConfig("kubernetes", opts.kubernetesVersion)
+		printConfig(out, "kubernetes", opts.kubernetesVersion)
 	}
 
 	if opts.agentImage != "" {
-		printConfig("agent-image", opts.agentImage)
+		printConfig(out, "agent-image", opts.agentImage)
 	}
 
 	if len(opts.nodeLabels) > 0 {
-		printConfig("node-labels", strings.Join(opts.nodeLabels, ", "))
+		printConfig(out, "node-labels", strings.Join(opts.nodeLabels, ", "))
 	}
 
 	if len(opts.taints) > 0 {
-		printConfig("taints", strings.Join(opts.taints, ", "))
+		printConfig(out, "taints", strings.Join(opts.taints, ", "))
 	}
 
-	printConfig("update-strategy", opts.updateStrategy)
-	fmt.Println()
+	printConfig(out, "update-strategy", opts.updateStrategy)
+	fprintln(out)
 
-	printStep("MachineConfigurationVersion v1 will be created by the controller")
-	fmt.Println()
+	printStep(out, "MachineConfigurationVersion v1 will be created by the controller")
+	fprintln(out)
 
 	return nil
 }

--- a/cmd/kubectl-unbounded/app/config_get.go
+++ b/cmd/kubectl-unbounded/app/config_get.go
@@ -6,7 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -39,24 +39,24 @@ Example:
 			}
 
 			if len(args) == 1 {
-				return runConfigGetOne(ctx, c, args[0])
+				return runConfigGetOne(ctx, c, args[0], cmd.OutOrStdout())
 			}
 
-			return runConfigGetAll(ctx, c)
+			return runConfigGetAll(ctx, c, cmd.OutOrStdout())
 		},
 	}
 
 	return cmd
 }
 
-func runConfigGetAll(ctx context.Context, c client.WithWatch) error {
+func runConfigGetAll(ctx context.Context, c client.WithWatch, out io.Writer) error {
 	var list v1alpha3.MachineConfigurationList
 	if err := c.List(ctx, &list); err != nil {
 		return fmt.Errorf("listing MachineConfigurations: %w", err)
 	}
 
 	if len(list.Items) == 0 {
-		fmt.Println("No MachineConfigurations found")
+		fprintln(out, "No MachineConfigurations found")
 		return nil
 	}
 
@@ -83,45 +83,45 @@ func runConfigGetAll(ctx context.Context, c client.WithWatch) error {
 		}})
 	}
 
-	return printers.NewTablePrinter(printers.PrintOptions{}).PrintObj(table, os.Stdout)
+	return printers.NewTablePrinter(printers.PrintOptions{}).PrintObj(table, out)
 }
 
-func runConfigGetOne(ctx context.Context, c client.WithWatch, name string) error {
+func runConfigGetOne(ctx context.Context, c client.WithWatch, name string, out io.Writer) error {
 	mc := &v1alpha3.MachineConfiguration{}
 	if err := c.Get(ctx, client.ObjectKey{Name: name}, mc); err != nil {
 		return fmt.Errorf("getting MachineConfiguration: %w", err)
 	}
 
-	printStep(fmt.Sprintf("MachineConfiguration: %s", mc.Name))
-	printConfig("latest-version", fmt.Sprintf("%d", mc.Status.LatestVersion))
-	printConfig("current-version", fmt.Sprintf("%d", mc.Status.CurrentVersion))
-	printConfig("update-strategy", string(mc.Spec.UpdateStrategy.Type))
-	printConfig("priority", fmt.Sprintf("%d", mc.Spec.Priority))
+	printStep(out, fmt.Sprintf("MachineConfiguration: %s", mc.Name))
+	printConfig(out, "latest-version", fmt.Sprintf("%d", mc.Status.LatestVersion))
+	printConfig(out, "current-version", fmt.Sprintf("%d", mc.Status.CurrentVersion))
+	printConfig(out, "update-strategy", string(mc.Spec.UpdateStrategy.Type))
+	printConfig(out, "priority", fmt.Sprintf("%d", mc.Spec.Priority))
 
 	if mc.Spec.Template.Kubernetes != nil {
 		k := mc.Spec.Template.Kubernetes
 		if k.Version != "" {
-			printConfig("k8s-version", k.Version)
+			printConfig(out, "k8s-version", k.Version)
 		}
 
 		if len(k.NodeLabels) > 0 {
 			for lk, lv := range k.NodeLabels {
-				printConfig("node-label", fmt.Sprintf("%s=%s", lk, lv))
+				printConfig(out, "node-label", fmt.Sprintf("%s=%s", lk, lv))
 			}
 		}
 
 		if len(k.RegisterWithTaints) > 0 {
 			for _, t := range k.RegisterWithTaints {
-				printConfig("taint", formatTaint(t))
+				printConfig(out, "taint", formatTaint(t))
 			}
 		}
 	}
 
 	if mc.Spec.Template.Agent != nil {
-		printConfig("agent-image", mc.Spec.Template.Agent.Image)
+		printConfig(out, "agent-image", mc.Spec.Template.Agent.Image)
 	}
 
-	fmt.Println()
+	fprintln(out)
 
 	return nil
 }

--- a/cmd/kubectl-unbounded/app/config_versions.go
+++ b/cmd/kubectl-unbounded/app/config_versions.go
@@ -6,7 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -37,14 +37,14 @@ Example:
 				return err
 			}
 
-			return runConfigVersions(ctx, c, args[0])
+			return runConfigVersions(ctx, c, args[0], cmd.OutOrStdout())
 		},
 	}
 
 	return cmd
 }
 
-func runConfigVersions(ctx context.Context, c client.WithWatch, name string) error {
+func runConfigVersions(ctx context.Context, c client.WithWatch, name string, out io.Writer) error {
 	var list v1alpha3.MachineConfigurationVersionList
 	if err := c.List(ctx, &list,
 		client.MatchingLabels{v1alpha3.MCVConfigurationLabelKey: name},
@@ -53,7 +53,7 @@ func runConfigVersions(ctx context.Context, c client.WithWatch, name string) err
 	}
 
 	if len(list.Items) == 0 {
-		fmt.Printf("No MachineConfigurationVersions found for %s\n", name)
+		fprintf(out, "No MachineConfigurationVersions found for %s\n", name)
 		return nil
 	}
 
@@ -96,5 +96,5 @@ func runConfigVersions(ctx context.Context, c client.WithWatch, name string) err
 		}})
 	}
 
-	return printers.NewTablePrinter(printers.PrintOptions{}).PrintObj(table, os.Stdout)
+	return printers.NewTablePrinter(printers.PrintOptions{}).PrintObj(table, out)
 }

--- a/cmd/kubectl-unbounded/app/machine_hard_reboot.go
+++ b/cmd/kubectl-unbounded/app/machine_hard_reboot.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ operation and updates MachineOperation status to "Complete" or "Failed".`,
 				return err
 			}
 
-			return runHardReboot(ctx, c, args[0], ttl)
+			return runHardReboot(ctx, c, args[0], ttl, cmd.OutOrStdout())
 		},
 	}
 
@@ -43,16 +44,16 @@ operation and updates MachineOperation status to "Complete" or "Failed".`,
 	return cmd
 }
 
-func runHardReboot(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32) error {
+func runHardReboot(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32, out io.Writer) error {
 	opName := fmt.Sprintf("%s-hard-reboot-%d", name, time.Now().Unix())
 
 	if err := createMachineOperation(ctx, c, name, opName, v1alpha3.OperationHostReboot, ttlSeconds); err != nil {
 		return err
 	}
 
-	printStep(fmt.Sprintf("Hard-rebooting Machine %s...", name))
-	printConfig("operation", opName)
-	fmt.Println()
+	printStep(out, fmt.Sprintf("Hard-rebooting Machine %s...", name))
+	printConfig(out, "operation", opName)
+	fprintln(out)
 
-	return watchMachineOperation(ctx, c, opName)
+	return watchMachineOperation(ctx, c, opName, out)
 }

--- a/cmd/kubectl-unbounded/app/machine_operation_create.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_create.go
@@ -181,7 +181,7 @@ func (o *machineOperationCreateOptions) runWithClient(ctx context.Context, c cli
 	waitCtx, cancel := contextWithOptionalTimeout(ctx, o.timeout)
 	defer cancel()
 
-	return waitForMachineOperation(waitCtx, c, op.Name)
+	return waitForMachineOperation(waitCtx, c, op.Name, o.out)
 }
 
 func (o *machineOperationCreateOptions) validate() error {

--- a/cmd/kubectl-unbounded/app/machine_operation_e2e_test.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_e2e_test.go
@@ -117,18 +117,15 @@ func TestMachineOperationCommandsEndToEnd(t *testing.T) {
 		require.Equal(t, "worker-01", op.OwnerReferences[0].Name)
 	})
 
-	replaceStdout := captureStdout(t, func() {
-		out, err = executeKubectlUnboundedMachineCommand(
-			ctx, rt,
-			"machine", "replace", "worker-01",
-			"--force",
-			"--operation-name", "replace-worker-01",
-			"--wait=false",
-		)
-	})
+	out, err = executeKubectlUnboundedMachineCommand(
+		ctx, rt,
+		"machine", "replace", "worker-01",
+		"--force",
+		"--operation-name", "replace-worker-01",
+		"--wait=false",
+	)
 	require.NoError(t, err)
-	require.Empty(t, out)
-	require.Contains(t, replaceStdout, "Replacing Machine worker-01")
+	require.Contains(t, out, "Replacing Machine worker-01")
 	assertMachineOperation(t, ctx, c, "replace-worker-01", func(op v1alpha3.MachineOperation) {
 		require.Equal(t, "worker-01", op.Spec.MachineRef)
 		require.Equal(t, v1alpha3.OperationHostReplace, op.Spec.OperationKind)
@@ -136,17 +133,12 @@ func TestMachineOperationCommandsEndToEnd(t *testing.T) {
 		require.Equal(t, "worker-01", op.OwnerReferences[0].Name)
 	})
 
-	var waitOut string
-
-	stdout := captureStdout(t, func() {
-		waitOut, err = executeKubectlUnboundedMachineCommand(
-			ctx, rt,
-			"machine", "operation", "wait", "wait-complete",
-		)
-	})
+	out, err = executeKubectlUnboundedMachineCommand(
+		ctx, rt,
+		"machine", "operation", "wait", "wait-complete",
+	)
 	require.NoError(t, err)
-	require.Empty(t, waitOut)
-	require.Contains(t, strings.TrimSpace(stdout), "ready")
+	require.Contains(t, strings.TrimSpace(out), "ready")
 }
 
 func newMachineOperationE2ERuntime(c client.WithWatch) *machineCommandRuntime {

--- a/cmd/kubectl-unbounded/app/machine_operation_test.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -350,7 +351,7 @@ func TestWatchMachineOperationUsesResourceVersion(t *testing.T) {
 
 	c := &recordingWatchClient{}
 
-	err := watchMachineOperationFromResourceVersion(context.Background(), c, "op-1", "12345")
+	err := watchMachineOperationFromResourceVersion(context.Background(), c, "op-1", "12345", io.Discard)
 	require.Error(t, err)
 	require.Equal(t, "12345", c.resourceVersion)
 	require.Equal(t, "metadata.name=op-1", c.fieldSelector)

--- a/cmd/kubectl-unbounded/app/machine_operation_wait.go
+++ b/cmd/kubectl-unbounded/app/machine_operation_wait.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -35,7 +36,7 @@ func newMachineOperationWaitCommand(rt *machineCommandRuntime) *cobra.Command {
 				return err
 			}
 
-			return waitForMachineOperation(ctx, c, args[0])
+			return waitForMachineOperation(ctx, c, args[0], cmd.OutOrStdout())
 		},
 	}
 
@@ -45,16 +46,16 @@ func newMachineOperationWaitCommand(rt *machineCommandRuntime) *cobra.Command {
 	return cmd
 }
 
-func waitForMachineOperation(ctx context.Context, c client.WithWatch, opName string) error {
-	return watchMachineOperation(ctx, c, opName)
+func waitForMachineOperation(ctx context.Context, c client.WithWatch, opName string, out io.Writer) error {
+	return watchMachineOperation(ctx, c, opName, out)
 }
 
-func finishMachineOperationWait(op *v1alpha3.MachineOperation) error {
+func finishMachineOperationWait(op *v1alpha3.MachineOperation, out io.Writer) error {
 	if op.Status.Phase == v1alpha3.OperationPhaseFailed {
 		return fmt.Errorf("operation failed: %s", op.Status.Message)
 	}
 
-	printReady()
+	printReady(out)
 
 	return nil
 }

--- a/cmd/kubectl-unbounded/app/machine_ops.go
+++ b/cmd/kubectl-unbounded/app/machine_ops.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -36,16 +37,27 @@ func buildScheme() *runtime.Scheme {
 	return s
 }
 
-func printStep(msg string) {
-	fmt.Printf("  %s-->%s %s\n", cyan, reset, msg)
+// fprintf and fprintln write best-effort styled/terminal output. A failed write
+// to the command's output stream is not actionable, so the error is intentionally
+// ignored here (centralizing the errcheck exception).
+func fprintf(out io.Writer, format string, args ...any) {
+	fmt.Fprintf(out, format, args...) //nolint:errcheck // best-effort terminal output
 }
 
-func printConfig(key, value string) {
-	fmt.Printf("  %s%-18s%s %s\n", dim, key, reset, value)
+func fprintln(out io.Writer, args ...any) {
+	fmt.Fprintln(out, args...) //nolint:errcheck // best-effort terminal output
 }
 
-func printReady() {
-	fmt.Printf("\n  %s%sready%s\n\n", green, bold, reset)
+func printStep(out io.Writer, msg string) {
+	fprintf(out, "  %s-->%s %s\n", cyan, reset, msg)
+}
+
+func printConfig(out io.Writer, key, value string) {
+	fprintf(out, "  %s%-18s%s %s\n", dim, key, reset, value)
+}
+
+func printReady(out io.Writer) {
+	fprintf(out, "\n  %s%sready%s\n\n", green, bold, reset)
 }
 
 type conditionState struct {
@@ -69,7 +81,7 @@ func conditionChanged(cond metav1.Condition, seen map[string]conditionState) boo
 	return true
 }
 
-func reportConditionTransitions(conditions []metav1.Condition, seen map[string]conditionState) {
+func reportConditionTransitions(out io.Writer, conditions []metav1.Condition, seen map[string]conditionState) {
 	ordered := append([]metav1.Condition(nil), conditions...)
 	sort.SliceStable(ordered, func(i, j int) bool {
 		return ordered[i].Type < ordered[j].Type
@@ -84,7 +96,7 @@ func reportConditionTransitions(conditions []metav1.Condition, seen map[string]c
 			continue
 		}
 
-		printStep(conditionStepText(cond))
+		printStep(out, conditionStepText(cond))
 	}
 }
 

--- a/cmd/kubectl-unbounded/app/machine_ops_test.go
+++ b/cmd/kubectl-unbounded/app/machine_ops_test.go
@@ -4,8 +4,7 @@
 package app
 
 import (
-	"io"
-	"os"
+	"bytes"
 	"strings"
 	"testing"
 
@@ -16,6 +15,8 @@ import (
 )
 
 func TestReportConditionTransitions(t *testing.T) {
+	t.Parallel()
+
 	seen := map[string]conditionState{}
 	cond := metav1.Condition{
 		Type:    v1alpha3.MachineOperationConditionCloudInitDone,
@@ -24,25 +25,28 @@ func TestReportConditionTransitions(t *testing.T) {
 		Message: "Machine machine-1 started first-boot cloud-init",
 	}
 
-	out := captureStdout(t, func() {
-		reportConditionTransitions([]metav1.Condition{cond}, seen)
-		reportConditionTransitions([]metav1.Condition{cond}, seen)
+	var buf bytes.Buffer
 
-		cond.Message = "Machine machine-1 is still running first-boot cloud-init"
-		reportConditionTransitions([]metav1.Condition{cond}, seen)
+	reportConditionTransitions(&buf, []metav1.Condition{cond}, seen)
+	reportConditionTransitions(&buf, []metav1.Condition{cond}, seen)
 
-		cond.Status = metav1.ConditionTrue
-		cond.Reason = "Succeeded"
-		cond.Message = "Machine machine-1 completed first-boot cloud-init successfully"
-		reportConditionTransitions([]metav1.Condition{cond}, seen)
-	})
+	cond.Message = "Machine machine-1 is still running first-boot cloud-init"
+	reportConditionTransitions(&buf, []metav1.Condition{cond}, seen)
 
+	cond.Status = metav1.ConditionTrue
+	cond.Reason = "Succeeded"
+	cond.Message = "Machine machine-1 completed first-boot cloud-init successfully"
+	reportConditionTransitions(&buf, []metav1.Condition{cond}, seen)
+
+	out := buf.String()
 	require.Equal(t, 1, strings.Count(out, "Running first-boot cloud-init"))
 	require.Contains(t, out, "Cloud-init complete")
 	require.NotContains(t, out, "Condition CloudInitDone")
 }
 
 func TestReportTargetTransitions(t *testing.T) {
+	t.Parallel()
+
 	seen := map[string]string{}
 	target := v1alpha3.MachineOperationTargetStatus{
 		MachineRef: "machine-1",
@@ -51,40 +55,19 @@ func TestReportTargetTransitions(t *testing.T) {
 		Message:    "waiting for PXE repave to complete",
 	}
 
-	out := captureStdout(t, func() {
-		reportTargetTransitions([]v1alpha3.MachineOperationTargetStatus{target}, seen)
-		reportTargetTransitions([]v1alpha3.MachineOperationTargetStatus{target}, seen)
+	var buf bytes.Buffer
 
-		target.Message = "still waiting for PXE repave"
-		reportTargetTransitions([]v1alpha3.MachineOperationTargetStatus{target}, seen)
+	reportTargetTransitions(&buf, []v1alpha3.MachineOperationTargetStatus{target}, seen)
+	reportTargetTransitions(&buf, []v1alpha3.MachineOperationTargetStatus{target}, seen)
 
-		target.Stage = v1alpha3.OperationStageWaitingNode
-		target.Message = "waiting for Node machine-1 to exist"
-		reportTargetTransitions([]v1alpha3.MachineOperationTargetStatus{target}, seen)
-	})
+	target.Message = "still waiting for PXE repave"
+	reportTargetTransitions(&buf, []v1alpha3.MachineOperationTargetStatus{target}, seen)
 
+	target.Stage = v1alpha3.OperationStageWaitingNode
+	target.Message = "waiting for Node machine-1 to exist"
+	reportTargetTransitions(&buf, []v1alpha3.MachineOperationTargetStatus{target}, seen)
+
+	out := buf.String()
 	require.Equal(t, 1, strings.Count(out, "Booting PXE installer"))
 	require.Contains(t, out, "Waiting for node to join cluster")
-}
-
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-
-	os.Stdout = w
-
-	fn()
-
-	require.NoError(t, w.Close())
-
-	os.Stdout = oldStdout
-
-	out, err := io.ReadAll(r)
-	require.NoError(t, err)
-	require.NoError(t, r.Close())
-
-	return string(out)
 }

--- a/cmd/kubectl-unbounded/app/machine_reboot.go
+++ b/cmd/kubectl-unbounded/app/machine_reboot.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -31,7 +32,7 @@ func machineRebootCommand() *cobra.Command {
 				return err
 			}
 
-			return runReboot(ctx, c, args[0], ttl)
+			return runReboot(ctx, c, args[0], ttl, cmd.OutOrStdout())
 		},
 	}
 	cmd.Flags().Int32Var(&ttl, "ttl", defaultTTLSeconds,
@@ -40,7 +41,7 @@ func machineRebootCommand() *cobra.Command {
 	return cmd
 }
 
-func runReboot(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32) error {
+func runReboot(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32, out io.Writer) error {
 	machine, err := getMachine(ctx, c, name)
 	if err != nil {
 		return err
@@ -55,9 +56,9 @@ func runReboot(ctx context.Context, c client.WithWatch, name string, ttlSeconds 
 		return err
 	}
 
-	printStep(fmt.Sprintf("Rebooting Machine %s...", name))
-	printConfig("operation", opName)
-	fmt.Println()
+	printStep(out, fmt.Sprintf("Rebooting Machine %s...", name))
+	printConfig(out, "operation", opName)
+	fprintln(out)
 
-	return watchMachineOperation(ctx, c, opName)
+	return watchMachineOperation(ctx, c, opName, out)
 }

--- a/cmd/kubectl-unbounded/app/machine_repave.go
+++ b/cmd/kubectl-unbounded/app/machine_repave.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -31,7 +32,7 @@ func machineRepaveCommand() *cobra.Command {
 				return err
 			}
 
-			return runRepave(ctx, c, args[0], ttl)
+			return runRepave(ctx, c, args[0], ttl, cmd.OutOrStdout())
 		},
 	}
 	cmd.Flags().Int32Var(&ttl, "ttl", defaultTTLSeconds,
@@ -40,16 +41,16 @@ func machineRepaveCommand() *cobra.Command {
 	return cmd
 }
 
-func runRepave(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32) error {
+func runRepave(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32, out io.Writer) error {
 	opName := fmt.Sprintf("%s-repave-%d", name, time.Now().Unix())
 
 	if err := createMachineOperation(ctx, c, name, opName, v1alpha3.OperationHostReplace, ttlSeconds); err != nil {
 		return err
 	}
 
-	printStep(fmt.Sprintf("Repaving Machine %s...", name))
-	printConfig("operation", opName)
-	fmt.Println()
+	printStep(out, fmt.Sprintf("Repaving Machine %s...", name))
+	printConfig(out, "operation", opName)
+	fprintln(out)
 
-	return watchMachineOperation(ctx, c, opName)
+	return watchMachineOperation(ctx, c, opName, out)
 }

--- a/cmd/kubectl-unbounded/app/machine_replace.go
+++ b/cmd/kubectl-unbounded/app/machine_replace.go
@@ -50,7 +50,7 @@ Host-local OS disk state is destroyed.`,
 				wait:          wait,
 				timeout:       timeout,
 				operationName: operationName,
-			})
+			}, cmd.OutOrStdout())
 		},
 	}
 
@@ -73,15 +73,15 @@ type machineReplaceOptions struct {
 	operationName string
 }
 
-func runReplace(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32, force bool) error {
+func runReplace(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32, force bool, out io.Writer) error {
 	return runReplaceWithOptions(ctx, c, name, machineReplaceOptions{
 		ttlSeconds: ttlSeconds,
 		force:      force,
 		wait:       true,
-	})
+	}, out)
 }
 
-func runReplaceWithOptions(ctx context.Context, c client.WithWatch, name string, opts machineReplaceOptions) error {
+func runReplaceWithOptions(ctx context.Context, c client.WithWatch, name string, opts machineReplaceOptions, out io.Writer) error {
 	if !opts.force {
 		if err := confirmReplace(name, os.Stdin, os.Stderr); err != nil {
 			return err
@@ -102,6 +102,7 @@ func runReplaceWithOptions(ctx context.Context, c client.WithWatch, name string,
 		dryRun:       dryRunNone,
 		fieldManager: fieldManagerID,
 		printCreated: false,
+		out:          out,
 	}
 	if err := createOptions.validate(); err != nil {
 		return err
@@ -120,9 +121,9 @@ func runReplaceWithOptions(ctx context.Context, c client.WithWatch, name string,
 		return err
 	}
 
-	printStep(fmt.Sprintf("Replacing Machine %s...", name))
-	printConfig("operation", opName)
-	fmt.Println()
+	printStep(out, fmt.Sprintf("Replacing Machine %s...", name))
+	printConfig(out, "operation", opName)
+	fprintln(out)
 
 	if !opts.wait {
 		return nil
@@ -131,7 +132,7 @@ func runReplaceWithOptions(ctx context.Context, c client.WithWatch, name string,
 	waitCtx, cancel := contextWithOptionalTimeout(ctx, opts.timeout)
 	defer cancel()
 
-	return waitForMachineOperation(waitCtx, c, opName)
+	return waitForMachineOperation(waitCtx, c, opName, out)
 }
 
 func confirmReplace(name string, in *os.File, out io.Writer) error {

--- a/cmd/kubectl-unbounded/app/machine_replace_test.go
+++ b/cmd/kubectl-unbounded/app/machine_replace_test.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestRunReplaceRequiresForceInNonInteractiveMode(t *testing.T) {
 	machine := &v1alpha3.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-1"}}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine).Build()
 
-	err := runReplace(context.Background(), c, "machine-1", 0, false)
+	err := runReplace(context.Background(), c, "machine-1", 0, false, io.Discard)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "--force")
 }
@@ -40,15 +41,11 @@ func TestRunReplaceCreatesNamedOperationWithoutWaiting(t *testing.T) {
 	machine := &v1alpha3.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-1"}}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(machine).Build()
 
-	var err error
-
-	_ = captureStdout(t, func() {
-		err = runReplaceWithOptions(context.Background(), c, "machine-1", machineReplaceOptions{
-			force:         true,
-			wait:          false,
-			operationName: "replace-machine-1",
-		})
-	})
+	err := runReplaceWithOptions(context.Background(), c, "machine-1", machineReplaceOptions{
+		force:         true,
+		wait:          false,
+		operationName: "replace-machine-1",
+	}, io.Discard)
 	require.NoError(t, err)
 
 	var op v1alpha3.MachineOperation

--- a/cmd/kubectl-unbounded/app/machine_soft_reboot.go
+++ b/cmd/kubectl-unbounded/app/machine_soft_reboot.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -45,7 +46,7 @@ to "Complete" or "Failed".`,
 				return err
 			}
 
-			return runSoftReboot(ctx, c, args[0], ttl)
+			return runSoftReboot(ctx, c, args[0], ttl, cmd.OutOrStdout())
 		},
 	}
 
@@ -55,18 +56,18 @@ to "Complete" or "Failed".`,
 	return cmd
 }
 
-func runSoftReboot(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32) error {
+func runSoftReboot(ctx context.Context, c client.WithWatch, name string, ttlSeconds int32, out io.Writer) error {
 	opName := fmt.Sprintf("%s-reboot-%d", name, time.Now().Unix())
 
 	if err := createMachineOperation(ctx, c, name, opName, v1alpha3.OperationNodeReboot, ttlSeconds); err != nil {
 		return err
 	}
 
-	printStep(fmt.Sprintf("Soft-rebooting Machine %s...", name))
-	printConfig("operation", opName)
-	fmt.Println()
+	printStep(out, fmt.Sprintf("Soft-rebooting Machine %s...", name))
+	printConfig(out, "operation", opName)
+	fprintln(out)
 
-	return watchMachineOperation(ctx, c, opName)
+	return watchMachineOperation(ctx, c, opName, out)
 }
 
 func createMachineOperation(ctx context.Context, c client.WithWatch, name, opName string, kind v1alpha3.OperationKind, ttlSeconds int32) error {
@@ -107,20 +108,20 @@ func createMachineOperation(ctx context.Context, c client.WithWatch, name, opNam
 
 // watchMachineOperation watches a MachineOperation CR until it reaches a
 // terminal phase (Complete or Failed).
-func watchMachineOperation(ctx context.Context, c client.WithWatch, opName string) error {
+func watchMachineOperation(ctx context.Context, c client.WithWatch, opName string, out io.Writer) error {
 	var initial v1alpha3.MachineOperation
 	if err := c.Get(ctx, client.ObjectKey{Name: opName}, &initial); err != nil {
 		return fmt.Errorf("getting MachineOperation: %w", err)
 	}
 
 	if initial.Status.IsTerminal() {
-		return finishMachineOperationWait(&initial)
+		return finishMachineOperationWait(&initial, out)
 	}
 
-	return watchMachineOperationFromResourceVersion(ctx, c, opName, initial.ResourceVersion)
+	return watchMachineOperationFromResourceVersion(ctx, c, opName, initial.ResourceVersion, out)
 }
 
-func watchMachineOperationFromResourceVersion(ctx context.Context, c client.WithWatch, opName, resourceVersion string) error {
+func watchMachineOperationFromResourceVersion(ctx context.Context, c client.WithWatch, opName, resourceVersion string, out io.Writer) error {
 	listOptions := []client.ListOption{
 		client.MatchingFields{"metadata.name": opName},
 	}
@@ -161,17 +162,17 @@ func watchMachineOperationFromResourceVersion(ctx context.Context, c client.With
 		}
 
 		phase := op.Status.Phase
-		reportConditionTransitions(op.Status.Conditions, seenConditions)
-		reportTargetTransitions(op.Status.Targets, seenTargets)
+		reportConditionTransitions(out, op.Status.Conditions, seenConditions)
+		reportTargetTransitions(out, op.Status.Targets, seenTargets)
 
 		if phase != lastPhase {
 			switch phase {
 			case v1alpha3.OperationPhaseInProgress:
-				printStep(fmt.Sprintf("Operation %s: %s in progress...", op.Spec.OperationKind, opName))
+				printStep(out, fmt.Sprintf("Operation %s: %s in progress...", op.Spec.OperationKind, opName))
 			case v1alpha3.OperationPhaseComplete:
-				printStep(fmt.Sprintf("Operation %s: %s completed", op.Spec.OperationKind, opName))
+				printStep(out, fmt.Sprintf("Operation %s: %s completed", op.Spec.OperationKind, opName))
 			case v1alpha3.OperationPhaseFailed:
-				printStep(fmt.Sprintf("Operation %s: %s failed: %s", op.Spec.OperationKind, opName, op.Status.Message))
+				printStep(out, fmt.Sprintf("Operation %s: %s failed: %s", op.Spec.OperationKind, opName, op.Status.Message))
 			}
 
 			lastPhase = phase
@@ -182,7 +183,7 @@ func watchMachineOperationFromResourceVersion(ctx context.Context, c client.With
 				return fmt.Errorf("operation failed: %s", op.Status.Message)
 			}
 
-			printReady()
+			printReady(out)
 
 			return nil
 		}
@@ -195,7 +196,7 @@ func watchMachineOperationFromResourceVersion(ctx context.Context, c client.With
 	return fmt.Errorf("watch closed before operation completed")
 }
 
-func reportTargetTransitions(targets []v1alpha3.MachineOperationTargetStatus, seen map[string]string) {
+func reportTargetTransitions(out io.Writer, targets []v1alpha3.MachineOperationTargetStatus, seen map[string]string) {
 	for _, target := range targets {
 		key := target.MachineRef
 		if key == "" {
@@ -214,7 +215,7 @@ func reportTargetTransitions(targets []v1alpha3.MachineOperationTargetStatus, se
 			text = targetTransitionState(target)
 		}
 
-		printStep(fmt.Sprintf("Target %s: %s", key, text))
+		printStep(out, fmt.Sprintf("Target %s: %s", key, text))
 	}
 }
 


### PR DESCRIPTION
## Problem

`go test -race ./...` intermittently fails in `cmd/kubectl-unbounded/app` with a data race on the process-global `os.Stdout`.

The machine-operation and machine-config commands print user-facing output with `fmt.Print*`, which writes to `os.Stdout`. Because that output only exists on the global stream, tests could capture it only by swapping `os.Stdout` for a pipe. At the same time, cobra's `OutOrStdout()` reads `os.Stdout` unconditionally (even when a command's output writer is set), so any test executing a command reads the global while the capturing test is swapping it. Run in parallel under the race detector, those two accesses collide.

It's a latent, scheduling-dependent flake: it surfaces only when the read and the swap happen to interleave, so it can pass for a long time and then fail on an unrelated PR.

## Solution

Give the commands an explicit output destination instead of the process global. Output is threaded as an `io.Writer`, sourced once per command from `cmd.OutOrStdout()`, through the command run, wait, status-report, and styled-print helpers.

With every write going to an injected writer, tests capture output with a per-test buffer rather than swapping `os.Stdout`. Nothing mutates the global anymore, so the remaining `OutOrStdout()` reads are read-only and race-free, and the affected tests run in parallel again.
