### PR TITLE
operator: per-Site image registry override for site-node workloads

### DIFF
--- a/api/machina/v1alpha3/site_types.go
+++ b/api/machina/v1alpha3/site_types.go
@@ -101,6 +101,25 @@ type SiteSpec struct {
 	// +optional
 	TunnelMTU *int32 `json:"tunnelMTU,omitempty"`
 
+	// ImageRegistry overrides the container image repository prefix for the
+	// operator-managed component workloads that run on this site's nodes
+	// (unbounded-net-node, gantry, metalman, and the unbounded-storage
+	// supervisor). It is a full repository prefix (registry host plus any
+	// org/namespace path); the operator appends the component's repository name
+	// and its own image tag, so imageRegistry=registry.corp.internal/unbounded
+	// yields registry.corp.internal/unbounded/unbounded-net-node:<tag>, matching
+	// the semantics of the operator-wide UNBOUNDED_IMAGE_REGISTRY setting.
+	//
+	// When empty the operator-wide registry is used. It is intended for sites
+	// whose networking cannot reach the default registry and must pull from a
+	// local mirror; the referenced registry must already host copies of the
+	// operator's component images at the operator's version. Pulls are anonymous
+	// (per-site pull credentials are not yet supported). Control-plane and other
+	// nodes that do not belong to any site are unaffected and keep pulling from
+	// the operator-wide registry.
+	// +optional
+	ImageRegistry string `json:"imageRegistry,omitempty"`
+
 	// Components declares optional Unbounded components managed for this site.
 	// +optional
 	Components SiteComponents `json:"components,omitempty"`

--- a/deploy/machina/crd/unbounded-cloud.io_sites.yaml
+++ b/deploy/machina/crd/unbounded-cloud.io_sites.yaml
@@ -165,6 +165,25 @@ spec:
                       Accepts either a duration string (e.g. "300ms") or an integer interpreted as milliseconds.
                     x-kubernetes-int-or-string: true
                 type: object
+              imageRegistry:
+                description: |-
+                  ImageRegistry overrides the container image repository prefix for the
+                  operator-managed component workloads that run on this site's nodes
+                  (unbounded-net-node, gantry, metalman, and the unbounded-storage
+                  supervisor). It is a full repository prefix (registry host plus any
+                  org/namespace path); the operator appends the component's repository name
+                  and its own image tag, so imageRegistry=registry.corp.internal/unbounded
+                  yields registry.corp.internal/unbounded/unbounded-net-node:<tag>, matching
+                  the semantics of the operator-wide UNBOUNDED_IMAGE_REGISTRY setting.
+
+                  When empty the operator-wide registry is used. It is intended for sites
+                  whose networking cannot reach the default registry and must pull from a
+                  local mirror; the referenced registry must already host copies of the
+                  operator's component images at the operator's version. Pulls are anonymous
+                  (per-site pull credentials are not yet supported). Control-plane and other
+                  nodes that do not belong to any site are unaffected and keep pulling from
+                  the operator-wide registry.
+                type: string
               localCidrs:
                 description: |-
                   LocalCIDRs are CIDR blocks that are considered local to this site.

--- a/docs/content/reference/networking/custom-resources.md
+++ b/docs/content/reference/networking/custom-resources.md
@@ -52,6 +52,7 @@ spec:
 | `spec.healthCheckSettings` | `HealthCheckSettings` | No | Health check settings for node-to-node routes within this site. |
 | `spec.tunnelProtocol` | `string` | No | `WireGuard`, `IPIP`, `GENEVE`, `VXLAN`, `None`, or `Auto` (default). |
 | `spec.tunnelMTU` | `*int32` | No | Tunnel MTU for routes in this scope (576-9000). |
+| `spec.imageRegistry` | `string` | No | Full image repository prefix (host plus org/path) for operator-managed workloads on this site's nodes (`unbounded-net-node`, `gantry`, `metalman`, `unbounded-storage-supervisor`). Empty uses the operator-wide registry. Pulls are anonymous; the registry must already host the images at the operator's version. |
 
 ### PodCidrAssignment Fields
 

--- a/docs/net/custom-resources.md
+++ b/docs/net/custom-resources.md
@@ -134,12 +134,24 @@ empty, the operator-wide registry is used.
 The override applies to the four operator-managed workloads that run on a site's
 nodes: `unbounded-net-node`, `gantry`, `metalman`, and the
 `unbounded-storage-supervisor`. The control-plane components (the net controller
-and machina) are unaffected. Each of these workloads runs as a per-site
-DaemonSet/Deployment (`<component>-<site>`) scheduled onto the site's nodes via
-the `unbounded-cloud.io/site` label, with its own per-site config ConfigMap
-(`<config>-<site>`) seeded from the shared default so existing tuning carries
-over. Nodes that do not belong to any site (for example control-plane nodes) keep
-running the cluster-wide "base" workloads from the operator-wide registry.
+and machina) are unaffected. Each of these runs as a per-site DaemonSet/Deployment
+(`<component>-<site>`) scheduled onto the site's nodes via the
+`unbounded-cloud.io/site` label. Nodes that do not belong to any site (for example
+control-plane nodes) keep running a cluster-wide "base" workload from the
+operator-wide registry.
+
+Per-site configuration:
+
+- **`unbounded-net-node`** mounts a per-site config (`unbounded-net-config-<site>`)
+  seeded from the shared `unbounded-net-config`. The operator keeps a per-site
+  config tracking the shared config until you edit it: while the per-site copy is
+  unchanged from what it was seeded with, a later change to the shared config is
+  propagated to it; once you edit the per-site copy it is preserved and no longer
+  overwritten.
+- **`gantry`** mounts a per-site config (`gantry-config-<site>`) seeded from the
+  shared `gantry-config`. This is site-owned (for example each site's
+  `upstream_registries`): it is preserved across reconciles and across a temporary
+  `gantry.enabled=false`, and is removed only when the Site is deleted.
 
 ```yaml
 apiVersion: unbounded-cloud.io/v1alpha3
@@ -163,9 +175,14 @@ spec:
   be reachable on every node (re)start.
 - The `gantry` pod's busybox init container is a third-party image
   (`mcr.microsoft.com/...`) and is not repointed by this override.
-- The first time an override is set on a site, each of the site's nodes hands the
-  affected workload off from the base to the per-site copy, causing a brief
-  restart on those nodes.
+- On the upgrade that introduces per-site DaemonSets, each site's nodes hand
+  `unbounded-net-node` (and `gantry`) off from the base to the per-site copy. Only
+  one net-node can own a node's dataplane at a time, so this is a brief restart
+  per node, equivalent to a normal net-node rollout; `unbounded-net-node` does not
+  tear down its dataplane on shutdown, so established traffic keeps flowing and
+  only new-pod networking briefly stalls. The operator applies the per-site
+  DaemonSets before narrowing the base, so a failed per-site apply leaves the base
+  covering the fleet rather than stranding nodes.
 
 ### NonMasqueradeCIDRs Behavior
 

--- a/docs/net/custom-resources.md
+++ b/docs/net/custom-resources.md
@@ -58,6 +58,7 @@ status:
 | `spec.healthCheckSettings` | `HealthCheckSettings` | No | Health check settings for node-to-node routes within this site. |
 | `spec.tunnelProtocol` | `string` | No | Tunnel encapsulation: `WireGuard`, `IPIP`, `GENEVE`, `VXLAN`, `None`, or `Auto` (default). When `Auto`, links using external IPs use WireGuard and links using only internal IPs use GENEVE. |
 | `spec.tunnelMTU` | `*int32` | No | Tunnel MTU for routes in this scope (576-9000). |
+| `spec.imageRegistry` | `string` | No | Overrides the container image registry prefix for operator-managed workloads on this site's nodes. See below. |
 | `status.nodeCount` | `int` | - | Read-only. Number of nodes assigned to this site. |
 | `status.sliceCount` | `int` | - | Read-only. Number of SiteNodeSlice objects. |
 
@@ -114,6 +115,57 @@ spec:
         - 10.244.0.0/16
       assignmentEnabled: false
 ```
+
+### Per-Site Image Registry
+
+Some sites have networking that cannot reach the default container registry the
+operator pulls its component images from. `spec.imageRegistry` lets such a site
+pull the operator-managed workloads that run on its nodes from a registry its
+network can reach.
+
+It is a full image repository prefix (registry host plus any org/namespace path),
+identical in meaning to the operator-wide `UNBOUNDED_IMAGE_REGISTRY` setting: the
+operator appends the component's repository name and its own image tag. With
+`spec.imageRegistry: registry.corp.internal/unbounded`, the site's
+`unbounded-net-node` resolves to
+`registry.corp.internal/unbounded/unbounded-net-node:<operator-version>`. When
+empty, the operator-wide registry is used.
+
+The override applies to the four operator-managed workloads that run on a site's
+nodes: `unbounded-net-node`, `gantry`, `metalman`, and the
+`unbounded-storage-supervisor`. The control-plane components (the net controller
+and machina) are unaffected. Each of these workloads runs as a per-site
+DaemonSet/Deployment (`<component>-<site>`) scheduled onto the site's nodes via
+the `unbounded-cloud.io/site` label, with its own per-site config ConfigMap
+(`<config>-<site>`) seeded from the shared default so existing tuning carries
+over. Nodes that do not belong to any site (for example control-plane nodes) keep
+running the cluster-wide "base" workloads from the operator-wide registry.
+
+```yaml
+apiVersion: unbounded-cloud.io/v1alpha3
+kind: Site
+metadata:
+  name: isolated-rack
+spec:
+  nodeCidrs:
+    - 10.20.0.0/16
+  imageRegistry: registry.corp.internal/unbounded
+```
+
+**Caveats:**
+
+- The referenced registry must already host copies of the operator's component
+  images at the operator's version; the operator only repoints image references,
+  it does not mirror images.
+- Pulls are anonymous. Registries that require credentials (per-site image pull
+  secrets) are not yet supported.
+- `unbounded-net-node` uses `imagePullPolicy: Always`, so the site registry must
+  be reachable on every node (re)start.
+- The `gantry` pod's busybox init container is a third-party image
+  (`mcr.microsoft.com/...`) and is not repointed by this override.
+- The first time an override is set on a site, each of the site's nodes hands the
+  affected workload off from the base to the per-site copy, causing a brief
+  restart on those nodes.
 
 ### NonMasqueradeCIDRs Behavior
 

--- a/e2e/operator/reaper_e2e_test.go
+++ b/e2e/operator/reaper_e2e_test.go
@@ -420,6 +420,16 @@ func stageTargetWorkloads(ctx context.Context, t *testing.T, cli client.Client) 
 
 	mustCreate(ctx, t, cli, netController)
 	mustCreate(ctx, t, cli, netNode)
+
+	// net-node is not opt-outable, so every Site must have its per-Site node
+	// DaemonSet present and carrying the migrated config hash before the legacy
+	// blanket net-node is reaped (the base above covers only un-Sited nodes).
+	for _, site := range []string{"cluster", "edge", repairSite} {
+		perSiteNode := readyDaemonSet(targetNS, "unbounded-net-node-"+site)
+		perSiteNode.Spec.Template.Annotations = map[string]string{"unbounded-cloud.io/net-config-hash": configMapHash(netConfig)}
+		mustCreate(ctx, t, cli, perSiteNode)
+	}
+
 	mustCreate(ctx, t, cli, readyDaemonSet(targetNS, "unbounded-storage-supervisor-cluster"))
 	mustCreate(ctx, t, cli, readyDaemonSet(targetNS, "unbounded-storage-supervisor-edge"))
 	mustCreate(ctx, t, cli, readyDaemonSet(targetNS, "unbounded-storage-supervisor-"+repairSite))
@@ -561,6 +571,11 @@ func updateTargetConfigHashes(ctx context.Context, t *testing.T, cli client.Clie
 	updateDaemonSetHash(ctx, t, cli, "unbounded-net-node", "unbounded-net-config", "unbounded-cloud.io/net-config-hash")
 
 	for _, site := range []string{"cluster", "edge", repairSite} {
+		updateDaemonSetHash(ctx, t, cli,
+			"unbounded-net-node-"+site,
+			"unbounded-net-config",
+			"unbounded-cloud.io/net-config-hash")
+
 		updateDaemonSetHash(ctx, t, cli,
 			"unbounded-storage-supervisor-"+site,
 			"unbounded-storage-config-"+site,

--- a/hack/discussion/gantry-per-site-mesh.svg
+++ b/hack/discussion/gantry-per-site-mesh.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="470" viewBox="0 0 820 470" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#444"/>
+    </marker>
+    <marker id="arrow-bad" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#c0392b"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="820" height="470" fill="#ffffff"/>
+  <text x="410" y="30" text-anchor="middle" font-size="20" font-weight="bold" fill="#222">One cross-Site mesh routes a pull to a puller that can't serve it</text>
+
+  <!-- Site A -->
+  <rect x="30" y="60" width="330" height="300" rx="10" fill="#eef5fb" stroke="#2b6cb0" stroke-width="2"/>
+  <text x="45" y="85" font-size="16" font-weight="bold" fill="#2b6cb0">Site A</text>
+
+  <!-- regA -->
+  <rect x="55" y="100" width="130" height="55" rx="6" fill="#ffffff" stroke="#2b6cb0" stroke-width="1.5"/>
+  <text x="120" y="123" text-anchor="middle" font-size="14" font-weight="bold" fill="#2b6cb0">regA</text>
+  <text x="120" y="141" text-anchor="middle" font-size="11" fill="#555">has image X</text>
+
+  <!-- Gantry A node -->
+  <rect x="55" y="230" width="130" height="70" rx="6" fill="#ffffff" stroke="#2b6cb0" stroke-width="1.5"/>
+  <text x="120" y="255" text-anchor="middle" font-size="13" font-weight="bold" fill="#222">Gantry A</text>
+  <text x="120" y="273" text-anchor="middle" font-size="11" fill="#555">upstream = regA</text>
+  <text x="120" y="289" text-anchor="middle" font-size="11" fill="#555">needs X (miss)</text>
+
+  <!-- Site B -->
+  <rect x="460" y="60" width="330" height="300" rx="10" fill="#fdeeee" stroke="#c0392b" stroke-width="2"/>
+  <text x="475" y="85" font-size="16" font-weight="bold" fill="#c0392b">Site B</text>
+
+  <!-- regB -->
+  <rect x="635" y="100" width="130" height="55" rx="6" fill="#ffffff" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="700" y="123" text-anchor="middle" font-size="14" font-weight="bold" fill="#c0392b">regB</text>
+  <text x="700" y="141" text-anchor="middle" font-size="11" fill="#555">no image X</text>
+
+  <!-- Gantry B node -->
+  <rect x="635" y="230" width="130" height="70" rx="6" fill="#ffffff" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="700" y="255" text-anchor="middle" font-size="13" font-weight="bold" fill="#222">Gantry B</text>
+  <text x="700" y="273" text-anchor="middle" font-size="11" fill="#555">upstream = regB</text>
+  <text x="700" y="289" text-anchor="middle" font-size="11" fill="#555">HRW puller for X</text>
+
+  <!-- Fabric / one mesh in the middle -->
+  <rect x="300" y="200" width="220" height="70" rx="35" fill="#f4f4f4" stroke="#888" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="410" y="230" text-anchor="middle" font-size="13" font-weight="bold" fill="#555">one /gantry mesh</text>
+  <text x="410" y="250" text-anchor="middle" font-size="11" fill="#777">over the Unbounded fabric</text>
+
+  <!-- mesh links -->
+  <line x1="185" y1="255" x2="300" y2="240" stroke="#888" stroke-width="1.5"/>
+  <line x1="520" y1="240" x2="635" y2="255" stroke="#888" stroke-width="1.5"/>
+
+  <!-- HRW picks Gantry B for the Site A miss (bad routing) -->
+  <path d="M188,238 C 330,150 560,150 700,225" fill="none" stroke="#c0392b" stroke-width="2.5" marker-end="url(#arrow-bad)"/>
+  <text x="410" y="140" text-anchor="middle" font-size="12" font-weight="bold" fill="#c0392b">HRW(node,digest) picks Gantry B - no Site awareness</text>
+
+  <!-- Gantry B tries regB -->
+  <path d="M700,230 L700,160" fill="none" stroke="#c0392b" stroke-width="2" marker-end="url(#arrow-bad)"/>
+
+  <!-- what should have happened: Gantry A -> regA -->
+  <path d="M120,230 L120,160" fill="none" stroke="#2b6cb0" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+  <text x="120" y="200" text-anchor="middle" font-size="10" fill="#2b6cb0">should pull here</text>
+
+  <!-- Failure callout -->
+  <rect x="560" y="315" width="205" height="34" rx="6" fill="#fff3f3" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="662" y="336" text-anchor="middle" font-size="12" font-weight="bold" fill="#c0392b">pull fails: regB has no X</text>
+
+  <!-- Legend -->
+  <text x="30" y="400" font-size="12" fill="#c0392b">red = actual (wrong) routing</text>
+  <text x="30" y="420" font-size="12" fill="#2b6cb0">blue dashed = what should happen (stay in Site A)</text>
+  <text x="30" y="440" font-size="12" fill="#555">Fix: give each Site its own mesh so a Site-A miss stays in Site A.</text>
+</svg>

--- a/hack/discussion/gantry-per-site.md
+++ b/hack/discussion/gantry-per-site.md
@@ -1,0 +1,256 @@
+# Per-Site registries and Gantry
+
+## Purpose
+
+This document explains a problem the Gantry developer needs to help solve, and a
+related design question about how users should name images. It exists so the
+Gantry work can proceed in parallel while the operator team builds the mechanical
+part (splitting workloads per Site) in a separate PR.
+
+You do not need operator internals to read this. Where Gantry code matters, file
+pointers are at the end.
+
+## Background: what we're building
+
+We're adding a feature to Unbounded: each **Site** can point at its own container
+image **registry**. Some Sites sit on networks that can't reach the normal
+registry (for example `ghcr.io`), so they need to pull images from a **local
+registry** inside the Site's network.
+
+Picture two Sites:
+
+- **Site A** has its own registry, `regA`.
+- **Site B** has its own registry, `regB`.
+
+These registries are separate. Site A generally cannot reach `regB`, and Site B
+cannot reach `regA`. But the two Sites *are* connected to each other through the
+Unbounded network fabric (pods in Site A can talk to pods in Site B). That fabric
+connection is the detail that causes the mesh problem below.
+
+On the operator side (what **we** build in the PR), we split the Gantry DaemonSet
+so each Site runs its own Gantry pods, with:
+
+- the Gantry **image** pulled from that Site's registry, and
+- a per-Site Gantry **config** whose `upstream_registries` points at that Site's
+  registry.
+
+That part is mechanical and we have it. The two things we need Gantry's help with
+are: (1) keeping each Site's mesh separate, and (2) agreeing on how users name
+images so per-Site redirection works.
+
+---
+
+## Part 1: The cross-Site mesh problem
+
+### How Gantry groups peers today (short version)
+
+1. **Membership pool.** Each Gantry agent watches Kubernetes for pods matching a
+   label selector, by default `app.kubernetes.io/name=gantry`, in its namespace.
+   Every matching pod is a "member."
+2. **DHT.** All agents join one libp2p Kademlia **DHT** (a distributed index of
+   "who has which blob"), keyed by content **digest** (a hash of the image data).
+   The DHT's protocol name is hardcoded to `/gantry`.
+3. **Origin puller selection.** On a cache miss (no peer has the blob), Gantry
+   picks **one** member to pull it from a real registry using **HRW hashing**
+   (rendezvous hashing). HRW takes `(node_id, digest)` and picks the highest-
+   scoring member. It does **not** look at Site or which registry the member can
+   reach.
+4. **What a puller pulls from.** The chosen member pulls from **its own**
+   `upstream_registries` config.
+
+Important nuance: image content is **content-addressed**. A blob with digest `D`
+is the same bytes no matter which registry it came from. So peers sharing blobs
+across Sites is fine *content-wise*. The problem is only the **origin pull** step
+(going to a real registry on a cache miss).
+
+### The problem
+
+Because Site A and Site B are connected by the fabric, and their Gantry pods
+share the same `app.kubernetes.io/name=gantry` label and the same `/gantry` DHT,
+**all** Gantry pods from both Sites end up in **one** mesh. Nothing today makes
+the mesh Site-aware.
+
+![One cross-Site mesh routes a pull to a puller that can't serve it](gantry-per-site-mesh.svg)
+
+Walk through a cache miss:
+
+1. A node in **Site A** needs image `X` (digest `D`). No peer has it yet.
+2. Gantry uses HRW over the whole mesh to pick the origin puller for `D`. HRW is
+   just a hash, so it might pick a node in **Site B**.
+3. That Site B node tries to pull `D` from **its own** registry, `regB`.
+4. If `regB` doesn't have `X` (say `X` only exists in `regA`), the pull fails -
+   even though a Site A node could have pulled it from `regA` fine.
+
+So the request gets routed to a puller that can't serve it. The reverse happens
+too: a Site B request can be assigned to a Site A puller that can only reach
+`regA`.
+
+There's a second, smaller issue: normal peer-to-peer serving also crosses Site
+boundaries. A Site A node might fetch a blob from a Site B node over the fabric.
+Content-wise that's correct, but it couples Sites that are supposed to be
+isolated and sends fabric traffic that maybe shouldn't be there.
+
+**Bottom line:** once each Site has its own registry, one big cross-Site mesh is
+wrong. Each Site's Gantry pods should form their **own** mesh and only ever pull
+from their **own** Site's registry.
+
+### What a fix probably needs (for you to design)
+
+Three "levers." Two are configuration the operator sets; one likely needs a code
+change in Gantry.
+
+1. **Membership selector per Site (config only, operator handles this).** Our
+   per-Site Gantry pods already carry a label `unbounded-cloud.io/site=<site>`.
+   We set `GANTRY_MEMBERS_LABEL_SELECTOR` per Site so each agent only counts
+   same-Site pods as members. For example Site A uses
+   `app.kubernetes.io/name=gantry,unbounded-cloud.io/site=siteA`. Un-Sited nodes
+   (like control-plane nodes) use `app.kubernetes.io/name=gantry,!unbounded-cloud.io/site`.
+   We confirmed `labels.Parse` accepts these selectors.
+2. **DHT isolation per Site (likely a Gantry code change).** The DHT protocol
+   prefix is hardcoded to `/gantry` in `discovery.FromConfig`. The
+   `Options.ProtocolPrefix` field already exists, so it looks like a small change
+   to make it configurable (config field + env var) and let us set it per Site,
+   e.g. `/gantry/siteA` vs `/gantry/siteB`. Our open question: **is scoping the
+   membership selector alone enough to keep the DHTs separate in practice** (since
+   bootstrap would only connect same-Site peers), **or do we also need the
+   per-Site protocol prefix** to be safe? We worry that once any cross-Site
+   connection forms, the DHTs could merge and stay merged.
+3. **Per-Site registry config (operator handles this).** Each Site's Gantry gets
+   its own `upstream_registries` pointing at that Site's registry.
+
+Base Gantry (control-plane / un-Sited nodes) forms its own pool on `/gantry` and
+pulls from the operator-wide registry.
+
+---
+
+## Part 2: How should users name images?
+
+Once Sites have different registries, there's a naming question: how does a user
+reference an image so it pulls from the local registry **regardless of which Site
+the pod lands in**? You can't put the Site's host in the name - `regA/foo:v1`
+breaks the moment the pod runs in Site B.
+
+The answer: **don't put a Site's registry host in the image name.** Use a stable,
+site-independent name and let the node redirect the pull. There are two cases.
+
+### Case 1: Operator bootstrap images (net-node, Gantry's own pod)
+
+These are written by the operator, which makes a **separate** workload per Site.
+So the operator can bake the site-local host into the reference directly:
+Site A's DaemonSet says `regA/gantry:tag`, Site B's says `regB/gantry:tag`.
+Putting the Site host in the name is fine here because there's a different object
+per Site and the operator knows which Site it's generating for. This is also the
+only way to bootstrap Gantry itself (Gantry can't serve its own image, and
+net-node is the network Gantry needs).
+
+### Case 2: User workloads (and anything that runs once Gantry is up)
+
+A single Deployment can land pods on nodes in different Sites, so it must use a
+**canonical, site-independent name**, and the node redirects the pull to the
+Site's local registry. The pieces already exist in Gantry:
+
+1. The Unbounded agent points containerd's **default** registry mirror at the
+   local Gantry agent (`127.0.0.1:5000`). Every image pull on the node goes to
+   Gantry first, no matter the image name.
+2. The pod uses a canonical name, e.g. `image: ghcr.io/org/foo:v1` (or a stable
+   synthetic name - see the open question). The Site host is **not** in it.
+3. containerd asks Gantry for that blob and passes the registry namespace
+   (`?ns=ghcr.io`).
+4. Gantry looks up that namespace in **its per-Site `upstream_registries`
+   config**, which maps `ghcr.io` to the **site-local** endpoint (`regA` in
+   Site A, `regB` in Site B), and pulls from there (or from a same-Site peer).
+
+So the same pod spec - `ghcr.io/org/foo:v1` - works in every Site. Site A's node
+quietly pulls from `regA`; Site B's node quietly pulls from `regB`. The pod never
+names a Site.
+
+**Rule for users:** never put a Site's registry host in a workload image name. If
+you write `regA/foo:v1`, you've hardcoded the Site and lost portability. Use the
+canonical name and let the node redirect.
+
+Note the dependency: on an isolated Site, Gantry **must** be up for user-workload
+pulls to work, because the default mirror falls through to the real registry
+(unreachable) when Gantry is down. That's why Gantry's own image uses the direct
+per-Site override (Case 1) to bootstrap.
+
+### Open design question: what canonical name, and how does the local registry serve it?
+
+For step 4 to work, each Site's local registry must be able to serve content
+under whatever canonical name the pod uses. A few ways to arrange this - picking
+one is a deployment + Gantry-config decision:
+
+- **Pull-through cache:** each site registry is a caching mirror of the real
+  upstream (e.g., `regA` mirrors `ghcr.io`). Pods use real names (`ghcr.io/...`);
+  Gantry points the `ghcr.io` namespace at `regA`; transparent. Cleanest if the
+  registries support it.
+- **Namespace alias:** the site registry hosts images under its own path, and
+  Gantry's `NSAlias` maps the canonical namespace onto that path. More config,
+  but works when the local registry isn't a pull-through cache.
+- **Synthetic canonical host:** pods use a stable fake host like
+  `images.internal/...` that never resolves to anything real; each Site's Gantry
+  maps `images.internal` to its local registry. Pods get one stable name; each
+  Site maps it locally.
+
+All three keep the Site host out of the pod spec; they differ in how the local
+registry is populated and how Gantry's per-Site config maps names.
+
+**Decision needed:** what canonical naming convention do we standardize on, and
+which mapping mode(s) do we support/recommend?
+
+---
+
+## Questions for the Gantry developer
+
+1. Is per-Site **membership selector** scoping enough on its own, or do we also
+   need the per-Site **DHT protocol prefix**? What's the safest minimum?
+2. Are there other places where Sites could accidentally merge that we're
+   missing - static bootstrap peers, mDNS/other discovery, speculative
+   **prefetch**, or shared negative-cache/coordination state?
+3. There's an existing `hrw_topology_scope=zone` knob keyed on
+   `topology.kubernetes.io/zone`. From our reading it only narrows the HRW
+   candidate set and does **not** scope the DHT. Is that right? Could we reuse a
+   "zone/cluster id" concept instead of a per-Site prefix, or is a new per-Site
+   identifier cleaner?
+4. How should a node that **changes Site** be handled (leave one mesh, join the
+   other)? Anything Gantry needs to do on that transition?
+5. For image naming (Part 2): which canonical-name mapping mode(s) should we
+   support, and is `upstream_registries` / `NSAlias` the right place to configure
+   it per Site?
+
+## What the operator PR does vs. what Gantry needs
+
+**In the operator PR (us):**
+
+- Split net-node and Gantry into a "base" DaemonSet for un-Sited nodes plus a
+  per-Site DaemonSet per Site.
+- Per-Site Gantry pods carry `unbounded-cloud.io/site=<site>`, pull their image
+  from the Site's registry, and mount a per-Site config with that Site's
+  `upstream_registries`.
+- Set `GANTRY_MEMBERS_LABEL_SELECTOR` per Site (and the un-Sited variant for the
+  base).
+- Document the user image-naming rule (Part 2).
+
+**Needs Gantry work (you):**
+
+- Make the DHT protocol prefix configurable so per-Site meshes can't merge (if
+  you agree that's needed).
+- Sanity-check the other cross-Site coupling points in
+  membership/discovery/HRW/prefetch and tell us the minimum set of changes for
+  true per-Site isolation.
+- Confirm the per-Site image-naming/redirect model (`upstream_registries` /
+  `NSAlias`) and which canonical-naming mode(s) to support.
+
+## Where to look in the code
+
+- Membership pool + selector: `internal/gantry/members/members.go` (selector at
+  ~line 121-153); config field `MembersLabelSelector` and env
+  `GANTRY_MEMBERS_LABEL_SELECTOR` in `internal/gantry/config/config.go`
+  (~159-162, ~455, ~581).
+- DHT + hardcoded prefix: `internal/gantry/discovery/discovery.go`
+  (`Options.ProtocolPrefix` ~81-84; hardcoded `/gantry` at line 131; applied
+  ~194-195).
+- HRW origin-puller selection: `internal/gantry/hrw` (`hrw.go` scoring) and
+  `internal/gantry/coldstart` (`coldstart.go`, `prefetch.go`).
+- What a puller pulls from / namespace resolution: `internal/gantry/mirror/mirror.go`
+  and `ResolveUpstream` in `internal/gantry/config/config.go`.
+- DaemonSet env wiring for reference: `deploy/gantry/daemonset.yaml.tmpl`.

--- a/internal/operator/compat.go
+++ b/internal/operator/compat.go
@@ -7,6 +7,7 @@ import (
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	"github.com/Azure/unbounded/internal/operator/components/machina"
 	"github.com/Azure/unbounded/internal/operator/components/metalman"
+	netcomponent "github.com/Azure/unbounded/internal/operator/components/net"
 	"github.com/Azure/unbounded/internal/operator/components/storage"
 )
 
@@ -25,6 +26,7 @@ var (
 	metalmanDeploymentName = metalman.DeploymentName
 	storageConfigName      = storage.SiteConfigName
 	storageDaemonSetName   = storage.SiteDaemonSetName
+	netSiteDaemonSetName   = netcomponent.SiteNodeDaemonSetName
 )
 
 // componentEnabled reports whether a Site enables the named component. It is used

--- a/internal/operator/component/env.go
+++ b/internal/operator/component/env.go
@@ -83,6 +83,20 @@ func (c Config) Image(repository string) string {
 	return strings.TrimRight(c.ImageRegistry, "/") + "/" + repository + ":" + c.ImageTag
 }
 
+// ConfigForSite returns the operator Config a site's node-scoped workloads
+// resolve their images from. When the Site sets spec.imageRegistry it overrides
+// ImageRegistry (keeping the operator's own ImageTag), so a site whose network
+// cannot reach the default registry pulls the operator's component images from a
+// local mirror instead. An empty override leaves the operator-wide Config
+// unchanged.
+func ConfigForSite(base Config, site *unboundedv1alpha3.Site) Config {
+	if site != nil && site.Spec.ImageRegistry != "" {
+		base.ImageRegistry = site.Spec.ImageRegistry
+	}
+
+	return base
+}
+
 // SetPodSpecImages replaces every init and main container image in a workload.
 func SetPodSpecImages(obj *unstructured.Unstructured, image string) error {
 	for _, field := range []string{"initContainers", "containers"} {
@@ -520,5 +534,32 @@ func siteNodeSelectorTerm(key, siteName string) corev1.NodeSelectorTerm {
 			Operator: corev1.NodeSelectorOpIn,
 			Values:   []string{siteName},
 		}},
+	}
+}
+
+// UnsitedNodeAffinity matches only Nodes that carry neither the canonical nor
+// the deprecated site label, i.e. Nodes that do not belong to any Site. The
+// cluster-wide "base" net-node and gantry DaemonSets use it so they run on
+// control-plane and other un-Sited Nodes while the per-Site DaemonSets (which
+// select on the site label via SiteNodeAffinity) cover the Nodes of each Site.
+// Because a Node carries at most one site value, the two selectors partition the
+// cluster: every Node is covered by exactly one DaemonSet.
+//
+// Both keys must be absent (a single term with two DoesNotExist requirements is
+// a logical AND) so a Node labelled with only the deprecated key during the
+// label migration window is still treated as Sited and left to its per-Site
+// DaemonSet rather than double-scheduled by the base.
+func UnsitedNodeAffinity() *corev1.Affinity {
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: SiteLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist},
+						{Key: DeprecatedSiteLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist},
+					},
+				}},
+			},
+		},
 	}
 }

--- a/internal/operator/component/env.go
+++ b/internal/operator/component/env.go
@@ -512,28 +512,45 @@ func controllerEqual(a, b *bool) bool {
 	return ptr.Deref(a, false) == ptr.Deref(b, false)
 }
 
-// SiteNodeAffinity matches Nodes carrying either the canonical site label or the
-// deprecated net-prefixed site label. The OR is required during migration.
+// SiteNodeAffinity matches Nodes that belong to siteName, treating the canonical
+// site label (unbounded-cloud.io/site) as authoritative and falling back to the
+// deprecated net-prefixed label only when the canonical label is absent.
+//
+// The two node-selector terms are logically OR'd:
+//   - canonical == siteName, or
+//   - canonical absent AND deprecated == siteName.
+//
+// Making the canonical label authoritative prevents a Node that briefly carries
+// conflicting values (for example canonical=A left over next to deprecated=B
+// during the label migration) from matching two Sites' per-Site DaemonSets at
+// once, which would double-schedule two privileged agents onto one Node.
 func SiteNodeAffinity(siteName string) *corev1.Affinity {
 	return &corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					siteNodeSelectorTerm(SiteLabelKey, siteName),
-					siteNodeSelectorTerm(DeprecatedSiteLabelKey, siteName),
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							siteInRequirement(SiteLabelKey, siteName),
+						},
+					},
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: SiteLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist},
+							siteInRequirement(DeprecatedSiteLabelKey, siteName),
+						},
+					},
 				},
 			},
 		},
 	}
 }
 
-func siteNodeSelectorTerm(key, siteName string) corev1.NodeSelectorTerm {
-	return corev1.NodeSelectorTerm{
-		MatchExpressions: []corev1.NodeSelectorRequirement{{
-			Key:      key,
-			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{siteName},
-		}},
+func siteInRequirement(key, siteName string) corev1.NodeSelectorRequirement {
+	return corev1.NodeSelectorRequirement{
+		Key:      key,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{siteName},
 	}
 }
 

--- a/internal/operator/component/env_test.go
+++ b/internal/operator/component/env_test.go
@@ -49,6 +49,65 @@ func TestConfigImage(t *testing.T) {
 	}
 }
 
+func TestConfigForSite(t *testing.T) {
+	base := Config{ImageRegistry: "ghcr.io/azure", ImageTag: "v1"}
+
+	override := ConfigForSite(base, &unboundedv1alpha3.Site{
+		Spec: unboundedv1alpha3.SiteSpec{ImageRegistry: "registry.corp.internal/unbounded"},
+	})
+	if override.ImageRegistry != "registry.corp.internal/unbounded" || override.ImageTag != "v1" {
+		t.Fatalf("override config = %#v", override)
+	}
+
+	if got := override.Image("gantry"); got != "registry.corp.internal/unbounded/gantry:v1" {
+		t.Fatalf("overridden image = %q", got)
+	}
+
+	if got := ConfigForSite(base, &unboundedv1alpha3.Site{}); got.ImageRegistry != "ghcr.io/azure" {
+		t.Fatalf("empty override changed registry: %#v", got)
+	}
+
+	if got := ConfigForSite(base, nil); got.ImageRegistry != "ghcr.io/azure" {
+		t.Fatalf("nil site changed registry: %#v", got)
+	}
+
+	if base.ImageRegistry != "ghcr.io/azure" {
+		t.Fatalf("base config was mutated: %#v", base)
+	}
+}
+
+func TestUnsitedNodeAffinity(t *testing.T) {
+	terms := UnsitedNodeAffinity().NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 {
+		t.Fatalf("node selector terms = %d, want 1 (AND of two DoesNotExist)", len(terms))
+	}
+
+	exprs := terms[0].MatchExpressions
+	if len(exprs) != 2 {
+		t.Fatalf("match expressions = %d, want 2", len(exprs))
+	}
+
+	want := map[string]bool{SiteLabelKey: false, DeprecatedSiteLabelKey: false}
+
+	for _, expr := range exprs {
+		if expr.Operator != corev1.NodeSelectorOpDoesNotExist || len(expr.Values) != 0 {
+			t.Fatalf("unexpected expression: %#v", expr)
+		}
+
+		if _, ok := want[expr.Key]; !ok {
+			t.Fatalf("unexpected key %q", expr.Key)
+		}
+
+		want[expr.Key] = true
+	}
+
+	for key, seen := range want {
+		if !seen {
+			t.Fatalf("un-Sited affinity missing key %q", key)
+		}
+	}
+}
+
 func TestSetPodSpecImages(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]any{
 		"spec": map[string]any{"template": map[string]any{"spec": map[string]any{

--- a/internal/operator/component/env_test.go
+++ b/internal/operator/component/env_test.go
@@ -6,6 +6,7 @@ package component
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -74,6 +75,95 @@ func TestConfigForSite(t *testing.T) {
 	if base.ImageRegistry != "ghcr.io/azure" {
 		t.Fatalf("base config was mutated: %#v", base)
 	}
+}
+
+func TestSiteNodeAffinityCanonicalAuthoritative(t *testing.T) {
+	terms := SiteNodeAffinity("rack-a").NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 2 {
+		t.Fatalf("terms = %d, want 2 (canonical, then deprecated-when-canonical-absent)", len(terms))
+	}
+
+	// Term 0: canonical In [rack-a].
+	if got := terms[0].MatchExpressions; len(got) != 1 ||
+		got[0].Key != SiteLabelKey || got[0].Operator != corev1.NodeSelectorOpIn ||
+		len(got[0].Values) != 1 || got[0].Values[0] != "rack-a" {
+		t.Fatalf("term 0 = %#v, want canonical In [rack-a]", got)
+	}
+
+	// Term 1: canonical DoesNotExist AND deprecated In [rack-a].
+	got := terms[1].MatchExpressions
+	if len(got) != 2 {
+		t.Fatalf("term 1 = %#v, want two expressions", got)
+	}
+
+	if got[0].Key != SiteLabelKey || got[0].Operator != corev1.NodeSelectorOpDoesNotExist {
+		t.Fatalf("term 1[0] = %#v, want canonical DoesNotExist", got[0])
+	}
+
+	if got[1].Key != DeprecatedSiteLabelKey || got[1].Operator != corev1.NodeSelectorOpIn ||
+		len(got[1].Values) != 1 || got[1].Values[0] != "rack-a" {
+		t.Fatalf("term 1[1] = %#v, want deprecated In [rack-a]", got[1])
+	}
+
+	// Semantics: a Node whose canonical label points at a different Site than the
+	// deprecated label must match only the canonical Site, never both. Evaluate
+	// the terms against representative Node label sets.
+	cases := []struct {
+		name   string
+		labels map[string]string
+		match  bool
+	}{
+		{name: "canonical match", labels: map[string]string{SiteLabelKey: "rack-a"}, match: true},
+		{name: "deprecated only", labels: map[string]string{DeprecatedSiteLabelKey: "rack-a"}, match: true},
+		{name: "both canonical+deprecated match", labels: map[string]string{SiteLabelKey: "rack-a", DeprecatedSiteLabelKey: "rack-a"}, match: true},
+		{name: "conflict: canonical elsewhere", labels: map[string]string{SiteLabelKey: "rack-b", DeprecatedSiteLabelKey: "rack-a"}, match: false},
+		{name: "canonical elsewhere only", labels: map[string]string{SiteLabelKey: "rack-b"}, match: false},
+		{name: "unlabelled", labels: map[string]string{}, match: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nodeMatchesTerms(terms, tc.labels); got != tc.match {
+				t.Fatalf("match(%v) = %t, want %t", tc.labels, got, tc.match)
+			}
+		})
+	}
+}
+
+// nodeMatchesTerms evaluates a RequiredDuringScheduling node selector (OR of
+// terms, AND of expressions) against a Node's labels, supporting the In and
+// DoesNotExist operators used by the site affinities.
+func nodeMatchesTerms(terms []corev1.NodeSelectorTerm, labels map[string]string) bool {
+	for _, term := range terms {
+		matched := true
+
+		for _, expr := range term.MatchExpressions {
+			value, present := labels[expr.Key]
+
+			switch expr.Operator {
+			case corev1.NodeSelectorOpIn:
+				if !present || !slices.Contains(expr.Values, value) {
+					matched = false
+				}
+			case corev1.NodeSelectorOpDoesNotExist:
+				if present {
+					matched = false
+				}
+			default:
+				matched = false
+			}
+
+			if !matched {
+				break
+			}
+		}
+
+		if matched {
+			return true
+		}
+	}
+
+	return false
 }
 
 func TestUnsitedNodeAffinity(t *testing.T) {

--- a/internal/operator/components/gantry/gantry.go
+++ b/internal/operator/components/gantry/gantry.go
@@ -135,11 +135,14 @@ func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unbo
 		return component.Failed(err)
 	}
 
-	if err := applyManifests(ctx, env, applyMutator(env.Config.Image(imageRepository), configHash)); err != nil {
+	// Apply the per-Site DaemonSets before narrowing the base to un-Sited nodes,
+	// so a per-Site apply failure leaves the base covering every Node rather than
+	// excluding Sited nodes with no replacement in place.
+	if err := reconcileSiteDaemonSets(ctx, env, sites); err != nil {
 		return component.Failed(err)
 	}
 
-	if err := reconcileSiteDaemonSets(ctx, env, sites); err != nil {
+	if err := applyManifests(ctx, env, applyMutator(env.Config.Image(imageRepository), configHash)); err != nil {
 		return component.Failed(err)
 	}
 
@@ -296,20 +299,16 @@ func reconcileSiteDaemonSets(ctx context.Context, env *component.Env, sites []un
 	return nil
 }
 
-// cleanupSiteDaemonSet removes the per-Site DaemonSet and config for a Site that
-// opts out of gantry. The Site's nodes then run no gantry (the base excludes
-// Sited nodes).
+// cleanupSiteDaemonSet removes the per-Site DaemonSet for a Site that opts out of
+// gantry, so the Site's nodes run no gantry (the base excludes Sited nodes). The
+// per-Site config ConfigMap is deliberately preserved: it is user-editable
+// (upstream_registries, credentials) and re-enabling the Site should not lose
+// those edits. It is owner-referenced to the Site, so it is still garbage
+// collected when the Site itself is deleted.
 func cleanupSiteDaemonSet(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) error {
-	if err := env.DeleteIfExists(ctx, &appsv1.DaemonSet{
+	return env.DeleteIfExists(ctx, &appsv1.DaemonSet{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "DaemonSet"},
 		ObjectMeta: metav1.ObjectMeta{Name: SiteDaemonSetName(site.Name), Namespace: env.Namespace},
-	}); err != nil {
-		return err
-	}
-
-	return env.DeleteIfExists(ctx, &corev1.ConfigMap{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
-		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName(site.Name), Namespace: env.Namespace},
 	})
 }
 

--- a/internal/operator/components/gantry/gantry.go
+++ b/internal/operator/components/gantry/gantry.go
@@ -551,11 +551,15 @@ func seedSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1al
 		return nil, fmt.Errorf("get gantry config to seed site %s: %w", site.Name, err)
 	}
 
+	// Deep-copy the payload so the per-Site ConfigMap does not alias the shared
+	// config's maps (a later mutation of either must not affect the other).
+	payload := shared.DeepCopy()
+
 	cm := &corev1.ConfigMap{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
 		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName(site.Name), Namespace: env.Namespace, OwnerReferences: []metav1.OwnerReference{component.SiteOwnerReference(site)}},
-		Data:       shared.Data,
-		BinaryData: shared.BinaryData,
+		Data:       payload.Data,
+		BinaryData: payload.BinaryData,
 	}
 
 	return cm, nil

--- a/internal/operator/components/gantry/gantry.go
+++ b/internal/operator/components/gantry/gantry.go
@@ -7,13 +7,25 @@
 // components it defaults to enabled: it is deployed unless every Site explicitly
 // opts out via spec.components.gantry.enabled=false.
 //
+// Like the net node dataplane, the agent DaemonSet is split so a Site can pull
+// the gantry image from its own registry and mount its own config. A cluster-wide
+// "base" DaemonSet (gantry) runs on the nodes that do not belong to any Site
+// using the operator-wide registry and the shared config, while a per-Site
+// DaemonSet (gantry-<site>) runs on each gantry-enabled Site's nodes using that
+// Site's imageRegistry override and per-Site config. Node affinity partitions the
+// two so every Node is covered by at most one DaemonSet.
+//
 // The unbounded agent manages the per-node containerd wiring, so the operator
 // installs only the Gantry workload and its Kubernetes configuration.
 package gantry
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,6 +33,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,6 +46,15 @@ import (
 const (
 	daemonSetName = "gantry"
 	configName    = "gantry-config"
+
+	// configPrefix names the per-Site config ConfigMaps (gantry-config-<site>).
+	// The shared config keeps the bare configName; the trailing hyphen keeps the
+	// two disjoint.
+	configPrefix = configName + "-"
+
+	// daemonSetManifest is the base DaemonSet within the embedded gantry
+	// manifests. Per-Site DaemonSets are derived from it.
+	daemonSetManifest = "daemonset.yaml"
 
 	// imageRepository is the operator-managed image repository for the gantry
 	// agent. The operator derives the full reference at reconcile time via
@@ -75,9 +98,10 @@ func EnabledFor(site *unboundedv1alpha3.Site) bool {
 	return *g.Enabled
 }
 
-// Reconcile deploys the gantry cluster singleton whenever at least one Site does
-// not opt out and keeps an existing installation reconciled when every Site opts
-// out.
+// Reconcile deploys the gantry base DaemonSet whenever at least one Site does not
+// opt out, keeps an existing installation reconciled when every Site opts out,
+// and reconciles a per-Site DaemonSet (and its config) for each gantry-enabled
+// Site.
 func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unboundedv1alpha3.Site) component.Result {
 	if err := cleanupLegacyNodeConfig(ctx, env); err != nil {
 		return component.Failed(err)
@@ -115,17 +139,31 @@ func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unbo
 		return component.Failed(err)
 	}
 
+	if err := reconcileSiteDaemonSets(ctx, env, sites); err != nil {
+		return component.Failed(err)
+	}
+
 	return component.Reconciled()
 }
 
-// SetupWatches reconciles Gantry on changes to its active resources and when
-// legacy node-config resources appear so they can be removed.
+// SetupWatches reconciles Gantry on changes to its active resources, when legacy
+// node-config resources appear so they can be removed, and on drift or deletion
+// of the per-Site DaemonSets (owned by their Site) and per-Site config.
 func (Component) SetupWatches(b *builder.Builder, env *component.Env) {
 	b.Watches(&corev1.ConfigMap{}, env.RequestSingletonAndAllSites(),
 		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceNamed(configName, legacyNodeConfigName))))
+	b.Watches(&corev1.ConfigMap{}, env.RequestSiteFromConfigName(configPrefix),
+		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceWithPrefix(configPrefix))))
 	b.Watches(&appsv1.DaemonSet{}, env.RequestSingleton(),
 		builder.WithPredicates(env.ManagedWorkloadPredicate(env.InNamespaceNamed(daemonSetName, legacyNodeConfigDaemonSetName))))
+	b.Owns(&appsv1.DaemonSet{}, builder.WithPredicates(env.OwnedWorkloadPredicate()))
 }
+
+// SiteConfigName is the per-Site gantry config ConfigMap name.
+func SiteConfigName(site string) string { return configPrefix + site }
+
+// SiteDaemonSetName is the per-Site gantry DaemonSet name.
+func SiteDaemonSetName(site string) string { return daemonSetName + "-" + site }
 
 // applyManifests applies Gantry's operator-managed top-level manifests. The
 // standalone node configurator and examples subtree are intentionally excluded.
@@ -181,9 +219,10 @@ func cleanupLegacyNodeConfig(ctx context.Context, env *component.Env) error {
 }
 
 // applyMutator skips CRDs and the separately reconciled gantry-config ConfigMap,
-// stamps the operator-derived agent image onto the agent DaemonSet, and stamps
-// the config payload hash on its pod template so a config change rolls the
-// DaemonSet. Only the agent's own container is re-imaged.
+// scopes the base agent DaemonSet to un-Sited nodes, stamps the operator-derived
+// agent image onto it, and stamps the config payload hash on its pod template so
+// a config change rolls the DaemonSet. Only the agent's own container is
+// re-imaged.
 func applyMutator(agentImage, configHash string) func(*unstructured.Unstructured) error {
 	return func(obj *unstructured.Unstructured) error {
 		if obj.GetKind() == component.CRDKind {
@@ -199,6 +238,12 @@ func applyMutator(agentImage, configHash string) func(*unstructured.Unstructured
 		}
 
 		if obj.GetKind() == "DaemonSet" && obj.GetName() == daemonSetName {
+			// The base DaemonSet runs only on nodes that do not belong to any
+			// Site; each Site's nodes are covered by its per-Site DaemonSet.
+			if err := setAffinity(obj, component.UnsitedNodeAffinity()); err != nil {
+				return fmt.Errorf("scope base gantry to un-Sited nodes: %w", err)
+			}
+
 			if err := component.SetNamedContainerImage(obj, agentContainerName, agentImage); err != nil {
 				return fmt.Errorf("set gantry agent image: %w", err)
 			}
@@ -208,6 +253,182 @@ func applyMutator(agentImage, configHash string) func(*unstructured.Unstructured
 
 		return nil
 	}
+}
+
+// reconcileSiteDaemonSets reconciles the per-Site gantry DaemonSet and its config
+// for every gantry-enabled Site, and tears down the per-Site resources of a Site
+// that opts out. The DaemonSets are owned by their Site, so they are also garbage
+// collected when the Site is deleted.
+func reconcileSiteDaemonSets(ctx context.Context, env *component.Env, sites []unboundedv1alpha3.Site) error {
+	base, err := baseDaemonSet()
+	if err != nil {
+		return err
+	}
+
+	for i := range sites {
+		site := &sites[i]
+
+		if !EnabledFor(site) {
+			if err := cleanupSiteDaemonSet(ctx, env, site); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		configHash, err := ensureSiteConfig(ctx, env, site)
+		if err != nil {
+			return err
+		}
+
+		ds := base.DeepCopy()
+		if err := scopeDaemonSetToSite(site, component.ConfigForSite(env.Config, site), configHash, ds); err != nil {
+			return fmt.Errorf("scope gantry for site %s: %w", site.Name, err)
+		}
+
+		env.RetargetNamespace(ds)
+
+		if err := env.ApplyObject(ctx, ds); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanupSiteDaemonSet removes the per-Site DaemonSet and config for a Site that
+// opts out of gantry. The Site's nodes then run no gantry (the base excludes
+// Sited nodes).
+func cleanupSiteDaemonSet(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) error {
+	if err := env.DeleteIfExists(ctx, &appsv1.DaemonSet{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "DaemonSet"},
+		ObjectMeta: metav1.ObjectMeta{Name: SiteDaemonSetName(site.Name), Namespace: env.Namespace},
+	}); err != nil {
+		return err
+	}
+
+	return env.DeleteIfExists(ctx, &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName(site.Name), Namespace: env.Namespace},
+	})
+}
+
+// baseDaemonSet decodes the base gantry DaemonSet from the embedded manifest,
+// which may bundle several documents (for example a PriorityClass) ahead of it.
+func baseDaemonSet() (*unstructured.Unstructured, error) {
+	data, err := fs.ReadFile(gantrymanifests.Manifests, daemonSetManifest)
+	if err != nil {
+		return nil, fmt.Errorf("read base gantry manifest: %w", err)
+	}
+
+	decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+	for {
+		obj := &unstructured.Unstructured{}
+		if err := decoder.Decode(obj); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return nil, fmt.Errorf("decode base gantry manifest: %w", err)
+		}
+
+		if obj.GetKind() == "DaemonSet" && obj.GetName() == daemonSetName {
+			return obj, nil
+		}
+	}
+
+	return nil, fmt.Errorf("base gantry DaemonSet %q not found in manifest", daemonSetName)
+}
+
+// scopeDaemonSetToSite turns the base gantry DaemonSet into the Site's own
+// DaemonSet: a per-Site name, labels, selector, node affinity, agent image (from
+// the Site's registry), config mount, config-hash, and Site owner reference.
+func scopeDaemonSetToSite(site *unboundedv1alpha3.Site, cfg component.Config, configHash string, obj *unstructured.Unstructured) error {
+	obj.SetName(SiteDaemonSetName(site.Name))
+	obj.SetOwnerReferences([]metav1.OwnerReference{component.SiteOwnerReference(site)})
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	labels[component.SiteLabelKey] = site.Name
+	obj.SetLabels(labels)
+
+	for _, path := range [][]string{
+		{"spec", "selector", "matchLabels", component.SiteLabelKey},
+		{"spec", "template", "metadata", "labels", component.SiteLabelKey},
+	} {
+		if err := unstructured.SetNestedField(obj.Object, site.Name, path...); err != nil {
+			return fmt.Errorf("scope gantry daemonset (%v): %w", path, err)
+		}
+	}
+
+	if err := setAffinity(obj, component.SiteNodeAffinity(site.Name)); err != nil {
+		return fmt.Errorf("set gantry affinity: %w", err)
+	}
+
+	if err := component.SetNamedContainerImage(obj, agentContainerName, cfg.Image(imageRepository)); err != nil {
+		return fmt.Errorf("set gantry agent image: %w", err)
+	}
+
+	if err := pointDaemonSetAtSiteConfig(site, obj); err != nil {
+		return err
+	}
+
+	return stampConfigHash(obj, configHashAnnotation, configHash)
+}
+
+// pointDaemonSetAtSiteConfig repoints the DaemonSet's config volume at the Site's
+// per-Site config ConfigMap so each Site mounts its own gantry config.
+func pointDaemonSetAtSiteConfig(site *unboundedv1alpha3.Site, obj *unstructured.Unstructured) error {
+	volumes, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
+	if err != nil {
+		return fmt.Errorf("get gantry volumes: %w", err)
+	}
+
+	if !found {
+		return nil
+	}
+
+	for i, v := range volumes {
+		vol, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		cm, ok := vol["configMap"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if cm["name"] == configName {
+			cm["name"] = SiteConfigName(site.Name)
+			vol["configMap"] = cm
+			volumes[i] = vol
+		}
+	}
+
+	if err := unstructured.SetNestedSlice(obj.Object, volumes, "spec", "template", "spec", "volumes"); err != nil {
+		return fmt.Errorf("set gantry volumes: %w", err)
+	}
+
+	return nil
+}
+
+// setAffinity sets the pod template node affinity on a workload.
+func setAffinity(obj *unstructured.Unstructured, affinity *corev1.Affinity) error {
+	affinityMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(affinity)
+	if err != nil {
+		return fmt.Errorf("convert affinity: %w", err)
+	}
+
+	if err := unstructured.SetNestedMap(obj.Object, affinityMap, "spec", "template", "spec", "affinity"); err != nil {
+		return fmt.Errorf("set affinity: %w", err)
+	}
+
+	return nil
 }
 
 // stampConfigHash sets a config-hash annotation on a workload's pod template so a
@@ -230,7 +451,7 @@ func stampConfigHash(obj *unstructured.Unstructured, annotation, hash string) er
 	return nil
 }
 
-// ensureConfig creates the embedded default only when no config exists. An
+// ensureConfig creates the embedded default only when no shared config exists. An
 // existing operator/user-managed payload (for example an edited
 // upstream_registries list) is never applied over.
 func ensureConfig(ctx context.Context, env *component.Env) (string, error) {
@@ -264,4 +485,97 @@ func ensureConfig(ctx context.Context, env *component.Env) (string, error) {
 	}
 
 	return component.ConfigMapPayloadHash(desired), nil
+}
+
+// ensureSiteConfig creates the per-Site config ConfigMap by cloning the shared
+// gantry config when it is absent, so a Site starts from the operator/user-tuned
+// baseline (for example an edited upstream_registries list). An existing per-Site
+// config is preserved and only adopted with a Site owner reference so it is
+// garbage collected with the Site.
+func ensureSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) (string, error) {
+	key := client.ObjectKey{Namespace: env.Namespace, Name: SiteConfigName(site.Name)}
+	existing := &corev1.ConfigMap{}
+
+	err := env.Client.Get(ctx, key, existing)
+	switch {
+	case err == nil:
+		if err := adoptSiteConfig(ctx, env, site, existing); err != nil {
+			return "", err
+		}
+
+		return component.ConfigMapPayloadHash(existing), nil
+	case !apierrors.IsNotFound(err):
+		return "", fmt.Errorf("get gantry site config %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	cm, err := seedSiteConfig(ctx, env, site)
+	if err != nil {
+		return "", err
+	}
+
+	if err := env.Client.Create(ctx, cm); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return "", fmt.Errorf("create gantry site config %s/%s: %w", cm.Namespace, cm.Name, err)
+		}
+
+		if getErr := env.Client.Get(ctx, key, existing); getErr != nil {
+			return "", fmt.Errorf("get raced gantry site config %s/%s: %w", key.Namespace, key.Name, getErr)
+		}
+
+		if err := adoptSiteConfig(ctx, env, site, existing); err != nil {
+			return "", err
+		}
+
+		return component.ConfigMapPayloadHash(existing), nil
+	}
+
+	return component.ConfigMapPayloadHash(cm), nil
+}
+
+// seedSiteConfig builds the per-Site config from the shared gantry config so
+// operator/user tuning carries over. It falls back to the embedded default if the
+// shared config is somehow absent.
+func seedSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) (*corev1.ConfigMap, error) {
+	shared := &corev1.ConfigMap{}
+	key := client.ObjectKey{Namespace: env.Namespace, Name: configName}
+
+	err := env.Client.Get(ctx, key, shared)
+	switch {
+	case err == nil:
+	case apierrors.IsNotFound(err):
+		shared, err = env.DefaultConfigMap(gantrymanifests.Manifests, configName, "gantry")
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("get gantry config to seed site %s: %w", site.Name, err)
+	}
+
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName(site.Name), Namespace: env.Namespace, OwnerReferences: []metav1.OwnerReference{component.SiteOwnerReference(site)}},
+		Data:       shared.Data,
+		BinaryData: shared.BinaryData,
+	}
+
+	return cm, nil
+}
+
+func adoptSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site, cm *corev1.ConfigMap) error {
+	owner := component.SiteOwnerReference(site)
+
+	refs, changed := component.UpsertOwnerReference(cm.OwnerReferences, owner)
+	if !changed {
+		return nil
+	}
+
+	before := cm.DeepCopy()
+	cm.OwnerReferences = refs
+
+	patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
+	if err := env.Client.Patch(ctx, cm, patch); err != nil {
+		return fmt.Errorf("adopt gantry site config %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	return nil
 }

--- a/internal/operator/components/gantry/gantry_test.go
+++ b/internal/operator/components/gantry/gantry_test.go
@@ -448,3 +448,221 @@ func TestResourcesExist(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyMutatorScopesBaseToUnsitedNodes(t *testing.T) {
+	base, err := baseDaemonSet()
+	if err != nil {
+		t.Fatalf("baseDaemonSet: %v", err)
+	}
+
+	if err := applyMutator("ghcr.io/azure/gantry:v1", "h")(base); err != nil {
+		t.Fatalf("applyMutator: %v", err)
+	}
+
+	affinity, ok, err := unstructured.NestedMap(base.Object, "spec", "template", "spec", "affinity")
+	if err != nil || !ok {
+		t.Fatalf("base gantry missing affinity: ok=%t err=%v", ok, err)
+	}
+
+	converted := &corev1.Affinity{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(affinity, converted); err != nil {
+		t.Fatalf("convert affinity: %v", err)
+	}
+
+	terms := converted.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 || len(terms[0].MatchExpressions) != 2 {
+		t.Fatalf("un-Sited affinity = %#v, want one term with two DoesNotExist", terms)
+	}
+
+	for _, expr := range terms[0].MatchExpressions {
+		if expr.Operator != corev1.NodeSelectorOpDoesNotExist {
+			t.Fatalf("expression %q operator = %q, want DoesNotExist", expr.Key, expr.Operator)
+		}
+	}
+}
+
+func TestScopeDaemonSetToSite(t *testing.T) {
+	base, err := baseDaemonSet()
+	if err != nil {
+		t.Fatalf("baseDaemonSet: %v", err)
+	}
+
+	wantInit := containerImage(t, base, "initContainers", "chown-hostpaths")
+
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"},
+		Spec:       unboundedv1alpha3.SiteSpec{ImageRegistry: "registry.corp.internal/unbounded"},
+	}
+	cfg := component.ConfigForSite(component.Config{ImageRegistry: "ghcr.io/azure", ImageTag: "v1.2.3"}, site)
+
+	ds := base.DeepCopy()
+	if err := scopeDaemonSetToSite(site, cfg, "gantry-hash", ds); err != nil {
+		t.Fatalf("scopeDaemonSetToSite: %v", err)
+	}
+
+	if got := ds.GetName(); got != "gantry-edge" {
+		t.Fatalf("name = %q, want gantry-edge", got)
+	}
+
+	for _, path := range [][]string{
+		{"spec", "selector", "matchLabels", component.SiteLabelKey},
+		{"spec", "template", "metadata", "labels", component.SiteLabelKey},
+	} {
+		got, ok, err := unstructured.NestedString(ds.Object, path...)
+		if err != nil || !ok || got != "edge" {
+			t.Fatalf("%v = %q (ok=%t err=%v), want edge", path, got, ok, err)
+		}
+	}
+
+	// Only the agent container is repointed at the Site's registry; the busybox
+	// init container keeps its pinned public image.
+	if got := containerImage(t, ds, "containers", agentContainerName); got != "registry.corp.internal/unbounded/gantry:v1.2.3" {
+		t.Fatalf("agent image = %q, want site-registry gantry", got)
+	}
+
+	if got := containerImage(t, ds, "initContainers", "chown-hostpaths"); got != wantInit {
+		t.Fatalf("busybox init image = %q, want unchanged %q", got, wantInit)
+	}
+
+	assertSiteAffinity(t, ds)
+	assertSiteOwnerRef(t, ds.GetOwnerReferences(), "edge", "edge-uid")
+
+	volumes, _, _ := unstructured.NestedSlice(ds.Object, "spec", "template", "spec", "volumes")
+	if name := configVolumeName(t, volumes); name != "gantry-config-edge" {
+		t.Fatalf("config volume = %q, want gantry-config-edge", name)
+	}
+
+	annotations, _, _ := unstructured.NestedStringMap(ds.Object, "spec", "template", "metadata", "annotations")
+	if annotations[configHashAnnotation] != "gantry-hash" {
+		t.Fatalf("config hash annotation = %q", annotations[configHashAnnotation])
+	}
+}
+
+func TestEnsureSiteConfigSeedsFromSharedConfig(t *testing.T) {
+	shared := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: component.DefaultNamespace},
+		Data:       map[string]string{"config.yaml": "upstream_registries:\n  - name: mirror\n"},
+	}
+	env := testEnv(t, shared)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"}}
+
+	hash, err := ensureSiteConfig(t.Context(), env, site)
+	if err != nil {
+		t.Fatalf("ensureSiteConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: SiteConfigName("edge")}, &got); err != nil {
+		t.Fatalf("get per-site config: %v", err)
+	}
+
+	if got.Data["config.yaml"] != "upstream_registries:\n  - name: mirror\n" {
+		t.Fatalf("per-site config not seeded from shared config: %#v", got.Data)
+	}
+
+	if hash != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("hash = %q, want exact payload hash", hash)
+	}
+
+	assertSiteOwnerRef(t, got.OwnerReferences, "edge", "edge-uid")
+}
+
+func TestReconcileFansOutPerSiteAndCleansUpOptedOut(t *testing.T) {
+	no := false
+	// A per-Site DaemonSet and config left over for a site that now opts out.
+	staleDS := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: SiteDaemonSetName("legacy")}}
+	staleConfig := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: component.DefaultNamespace, Name: SiteConfigName("legacy")}}
+
+	env, applied := reconcilerEnv(t, staleDS, staleConfig)
+
+	sites := []unboundedv1alpha3.Site{
+		*siteWithGantry("edge", nil),   // enabled (default)
+		*siteWithGantry("legacy", &no), // opted out
+	}
+
+	res := Component{}.Reconcile(t.Context(), env, sites)
+	if !res.Ready || res.Err != nil {
+		t.Fatalf("Reconcile = %+v, want ready", res)
+	}
+
+	// Base plus the enabled Site's DaemonSet are applied.
+	if !applied["DaemonSet/gantry"] || !applied["DaemonSet/gantry-edge"] {
+		t.Fatalf("expected base and per-site DaemonSets applied; applied=%#v", applied)
+	}
+
+	// The opted-out Site gets no per-site DaemonSet applied and its stale one is
+	// removed.
+	if applied["DaemonSet/gantry-legacy"] {
+		t.Fatal("opted-out site had a per-site DaemonSet applied")
+	}
+
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(staleDS), &appsv1.DaemonSet{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("opted-out per-site DaemonSet not cleaned up: %v", err)
+	}
+
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(staleConfig), &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("opted-out per-site config not cleaned up: %v", err)
+	}
+
+	// The enabled Site's config is created.
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: SiteConfigName("edge")}, &corev1.ConfigMap{}); err != nil {
+		t.Fatalf("enabled site config not created: %v", err)
+	}
+}
+
+func assertSiteAffinity(t *testing.T, obj *unstructured.Unstructured) {
+	t.Helper()
+
+	affinity, ok, err := unstructured.NestedMap(obj.Object, "spec", "template", "spec", "affinity")
+	if err != nil || !ok {
+		t.Fatalf("missing site affinity: ok=%t err=%v", ok, err)
+	}
+
+	converted := &corev1.Affinity{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(affinity, converted); err != nil {
+		t.Fatalf("convert affinity: %v", err)
+	}
+
+	terms := converted.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 2 {
+		t.Fatalf("site affinity terms = %d, want 2", len(terms))
+	}
+}
+
+func assertSiteOwnerRef(t *testing.T, refs []metav1.OwnerReference, siteName, uid string) {
+	t.Helper()
+
+	if len(refs) != 1 {
+		t.Fatalf("ownerReferences len = %d, want 1: %#v", len(refs), refs)
+	}
+
+	ref := refs[0]
+	if ref.Kind != "Site" || ref.Name != siteName || string(ref.UID) != uid {
+		t.Fatalf("unexpected ownerRef: %#v", ref)
+	}
+
+	if ref.Controller == nil || !*ref.Controller {
+		t.Fatalf("ownerRef is not a controller reference: %#v", ref)
+	}
+}
+
+func configVolumeName(t *testing.T, volumes []any) string {
+	t.Helper()
+
+	for _, v := range volumes {
+		vol, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if cm, ok := vol["configMap"].(map[string]any); ok && vol["name"] == "config" {
+			name, _ := cm["name"].(string)
+
+			return name
+		}
+	}
+
+	t.Fatal("config volume not found")
+
+	return ""
+}

--- a/internal/operator/components/gantry/gantry_test.go
+++ b/internal/operator/components/gantry/gantry_test.go
@@ -600,13 +600,59 @@ func TestReconcileFansOutPerSiteAndCleansUpOptedOut(t *testing.T) {
 		t.Fatalf("opted-out per-site DaemonSet not cleaned up: %v", err)
 	}
 
-	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(staleConfig), &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
-		t.Fatalf("opted-out per-site config not cleaned up: %v", err)
+	// The opted-out Site's config is preserved (user-editable; only GC'd with the
+	// Site), so re-enabling does not lose custom registries/credentials.
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(staleConfig), &corev1.ConfigMap{}); err != nil {
+		t.Fatalf("opted-out per-site config was deleted, want preserved: %v", err)
 	}
 
 	// The enabled Site's config is created.
 	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: SiteConfigName("edge")}, &corev1.ConfigMap{}); err != nil {
 		t.Fatalf("enabled site config not created: %v", err)
+	}
+}
+
+func TestReconcileFailSafeOrderingKeepsBaseOnPerSiteFailure(t *testing.T) {
+	scheme := testScheme(t)
+	applied := map[string]bool{}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				o, ok := obj.(interface {
+					GetName() string
+					GetKind() string
+				})
+				if !ok {
+					t.Fatalf("applied object has unexpected type %T", obj)
+				}
+
+				applied[o.GetKind()+"/"+o.GetName()] = true
+
+				if o.GetKind() == "DaemonSet" && o.GetName() == SiteDaemonSetName("edge") {
+					return errors.New("apply per-site gantry failed")
+				}
+
+				return nil
+			},
+		}).
+		Build()
+
+	env := &component.Env{Client: cl, Scheme: scheme, Namespace: component.DefaultNamespace}
+
+	res := Component{}.Reconcile(t.Context(), env, []unboundedv1alpha3.Site{*siteWithGantry("edge", nil)})
+	if res.Ready || res.Err == nil {
+		t.Fatalf("Reconcile = %+v, want failure", res)
+	}
+
+	// The base gantry DaemonSet must not be applied after the per-site apply
+	// failed, so the blanket base keeps covering the fleet.
+	if applied["DaemonSet/"+daemonSetName] {
+		t.Fatalf("base gantry DaemonSet was applied despite per-site failure; applied=%#v", applied)
+	}
+
+	if !applied["DaemonSet/"+SiteDaemonSetName("edge")] {
+		t.Fatalf("per-site apply was not attempted; applied=%#v", applied)
 	}
 }
 

--- a/internal/operator/components/metalman/metalman.go
+++ b/internal/operator/components/metalman/metalman.go
@@ -46,7 +46,7 @@ func (Component) Reconcile(ctx context.Context, env *component.Env, site *unboun
 		return component.Failed(err)
 	}
 
-	if err := env.ApplyObject(ctx, deployment(site, env.Namespace, env.Config)); err != nil {
+	if err := env.ApplyObject(ctx, deployment(site, env.Namespace, component.ConfigForSite(env.Config, site))); err != nil {
 		return component.Failed(err)
 	}
 

--- a/internal/operator/components/metalman/metalman_test.go
+++ b/internal/operator/components/metalman/metalman_test.go
@@ -273,32 +273,38 @@ func assertSiteAffinity(t *testing.T, affinity *corev1.Affinity, siteName string
 	}
 
 	terms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	assertCanonicalAuthoritativeSiteAffinity(t, terms, siteName)
+}
+
+// assertCanonicalAuthoritativeSiteAffinity checks the SiteNodeAffinity shape:
+// term 0 matches the canonical label, term 1 matches the deprecated label only
+// when the canonical label is absent.
+func assertCanonicalAuthoritativeSiteAffinity(t *testing.T, terms []corev1.NodeSelectorTerm, siteName string) {
+	t.Helper()
+
 	if len(terms) != 2 {
 		t.Fatalf("node selector terms len = %d, want 2: %#v", len(terms), terms)
 	}
 
-	want := map[string]bool{component.SiteLabelKey: false, component.DeprecatedSiteLabelKey: false}
-
-	for _, term := range terms {
-		if len(term.MatchExpressions) != 1 {
-			t.Fatalf("term must have one expression: %#v", term)
-		}
-
-		expr := term.MatchExpressions[0]
-		if expr.Operator != corev1.NodeSelectorOpIn || len(expr.Values) != 1 || expr.Values[0] != siteName {
-			t.Fatalf("unexpected site affinity expression: %#v", expr)
-		}
-
-		if _, ok := want[expr.Key]; !ok {
-			t.Fatalf("unexpected site affinity key %q", expr.Key)
-		}
-
-		want[expr.Key] = true
+	canonical := terms[0].MatchExpressions
+	if len(canonical) != 1 ||
+		canonical[0].Key != component.SiteLabelKey ||
+		canonical[0].Operator != corev1.NodeSelectorOpIn ||
+		len(canonical[0].Values) != 1 || canonical[0].Values[0] != siteName {
+		t.Fatalf("term 0 must be canonical In [%s]: %#v", siteName, canonical)
 	}
 
-	for key, seen := range want {
-		if !seen {
-			t.Fatalf("site affinity missing key %q", key)
-		}
+	deprecated := terms[1].MatchExpressions
+	if len(deprecated) != 2 {
+		t.Fatalf("term 1 must have two expressions (canonical DoesNotExist, deprecated In): %#v", deprecated)
+	}
+
+	if deprecated[0].Key != component.SiteLabelKey || deprecated[0].Operator != corev1.NodeSelectorOpDoesNotExist {
+		t.Fatalf("term 1[0] must be canonical DoesNotExist: %#v", deprecated[0])
+	}
+
+	if deprecated[1].Key != component.DeprecatedSiteLabelKey || deprecated[1].Operator != corev1.NodeSelectorOpIn ||
+		len(deprecated[1].Values) != 1 || deprecated[1].Values[0] != siteName {
+		t.Fatalf("term 1[1] must be deprecated In [%s]: %#v", siteName, deprecated[1])
 	}
 }

--- a/internal/operator/components/metalman/metalman_test.go
+++ b/internal/operator/components/metalman/metalman_test.go
@@ -154,6 +154,28 @@ func TestDeployment(t *testing.T) {
 	}
 }
 
+func TestDeploymentUsesSiteImageRegistry(t *testing.T) {
+	enabled := true
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
+		Spec: unboundedv1alpha3.SiteSpec{
+			ImageRegistry: "registry.corp.internal/unbounded",
+			Components: unboundedv1alpha3.SiteComponents{Metalman: &unboundedv1alpha3.MetalmanComponentSpec{
+				SiteComponentSpec: unboundedv1alpha3.SiteComponentSpec{Enabled: &enabled},
+			}},
+		},
+	}
+
+	// Reconcile resolves the image through component.ConfigForSite, so a Site
+	// with an imageRegistry override pulls metalman from that registry.
+	cfg := component.ConfigForSite(component.Config{ImageRegistry: "ghcr.io/azure", ImageTag: "v1.2.3"}, site)
+
+	d := deployment(site, component.DefaultNamespace, cfg)
+	if got := d.Spec.Template.Spec.Containers[0].Image; got != "registry.corp.internal/unbounded/metalman:v1.2.3" {
+		t.Fatalf("image = %q, want site-registry metalman", got)
+	}
+}
+
 func TestDeploymentRespectsNamespaceAndDefaults(t *testing.T) {
 	enabled := true
 	site := &unboundedv1alpha3.Site{

--- a/internal/operator/components/net/net.go
+++ b/internal/operator/components/net/net.go
@@ -2,19 +2,35 @@
 // Licensed under the MIT License.
 
 // Package net implements the unbounded-net cluster component. Net is not a
-// per-Site component: one controller/node pair reads every Site, so it is
-// reconciled as a cluster singleton whenever at least one Site exists and kept
-// reconciled if it was already installed.
+// per-Site component in the classic sense: one controller reads every Site, so
+// the controller and its config are reconciled as cluster singletons whenever at
+// least one Site exists and kept reconciled if already installed.
+//
+// The node dataplane, however, is split so a Site can pull the node image from
+// its own registry and mount its own config. A cluster-wide "base" node
+// DaemonSet (unbounded-net-node) runs on the nodes that do not belong to any
+// Site (control plane and other un-Sited nodes) using the operator-wide registry
+// and the shared config, while a per-Site DaemonSet (unbounded-net-node-<site>)
+// runs on each Site's nodes using that Site's imageRegistry override and per-Site
+// config. Node affinity partitions the two (a Node carries at most one site
+// label), so every Node is covered by exactly one DaemonSet.
 package net
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,6 +43,15 @@ const (
 	configName     = "unbounded-net-config"
 	controllerName = "unbounded-net-controller"
 	nodeName       = "unbounded-net-node"
+
+	// nodeConfigPrefix names the per-Site node config ConfigMaps
+	// (unbounded-net-config-<site>). The shared config keeps the bare
+	// configName, so the trailing hyphen keeps the two disjoint.
+	nodeConfigPrefix = configName + "-"
+
+	// nodeDaemonSetManifest is the base node DaemonSet within the embedded net
+	// manifests. Per-Site node DaemonSets are derived from it.
+	nodeDaemonSetManifest = "node/03-daemonset.yaml"
 
 	ConfigHashAnnotation = "unbounded-cloud.io/net-config-hash"
 )
@@ -43,8 +68,9 @@ func (Component) Name() string { return "net" }
 // ConditionType implements component.ClusterComponent.
 func (Component) ConditionType() string { return "NetReady" }
 
-// Reconcile deploys the unbounded-net cluster singleton whenever at least one
-// Site exists and keeps an existing installation reconciled with no Sites.
+// Reconcile deploys the unbounded-net controller and base node DaemonSet whenever
+// at least one Site exists, keeps an existing installation reconciled with no
+// Sites, and reconciles a per-Site node DaemonSet (and its config) for each Site.
 func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unboundedv1alpha3.Site) component.Result {
 	if len(sites) == 0 {
 		// Net is the cluster dataplane. Do not auto-delete it just because the
@@ -70,19 +96,34 @@ func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unbo
 		return component.Failed(err)
 	}
 
+	if err := reconcileSiteNodes(ctx, env, sites); err != nil {
+		return component.Failed(err)
+	}
+
 	return component.Reconciled()
 }
 
-// SetupWatches reconciles net on changes to its config payload and on
-// create/delete/generation changes of its managed workloads.
+// SetupWatches reconciles net on changes to its config payloads and on
+// create/delete/generation changes of its managed workloads. Per-Site node
+// DaemonSets are owned by their Site, so Owns() re-enqueues the Site when one
+// drifts or is deleted.
 func (Component) SetupWatches(b *builder.Builder, env *component.Env) {
 	b.Watches(&corev1.ConfigMap{}, env.RequestSingletonAndAllSites(),
 		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceNamed(configName))))
+	b.Watches(&corev1.ConfigMap{}, env.RequestSiteFromConfigName(nodeConfigPrefix),
+		builder.WithPredicates(env.ManagedConfigPredicate(env.InNamespaceWithPrefix(nodeConfigPrefix))))
 	b.Watches(&appsv1.Deployment{}, env.RequestSingleton(),
 		builder.WithPredicates(env.ManagedWorkloadPredicate(env.InNamespaceNamed(controllerName))))
 	b.Watches(&appsv1.DaemonSet{}, env.RequestSingleton(),
 		builder.WithPredicates(env.ManagedWorkloadPredicate(env.InNamespaceNamed(nodeName))))
+	b.Owns(&appsv1.DaemonSet{}, builder.WithPredicates(env.OwnedWorkloadPredicate()))
 }
+
+// SiteConfigName is the per-Site node config ConfigMap name.
+func SiteConfigName(site string) string { return nodeConfigPrefix + site }
+
+// SiteNodeDaemonSetName is the per-Site node DaemonSet name.
+func SiteNodeDaemonSetName(site string) string { return nodeName + "-" + site }
 
 func resourcesExist(ctx context.Context, env *component.Env) (bool, error) {
 	for _, object := range []client.Object{
@@ -110,8 +151,9 @@ func resourcesExist(ctx context.Context, env *component.Env) (bool, error) {
 	return false, nil
 }
 
-// applyMutator skips the separately reconciled ConfigMap and stamps its exact
-// payload hash on both net workloads so config changes roll them together.
+// applyMutator skips the separately reconciled ConfigMap and CRDs, scopes the
+// base node DaemonSet to un-Sited nodes, and stamps the shared config payload
+// hash on both cluster workloads so config changes roll them together.
 func applyMutator(cfg component.Config, configHash string) func(*unstructured.Unstructured) error {
 	return func(obj *unstructured.Unstructured) error {
 		if obj.GetKind() == component.CRDKind {
@@ -126,24 +168,22 @@ func applyMutator(cfg component.Config, configHash string) func(*unstructured.Un
 			return nil
 		}
 
+		if obj.GetKind() == "DaemonSet" && obj.GetName() == nodeName {
+			// The base node DaemonSet runs only on nodes that do not belong to
+			// any Site; each Site's nodes are covered by its per-Site DaemonSet.
+			if err := setAffinity(obj, component.UnsitedNodeAffinity()); err != nil {
+				return fmt.Errorf("scope base net node to un-Sited nodes: %w", err)
+			}
+		}
+
 		if (obj.GetKind() == "Deployment" && obj.GetName() == controllerName) ||
 			(obj.GetKind() == "DaemonSet" && obj.GetName() == nodeName) {
 			if err := component.SetPodSpecImages(obj, cfg.Image(obj.GetName())); err != nil {
 				return fmt.Errorf("set net workload images: %w", err)
 			}
 
-			annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
-			if err != nil {
-				return fmt.Errorf("get net pod template annotations: %w", err)
-			}
-
-			if annotations == nil {
-				annotations = map[string]string{}
-			}
-
-			annotations[ConfigHashAnnotation] = configHash
-			if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
-				return fmt.Errorf("set net config hash annotation: %w", err)
+			if err := stampConfigHash(obj, configHash); err != nil {
+				return err
 			}
 		}
 
@@ -151,8 +191,232 @@ func applyMutator(cfg component.Config, configHash string) func(*unstructured.Un
 	}
 }
 
-// ensureConfig creates the embedded default only when no config exists. Existing
-// migrated or user-managed payloads are never applied over.
+// reconcileSiteNodes reconciles the per-Site node DaemonSet and its config for
+// every Site. The DaemonSets are owned by their Site, so they are garbage
+// collected when the Site is deleted.
+func reconcileSiteNodes(ctx context.Context, env *component.Env, sites []unboundedv1alpha3.Site) error {
+	base, err := baseNodeDaemonSet()
+	if err != nil {
+		return err
+	}
+
+	for i := range sites {
+		site := &sites[i]
+
+		configHash, err := ensureSiteConfig(ctx, env, site)
+		if err != nil {
+			return err
+		}
+
+		ds := base.DeepCopy()
+		if err := scopeNodeDaemonSetToSite(site, component.ConfigForSite(env.Config, site), configHash, ds); err != nil {
+			return fmt.Errorf("scope net node for site %s: %w", site.Name, err)
+		}
+
+		env.RetargetNamespace(ds)
+
+		if err := env.ApplyObject(ctx, ds); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// baseNodeDaemonSet decodes the base node DaemonSet from the embedded manifest,
+// which may bundle several documents ahead of it.
+func baseNodeDaemonSet() (*unstructured.Unstructured, error) {
+	data, err := fs.ReadFile(netmanifests.Manifests, nodeDaemonSetManifest)
+	if err != nil {
+		return nil, fmt.Errorf("read base net node manifest: %w", err)
+	}
+
+	decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+	for {
+		obj := &unstructured.Unstructured{}
+		if err := decoder.Decode(obj); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return nil, fmt.Errorf("decode base net node manifest: %w", err)
+		}
+
+		if obj.GetKind() == "DaemonSet" && obj.GetName() == nodeName {
+			return obj, nil
+		}
+	}
+
+	return nil, fmt.Errorf("base net node DaemonSet %q not found in manifest", nodeName)
+}
+
+// scopeNodeDaemonSetToSite turns the base node DaemonSet into the Site's own
+// DaemonSet: a per-Site name, labels, selector, node affinity, image (from the
+// Site's registry), config mount, config-hash, and Site owner reference.
+func scopeNodeDaemonSetToSite(site *unboundedv1alpha3.Site, cfg component.Config, configHash string, obj *unstructured.Unstructured) error {
+	obj.SetName(SiteNodeDaemonSetName(site.Name))
+	obj.SetOwnerReferences([]metav1.OwnerReference{component.SiteOwnerReference(site)})
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	labels[component.SiteLabelKey] = site.Name
+	obj.SetLabels(labels)
+
+	for _, path := range [][]string{
+		{"spec", "selector", "matchLabels", component.SiteLabelKey},
+		{"spec", "template", "metadata", "labels", component.SiteLabelKey},
+	} {
+		if err := unstructured.SetNestedField(obj.Object, site.Name, path...); err != nil {
+			return fmt.Errorf("scope net node daemonset (%v): %w", path, err)
+		}
+	}
+
+	if err := setAffinity(obj, component.SiteNodeAffinity(site.Name)); err != nil {
+		return fmt.Errorf("set net node affinity: %w", err)
+	}
+
+	if err := component.SetPodSpecImages(obj, cfg.Image(nodeName)); err != nil {
+		return fmt.Errorf("set net node image: %w", err)
+	}
+
+	if err := pointNodeDaemonSetAtSiteConfig(site, obj); err != nil {
+		return err
+	}
+
+	return stampConfigHash(obj, configHash)
+}
+
+// pointNodeDaemonSetAtSiteConfig repoints the DaemonSet's config volume and the
+// LOG_LEVEL env reference at the Site's per-Site config ConfigMap so each Site
+// mounts its own node config.
+func pointNodeDaemonSetAtSiteConfig(site *unboundedv1alpha3.Site, obj *unstructured.Unstructured) error {
+	siteConfig := SiteConfigName(site.Name)
+
+	volumes, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
+	if err != nil {
+		return fmt.Errorf("get net node volumes: %w", err)
+	}
+
+	if found {
+		for i, v := range volumes {
+			vol, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			cm, ok := vol["configMap"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if cm["name"] == configName {
+				cm["name"] = siteConfig
+				vol["configMap"] = cm
+				volumes[i] = vol
+			}
+		}
+
+		if err := unstructured.SetNestedSlice(obj.Object, volumes, "spec", "template", "spec", "volumes"); err != nil {
+			return fmt.Errorf("set net node volumes: %w", err)
+		}
+	}
+
+	return repointConfigEnv(obj, configName, siteConfig)
+}
+
+// repointConfigEnv rewrites every container env var that sources a value from
+// the old ConfigMap to the new one, so per-Site node pods read LOG_LEVEL (and any
+// other configMapKeyRef) from their own config.
+func repointConfigEnv(obj *unstructured.Unstructured, oldName, newName string) error {
+	containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+	if err != nil {
+		return fmt.Errorf("get net node containers: %w", err)
+	}
+
+	if !found {
+		return nil
+	}
+
+	for i := range containers {
+		container, ok := containers[i].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		envVars, ok := container["env"].([]any)
+		if !ok {
+			continue
+		}
+
+		for j := range envVars {
+			envVar, ok := envVars[j].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			valueFrom, ok := envVar["valueFrom"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			ref, ok := valueFrom["configMapKeyRef"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if ref["name"] == oldName {
+				ref["name"] = newName
+			}
+		}
+	}
+
+	if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+		return fmt.Errorf("set net node containers: %w", err)
+	}
+
+	return nil
+}
+
+// setAffinity sets the pod template node affinity on a workload.
+func setAffinity(obj *unstructured.Unstructured, affinity *corev1.Affinity) error {
+	affinityMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(affinity)
+	if err != nil {
+		return fmt.Errorf("convert affinity: %w", err)
+	}
+
+	if err := unstructured.SetNestedMap(obj.Object, affinityMap, "spec", "template", "spec", "affinity"); err != nil {
+		return fmt.Errorf("set affinity: %w", err)
+	}
+
+	return nil
+}
+
+// stampConfigHash sets the net config-hash annotation on a workload pod template
+// so a config change rolls it.
+func stampConfigHash(obj *unstructured.Unstructured, configHash string) error {
+	annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		return fmt.Errorf("get net pod template annotations: %w", err)
+	}
+
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[ConfigHashAnnotation] = configHash
+	if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
+		return fmt.Errorf("set net config hash annotation: %w", err)
+	}
+
+	return nil
+}
+
+// ensureConfig creates the embedded default only when no shared config exists.
+// Existing migrated or user-managed payloads are never applied over.
 func ensureConfig(ctx context.Context, env *component.Env) (string, error) {
 	key := client.ObjectKey{Namespace: env.Namespace, Name: configName}
 	existing := &corev1.ConfigMap{}
@@ -184,4 +448,97 @@ func ensureConfig(ctx context.Context, env *component.Env) (string, error) {
 	}
 
 	return component.ConfigMapPayloadHash(desired), nil
+}
+
+// ensureSiteConfig creates the per-Site node config ConfigMap by cloning the
+// shared config when it is absent, so a Site starts from the operator-tuned
+// baseline. An existing per-Site config (operator/user-edited) is preserved and
+// only adopted with a Site owner reference so it is garbage collected with the
+// Site.
+func ensureSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) (string, error) {
+	key := client.ObjectKey{Namespace: env.Namespace, Name: SiteConfigName(site.Name)}
+	existing := &corev1.ConfigMap{}
+
+	err := env.Client.Get(ctx, key, existing)
+	switch {
+	case err == nil:
+		if err := adoptSiteConfig(ctx, env, site, existing); err != nil {
+			return "", err
+		}
+
+		return component.ConfigMapPayloadHash(existing), nil
+	case !apierrors.IsNotFound(err):
+		return "", fmt.Errorf("get net site config %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	cm, err := seedSiteConfig(ctx, env, site)
+	if err != nil {
+		return "", err
+	}
+
+	if err := env.Client.Create(ctx, cm); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return "", fmt.Errorf("create net site config %s/%s: %w", cm.Namespace, cm.Name, err)
+		}
+
+		if getErr := env.Client.Get(ctx, key, existing); getErr != nil {
+			return "", fmt.Errorf("get raced net site config %s/%s: %w", key.Namespace, key.Name, getErr)
+		}
+
+		if err := adoptSiteConfig(ctx, env, site, existing); err != nil {
+			return "", err
+		}
+
+		return component.ConfigMapPayloadHash(existing), nil
+	}
+
+	return component.ConfigMapPayloadHash(cm), nil
+}
+
+// seedSiteConfig builds the per-Site node config from the shared config so
+// operator tuning carries over. It falls back to the embedded default if the
+// shared config is somehow absent.
+func seedSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) (*corev1.ConfigMap, error) {
+	shared := &corev1.ConfigMap{}
+	key := client.ObjectKey{Namespace: env.Namespace, Name: configName}
+
+	err := env.Client.Get(ctx, key, shared)
+	switch {
+	case err == nil:
+	case apierrors.IsNotFound(err):
+		shared, err = env.DefaultConfigMap(netmanifests.Manifests, configName, "net")
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("get net config to seed site %s: %w", site.Name, err)
+	}
+
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName(site.Name), Namespace: env.Namespace, OwnerReferences: []metav1.OwnerReference{component.SiteOwnerReference(site)}},
+		Data:       shared.Data,
+		BinaryData: shared.BinaryData,
+	}
+
+	return cm, nil
+}
+
+func adoptSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site, cm *corev1.ConfigMap) error {
+	owner := component.SiteOwnerReference(site)
+
+	refs, changed := component.UpsertOwnerReference(cm.OwnerReferences, owner)
+	if !changed {
+		return nil
+	}
+
+	before := cm.DeepCopy()
+	cm.OwnerReferences = refs
+
+	patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
+	if err := env.Client.Patch(ctx, cm, patch); err != nil {
+		return fmt.Errorf("adopt net site config %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	return nil
 }

--- a/internal/operator/components/net/net.go
+++ b/internal/operator/components/net/net.go
@@ -328,54 +328,61 @@ func pointNodeDaemonSetAtSiteConfig(site *unboundedv1alpha3.Site, obj *unstructu
 	return repointConfigEnv(obj, configName, siteConfig)
 }
 
-// repointConfigEnv rewrites every container env var that sources a value from
-// the old ConfigMap to the new one, so per-Site node pods read LOG_LEVEL (and any
-// other configMapKeyRef) from their own config.
+// repointConfigEnv rewrites every container env var (init and main) that sources
+// a value from the old ConfigMap to the new one, so per-Site node pods read
+// LOG_LEVEL (and any other configMapKeyRef) from their own config.
 func repointConfigEnv(obj *unstructured.Unstructured, oldName, newName string) error {
-	containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
-	if err != nil {
-		return fmt.Errorf("get net node containers: %w", err)
-	}
+	for _, field := range []string{"initContainers", "containers"} {
+		containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", field)
+		if err != nil {
+			return fmt.Errorf("get net node %s: %w", field, err)
+		}
 
-	if !found {
-		return nil
-	}
-
-	for i := range containers {
-		container, ok := containers[i].(map[string]any)
-		if !ok {
+		if !found {
 			continue
 		}
 
-		envVars, ok := container["env"].([]any)
-		if !ok {
-			continue
+		changed := false
+
+		for i := range containers {
+			container, ok := containers[i].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			envVars, ok := container["env"].([]any)
+			if !ok {
+				continue
+			}
+
+			for j := range envVars {
+				envVar, ok := envVars[j].(map[string]any)
+				if !ok {
+					continue
+				}
+
+				valueFrom, ok := envVar["valueFrom"].(map[string]any)
+				if !ok {
+					continue
+				}
+
+				ref, ok := valueFrom["configMapKeyRef"].(map[string]any)
+				if !ok {
+					continue
+				}
+
+				if ref["name"] == oldName {
+					ref["name"] = newName
+					changed = true
+				}
+			}
 		}
 
-		for j := range envVars {
-			envVar, ok := envVars[j].(map[string]any)
-			if !ok {
-				continue
-			}
-
-			valueFrom, ok := envVar["valueFrom"].(map[string]any)
-			if !ok {
-				continue
-			}
-
-			ref, ok := valueFrom["configMapKeyRef"].(map[string]any)
-			if !ok {
-				continue
-			}
-
-			if ref["name"] == oldName {
-				ref["name"] = newName
+		if changed {
+			if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", field); err != nil {
+				return fmt.Errorf("set net node %s: %w", field, err)
 			}
 		}
-	}
-
-	if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
-		return fmt.Errorf("set net node containers: %w", err)
 	}
 
 	return nil
@@ -514,11 +521,15 @@ func seedSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1al
 		return nil, fmt.Errorf("get net config to seed site %s: %w", site.Name, err)
 	}
 
+	// Deep-copy the payload so the per-Site ConfigMap does not alias the shared
+	// config's maps (a later mutation of either must not affect the other).
+	payload := shared.DeepCopy()
+
 	cm := &corev1.ConfigMap{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
 		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName(site.Name), Namespace: env.Namespace, OwnerReferences: []metav1.OwnerReference{component.SiteOwnerReference(site)}},
-		Data:       shared.Data,
-		BinaryData: shared.BinaryData,
+		Data:       payload.Data,
+		BinaryData: payload.BinaryData,
 	}
 
 	return cm, nil

--- a/internal/operator/components/net/net.go
+++ b/internal/operator/components/net/net.go
@@ -54,6 +54,13 @@ const (
 	nodeDaemonSetManifest = "node/03-daemonset.yaml"
 
 	ConfigHashAnnotation = "unbounded-cloud.io/net-config-hash"
+
+	// seedHashAnnotation records the shared-config payload hash a per-Site config
+	// was last seeded from. While the per-Site config's own payload still matches
+	// this hash (the Site has not edited it), the operator keeps it tracking the
+	// shared config; once the payload diverges the Site owns it and it is
+	// preserved.
+	seedHashAnnotation = "unbounded-cloud.io/net-config-seed-hash"
 )
 
 // Component reconciles the unbounded-net cluster singleton.
@@ -92,11 +99,17 @@ func (Component) Reconcile(ctx context.Context, env *component.Env, sites []unbo
 		return component.Failed(err)
 	}
 
-	if err := env.ApplyManifestFS(ctx, netmanifests.Manifests, applyMutator(env.Config, configHash)); err != nil {
+	// Apply the per-Site node DaemonSets before narrowing the base to un-Sited
+	// nodes. net-node is hostNetwork and only one instance can own a Node's
+	// dataplane, so the handoff is break-before-make; applying per-Site first
+	// means a per-Site apply failure returns here with the base still covering
+	// every Node (blanket), rather than excluding Sited nodes with no
+	// replacement in place.
+	if err := reconcileSiteNodes(ctx, env, sites); err != nil {
 		return component.Failed(err)
 	}
 
-	if err := reconcileSiteNodes(ctx, env, sites); err != nil {
+	if err := env.ApplyManifestFS(ctx, netmanifests.Manifests, applyMutator(env.Config, configHash)); err != nil {
 		return component.Failed(err)
 	}
 
@@ -457,32 +470,37 @@ func ensureConfig(ctx context.Context, env *component.Env) (string, error) {
 	return component.ConfigMapPayloadHash(desired), nil
 }
 
-// ensureSiteConfig creates the per-Site node config ConfigMap by cloning the
-// shared config when it is absent, so a Site starts from the operator-tuned
-// baseline. An existing per-Site config (operator/user-edited) is preserved and
-// only adopted with a Site owner reference so it is garbage collected with the
-// Site.
+// ensureSiteConfig reconciles the per-Site node config ConfigMap and returns its
+// payload hash for the DaemonSet's config-hash annotation.
+//
+// The per-Site config is created by cloning the shared config, and it keeps
+// tracking the shared config until the Site edits it: on each reconcile, if the
+// per-Site payload is still exactly what it was seeded with (recorded in the
+// seed-hash annotation) and the shared config has since changed, the per-Site
+// config is re-seeded from the shared config. Once the payload diverges (a user
+// edit) it no longer matches the seed hash, so it is preserved. This closes the
+// window where a per-Site config seeded from an embedded default before the
+// operator/reaper installs the intended shared config would otherwise stay stale
+// forever. The ConfigMap is owner-referenced to the Site so it is garbage
+// collected with the Site.
 func ensureSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) (string, error) {
-	key := client.ObjectKey{Namespace: env.Namespace, Name: SiteConfigName(site.Name)}
-	existing := &corev1.ConfigMap{}
-
-	err := env.Client.Get(ctx, key, existing)
-	switch {
-	case err == nil:
-		if err := adoptSiteConfig(ctx, env, site, existing); err != nil {
-			return "", err
-		}
-
-		return component.ConfigMapPayloadHash(existing), nil
-	case !apierrors.IsNotFound(err):
-		return "", fmt.Errorf("get net site config %s/%s: %w", key.Namespace, key.Name, err)
-	}
-
-	cm, err := seedSiteConfig(ctx, env, site)
+	shared, sharedHash, err := sharedConfig(ctx, env, site)
 	if err != nil {
 		return "", err
 	}
 
+	key := client.ObjectKey{Namespace: env.Namespace, Name: SiteConfigName(site.Name)}
+	existing := &corev1.ConfigMap{}
+
+	err = env.Client.Get(ctx, key, existing)
+	switch {
+	case err == nil:
+		return reconcileExistingSiteConfig(ctx, env, site, existing, shared, sharedHash)
+	case !apierrors.IsNotFound(err):
+		return "", fmt.Errorf("get net site config %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	cm := newSiteConfig(site, env.Namespace, shared, sharedHash)
 	if err := env.Client.Create(ctx, cm); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return "", fmt.Errorf("create net site config %s/%s: %w", cm.Namespace, cm.Name, err)
@@ -492,20 +510,15 @@ func ensureSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1
 			return "", fmt.Errorf("get raced net site config %s/%s: %w", key.Namespace, key.Name, getErr)
 		}
 
-		if err := adoptSiteConfig(ctx, env, site, existing); err != nil {
-			return "", err
-		}
-
-		return component.ConfigMapPayloadHash(existing), nil
+		return reconcileExistingSiteConfig(ctx, env, site, existing, shared, sharedHash)
 	}
 
 	return component.ConfigMapPayloadHash(cm), nil
 }
 
-// seedSiteConfig builds the per-Site node config from the shared config so
-// operator tuning carries over. It falls back to the embedded default if the
-// shared config is somehow absent.
-func seedSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) (*corev1.ConfigMap, error) {
+// sharedConfig returns the shared net config and its payload hash, falling back
+// to the embedded default when the shared ConfigMap is absent.
+func sharedConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site) (*corev1.ConfigMap, string, error) {
 	shared := &corev1.ConfigMap{}
 	key := client.ObjectKey{Namespace: env.Namespace, Name: configName}
 
@@ -515,24 +528,84 @@ func seedSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1al
 	case apierrors.IsNotFound(err):
 		shared, err = env.DefaultConfigMap(netmanifests.Manifests, configName, "net")
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	default:
-		return nil, fmt.Errorf("get net config to seed site %s: %w", site.Name, err)
+		return nil, "", fmt.Errorf("get net config to seed site %s: %w", site.Name, err)
 	}
 
+	return shared, component.ConfigMapPayloadHash(shared), nil
+}
+
+// newSiteConfig builds a fresh per-Site config cloned from the shared config,
+// stamped with the seed-hash provenance annotation and the Site owner reference.
+func newSiteConfig(site *unboundedv1alpha3.Site, namespace string, shared *corev1.ConfigMap, sharedHash string) *corev1.ConfigMap {
 	// Deep-copy the payload so the per-Site ConfigMap does not alias the shared
 	// config's maps (a later mutation of either must not affect the other).
 	payload := shared.DeepCopy()
 
-	cm := &corev1.ConfigMap{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
-		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName(site.Name), Namespace: env.Namespace, OwnerReferences: []metav1.OwnerReference{component.SiteOwnerReference(site)}},
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            SiteConfigName(site.Name),
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{component.SiteOwnerReference(site)},
+			Annotations:     map[string]string{seedHashAnnotation: sharedHash},
+		},
 		Data:       payload.Data,
 		BinaryData: payload.BinaryData,
 	}
+}
 
-	return cm, nil
+// reconcileExistingSiteConfig re-seeds an existing per-Site config from the
+// shared config when the Site has not edited it and the shared config changed,
+// otherwise preserves it. Either way it ensures the Site owner reference.
+func reconcileExistingSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site, existing, shared *corev1.ConfigMap, sharedHash string) (string, error) {
+	seedHash := existing.Annotations[seedHashAnnotation]
+	payloadHash := component.ConfigMapPayloadHash(existing)
+
+	// Re-seed only when the per-Site payload is still exactly what it was seeded
+	// with (the Site has not edited it) and the shared config has since changed.
+	if seedHash != "" && payloadHash == seedHash && sharedHash != seedHash {
+		if err := reseedSiteConfig(ctx, env, site, existing, shared, sharedHash); err != nil {
+			return "", err
+		}
+
+		return sharedHash, nil
+	}
+
+	if err := adoptSiteConfig(ctx, env, site, existing); err != nil {
+		return "", err
+	}
+
+	return payloadHash, nil
+}
+
+// reseedSiteConfig overwrites an existing per-Site config's payload from the
+// shared config and refreshes the seed-hash annotation and Site owner reference.
+func reseedSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site, existing, shared *corev1.ConfigMap, sharedHash string) error {
+	before := existing.DeepCopy()
+	payload := shared.DeepCopy()
+
+	existing.Data = payload.Data
+	existing.BinaryData = payload.BinaryData
+
+	if existing.Annotations == nil {
+		existing.Annotations = map[string]string{}
+	}
+
+	existing.Annotations[seedHashAnnotation] = sharedHash
+
+	if refs, changed := component.UpsertOwnerReference(existing.OwnerReferences, component.SiteOwnerReference(site)); changed {
+		existing.OwnerReferences = refs
+	}
+
+	patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
+	if err := env.Client.Patch(ctx, existing, patch); err != nil {
+		return fmt.Errorf("re-seed net site config %s/%s: %w", existing.Namespace, existing.Name, err)
+	}
+
+	return nil
 }
 
 func adoptSiteConfig(ctx context.Context, env *component.Env, site *unboundedv1alpha3.Site, cm *corev1.ConfigMap) error {

--- a/internal/operator/components/net/net_test.go
+++ b/internal/operator/components/net/net_test.go
@@ -5,6 +5,7 @@ package net
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -408,7 +409,92 @@ func TestEnsureSiteConfigSeedsFromSharedConfig(t *testing.T) {
 		t.Fatalf("hash = %q, want exact payload hash", hash)
 	}
 
+	if got.Annotations[seedHashAnnotation] != component.ConfigMapPayloadHash(shared) {
+		t.Fatalf("seed-hash annotation = %q, want shared payload hash", got.Annotations[seedHashAnnotation])
+	}
+
 	assertSiteOwnerRef(t, got.OwnerReferences, "edge", "edge-uid")
+}
+
+func TestEnsureSiteConfigReseedsUntouchedWhenSharedChanges(t *testing.T) {
+	shared := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: component.DefaultNamespace},
+		Data:       map[string]string{"config.yaml": "shared: v1"},
+	}
+	env := testEnv(t, shared)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"}}
+
+	// First reconcile seeds the per-site config from shared v1.
+	if _, err := ensureSiteConfig(t.Context(), env, site); err != nil {
+		t.Fatalf("ensureSiteConfig (seed): %v", err)
+	}
+
+	// The shared config changes (for example a migrated legacy config lands).
+	shared.Data["config.yaml"] = "shared: v2"
+	if err := env.Client.Update(t.Context(), shared); err != nil {
+		t.Fatalf("update shared config: %v", err)
+	}
+
+	hash, err := ensureSiteConfig(t.Context(), env, site)
+	if err != nil {
+		t.Fatalf("ensureSiteConfig (reseed): %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: SiteConfigName("edge")}, &got); err != nil {
+		t.Fatalf("get per-site config: %v", err)
+	}
+
+	if got.Data["config.yaml"] != "shared: v2" {
+		t.Fatalf("untouched per-site config was not re-seeded: %#v", got.Data)
+	}
+
+	if got.Annotations[seedHashAnnotation] != component.ConfigMapPayloadHash(shared) || hash != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("re-seed did not refresh provenance/hash: ann=%q hash=%q", got.Annotations[seedHashAnnotation], hash)
+	}
+}
+
+func TestEnsureSiteConfigPreservesUserEdits(t *testing.T) {
+	shared := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: component.DefaultNamespace},
+		Data:       map[string]string{"config.yaml": "shared: v1"},
+	}
+	env := testEnv(t, shared)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"}}
+
+	if _, err := ensureSiteConfig(t.Context(), env, site); err != nil {
+		t.Fatalf("ensureSiteConfig (seed): %v", err)
+	}
+
+	// The Site edits its per-site config.
+	var perSite corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: SiteConfigName("edge")}, &perSite); err != nil {
+		t.Fatalf("get per-site config: %v", err)
+	}
+
+	perSite.Data["config.yaml"] = "site: custom"
+	if err := env.Client.Update(t.Context(), &perSite); err != nil {
+		t.Fatalf("edit per-site config: %v", err)
+	}
+
+	// The shared config also changes; the edited per-site config must be kept.
+	shared.Data["config.yaml"] = "shared: v2"
+	if err := env.Client.Update(t.Context(), shared); err != nil {
+		t.Fatalf("update shared config: %v", err)
+	}
+
+	if _, err := ensureSiteConfig(t.Context(), env, site); err != nil {
+		t.Fatalf("ensureSiteConfig (preserve): %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: SiteConfigName("edge")}, &got); err != nil {
+		t.Fatalf("get per-site config: %v", err)
+	}
+
+	if got.Data["config.yaml"] != "site: custom" {
+		t.Fatalf("user-edited per-site config was overwritten: %#v", got.Data)
+	}
 }
 
 func TestEnsureSiteConfigPreservesExisting(t *testing.T) {
@@ -468,6 +554,60 @@ func TestReconcileCreatesPerSiteNodeAndConfig(t *testing.T) {
 	containers, _, _ := unstructured.NestedSlice(perSite.Object, "spec", "template", "spec", "containers")
 	if got := containers[0].(map[string]any)["image"]; got != "registry.corp.internal/unbounded/unbounded-net-node:v1.2.3" {
 		t.Fatalf("per-site node image = %q, want site registry", got)
+	}
+}
+
+func TestReconcileFailSafeOrderingKeepsBaseOnPerSiteFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{appsv1.AddToScheme, corev1.AddToScheme, unboundedv1alpha3.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add to scheme: %v", err)
+		}
+	}
+
+	applied := map[string]bool{}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				o, ok := obj.(interface{ GetName() string })
+				if !ok {
+					t.Fatalf("applied object has unexpected type %T", obj)
+				}
+
+				applied[o.GetName()] = true
+
+				// Fail the per-site DaemonSet apply.
+				if o.GetName() == SiteNodeDaemonSetName("edge") {
+					return errors.New("apply per-site net node failed")
+				}
+
+				return nil
+			},
+		}).
+		Build()
+
+	env := &component.Env{
+		Client:    cl,
+		Scheme:    scheme,
+		Namespace: component.DefaultNamespace,
+		Config:    component.Config{ImageRegistry: "ghcr.io/azure", ImageTag: "v1.2.3"},
+	}
+	site := unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"}}
+
+	res := Component{}.Reconcile(t.Context(), env, []unboundedv1alpha3.Site{site})
+	if res.Ready || res.Err == nil {
+		t.Fatalf("Reconcile = %+v, want failure", res)
+	}
+
+	// The base node DaemonSet must not have been narrowed/applied after the
+	// per-site apply failed, so the blanket base keeps covering the fleet.
+	if applied[nodeName] {
+		t.Fatalf("base node DaemonSet was applied despite per-site failure; applied=%#v", applied)
+	}
+
+	if !applied[SiteNodeDaemonSetName("edge")] {
+		t.Fatalf("per-site apply was not attempted; applied=%#v", applied)
 	}
 }
 

--- a/internal/operator/components/net/net_test.go
+++ b/internal/operator/components/net/net_test.go
@@ -260,3 +260,354 @@ func retainedEnv(t *testing.T, objects ...client.Object) (*component.Env, map[st
 
 	return &component.Env{Client: cl, Scheme: scheme, Namespace: component.DefaultNamespace}, appliedHashes
 }
+
+func TestApplyMutatorScopesBaseNodeToUnsitedNodes(t *testing.T) {
+	cfg := component.Config{ImageRegistry: "ghcr.io/azure", ImageTag: "v1"}
+
+	node := daemonSetObject(nodeName)
+	if err := applyMutator(cfg, "net-hash")(node); err != nil {
+		t.Fatalf("applyMutator node: %v", err)
+	}
+
+	assertUnsitedAffinity(t, node)
+
+	// The controller Deployment runs on the control plane and must not be scoped
+	// to un-Sited nodes.
+	controller := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment",
+		"metadata": map[string]any{"name": controllerName},
+		"spec": map[string]any{"template": map[string]any{
+			"metadata": map[string]any{},
+			"spec":     map[string]any{"containers": []any{map[string]any{"name": "controller", "image": "old"}}},
+		}},
+	}}
+	if err := applyMutator(cfg, "net-hash")(controller); err != nil {
+		t.Fatalf("applyMutator controller: %v", err)
+	}
+
+	if _, ok, _ := unstructured.NestedMap(controller.Object, "spec", "template", "spec", "affinity"); ok {
+		t.Fatal("controller Deployment must not be scoped to un-Sited nodes")
+	}
+}
+
+func TestScopeNodeDaemonSetToSite(t *testing.T) {
+	base, err := baseNodeDaemonSet()
+	if err != nil {
+		t.Fatalf("baseNodeDaemonSet: %v", err)
+	}
+
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"},
+		Spec:       unboundedv1alpha3.SiteSpec{ImageRegistry: "registry.corp.internal/unbounded"},
+	}
+	cfg := component.ConfigForSite(component.Config{ImageRegistry: "ghcr.io/azure", ImageTag: "v1.2.3"}, site)
+
+	ds := base.DeepCopy()
+	if err := scopeNodeDaemonSetToSite(site, cfg, "net-hash", ds); err != nil {
+		t.Fatalf("scopeNodeDaemonSetToSite: %v", err)
+	}
+
+	if got := ds.GetName(); got != "unbounded-net-node-edge" {
+		t.Fatalf("name = %q, want unbounded-net-node-edge", got)
+	}
+
+	for _, path := range [][]string{
+		{"spec", "selector", "matchLabels", component.SiteLabelKey},
+		{"spec", "template", "metadata", "labels", component.SiteLabelKey},
+	} {
+		got, ok, err := unstructured.NestedString(ds.Object, path...)
+		if err != nil || !ok || got != "edge" {
+			t.Fatalf("%v = %q (ok=%t err=%v), want edge", path, got, ok, err)
+		}
+	}
+
+	assertSiteAffinity(t, ds)
+	assertSiteOwnerRef(t, ds.GetOwnerReferences(), "edge", "edge-uid")
+
+	// Every container (init and main) pulls from the Site's registry.
+	for _, field := range []string{"initContainers", "containers"} {
+		containers, _, _ := unstructured.NestedSlice(ds.Object, "spec", "template", "spec", field)
+		for _, c := range containers {
+			if got := c.(map[string]any)["image"]; got != "registry.corp.internal/unbounded/unbounded-net-node:v1.2.3" {
+				t.Fatalf("%s image = %q, want site-registry net node", field, got)
+			}
+		}
+	}
+
+	// The config volume and the LOG_LEVEL env both point at the per-Site config.
+	volumes, _, _ := unstructured.NestedSlice(ds.Object, "spec", "template", "spec", "volumes")
+	if name := configVolumeName(t, volumes); name != "unbounded-net-config-edge" {
+		t.Fatalf("config volume = %q, want unbounded-net-config-edge", name)
+	}
+
+	if name := logLevelConfigRef(t, ds); name != "unbounded-net-config-edge" {
+		t.Fatalf("LOG_LEVEL configMapKeyRef = %q, want unbounded-net-config-edge", name)
+	}
+
+	annotations, _, _ := unstructured.NestedStringMap(ds.Object, "spec", "template", "metadata", "annotations")
+	if annotations[ConfigHashAnnotation] != "net-hash" {
+		t.Fatalf("config hash annotation = %q", annotations[ConfigHashAnnotation])
+	}
+}
+
+func TestEnsureSiteConfigSeedsFromSharedConfig(t *testing.T) {
+	shared := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: component.DefaultNamespace},
+		Data:       map[string]string{"config.yaml": "shared: tuned", "LOG_LEVEL": "4"},
+	}
+	env := testEnv(t, shared)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"}}
+
+	hash, err := ensureSiteConfig(t.Context(), env, site)
+	if err != nil {
+		t.Fatalf("ensureSiteConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: SiteConfigName("edge")}, &got); err != nil {
+		t.Fatalf("get per-site config: %v", err)
+	}
+
+	if got.Data["config.yaml"] != "shared: tuned" || got.Data["LOG_LEVEL"] != "4" {
+		t.Fatalf("per-site config not seeded from shared config: %#v", got.Data)
+	}
+
+	if hash != component.ConfigMapPayloadHash(&got) {
+		t.Fatalf("hash = %q, want exact payload hash", hash)
+	}
+
+	assertSiteOwnerRef(t, got.OwnerReferences, "edge", "edge-uid")
+}
+
+func TestEnsureSiteConfigPreservesExisting(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: SiteConfigName("edge"), Namespace: component.DefaultNamespace},
+		Data:       map[string]string{"config.yaml": "custom: true"},
+	}
+	env := testEnv(t, existing)
+	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"}}
+
+	if _, err := ensureSiteConfig(t.Context(), env, site); err != nil {
+		t.Fatalf("ensureSiteConfig: %v", err)
+	}
+
+	var got corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKeyFromObject(existing), &got); err != nil {
+		t.Fatalf("get preserved per-site config: %v", err)
+	}
+
+	if got.Data["config.yaml"] != "custom: true" {
+		t.Fatalf("existing per-site config changed: %#v", got.Data)
+	}
+
+	assertSiteOwnerRef(t, got.OwnerReferences, "edge", "edge-uid")
+}
+
+func TestReconcileCreatesPerSiteNodeAndConfig(t *testing.T) {
+	env, applied := appliedEnv(t)
+	site := unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "edge", UID: "edge-uid"},
+		Spec:       unboundedv1alpha3.SiteSpec{ImageRegistry: "registry.corp.internal/unbounded"},
+	}
+
+	res := Component{}.Reconcile(t.Context(), env, []unboundedv1alpha3.Site{site})
+	if !res.Ready || res.Err != nil {
+		t.Fatalf("Reconcile = %+v, want ready", res)
+	}
+
+	// Per-site config is created from the seeded shared default.
+	var cfg corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: SiteConfigName("edge")}, &cfg); err != nil {
+		t.Fatalf("per-site config not created: %v", err)
+	}
+
+	base := applied[nodeName]
+	if base == nil {
+		t.Fatalf("base node DaemonSet not applied; applied=%v", appliedNames(applied))
+	}
+
+	assertUnsitedAffinity(t, base)
+
+	perSite := applied["unbounded-net-node-edge"]
+	if perSite == nil {
+		t.Fatalf("per-site node DaemonSet not applied; applied=%v", appliedNames(applied))
+	}
+
+	containers, _, _ := unstructured.NestedSlice(perSite.Object, "spec", "template", "spec", "containers")
+	if got := containers[0].(map[string]any)["image"]; got != "registry.corp.internal/unbounded/unbounded-net-node:v1.2.3" {
+		t.Fatalf("per-site node image = %q, want site registry", got)
+	}
+}
+
+func daemonSetObject(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1", "kind": "DaemonSet",
+		"metadata": map[string]any{"name": name},
+		"spec": map[string]any{"template": map[string]any{
+			"metadata": map[string]any{},
+			"spec":     map[string]any{"containers": []any{map[string]any{"name": "node", "image": "old"}}},
+		}},
+	}}
+}
+
+func configVolumeName(t *testing.T, volumes []any) string {
+	t.Helper()
+
+	for _, v := range volumes {
+		vol, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		cm, ok := vol["configMap"].(map[string]any)
+		if ok && vol["name"] == "runtime-config" {
+			name, _ := cm["name"].(string)
+
+			return name
+		}
+	}
+
+	t.Fatal("runtime-config volume not found")
+
+	return ""
+}
+
+func logLevelConfigRef(t *testing.T, ds *unstructured.Unstructured) string {
+	t.Helper()
+
+	containers, _, _ := unstructured.NestedSlice(ds.Object, "spec", "template", "spec", "containers")
+	for _, c := range containers {
+		container, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		envVars, _ := container["env"].([]any)
+		for _, e := range envVars {
+			envVar, ok := e.(map[string]any)
+			if !ok || envVar["name"] != "LOG_LEVEL" {
+				continue
+			}
+
+			valueFrom, _ := envVar["valueFrom"].(map[string]any)
+			ref, _ := valueFrom["configMapKeyRef"].(map[string]any)
+			name, _ := ref["name"].(string)
+
+			return name
+		}
+	}
+
+	t.Fatal("LOG_LEVEL configMapKeyRef not found")
+
+	return ""
+}
+
+func assertUnsitedAffinity(t *testing.T, obj *unstructured.Unstructured) {
+	t.Helper()
+
+	affinity, ok, err := unstructured.NestedMap(obj.Object, "spec", "template", "spec", "affinity")
+	if err != nil || !ok {
+		t.Fatalf("missing affinity: ok=%t err=%v", ok, err)
+	}
+
+	converted := &corev1.Affinity{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(affinity, converted); err != nil {
+		t.Fatalf("convert affinity: %v", err)
+	}
+
+	terms := converted.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 || len(terms[0].MatchExpressions) != 2 {
+		t.Fatalf("un-Sited affinity = %#v, want one term with two DoesNotExist", terms)
+	}
+
+	for _, expr := range terms[0].MatchExpressions {
+		if expr.Operator != corev1.NodeSelectorOpDoesNotExist {
+			t.Fatalf("expression %q operator = %q, want DoesNotExist", expr.Key, expr.Operator)
+		}
+	}
+}
+
+func assertSiteAffinity(t *testing.T, obj *unstructured.Unstructured) {
+	t.Helper()
+
+	affinity, ok, err := unstructured.NestedMap(obj.Object, "spec", "template", "spec", "affinity")
+	if err != nil || !ok {
+		t.Fatalf("missing site affinity: ok=%t err=%v", ok, err)
+	}
+
+	converted := &corev1.Affinity{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(affinity, converted); err != nil {
+		t.Fatalf("convert affinity: %v", err)
+	}
+
+	terms := converted.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 2 {
+		t.Fatalf("site affinity terms = %d, want 2", len(terms))
+	}
+}
+
+func assertSiteOwnerRef(t *testing.T, refs []metav1.OwnerReference, siteName, uid string) {
+	t.Helper()
+
+	if len(refs) != 1 {
+		t.Fatalf("ownerReferences len = %d, want 1: %#v", len(refs), refs)
+	}
+
+	ref := refs[0]
+	if ref.Kind != "Site" || ref.Name != siteName || string(ref.UID) != uid {
+		t.Fatalf("unexpected ownerRef: %#v", ref)
+	}
+
+	if ref.Controller == nil || !*ref.Controller {
+		t.Fatalf("ownerRef is not a controller reference: %#v", ref)
+	}
+}
+
+func appliedNames(applied map[string]*unstructured.Unstructured) []string {
+	names := make([]string, 0, len(applied))
+	for name := range applied {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// appliedEnv builds an Env whose Apply interceptor captures each applied object
+// by name so tests can assert on the server-side-applied content.
+func appliedEnv(t *testing.T) (*component.Env, map[string]*unstructured.Unstructured) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{appsv1.AddToScheme, corev1.AddToScheme, unboundedv1alpha3.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add to scheme: %v", err)
+		}
+	}
+
+	applied := map[string]*unstructured.Unstructured{}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				o, ok := obj.(interface {
+					GetName() string
+					UnstructuredContent() map[string]any
+				})
+				if !ok {
+					t.Fatalf("applied object has unexpected type %T", obj)
+				}
+
+				applied[o.GetName()] = &unstructured.Unstructured{Object: o.UnstructuredContent()}
+
+				return nil
+			},
+		}).
+		Build()
+
+	return &component.Env{
+		Client:    cl,
+		Scheme:    scheme,
+		Namespace: component.DefaultNamespace,
+		Config:    component.Config{ImageRegistry: "ghcr.io/azure", ImageTag: "v1.2.3"},
+	}, applied
+}

--- a/internal/operator/components/net/net_test.go
+++ b/internal/operator/components/net/net_test.go
@@ -350,6 +350,38 @@ func TestScopeNodeDaemonSetToSite(t *testing.T) {
 	}
 }
 
+func TestRepointConfigEnvCoversInitAndMainContainers(t *testing.T) {
+	envWithRef := func(name string) []any {
+		return []any{map[string]any{
+			"name":      "LOG_LEVEL",
+			"valueFrom": map[string]any{"configMapKeyRef": map[string]any{"name": name, "key": "LOG_LEVEL"}},
+		}}
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{"template": map[string]any{"spec": map[string]any{
+			"initContainers": []any{map[string]any{"name": "install", "env": envWithRef(configName)}},
+			"containers":     []any{map[string]any{"name": "node", "env": envWithRef(configName)}},
+		}}},
+	}}
+
+	if err := repointConfigEnv(obj, configName, "unbounded-net-config-edge"); err != nil {
+		t.Fatalf("repointConfigEnv: %v", err)
+	}
+
+	// Both the init container and the main container are repointed.
+	for _, field := range []string{"initContainers", "containers"} {
+		containers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", field)
+		container := containers[0].(map[string]any)
+		envVar := container["env"].([]any)[0].(map[string]any)
+		ref := envVar["valueFrom"].(map[string]any)["configMapKeyRef"].(map[string]any)
+
+		if ref["name"] != "unbounded-net-config-edge" {
+			t.Fatalf("%s configMapKeyRef = %q, want per-site config", field, ref["name"])
+		}
+	}
+}
+
 func TestEnsureSiteConfigSeedsFromSharedConfig(t *testing.T) {
 	shared := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: configName, Namespace: component.DefaultNamespace},

--- a/internal/operator/components/storage/storage.go
+++ b/internal/operator/components/storage/storage.go
@@ -67,7 +67,7 @@ func (Component) Reconcile(ctx context.Context, env *component.Env, site *unboun
 	}
 
 	if err := env.ApplyManifestFS(ctx, storagemanifests.Manifests, func(obj *unstructured.Unstructured) error {
-		return mutateObject(site, env.Config, configHash, obj)
+		return mutateObject(site, component.ConfigForSite(env.Config, site), configHash, obj)
 	}); err != nil {
 		return component.Failed(err)
 	}

--- a/internal/operator/components/storage/storage_test.go
+++ b/internal/operator/components/storage/storage_test.go
@@ -305,20 +305,20 @@ func assertSiteAffinityMap(t *testing.T, affinity map[string]any, siteName strin
 		t.Fatalf("node selector terms len = %d, want 2", len(terms))
 	}
 
-	want := map[string]bool{component.SiteLabelKey: false, component.DeprecatedSiteLabelKey: false}
-
-	for _, term := range terms {
-		expr := term.MatchExpressions[0]
-		if len(expr.Values) != 1 || expr.Values[0] != siteName {
-			t.Fatalf("unexpected site affinity expression: %#v", expr)
-		}
-
-		want[expr.Key] = true
+	// term 0: canonical In [site]
+	canonical := terms[0].MatchExpressions
+	if len(canonical) != 1 || canonical[0].Key != component.SiteLabelKey ||
+		canonical[0].Operator != corev1.NodeSelectorOpIn ||
+		len(canonical[0].Values) != 1 || canonical[0].Values[0] != siteName {
+		t.Fatalf("term 0 must be canonical In [%s]: %#v", siteName, canonical)
 	}
 
-	for key, seen := range want {
-		if !seen {
-			t.Fatalf("site affinity missing key %q", key)
-		}
+	// term 1: canonical DoesNotExist AND deprecated In [site]
+	deprecated := terms[1].MatchExpressions
+	if len(deprecated) != 2 ||
+		deprecated[0].Key != component.SiteLabelKey || deprecated[0].Operator != corev1.NodeSelectorOpDoesNotExist ||
+		deprecated[1].Key != component.DeprecatedSiteLabelKey || deprecated[1].Operator != corev1.NodeSelectorOpIn ||
+		len(deprecated[1].Values) != 1 || deprecated[1].Values[0] != siteName {
+		t.Fatalf("term 1 must be canonical DoesNotExist AND deprecated In [%s]: %#v", siteName, deprecated)
 	}
 }

--- a/internal/operator/components/storage/storage_test.go
+++ b/internal/operator/components/storage/storage_test.go
@@ -117,6 +117,38 @@ func TestMutateObjectScopesDaemonSetToSite(t *testing.T) {
 	}
 }
 
+func TestMutateObjectUsesSiteImageRegistry(t *testing.T) {
+	site := &unboundedv1alpha3.Site{
+		ObjectMeta: metav1.ObjectMeta{Name: "rack-a"},
+		Spec:       unboundedv1alpha3.SiteSpec{ImageRegistry: "registry.corp.internal/unbounded"},
+	}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "DaemonSet",
+		"metadata":   map[string]any{"name": daemonSetName},
+		"spec": map[string]any{
+			"selector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": daemonSetName}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app.kubernetes.io/name": daemonSetName}},
+				"spec": map[string]any{
+					"containers": []any{map[string]any{"name": "run", "image": "old:run"}},
+				},
+			},
+		},
+	}}
+
+	// Reconcile resolves the image through component.ConfigForSite.
+	cfg := component.ConfigForSite(component.Config{ImageRegistry: "ghcr.io/azure", ImageTag: "v1.2.3"}, site)
+	if err := mutateObject(site, cfg, "storage-hash", obj); err != nil {
+		t.Fatalf("mutateObject returned error: %v", err)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+	if got := containers[0].(map[string]any)["image"]; got != "registry.corp.internal/unbounded/unbounded-storage-supervisor:v1.2.3" {
+		t.Fatalf("image = %q, want site-registry storage supervisor", got)
+	}
+}
+
 func TestDaemonSetPointsAtPerSiteConfig(t *testing.T) {
 	site := &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "rack-a"}}
 	obj := &unstructured.Unstructured{Object: map[string]any{

--- a/internal/operator/migrate.go
+++ b/internal/operator/migrate.go
@@ -1256,6 +1256,31 @@ func (r *LegacyReaper) netTargetsPresent(ctx context.Context, target string) (bo
 		return false, nil
 	}
 
+	// Every Site must have its per-Site node DaemonSet in place carrying the
+	// migrated config hash before the legacy blanket net-node is reaped. The base
+	// DaemonSet above covers only un-Sited nodes, so a Site whose per-Site
+	// DaemonSet has not yet been applied/rolled would otherwise be left with no
+	// net agent once the legacy blanket is deleted.
+	var sites unboundedv1alpha3.SiteList
+	if err := reader.List(ctx, &sites); err != nil {
+		return false, fmt.Errorf("list sites: %w", err)
+	}
+
+	for i := range sites.Items {
+		var siteDS appsv1.DaemonSet
+		if err := reader.Get(ctx, client.ObjectKey{Namespace: target, Name: netSiteDaemonSetName(sites.Items[i].Name)}, &siteDS); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		if siteDS.Spec.Template.Annotations[netConfigHashAnnotation] != wantHash {
+			return false, nil
+		}
+	}
+
 	targetCurrent, err := r.configMapPayloadStillCurrent(ctx, &config)
 	if err != nil || !targetCurrent {
 		return false, err

--- a/internal/operator/migrate_test.go
+++ b/internal/operator/migrate_test.go
@@ -1095,6 +1095,57 @@ func TestNetTargetsPresentRequiresCurrentHashOnBothWorkloads(t *testing.T) {
 	}
 }
 
+func TestNetTargetsPresentRequiresPerSiteDaemonSets(t *testing.T) {
+	const target = "unbounded-system"
+
+	r := newReaper(t, ns(target))
+
+	cm, deploy, ds := netConfigAndTargets(target, "sentinel: current", true)
+	for _, obj := range []client.Object{cm, deploy, ds} {
+		if err := r.Create(t.Context(), obj); err != nil {
+			t.Fatalf("create net target %T: %v", obj, err)
+		}
+	}
+
+	// With no Sites the base singletons are sufficient.
+	if present, err := r.netTargetsPresent(t.Context(), target); err != nil || !present {
+		t.Fatalf("netTargetsPresent (no sites) = %t, err=%v; want present", present, err)
+	}
+
+	// Adding a Site requires its per-Site node DaemonSet before reaping the
+	// legacy blanket net-node, since the base covers only un-Sited nodes.
+	if err := r.Create(t.Context(), &unboundedv1alpha3.Site{ObjectMeta: metav1.ObjectMeta{Name: "edge"}}); err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	if present, err := r.netTargetsPresent(t.Context(), target); err != nil || present {
+		t.Fatalf("netTargetsPresent (missing per-site DS) = %t, err=%v; want not present", present, err)
+	}
+
+	// A present per-Site node DaemonSet carrying the current config hash unblocks.
+	wantHash := configMapPayloadHash(cm)
+	siteDS := readyDaemonSet(target, netSiteDaemonSetName("edge"))
+	siteDS.Spec.Template.Annotations = map[string]string{netConfigHashAnnotation: wantHash}
+
+	if err := r.Create(t.Context(), siteDS); err != nil {
+		t.Fatalf("create per-site node: %v", err)
+	}
+
+	if present, err := r.netTargetsPresent(t.Context(), target); err != nil || !present {
+		t.Fatalf("netTargetsPresent (per-site DS present) = %t, err=%v; want present", present, err)
+	}
+
+	// A stale per-Site config hash blocks reaping again.
+	siteDS.Spec.Template.Annotations[netConfigHashAnnotation] = "stale"
+	if err := r.Update(t.Context(), siteDS); err != nil {
+		t.Fatalf("update per-site node: %v", err)
+	}
+
+	if present, err := r.netTargetsPresent(t.Context(), target); err != nil || present {
+		t.Fatalf("netTargetsPresent (stale per-site hash) = %t, err=%v; want not present", present, err)
+	}
+}
+
 func TestReapOnceReapsNetWhenNewNetNotReady(t *testing.T) {
 	// The new net workloads exist but are NOT Ready (they stay Pending until the
 	// old net frees the shared host ports). Net must still be reaped: gating net


### PR DESCRIPTION
## Problem

Some Sites sit on networks that cannot reach the operator's default container
registry (e.g. `ghcr.io/azure`). Today every Site pulls the operator-managed
component images from that one registry, so a network-isolated Site cannot start
the workloads that run on its nodes. We need a way, per Site, to pull those images
from a registry the Site's network *can* reach.

## Solution

Add `spec.imageRegistry` to the `Site` CR: a full image-repository prefix (host
plus any org/namespace path), identical in meaning to the operator-wide
`UNBOUNDED_IMAGE_REGISTRY`. When set, the operator-managed workloads that run on
that Site's nodes resolve their images from that prefix instead of the operator
default. Empty = operator default (byte-for-byte unchanged from today).

```yaml
apiVersion: unbounded-cloud.io/v1alpha3
kind: Site
metadata:
  name: isolated-rack
spec:
  nodeCidrs: ["10.20.0.0/16"]
  imageRegistry: registry.corp.internal/unbounded
```

### Architecture: base + per-Site DaemonSet split

The override applies to the four operator-managed workloads that land on a Site's
nodes: `unbounded-net-node`, `gantry`, `metalman`, and the
`unbounded-storage-supervisor`. Control-plane components (net controller, machina)
are unaffected.

- `metalman` and `unbounded-storage-supervisor` already run per-Site; they now
  resolve their image through `component.ConfigForSite`.
- `unbounded-net-node` and `gantry` were single cluster-wide DaemonSets. Each is
  split into a **base** DaemonSet that runs only on **un-Sited** nodes (control
  plane, etc.) using the operator-wide registry, plus a **per-Site** DaemonSet
  (`<component>-<site>`) node-affined to the Site, owner-referenced to the Site,
  using the Site's registry.

Node affinity partitions scheduling so every node runs exactly one copy. Nodes are
matched to a Site by the existing net-controller labeling
(`unbounded-cloud.io/site`), and the existing `nodeCidrs` overlap guards keep a
node in at most one Site, so registry selection is unambiguous.

### Safety / correctness hardening

This split of host-network, single-owner dataplane agents surfaced several
correctness concerns (raised in review); the bulk of the PR addresses them:

- **Canonical-authoritative site affinity.** `SiteNodeAffinity` now matches the
  canonical `unbounded-cloud.io/site` label, falling back to the deprecated label
  only when the canonical one is absent. A node briefly carrying conflicting
  values (`canonical=A`, `deprecated=B`) can no longer match two Sites and
  double-schedule two privileged agents.
- **Per-Site net config that tracks shared unless customized.** Each
  `unbounded-net-config-<site>` records the shared-config hash it was seeded from;
  while unchanged it re-seeds when the shared config changes, and once a Site edits
  it the copy is preserved. This closes the window where a per-Site config seeded
  from an embedded default before the intended (or migrated) shared config lands
  would stay stale forever.
- **Fail-safe fleet cutover.** net and gantry apply their per-Site DaemonSets
  **before** narrowing the base to un-Sited nodes, so a per-Site apply failure
  leaves the blanket base covering the fleet rather than stranding Sited nodes.
  net-node is host-network / single-owner, so the handoff is break-before-make;
  because net-node does not tear down its dataplane on shutdown, established
  traffic survives the swap and only new-pod networking briefly stalls (equivalent
  to a normal net-node rollout, which already runs at `maxUnavailable: 100%`).
- **Gantry per-Site config preserved on opt-out.** A temporary
  `gantry.enabled=false` deletes only the DaemonSet; the Site-owned config
  (`upstream_registries`, credentials) is kept and GC'd only when the Site is
  deleted.
- **Legacy reaper gate.** The migration reaper now requires every Site's per-Site
  `unbounded-net-node-<site>` DaemonSet to be present and current before it reaps
  the legacy blanket net-node, mirroring the storage gate.

## Caveats / known limitations

- The referenced registry must already host copies of the operator's component
  images at the operator's version; the operator only repoints references, it does
  not mirror images.
- Pulls are anonymous (per-Site image pull secrets are a follow-up).
- gantry's third-party busybox init image (`mcr.microsoft.com/...`) is not
  repointed.
- `unbounded-net-node` uses `imagePullPolicy: Always`, so the Site registry must
  be reachable on every node (re)start.

## Follow-ups

- Per-Site gantry mesh scoping (membership + DHT) and workload image-naming
  convention - `hack/discussion/gantry-per-site.md`.
- Per-Site image pull secrets.
- Optional paced (batched) cutover if very large single-Site fleets need the
  new-pod-networking gap bounded to a rolling subset of nodes.
