### PR TITLE
Agent: add host-driven binary upgrade

### DIFF
--- a/.github/workflows/agent-e2e-kind.yaml
+++ b/.github/workflows/agent-e2e-kind.yaml
@@ -116,6 +116,9 @@ jobs:
       - name: Validate node restart operation
         run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-node-reboot-operation
 
+      - name: Validate host-driven agent upgrade
+        run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-host-agent-upgrade
+
       - name: Validate agent upgrade operation
         run: python3 ./hack/agent/e2e-kind/e2e.py --verbose validate-agent-upgrade-operation
 

--- a/cmd/agent/internal/cmd/agentupgrade.go
+++ b/cmd/agent/internal/cmd/agentupgrade.go
@@ -5,10 +5,12 @@ package cmd
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +20,13 @@ import (
 )
 
 const hostAgentBinaryMode = 0o755
+
+//go:embed assets/agent-upgrade-plan.txt.tmpl
+var hostAgentUpgradePlanTemplateText string
+
+var hostAgentUpgradePlanTemplate = template.Must(
+	template.New("host-agent-upgrade-plan").Parse(hostAgentUpgradePlanTemplateText),
+)
 
 type hostAgentUpgradeHandler struct {
 	cmdCtx       *CommandContext
@@ -42,9 +51,12 @@ func newCmdHostAgentUpgrade(cmdCtx *CommandContext) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:    "agent-upgrade",
-		Short:  "Activate this executable as the host agent daemon",
-		Long:   "Activate this executable as the host agent daemon without creating a MachineOperation.",
+		Use:   "agent-upgrade",
+		Short: "Activate this executable as the host agent daemon",
+		Long:  "Activate this executable as the host agent daemon without creating a MachineOperation.",
+		// Host delivery automation invokes this command from a separately staged
+		// candidate. Keep it out of normal user-facing help because the supported
+		// interactive upgrade surface is the coordinated MachineOperation command.
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -85,7 +97,7 @@ func (h *hostAgentUpgradeHandler) execute(ctx context.Context) error {
 			LastGoodPath: paths.LastGoodPath,
 		},
 		CandidatePath: candidatePath,
-		Mode:          hostAgentBinaryMode,
+		BinaryMode:    hostAgentBinaryMode,
 		LockPath:      goalstates.DaemonAgentUpgradeLockPath,
 	}
 	service := h.newService(paths)
@@ -123,51 +135,7 @@ func resolveExecutablePath(path string) (string, error) {
 }
 
 func writeHostAgentUpgradePlan(w io.Writer, plan agentbinary.ActivationPlan) error {
-	if _, err := fmt.Fprintln(w, "Agent upgrade mode: host-driven"); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintln(w, "Kubernetes MachineOperation: not created"); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintf(w, "Candidate: %s\n", plan.CandidatePath); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintf(w, "Active binary: %s\n", plan.ActivePath); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintf(w, "Install target: %s\n", plan.TargetPath); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintf(w, "Current link: %s -> %s\n", plan.CurrentLinkPath, plan.TargetPath); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintf(w, "Last-good link: %s -> %s\n", plan.LastGoodLinkPath, plan.RollbackPath); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintf(w, "Initialize managed layout: %t\n", plan.InitializeLayout); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintln(w, "Planned actions:"); err != nil {
-		return err
-	}
-
-	for _, action := range plan.Actions {
-		if _, err := fmt.Fprintf(w, "  - %s\n", action); err != nil {
-			return err
-		}
-	}
-
-	_, err := fmt.Fprintln(w, "Preflight: no changes applied")
-
-	return err
+	return hostAgentUpgradePlanTemplate.Execute(w, plan)
 }
 
 func newCmdRecordAgentUpgradeFailureSignal() *cobra.Command {

--- a/cmd/agent/internal/cmd/agentupgrade.go
+++ b/cmd/agent/internal/cmd/agentupgrade.go
@@ -4,10 +4,171 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 
 	"github.com/Azure/unbounded/cmd/agent/internal/daemon"
+	"github.com/Azure/unbounded/pkg/agent/agentbinary"
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
 )
+
+const hostAgentBinaryMode = 0o755
+
+type hostAgentUpgradeHandler struct {
+	cmdCtx       *CommandContext
+	preflight    bool
+	writer       io.Writer
+	executable   func() (string, error)
+	resolvedPath func() (goalstates.AgentUpgradePaths, error)
+	newService   func(goalstates.AgentUpgradePaths) agentbinary.DaemonService
+	geteuid      func() int
+}
+
+func newCmdHostAgentUpgrade(cmdCtx *CommandContext) *cobra.Command {
+	handler := &hostAgentUpgradeHandler{
+		cmdCtx:       cmdCtx,
+		writer:       os.Stdout,
+		executable:   os.Executable,
+		resolvedPath: goalstates.ResolvedAgentUpgradePaths,
+		geteuid:      os.Geteuid,
+	}
+	handler.newService = func(paths goalstates.AgentUpgradePaths) agentbinary.DaemonService {
+		return daemon.NewHostDaemonActivationService(handler.cmdCtx.Logger, paths)
+	}
+
+	cmd := &cobra.Command{
+		Use:    "agent-upgrade",
+		Short:  "Activate this executable as the host agent daemon",
+		Long:   "Activate this executable as the host agent daemon without creating a MachineOperation.",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			handler.writer = cmd.OutOrStdout()
+			return handler.execute(cmd.Context())
+		},
+	}
+
+	cmd.Flags().BoolVar(&handler.preflight, "preflight", false, "Show and validate the host activation plan without applying it")
+
+	return cmd
+}
+
+func (h *hostAgentUpgradeHandler) execute(ctx context.Context) error {
+	h.cmdCtx.Setup()
+
+	candidatePath, err := h.executable()
+	if err != nil {
+		return fmt.Errorf("resolve candidate executable: %w", err)
+	}
+
+	candidatePath, err = resolveExecutablePath(candidatePath)
+	if err != nil {
+		return err
+	}
+
+	paths, err := h.resolvedPath()
+	if err != nil {
+		return fmt.Errorf("resolve agent binary paths: %w", err)
+	}
+
+	options := agentbinary.ActivationOptions{
+		Layout: agentbinary.Layout{
+			BinaryPath:   paths.BinaryPath,
+			BluePath:     paths.BluePath,
+			GreenPath:    paths.GreenPath,
+			CurrentPath:  paths.CurrentPath,
+			LastGoodPath: paths.LastGoodPath,
+		},
+		CandidatePath: candidatePath,
+		Mode:          hostAgentBinaryMode,
+		LockPath:      goalstates.DaemonAgentUpgradeLockPath,
+	}
+	service := h.newService(paths)
+
+	if h.preflight {
+		plan, err := agentbinary.PreflightHostDaemonActivation(ctx, options, service)
+		if err != nil {
+			return err
+		}
+
+		return writeHostAgentUpgradePlan(h.writer, plan)
+	}
+
+	if h.geteuid() != 0 {
+		return fmt.Errorf("host agent upgrade requires root privileges")
+	}
+
+	result, err := agentbinary.ActivateHostDaemon(ctx, h.cmdCtx.Logger, options, service)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(h.writer, "activated host agent daemon: %s -> %s\n", result.PreviousPath, result.CurrentPath)
+
+	return err
+}
+
+func resolveExecutablePath(path string) (string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute candidate executable path: %w", err)
+	}
+
+	return filepath.Clean(path), nil
+}
+
+func writeHostAgentUpgradePlan(w io.Writer, plan agentbinary.ActivationPlan) error {
+	if _, err := fmt.Fprintln(w, "Agent upgrade mode: host-driven"); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(w, "Kubernetes MachineOperation: not created"); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Candidate: %s\n", plan.CandidatePath); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Active binary: %s\n", plan.ActivePath); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Install target: %s\n", plan.TargetPath); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Current link: %s -> %s\n", plan.CurrentLinkPath, plan.TargetPath); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Last-good link: %s -> %s\n", plan.LastGoodLinkPath, plan.RollbackPath); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Initialize managed layout: %t\n", plan.InitializeLayout); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(w, "Planned actions:"); err != nil {
+		return err
+	}
+
+	for _, action := range plan.Actions {
+		if _, err := fmt.Fprintf(w, "  - %s\n", action); err != nil {
+			return err
+		}
+	}
+
+	_, err := fmt.Fprintln(w, "Preflight: no changes applied")
+
+	return err
+}
 
 func newCmdRecordAgentUpgradeFailureSignal() *cobra.Command {
 	var message string

--- a/cmd/agent/internal/cmd/agentupgrade_test.go
+++ b/cmd/agent/internal/cmd/agentupgrade_test.go
@@ -69,6 +69,19 @@ func TestHostAgentUpgradePreflight(t *testing.T) {
 	}
 }
 
+func TestWriteHostAgentUpgradePlanOmitsUnchangedLastGood(t *testing.T) {
+	var output bytes.Buffer
+
+	plan := agentbinary.ActivationPlan{
+		CurrentLinkPath:  "/usr/local/bin/unbounded-agent-current",
+		LastGoodLinkPath: "/usr/local/bin/unbounded-agent-last-good",
+		RollbackPath:     "/usr/local/bin/unbounded-agent-blue",
+	}
+
+	require.NoError(t, writeHostAgentUpgradePlan(&output, plan))
+	assert.NotContains(t, output.String(), "Last-good link:")
+}
+
 func TestRecordAgentUpgradeFailureSignalCommand(t *testing.T) {
 	dir := t.TempDir()
 	signalPath := filepath.Join(dir, "agent-upgrade-signal")

--- a/cmd/agent/internal/cmd/agentupgrade_test.go
+++ b/cmd/agent/internal/cmd/agentupgrade_test.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,8 +13,61 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Azure/unbounded/pkg/agent/agentbinary"
 	"github.com/Azure/unbounded/pkg/agent/goalstates"
 )
+
+type preflightOnlyDaemonService struct{}
+
+func (preflightOnlyDaemonService) Preflight(context.Context, string) (agentbinary.ServicePlan, error) {
+	return agentbinary.ServicePlan{UpdateRequired: true, Description: "update test service"}, nil
+}
+
+func (preflightOnlyDaemonService) Prepare(context.Context, string) error { return nil }
+func (preflightOnlyDaemonService) Reload(context.Context) error          { return nil }
+func (preflightOnlyDaemonService) Restart(context.Context) error         { return nil }
+func (preflightOnlyDaemonService) WaitHealthy(context.Context, string) error {
+	return nil
+}
+
+func TestHostAgentUpgradePreflight(t *testing.T) {
+	dir := t.TempDir()
+	paths := goalstates.AgentUpgradePaths{
+		BinaryPath:   filepath.Join(dir, "unbounded-agent"),
+		BluePath:     filepath.Join(dir, "unbounded-agent-blue"),
+		GreenPath:    filepath.Join(dir, "unbounded-agent-green"),
+		CurrentPath:  filepath.Join(dir, "unbounded-agent-current"),
+		LastGoodPath: filepath.Join(dir, "unbounded-agent-last-good"),
+		SignalPath:   filepath.Join(dir, "agent-upgrade-signal"),
+	}
+	require.NoError(t, os.WriteFile(paths.BinaryPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	require.NoError(t, os.WriteFile(candidatePath, []byte("#!/bin/sh\nexit 0\n# candidate\n"), 0o755))
+
+	var output bytes.Buffer
+
+	handler := &hostAgentUpgradeHandler{
+		cmdCtx:       &CommandContext{LogFormat: "text"},
+		preflight:    true,
+		writer:       &output,
+		executable:   func() (string, error) { return candidatePath, nil },
+		resolvedPath: func() (goalstates.AgentUpgradePaths, error) { return paths, nil },
+		newService:   func(goalstates.AgentUpgradePaths) agentbinary.DaemonService { return preflightOnlyDaemonService{} },
+		geteuid:      func() int { return 1000 },
+	}
+
+	require.NoError(t, handler.execute(context.Background()))
+	assert.Contains(t, output.String(), "Agent upgrade mode: host-driven")
+	assert.Contains(t, output.String(), "Kubernetes MachineOperation: not created")
+	assert.Contains(t, output.String(), "Install target: "+paths.GreenPath)
+	assert.Contains(t, output.String(), "Preflight: no changes applied")
+
+	for _, path := range []string{paths.BluePath, paths.GreenPath, paths.CurrentPath, paths.LastGoodPath} {
+		_, err := os.Lstat(path)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
 
 func TestRecordAgentUpgradeFailureSignalCommand(t *testing.T) {
 	dir := t.TempDir()

--- a/cmd/agent/internal/cmd/assets/agent-upgrade-plan.txt.tmpl
+++ b/cmd/agent/internal/cmd/assets/agent-upgrade-plan.txt.tmpl
@@ -4,8 +4,8 @@ Candidate: {{ .CandidatePath }}
 Active binary: {{ .ActivePath }}
 Install target: {{ .TargetPath }}
 Current link: {{ .CurrentLinkPath }} -> {{ .TargetPath }}
-Last-good link: {{ .LastGoodLinkPath }} -> {{ .RollbackPath }}
-Initialize managed layout: {{ .InitializeLayout }}
+{{if .UpdateLastGood}}Last-good link: {{ .LastGoodLinkPath }} -> {{ .RollbackPath }}
+{{end}}Initialize managed layout: {{ .InitializeLayout }}
 Planned actions:
 {{- range .Actions }}
   - {{ . }}

--- a/cmd/agent/internal/cmd/assets/agent-upgrade-plan.txt.tmpl
+++ b/cmd/agent/internal/cmd/assets/agent-upgrade-plan.txt.tmpl
@@ -1,0 +1,13 @@
+Agent upgrade mode: host-driven
+Kubernetes MachineOperation: not created
+Candidate: {{ .CandidatePath }}
+Active binary: {{ .ActivePath }}
+Install target: {{ .TargetPath }}
+Current link: {{ .CurrentLinkPath }} -> {{ .TargetPath }}
+Last-good link: {{ .LastGoodLinkPath }} -> {{ .RollbackPath }}
+Initialize managed layout: {{ .InitializeLayout }}
+Planned actions:
+{{- range .Actions }}
+  - {{ . }}
+{{- end }}
+Preflight: no changes applied

--- a/cmd/agent/internal/cmd/cmd.go
+++ b/cmd/agent/internal/cmd/cmd.go
@@ -30,6 +30,7 @@ func Run() {
 		newCmdDaemon(cmdCtx),
 		newCmdReset(cmdCtx),
 		newCmdVersion(),
+		newCmdHostAgentUpgrade(cmdCtx),
 		newCmdRecordAgentUpgradeFailureSignal(),
 	)
 

--- a/cmd/agent/internal/daemon/controller.go
+++ b/cmd/agent/internal/daemon/controller.go
@@ -23,6 +23,7 @@ import (
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	daemon "github.com/Azure/unbounded/pkg/agent/daemon"
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
 )
 
 type repaveReconciler struct {
@@ -68,10 +69,11 @@ func runController(
 
 	c := mgr.GetClient()
 	machineOperations := &machineOperationTarget{
-		Client:       c,
-		log:          log,
-		machineName:  machineName,
-		nodeOperator: nodeOperator,
+		Client:               c,
+		log:                  log,
+		machineName:          machineName,
+		nodeOperator:         nodeOperator,
+		agentUpgradeLockPath: goalstates.DaemonAgentUpgradeLockPath,
 	}
 
 	machineOperationReconciler, err := daemon.NewMachinaMachineOperationReconciler(

--- a/cmd/agent/internal/daemon/controller_machineoperation.go
+++ b/cmd/agent/internal/daemon/controller_machineoperation.go
@@ -5,21 +5,28 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	"github.com/Azure/unbounded/pkg/agent/agentbinary"
 	daemon "github.com/Azure/unbounded/pkg/agent/daemon"
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
 )
+
+const agentUpgradeLockRetryDelay = 2 * time.Second
 
 type machineOperationTarget struct {
 	client.Client
-	log          *slog.Logger
-	machineName  string
-	nodeOperator nodeOperator
+	log                  *slog.Logger
+	machineName          string
+	nodeOperator         nodeOperator
+	agentUpgradeLockPath string
 }
 
 func (t *machineOperationTarget) reconcileNodeReboot(ctx context.Context, store daemon.MachineOperationStore[int64], op daemon.MachineOperation) (ctrl.Result, error) {
@@ -50,6 +57,27 @@ func (t *machineOperationTarget) reconcileNodeReboot(ctx context.Context, store 
 }
 
 func (t *machineOperationTarget) reconcileAgentUpgrade(ctx context.Context, store daemon.MachineOperationStore[int64], op daemon.MachineOperation) (ctrl.Result, error) {
+	lockPath := t.agentUpgradeLockPath
+	if lockPath == "" {
+		lockPath = goalstates.DaemonAgentUpgradeLockPath
+	}
+
+	lock, err := agentbinary.AcquireHostActivationLock(lockPath)
+	if errors.Is(err, agentbinary.ErrActivationInProgress) {
+		t.log.Info("waiting for host agent activation lock", "operation", op.Name)
+		return ctrl.Result{RequeueAfter: agentUpgradeLockRetryDelay}, nil
+	}
+
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("acquire host agent activation lock: %w", err)
+	}
+
+	defer func() {
+		if err := lock.Close(); err != nil {
+			t.log.Warn("failed to release host agent activation lock", "error", err)
+		}
+	}()
+
 	if err := store.MarkInProgress(ctx, op, "staging upgraded host agent binary"); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/cmd/agent/internal/daemon/controller_test.go
+++ b/cmd/agent/internal/daemon/controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	"github.com/Azure/unbounded/internal/provision"
+	"github.com/Azure/unbounded/pkg/agent/agentbinary"
 	daemon "github.com/Azure/unbounded/pkg/agent/daemon"
 	"github.com/Azure/unbounded/pkg/agent/goalstates"
 )
@@ -120,11 +121,28 @@ func fakeStatusClient(objs ...client.Object) client.Client {
 func newTestMachinaMachineOperationReconciler(t *testing.T, c client.Client, op nodeOperator) *daemon.MachinaMachineOperationReconciler {
 	t.Helper()
 
+	return newTestMachinaMachineOperationReconcilerWithLockPath(
+		t,
+		c,
+		op,
+		filepath.Join(t.TempDir(), "agent-upgrade.lock"),
+	)
+}
+
+func newTestMachinaMachineOperationReconcilerWithLockPath(
+	t *testing.T,
+	c client.Client,
+	op nodeOperator,
+	lockPath string,
+) *daemon.MachinaMachineOperationReconciler {
+	t.Helper()
+
 	target := &machineOperationTarget{
-		Client:       c,
-		log:          discardLogger(),
-		machineName:  "test-machine",
-		nodeOperator: op,
+		Client:               c,
+		log:                  discardLogger(),
+		machineName:          "test-machine",
+		nodeOperator:         op,
+		agentUpgradeLockPath: lockPath,
 	}
 
 	reconciler, err := daemon.NewMachinaMachineOperationReconciler(
@@ -276,6 +294,40 @@ func TestReconcileAgentUpgrade_Complete(t *testing.T) {
 	require.NotNil(t, updated.Status.StartedAt)
 	require.NotNil(t, updated.Status.CompletedAt)
 	assert.NoFileExists(t, signalPath)
+}
+
+func TestReconcileAgentUpgrade_WaitsForActivationLock(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "agent-upgrade.lock")
+	lock, err := agentbinary.AcquireHostActivationLock(lockPath)
+	require.NoError(t, err)
+
+	defer lock.Close() //nolint:errcheck // test cleanup
+
+	machine := &v1alpha3.Machine{ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Generation: 9}}
+	machineOp := &v1alpha3.MachineOperation{
+		ObjectMeta: metav1.ObjectMeta{Name: "op-1"},
+		Spec: v1alpha3.MachineOperationSpec{
+			MachineRef:    "test-machine",
+			OperationKind: v1alpha3.OperationAgentUpgrade,
+			Parameters: map[string]string{
+				agentUpgradeDownloadURLParameter: "https://example.com/unbounded-agent.tar.gz",
+			},
+		},
+	}
+
+	op := &fakeNodeOperator{}
+	c := fakeStatusClient(machine, machineOp)
+	reconciler := newTestMachinaMachineOperationReconcilerWithLockPath(t, c, op, lockPath)
+
+	result, err := reconciler.ReconcileMachineOperation(context.Background(), "op-1")
+	require.NoError(t, err)
+	assert.Equal(t, agentUpgradeLockRetryDelay, result.RequeueAfter)
+	assert.False(t, op.stageUpgradeCalled)
+	assert.False(t, op.restartAgentCalled)
+
+	var updated v1alpha3.MachineOperation
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "op-1"}, &updated))
+	assert.Empty(t, updated.Status.Phase)
 }
 
 func TestReconcileAgentUpgrade_MissingDownloadURL(t *testing.T) {

--- a/cmd/agent/internal/daemon/hostupgrade.go
+++ b/cmd/agent/internal/daemon/hostupgrade.go
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Azure/unbounded/internal/executil"
+	"github.com/Azure/unbounded/pkg/agent/agentbinary"
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
+)
+
+const (
+	hostDaemonHealthTimeout  = 30 * time.Second
+	hostDaemonStableDuration = 3 * time.Second
+	hostDaemonHealthPoll     = 250 * time.Millisecond
+)
+
+// HostDaemonActivationService manages the Unbounded systemd units used by a
+// host-driven agent binary activation.
+type HostDaemonActivationService struct {
+	log   *slog.Logger
+	paths goalstates.AgentUpgradePaths
+}
+
+// NewHostDaemonActivationService returns the Unbounded systemd adapter for
+// host-driven agent activation.
+func NewHostDaemonActivationService(log *slog.Logger, paths goalstates.AgentUpgradePaths) *HostDaemonActivationService {
+	return &HostDaemonActivationService{log: log, paths: paths}
+}
+
+// Preflight reports whether the installed daemon assets differ from the
+// desired assets. It does not change the host.
+func (s *HostDaemonActivationService) Preflight(_ context.Context, currentBinaryPath string) (agentbinary.ServicePlan, error) {
+	if _, err := os.Stat(s.paths.SignalPath); err == nil {
+		return agentbinary.ServicePlan{}, fmt.Errorf("AgentUpgrade MachineOperation signal exists at %s", s.paths.SignalPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return agentbinary.ServicePlan{}, fmt.Errorf("inspect AgentUpgrade MachineOperation signal: %w", err)
+	}
+
+	assets, err := s.desiredAssets(currentBinaryPath)
+	if err != nil {
+		return agentbinary.ServicePlan{}, err
+	}
+
+	for path, desired := range assets {
+		actual, readErr := os.ReadFile(path)
+		if errors.Is(readErr, os.ErrNotExist) || readErr == nil && !bytes.Equal(actual, desired.content) {
+			return agentbinary.ServicePlan{
+				UpdateRequired: true,
+				Description:    "install or update Unbounded agent daemon systemd assets",
+			}, nil
+		}
+
+		if readErr != nil {
+			return agentbinary.ServicePlan{}, fmt.Errorf("read daemon asset %s: %w", path, readErr)
+		}
+	}
+
+	return agentbinary.ServicePlan{Description: "Unbounded agent daemon systemd assets are current"}, nil
+}
+
+// Prepare installs the daemon service, recovery service, and recovery script.
+// It does not reload systemd or restart the daemon.
+func (s *HostDaemonActivationService) Prepare(_ context.Context, currentBinaryPath string) error {
+	assets, err := s.desiredAssets(currentBinaryPath)
+	if err != nil {
+		return err
+	}
+
+	for path, asset := range assets {
+		if err := writeFile(path, asset.content, asset.mode); err != nil {
+			return fmt.Errorf("write daemon asset %s: %w", path, err)
+		}
+	}
+
+	return nil
+}
+
+// Reload reloads systemd configuration.
+func (s *HostDaemonActivationService) Reload(ctx context.Context) error {
+	if err := executil.RunCmd(ctx, s.log, executil.Systemctl(), "daemon-reload"); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %w", err)
+	}
+
+	return nil
+}
+
+// Restart restarts the Unbounded daemon synchronously.
+func (s *HostDaemonActivationService) Restart(ctx context.Context) error {
+	if err := executil.RunCmd(ctx, s.log, executil.Systemctl(), "restart", goalstates.DaemonUnit); err != nil {
+		return fmt.Errorf("systemctl restart %s: %w", goalstates.DaemonUnit, err)
+	}
+
+	return nil
+}
+
+// WaitHealthy waits until systemd reports a stable daemon process executing
+// the expected binary target.
+func (s *HostDaemonActivationService) WaitHealthy(ctx context.Context, expectedBinaryPath string) error {
+	healthCtx, cancel := context.WithTimeout(ctx, hostDaemonHealthTimeout)
+	defer cancel()
+
+	expected, err := filepath.EvalSymlinks(expectedBinaryPath)
+	if err != nil {
+		return fmt.Errorf("resolve expected daemon binary: %w", err)
+	}
+
+	var healthySince time.Time
+
+	ticker := time.NewTicker(hostDaemonHealthPoll)
+	defer ticker.Stop()
+
+	for {
+		healthy, checkErr := s.isExpectedDaemonActive(healthCtx, expected)
+		if checkErr == nil && healthy {
+			if healthySince.IsZero() {
+				healthySince = time.Now()
+			} else if time.Since(healthySince) >= hostDaemonStableDuration {
+				return nil
+			}
+		} else {
+			healthySince = time.Time{}
+		}
+
+		select {
+		case <-healthCtx.Done():
+			if checkErr != nil {
+				return fmt.Errorf("daemon did not become healthy: %w", checkErr)
+			}
+
+			return fmt.Errorf("daemon did not execute expected binary %s: %w", expected, healthCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *HostDaemonActivationService) isExpectedDaemonActive(ctx context.Context, expected string) (bool, error) {
+	output, err := executil.OutputCmd(ctx, s.log, "systemctl", "show", "--property", "MainPID", "--value", goalstates.DaemonUnit)
+	if err != nil {
+		return false, err
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(output))
+	if err != nil || pid <= 0 {
+		return false, fmt.Errorf("invalid daemon MainPID %q", output)
+	}
+
+	running, err := filepath.EvalSymlinks(fmt.Sprintf("/proc/%d/exe", pid))
+	if err != nil {
+		return false, err
+	}
+
+	return running == expected, nil
+}
+
+type daemonAsset struct {
+	content []byte
+	mode    os.FileMode
+}
+
+func (s *HostDaemonActivationService) desiredAssets(currentBinaryPath string) (map[string]daemonAsset, error) {
+	paths := s.paths
+	paths.CurrentPath = currentBinaryPath
+
+	service, err := renderDaemonAssetForPaths("daemon-service", daemonServiceContent, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	recoveryService, err := renderDaemonAssetForPaths("daemon-recovery-service", daemonRecoveryServiceContent, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	recoveryScript, err := renderDaemonAssetForPaths("daemon-recovery-script", daemonRecoveryScriptContent, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]daemonAsset{
+		filepath.Join(goalstates.SystemdSystemDir, goalstates.DaemonUnit):         {content: service, mode: 0o644},
+		filepath.Join(goalstates.SystemdSystemDir, goalstates.DaemonRecoveryUnit): {content: recoveryService, mode: 0o644},
+		goalstates.DaemonRecoveryScriptPath:                                       {content: recoveryScript, mode: 0o755},
+	}, nil
+}
+
+var _ agentbinary.DaemonService = (*HostDaemonActivationService)(nil)

--- a/cmd/agent/internal/daemon/hostupgrade_test.go
+++ b/cmd/agent/internal/daemon/hostupgrade_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
+)
+
+func TestHostDaemonActivationServicePreflightRejectsMachineOperationSignal(t *testing.T) {
+	dir := t.TempDir()
+	signalPath := filepath.Join(dir, "agent-upgrade-signal")
+	require.NoError(t, os.WriteFile(signalPath, []byte(`{"operationName":"op-1"}`), 0o600))
+
+	service := NewHostDaemonActivationService(discardLogger(), goalstates.AgentUpgradePaths{
+		SignalPath: signalPath,
+	})
+	_, err := service.Preflight(context.Background(), filepath.Join(dir, "unbounded-agent-current"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MachineOperation signal exists")
+}

--- a/cmd/agent/internal/daemon/lifecycle.go
+++ b/cmd/agent/internal/daemon/lifecycle.go
@@ -106,6 +106,15 @@ func (d *enableDaemon) Do(ctx context.Context) error {
 }
 
 func renderDaemonAsset(name string, content []byte) ([]byte, error) {
+	paths, err := goalstates.ResolvedAgentUpgradePaths()
+	if err != nil {
+		return nil, err
+	}
+
+	return renderDaemonAssetForPaths(name, content, paths)
+}
+
+func renderDaemonAssetForPaths(name string, content []byte, paths goalstates.AgentUpgradePaths) ([]byte, error) {
 	data := struct {
 		DaemonUnit                   string
 		DaemonRecoveryUnit           string
@@ -116,10 +125,10 @@ func renderDaemonAsset(name string, content []byte) ([]byte, error) {
 	}{
 		DaemonUnit:                   goalstates.DaemonUnit,
 		DaemonRecoveryUnit:           goalstates.DaemonRecoveryUnit,
-		DaemonBinaryCurrentPath:      goalstates.DaemonBinaryCurrentPath,
-		DaemonBinaryLastGoodPath:     goalstates.DaemonBinaryLastGoodPath,
+		DaemonBinaryCurrentPath:      paths.CurrentPath,
+		DaemonBinaryLastGoodPath:     paths.LastGoodPath,
 		DaemonRecoveryScriptPath:     goalstates.DaemonRecoveryScriptPath,
-		DaemonAgentUpgradeSignalPath: goalstates.DaemonAgentUpgradeSignalPath,
+		DaemonAgentUpgradeSignalPath: paths.SignalPath,
 	}
 
 	tmpl, err := template.New(name).Parse(string(content))

--- a/designs/agent-upgrade.md
+++ b/designs/agent-upgrade.md
@@ -172,8 +172,9 @@ PreflightHostDaemonActivation(ctx, options, serviceInspector) (ActivationPlan, e
 ActivateHostDaemon(ctx, log, options, service) (ActivationResult, error)
 ```
 
-`ActivationOptions` supplies an explicit candidate path, binary layout, mode,
-and lock path. The CLI adapter obtains the candidate with `os.Executable()`.
+`ActivationOptions` supplies an explicit candidate path, binary layout, binary
+file mode, and lock path. The CLI adapter obtains the candidate with
+`os.Executable()`.
 The service integration supplies operations to prepare the daemon entrypoint,
 reload the service manager, restart the daemon, and wait for health.
 

--- a/designs/agent-upgrade.md
+++ b/designs/agent-upgrade.md
@@ -92,6 +92,11 @@ The host-driven command does not:
 - Publish success or failure through Kubernetes.
 
 It reports through command output, its exit status, and daemon service logs.
+It refuses to proceed while the shared AgentUpgrade operation signal exists,
+which covers the interval after a MachineOperation-driven daemon releases its
+process-owned activation lock and before startup publishes success or rollback
+failure.
+
 The command remains named `agent-upgrade` to match the MachineOperation naming
 convention, even though the activation primitive does not enforce semantic
 version ordering and may also be used for reinstall, repair, or downgrade.
@@ -190,6 +195,11 @@ locking, and rollback behavior.
 Pending MachineOperation
         |
         v
+Acquire shared host activation lock
+        |
+        +-- lock busy -----------------------------------> Requeue as Pending
+        |
+        v
 Validate parameters
         |
         +-- missing/invalid HTTP(S) URL -----------------> Failed
@@ -225,6 +235,14 @@ Old process exits, new daemon starts
 ```
 
 ## Staging and switching
+
+The daemon first acquires the same host activation lock used by the direct
+`unbounded-agent agent-upgrade` command. It holds the lock through archive
+staging, link switching, pending signal creation, and the systemd restart
+request. Lock contention leaves the operation Pending and requeues it instead
+of failing it. Process termination during restart releases the lock, while the
+pending signal prevents a direct host activation from entering the remaining
+startup window.
 
 The daemon reads `spec.parameters["downloadURL"]` and the optional
 `spec.parameters["sha256"]` from the `MachineOperation`, resolves the current

--- a/designs/agent-upgrade.md
+++ b/designs/agent-upgrade.md
@@ -107,9 +107,12 @@ Without `--preflight`, the command performs one transactional activation:
 
 1. Require sufficient host privileges and acquire an exclusive activation
    lock.
-2. Resolve the executing candidate path and inspect the current binary layout.
-3. Validate path safety and reject path collisions or unsafe aliases.
-4. Verify the candidate by running its `version` command.
+2. Open the executing candidate once and copy that inode into a private,
+   root-owned snapshot so later path replacement cannot change the bytes being
+   activated.
+3. Inspect the current binary layout and validate path safety, destination
+   entry types, collisions, and unsafe aliases.
+4. Verify the pinned candidate snapshot by running its `version` command.
 5. If the managed layout is not initialized, preserve the existing
    single-path daemon binary in one slot and establish `CurrentPath` and
    `LastGoodPath`.
@@ -121,7 +124,8 @@ Without `--preflight`, the command performs one transactional activation:
    service manager.
 9. Restart the daemon and wait for the caller-defined health check.
 10. If restart or health verification fails, restore `CurrentPath` to
-    `LastGoodPath`, restart the previous daemon, and return a failure.
+    `LastGoodPath`, restart the previous daemon using a bounded cleanup context
+    independent of caller cancellation, and return a failure.
 11. Return success only after the candidate daemon passes its health check.
 
 The command must be idempotent. Re-executing the active binary may repair

--- a/designs/agent-upgrade.md
+++ b/designs/agent-upgrade.md
@@ -12,6 +12,10 @@ publish success or rollback failure back to the operation.
 - Complete the `MachineOperation` only after the restarted daemon is healthy
   enough to publish startup state.
 - Roll back automatically when systemd cannot keep the upgraded daemon running.
+- Support host-driven binary activation when a Kubernetes `MachineOperation` is
+  unavailable or intentionally not used.
+- Keep the host activation logic reusable by other consumers, including AKS
+  Flex, without depending on Kubernetes APIs or Unbounded command packages.
 - Keep signal file structure in Go code instead of shell scripts.
 
 ## Host paths
@@ -54,7 +58,133 @@ the systemd unit:
 This preserves legacy installs while making the daemon run through
 `CurrentPath` for future upgrades.
 
-## Operation state machine
+## Host-driven agent-upgrade command
+
+A newer agent binary also exposes this hidden command:
+
+```text
+unbounded-agent agent-upgrade [--preflight]
+```
+
+The command is a host-driven alternative to the Kubernetes-driven
+`AgentUpgrade` `MachineOperation`. It is useful for upgrading an existing
+deployment that might not support the `AgentUpgrade` `MachineOperation` yet,
+without reimaging the host or repaving the nspawn worker. It is intended for
+host provisioning and management systems that have already
+delivered a candidate binary, including AKS Flex node-side integration. The
+candidate is invoked directly from its staging path:
+
+```bash
+/var/tmp/unbounded-agent-candidate agent-upgrade --preflight
+/var/tmp/unbounded-agent-candidate agent-upgrade
+```
+
+The command does not download a release archive. The caller is responsible for
+obtaining and authenticating the candidate before execution. The command uses
+the executable that contains the command as the candidate, rather than
+accepting another candidate path from a flag.
+
+The host-driven command does not:
+
+- Create or update a `MachineOperation`.
+- Read `downloadURL` or `sha256` operation parameters.
+- Write the AgentUpgrade operation signal file.
+- Publish success or failure through Kubernetes.
+
+It reports through command output, its exit status, and daemon service logs.
+The command remains named `agent-upgrade` to match the MachineOperation naming
+convention, even though the activation primitive does not enforce semantic
+version ordering and may also be used for reinstall, repair, or downgrade.
+
+### Host activation flow
+
+Without `--preflight`, the command performs one transactional activation:
+
+1. Require sufficient host privileges and acquire an exclusive activation
+   lock.
+2. Resolve the executing candidate path and inspect the current binary layout.
+3. Validate path safety and reject path collisions or unsafe aliases.
+4. Verify the candidate by running its `version` command.
+5. If the managed layout is not initialized, preserve the existing
+   single-path daemon binary in one slot and establish `CurrentPath` and
+   `LastGoodPath`.
+6. Install the candidate atomically into the inactive slot. If the managed
+   layout already exists, use the normal blue-green slot selection.
+7. Preserve the active binary through `LastGoodPath` and atomically switch
+   `CurrentPath` to the candidate.
+8. Ensure the daemon service runs through `CurrentPath`, then reload the
+   service manager.
+9. Restart the daemon and wait for the caller-defined health check.
+10. If restart or health verification fails, restore `CurrentPath` to
+    `LastGoodPath`, restart the previous daemon, and return a failure.
+11. Return success only after the candidate daemon passes its health check.
+
+The command must be idempotent. Re-executing the active binary may repair
+missing links or service configuration, but it must not unnecessarily replace
+an identical active binary. Candidate and active binary content can be compared
+by SHA-256 when determining whether a binary change is required.
+
+The command must not be run from a path that has already destructively replaced
+the only copy of the previous daemon binary. Host delivery must stage the
+candidate separately so the previous executable remains available for
+last-good initialization and rollback.
+
+### Preflight
+
+`--preflight` computes and displays the host activation plan without applying
+it. A successful preflight reports at least:
+
+- The candidate and currently active binary paths.
+- Whether the managed layout needs initialization or repair.
+- The inactive slot selected as the installation target.
+- The planned current and last-good link changes.
+- Whether daemon service configuration needs an update.
+- The planned reload, restart, health check, and rollback actions.
+
+Preflight may inspect files, links, binary digests, service configuration, and
+service status. It must not:
+
+- Create, replace, or remove binaries, links, directories, or lock files.
+- Write service units or drop-ins.
+- Reload, start, stop, or restart a service.
+- Create an AgentUpgrade signal.
+
+Preflight exits nonzero when it finds a condition that would block activation.
+Because host state can change after preflight, the applying command repeats all
+validation while holding the activation lock.
+
+### Reusable activation library
+
+The safety-sensitive host activation behavior lives in an exported package,
+not under `cmd/agent/internal`. The hidden command is a thin adapter over that
+library. Other node-side consumers can use the same implementation with their
+own paths, service unit, and health definition.
+
+The reusable boundary has two conceptual operations:
+
+```go
+PreflightHostDaemonActivation(ctx, options, serviceInspector) (ActivationPlan, error)
+ActivateHostDaemon(ctx, log, options, service) (ActivationResult, error)
+```
+
+`ActivationOptions` supplies an explicit candidate path, binary layout, mode,
+and lock path. The CLI adapter obtains the candidate with `os.Executable()`.
+The service integration supplies operations to prepare the daemon entrypoint,
+reload the service manager, restart the daemon, and wait for health.
+
+The reusable library must not:
+
+- Import `cmd/agent` packages.
+- Depend on Kubernetes clients or `MachineOperation` types.
+- Hard-code the Unbounded systemd unit or operation signal schema.
+- Download or authenticate a candidate implicitly.
+
+The Unbounded CLI supplies an adapter for
+`unbounded-agent-daemon.service`. AKS Flex can supply its own service adapter
+and binary paths while sharing installation, link switching, idempotency,
+locking, and rollback behavior.
+
+## MachineOperation state machine
 
 ```text
 Pending MachineOperation

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -41,6 +41,7 @@ Subcommands (called as individual workflow steps):
     delete-machine-cr                  Delete the Machine CR.
     validate-machine-cr-created        Verify agent self-registered a Machine CR.
     validate-node-reboot-operation     Verify NodeReboot MachineOperation restarts the node.
+    validate-host-agent-upgrade        Verify host-driven upgrade adopts a single-binary deployment.
     validate-agent-upgrade-operation   Verify AgentUpgrade switches the host daemon binary.
     validate-agent-upgrade-rollback    Verify AgentUpgrade rollback restores last-known-good.
     validate-node-repave-upgrade       Verify OnDelete repave applies a new MCV Kubernetes version.
@@ -141,6 +142,9 @@ TEST_NS = "e2e-workload-test"
 UNBOUNDED_NS = "unbounded-system"
 E2E_WORKLOAD_IMAGE = "docker.io/library/busybox:1.36"
 MACHINE_CONFIG_NAME = f"{AGENT_MACHINE_NAME}-config"
+DAEMON_BINARY = "/usr/local/bin/unbounded-agent"
+DAEMON_BINARY_BLUE = "/usr/local/bin/unbounded-agent-blue"
+DAEMON_BINARY_GREEN = "/usr/local/bin/unbounded-agent-green"
 DAEMON_BINARY_CURRENT = "/usr/local/bin/unbounded-agent-current"
 DAEMON_BINARY_LAST_GOOD = "/usr/local/bin/unbounded-agent-last-good"
 BPFFS_SENTINEL = "unbounded-e2e-bpffs-sentinel"
@@ -3850,6 +3854,107 @@ def validate_node_reboot_operation() -> None:
 
 
 # ---------------------------------------------------------------------------
+# validate-host-agent-upgrade
+# ---------------------------------------------------------------------------
+def validate_host_agent_upgrade() -> None:
+    """Validate host-driven activation from a single-binary deployment."""
+
+    marker = "e2e-host-agent-upgrade"
+    candidate = VM_DIR / "unbounded-agent-host-upgrade"
+    remote_candidate = "/var/tmp/unbounded-agent-host-upgrade"
+    legacy_copy = "/var/tmp/unbounded-agent-host-upgrade-previous"
+
+    log("Building host-driven agent upgrade candidate...")
+    run([
+        "go", "build",
+        "-ldflags", f"-X github.com/Azure/unbounded/internal/version.Version={marker}",
+        "-o", str(candidate),
+        str(REPO_ROOT / "cmd" / "agent" / "main.go"),
+    ], env={**os.environ, "GOOS": "linux", "GOARCH": "amd64"})
+    scp_cmd(str(candidate), f"{SSH_TARGET}:{remote_candidate}")
+    ssh_cmd(f"sudo chmod 0755 {remote_candidate}")
+
+    operations_before = {
+        item["metadata"]["name"]
+        for item in json.loads(kubectl_capture([
+            "get", _machine_operation_resource(), "-o", "json",
+        ])).get("items", [])
+    }
+
+    before_current = read_daemon_current_target()
+    if not before_current:
+        die("daemon current binary symlink target was empty before host-driven upgrade")
+
+    log(f"Converting managed layout to an existing single-binary deployment from {before_current}...")
+    ssh_cmd(
+        "set -eu; "
+        f"sudo install -m 0755 {before_current} {legacy_copy}; "
+        f"sudo rm -f {DAEMON_BINARY}; "
+        f"sudo install -m 0755 {legacy_copy} {DAEMON_BINARY}; "
+        f"sudo rm -f {DAEMON_BINARY_CURRENT} {DAEMON_BINARY_LAST_GOOD} "
+        f"{DAEMON_BINARY_BLUE} {DAEMON_BINARY_GREEN}"
+    )
+    legacy_digest = ssh_capture(f"sudo sha256sum {DAEMON_BINARY} | awk '{{print $1}}'").strip()
+
+    log("Running host-driven agent upgrade preflight...")
+    preflight = ssh_capture(f"sudo {remote_candidate} agent-upgrade --preflight")
+    for expected in (
+        "Agent upgrade mode: host-driven",
+        "Kubernetes MachineOperation: not created",
+        "Initialize managed layout: true",
+        "Preflight: no changes applied",
+    ):
+        if expected not in preflight:
+            die(f"host-driven preflight output missing {expected!r}: {preflight!r}")
+
+    ssh_cmd(
+        "set -eu; "
+        f"test -f {DAEMON_BINARY}; test ! -L {DAEMON_BINARY}; "
+        f"test ! -e {DAEMON_BINARY_CURRENT}; test ! -L {DAEMON_BINARY_CURRENT}; "
+        f"test ! -e {DAEMON_BINARY_LAST_GOOD}; test ! -L {DAEMON_BINARY_LAST_GOOD}; "
+        f"test ! -e {DAEMON_BINARY_BLUE}; test ! -e {DAEMON_BINARY_GREEN}"
+    )
+
+    log("Applying host-driven agent upgrade...")
+    activation = ssh_capture(f"sudo {remote_candidate} agent-upgrade")
+    if "activated host agent daemon" not in activation:
+        die(f"unexpected host-driven activation output: {activation!r}")
+
+    wait_for_daemon_active()
+    after_current = read_daemon_current_target()
+    last_good = read_daemon_last_good_target()
+    if after_current != DAEMON_BINARY_GREEN:
+        die(f"host-driven current target mismatch: got {after_current!r}, expected {DAEMON_BINARY_GREEN!r}")
+    if last_good != DAEMON_BINARY_BLUE:
+        die(f"host-driven last-good target mismatch: got {last_good!r}, expected {DAEMON_BINARY_BLUE!r}")
+
+    preserved_digest = ssh_capture(f"sudo sha256sum {DAEMON_BINARY_BLUE} | awk '{{print $1}}'").strip()
+    if preserved_digest != legacy_digest:
+        die(f"host-driven activation did not preserve the previous binary: {preserved_digest!r} != {legacy_digest!r}")
+
+    version_output = ssh_capture(f"sudo {DAEMON_BINARY_CURRENT} version")
+    if marker not in version_output:
+        die(f"activated host daemon does not contain candidate version marker: {version_output!r}")
+
+    operations_after = {
+        item["metadata"]["name"]
+        for item in json.loads(kubectl_capture([
+            "get", _machine_operation_resource(), "-o", "json",
+        ])).get("items", [])
+    }
+    if operations_after != operations_before:
+        die(
+            "host-driven activation unexpectedly changed MachineOperations: "
+            f"before={sorted(operations_before)!r}, after={sorted(operations_after)!r}"
+        )
+
+    wait_for_node_ready(AGENT_MACHINE_NAME)
+    log("============================================")
+    log("  Host-driven agent upgrade validation PASSED")
+    log("============================================")
+
+
+# ---------------------------------------------------------------------------
 # validate-agent-upgrade-operation
 # ---------------------------------------------------------------------------
 def validate_agent_upgrade_operation() -> None:
@@ -4325,6 +4430,7 @@ COMMANDS: dict[str, Command] = {
     "delete-machine-cr": _without_node_config(delete_machine_cr),
     "validate-machine-cr-created": validate_machine_cr_created,
     "validate-node-reboot-operation": _without_node_config(validate_node_reboot_operation),
+    "validate-host-agent-upgrade": _without_node_config(validate_host_agent_upgrade),
     "validate-agent-upgrade-operation": _without_node_config(validate_agent_upgrade_operation),
     "validate-agent-upgrade-rollback": _without_node_config(validate_agent_upgrade_rollback),
     "validate-node-repave-upgrade": validate_node_repave_upgrade,

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -3898,14 +3898,7 @@ def validate_host_agent_upgrade() -> None:
 
     log("Running host-driven agent upgrade preflight...")
     preflight = ssh_capture(f"sudo {remote_candidate} agent-upgrade --preflight")
-    for expected in (
-        "Agent upgrade mode: host-driven",
-        "Kubernetes MachineOperation: not created",
-        "Initialize managed layout: true",
-        "Preflight: no changes applied",
-    ):
-        if expected not in preflight:
-            die(f"host-driven preflight output missing {expected!r}: {preflight!r}")
+    print(preflight, flush=True)
 
     ssh_cmd(
         "set -eu; "

--- a/pkg/agent/agentbinary/activation.go
+++ b/pkg/agent/agentbinary/activation.go
@@ -86,7 +86,7 @@ func ActivateHostDaemon(
 	service DaemonService,
 ) (ActivationResult, error) {
 	if log == nil {
-		log = slog.Default()
+		return ActivationResult{}, fmt.Errorf("logger is required")
 	}
 
 	if err := validateActivationOptions(opts); err != nil {

--- a/pkg/agent/agentbinary/activation.go
+++ b/pkg/agent/agentbinary/activation.go
@@ -5,10 +5,8 @@ package agentbinary
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -26,7 +24,7 @@ var ErrActivationInProgress = errors.New("host agent activation is already in pr
 type ActivationOptions struct {
 	Layout        Layout
 	CandidatePath string
-	Mode          os.FileMode
+	BinaryMode    os.FileMode
 	LockPath      string
 }
 
@@ -78,99 +76,6 @@ type ActivationResult struct {
 	RolledBack   bool
 }
 
-// PreflightHostDaemonActivation validates and plans a host-driven activation
-// without changing files, links, services, or locks.
-func PreflightHostDaemonActivation(
-	ctx context.Context,
-	opts ActivationOptions,
-	service DaemonServiceInspector,
-) (ActivationPlan, error) {
-	if service == nil {
-		return ActivationPlan{}, fmt.Errorf("daemon service is required")
-	}
-
-	if err := validateActivationOptions(opts); err != nil {
-		return ActivationPlan{}, err
-	}
-
-	candidatePath, err := executablePath(opts.CandidatePath)
-	if err != nil {
-		return ActivationPlan{}, fmt.Errorf("resolve candidate agent binary: %w", err)
-	}
-
-	currentPath, initialized, err := activationCurrentPath(opts.Layout)
-	if err != nil {
-		return ActivationPlan{}, err
-	}
-
-	if !initialized && candidatePath == currentPath {
-		return ActivationPlan{}, fmt.Errorf("candidate must be staged separately from the existing single-path agent binary")
-	}
-
-	changed, err := filesDiffer(candidatePath, currentPath)
-	if err != nil {
-		return ActivationPlan{}, fmt.Errorf("compare candidate and active agent binaries: %w", err)
-	}
-
-	plan := ActivationPlan{
-		CandidatePath:    candidatePath,
-		ActivePath:       currentPath,
-		CurrentLinkPath:  opts.Layout.CurrentPath,
-		LastGoodLinkPath: opts.Layout.LastGoodPath,
-		RollbackPath:     currentPath,
-		InitializeLayout: !initialized,
-		CandidateChanged: changed,
-	}
-
-	if !initialized {
-		plan.RollbackPath = opts.Layout.BluePath
-
-		plan.TargetPath = opts.Layout.BluePath
-		if changed {
-			plan.TargetPath = opts.Layout.GreenPath
-		}
-	} else {
-		plan.TargetPath = currentPath
-		if changed {
-			currentIsBlue, resolveErr := pathResolvesTo(opts.Layout.BluePath, currentPath)
-			if resolveErr != nil {
-				return ActivationPlan{}, fmt.Errorf("resolve blue agent binary: %w", resolveErr)
-			}
-
-			plan.TargetPath = opts.Layout.BluePath
-			if currentIsBlue {
-				plan.TargetPath = opts.Layout.GreenPath
-			}
-		}
-	}
-
-	lastGoodExists, lastGoodTarget, err := readSymlinkState(opts.Layout.LastGoodPath)
-	if err != nil {
-		return ActivationPlan{}, fmt.Errorf("inspect last-good agent symlink: %w", err)
-	}
-
-	plan.previousLastGoodExists = lastGoodExists
-	plan.previousLastGoodTarget = lastGoodTarget
-
-	if !plan.InitializeLayout && !plan.CandidateChanged {
-		if _, err := executablePath(opts.Layout.LastGoodPath); errors.Is(err, os.ErrNotExist) {
-			plan.RepairLastGood = true
-		} else if err != nil {
-			return ActivationPlan{}, fmt.Errorf("resolve last-good agent binary: %w", err)
-		}
-	}
-
-	servicePlan, err := service.Preflight(ctx, opts.Layout.CurrentPath)
-	if err != nil {
-		return ActivationPlan{}, fmt.Errorf("preflight daemon service: %w", err)
-	}
-
-	plan.Service = servicePlan
-	plan.Actions = activationActions(plan, opts.Layout)
-
-	return plan, nil
-}
-
 // ActivateHostDaemon installs the candidate, switches the daemon entrypoint,
 // restarts the service, verifies health, and rolls back on restart or health
 // failure.
@@ -208,7 +113,7 @@ func ActivateHostDaemon(
 		return ActivationResult{}, fmt.Errorf("verify candidate agent binary: %w", err)
 	}
 
-	mode := opts.Mode
+	mode := opts.BinaryMode
 	if mode == 0 {
 		mode = daemonBinaryMode
 	}
@@ -299,97 +204,6 @@ func ActivateHostDaemon(
 	return result, nil
 }
 
-func validateActivationOptions(opts ActivationOptions) error {
-	if err := validateLayout(opts.Layout); err != nil {
-		return err
-	}
-
-	if opts.CandidatePath == "" || !filepath.IsAbs(opts.CandidatePath) || filepath.Clean(opts.CandidatePath) != opts.CandidatePath {
-		return fmt.Errorf("invalid candidate agent binary path %q", opts.CandidatePath)
-	}
-
-	if opts.LockPath == "" || !filepath.IsAbs(opts.LockPath) || filepath.Clean(opts.LockPath) != opts.LockPath {
-		return fmt.Errorf("invalid agent activation lock path %q", opts.LockPath)
-	}
-
-	if opts.Mode != 0 && opts.Mode.Perm() != opts.Mode {
-		return fmt.Errorf("agent binary mode must contain permission bits only")
-	}
-
-	return nil
-}
-
-func activationCurrentPath(layout Layout) (string, bool, error) {
-	currentPath, err := executablePath(layout.CurrentPath)
-	if err == nil {
-		currentIsBlue, blueErr := pathResolvesTo(layout.BluePath, currentPath)
-		if blueErr != nil {
-			return "", false, fmt.Errorf("resolve blue agent binary: %w", blueErr)
-		}
-
-		currentIsGreen, greenErr := pathResolvesTo(layout.GreenPath, currentPath)
-		if greenErr != nil {
-			return "", false, fmt.Errorf("resolve green agent binary: %w", greenErr)
-		}
-
-		return currentPath, currentIsBlue || currentIsGreen, nil
-	}
-
-	if !errors.Is(err, os.ErrNotExist) {
-		return "", false, fmt.Errorf("resolve current agent binary: %w", err)
-	}
-
-	for _, fallbackPath := range []string{
-		layout.LastGoodPath,
-		layout.BluePath,
-		layout.GreenPath,
-		layout.BinaryPath,
-	} {
-		fallback, fallbackErr := executablePath(fallbackPath)
-		if fallbackErr == nil {
-			return fallback, false, nil
-		}
-
-		if !errors.Is(fallbackErr, os.ErrNotExist) {
-			return "", false, fmt.Errorf("resolve fallback agent binary %s: %w", fallbackPath, fallbackErr)
-		}
-	}
-
-	return "", false, fmt.Errorf("no executable existing agent binary found")
-}
-
-func activationActions(plan ActivationPlan, layout Layout) []string {
-	actions := make([]string, 0, 9)
-	actions = append(actions, "verify candidate binary")
-
-	if plan.InitializeLayout {
-		actions = append(actions, "initialize managed binary layout")
-	}
-
-	if plan.CandidateChanged {
-		actions = append(actions,
-			"install candidate into "+plan.TargetPath,
-			"preserve "+plan.RollbackPath+" as last-good",
-			"switch "+layout.CurrentPath+" to "+plan.TargetPath,
-		)
-	}
-
-	if plan.RepairLastGood {
-		actions = append(actions, "repair last-good agent symlink")
-	}
-
-	if plan.Service.UpdateRequired {
-		actions = append(actions, "update daemon service configuration")
-	}
-
-	return append(actions,
-		"reload daemon service manager",
-		"restart daemon service",
-		"wait for daemon health",
-		"roll back to "+plan.RollbackPath+" if activation fails",
-	)
-}
-
 func switchActivationLinks(layout Layout, plan ActivationPlan) error {
 	if plan.InitializeLayout || plan.CandidateChanged || plan.RepairLastGood {
 		if err := utilio.UpdateSymlink(layout.LastGoodPath, plan.RollbackPath); err != nil {
@@ -410,28 +224,6 @@ func switchActivationLinks(layout Layout, plan ActivationPlan) error {
 	}
 
 	return nil
-}
-
-func readSymlinkState(path string) (bool, string, error) {
-	info, err := os.Lstat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return false, "", nil
-	}
-
-	if err != nil {
-		return false, "", err
-	}
-
-	if info.Mode()&os.ModeSymlink == 0 {
-		return false, "", fmt.Errorf("%s is not a symlink", path)
-	}
-
-	target, err := os.Readlink(path)
-	if err != nil {
-		return false, "", err
-	}
-
-	return true, target, nil
 }
 
 func restoreLastGoodSymlink(path string, plan ActivationPlan) error {
@@ -464,39 +256,6 @@ func rollbackHostActivation(ctx context.Context, layout Layout, plan ActivationP
 	}
 
 	return nil
-}
-
-func filesDiffer(firstPath, secondPath string) (bool, error) {
-	first, err := fileSHA256(firstPath)
-	if err != nil {
-		return false, err
-	}
-
-	second, err := fileSHA256(secondPath)
-	if err != nil {
-		return false, err
-	}
-
-	return first != second, nil
-}
-
-func fileSHA256(path string) ([sha256.Size]byte, error) {
-	var digest [sha256.Size]byte
-
-	file, err := os.Open(path)
-	if err != nil {
-		return digest, err
-	}
-	defer file.Close() //nolint:errcheck // read error is authoritative
-
-	hasher := sha256.New()
-	if _, err := io.Copy(hasher, file); err != nil {
-		return digest, err
-	}
-
-	copy(digest[:], hasher.Sum(nil))
-
-	return digest, nil
 }
 
 // HostActivationLock is an exclusive lock shared by host-driven and

--- a/pkg/agent/agentbinary/activation.go
+++ b/pkg/agent/agentbinary/activation.go
@@ -61,6 +61,7 @@ type ActivationPlan struct {
 	RollbackPath     string
 	InitializeLayout bool
 	CandidateChanged bool
+	RepairLastGood   bool
 	Service          ServicePlan
 	Actions          []string
 }
@@ -137,6 +138,14 @@ func PreflightHostDaemonActivation(
 			if currentIsBlue {
 				plan.TargetPath = opts.Layout.GreenPath
 			}
+		}
+	}
+
+	if !plan.InitializeLayout && !plan.CandidateChanged {
+		if _, err := executablePath(opts.Layout.LastGoodPath); errors.Is(err, os.ErrNotExist) {
+			plan.RepairLastGood = true
+		} else if err != nil {
+			return ActivationPlan{}, fmt.Errorf("resolve last-good agent binary: %w", err)
 		}
 	}
 
@@ -225,7 +234,12 @@ func ActivateHostDaemon(
 	}
 
 	if err := switchActivationLinks(opts.Layout, plan); err != nil {
-		return ActivationResult{}, err
+		rollbackErr := utilio.UpdateSymlink(opts.Layout.CurrentPath, plan.RollbackPath)
+		if rollbackErr != nil {
+			rollbackErr = fmt.Errorf("restore current agent symlink after switch failure: %w", rollbackErr)
+		}
+
+		return ActivationResult{}, errors.Join(err, rollbackErr)
 	}
 
 	result := ActivationResult{
@@ -306,12 +320,23 @@ func activationCurrentPath(layout Layout) (string, bool, error) {
 		return "", false, fmt.Errorf("resolve current agent binary: %w", err)
 	}
 
-	legacyPath, legacyErr := executablePath(layout.BinaryPath)
-	if legacyErr != nil {
-		return "", false, fmt.Errorf("resolve existing agent binary: %w", legacyErr)
+	for _, fallbackPath := range []string{
+		layout.LastGoodPath,
+		layout.BluePath,
+		layout.GreenPath,
+		layout.BinaryPath,
+	} {
+		fallback, fallbackErr := executablePath(fallbackPath)
+		if fallbackErr == nil {
+			return fallback, false, nil
+		}
+
+		if !errors.Is(fallbackErr, os.ErrNotExist) {
+			return "", false, fmt.Errorf("resolve fallback agent binary %s: %w", fallbackPath, fallbackErr)
+		}
 	}
 
-	return legacyPath, false, nil
+	return "", false, fmt.Errorf("no executable existing agent binary found")
 }
 
 func activationActions(plan ActivationPlan, layout Layout) []string {
@@ -330,6 +355,10 @@ func activationActions(plan ActivationPlan, layout Layout) []string {
 		)
 	}
 
+	if plan.RepairLastGood {
+		actions = append(actions, "repair last-good agent symlink")
+	}
+
 	if plan.Service.UpdateRequired {
 		actions = append(actions, "update daemon service configuration")
 	}
@@ -343,12 +372,16 @@ func activationActions(plan ActivationPlan, layout Layout) []string {
 }
 
 func switchActivationLinks(layout Layout, plan ActivationPlan) error {
-	if err := utilio.UpdateSymlink(layout.LastGoodPath, plan.RollbackPath); err != nil {
-		return fmt.Errorf("update last-good agent symlink: %w", err)
+	if plan.InitializeLayout || plan.CandidateChanged || plan.RepairLastGood {
+		if err := utilio.UpdateSymlink(layout.LastGoodPath, plan.RollbackPath); err != nil {
+			return fmt.Errorf("update last-good agent symlink: %w", err)
+		}
 	}
 
-	if err := utilio.UpdateSymlink(layout.CurrentPath, plan.TargetPath); err != nil {
-		return fmt.Errorf("update current agent symlink: %w", err)
+	if plan.InitializeLayout || plan.CandidateChanged {
+		if err := utilio.UpdateSymlink(layout.CurrentPath, plan.TargetPath); err != nil {
+			return fmt.Errorf("update current agent symlink: %w", err)
+		}
 	}
 
 	if err := utilio.UpdateSymlink(layout.BinaryPath, layout.CurrentPath); err != nil {

--- a/pkg/agent/agentbinary/activation.go
+++ b/pkg/agent/agentbinary/activation.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -19,6 +20,8 @@ import (
 // ErrActivationInProgress indicates that another host agent activation owns
 // the shared activation lock.
 var ErrActivationInProgress = errors.New("host agent activation is already in progress")
+
+const activationRollbackTimeout = time.Minute
 
 // ActivationOptions configures a host-driven daemon binary activation.
 type ActivationOptions struct {
@@ -60,6 +63,7 @@ type ActivationPlan struct {
 	InitializeLayout bool
 	CandidateChanged bool
 	RepairLastGood   bool
+	UpdateLastGood   bool
 	Service          ServicePlan
 	Actions          []string
 
@@ -85,13 +89,13 @@ func ActivateHostDaemon(
 	opts ActivationOptions,
 	service DaemonService,
 ) (ActivationResult, error) {
-	log.Debug("host agent activation step", "step", "validate-options")
+	log.Debug("validating host agent activation options")
 
 	if err := validateActivationOptions(opts); err != nil {
 		return ActivationResult{}, err
 	}
 
-	log.Debug("host agent activation step", "step", "acquire-lock", "path", opts.LockPath)
+	log.Debug("acquiring host agent activation lock", "path", opts.LockPath)
 
 	lock, err := AcquireHostActivationLock(opts.LockPath)
 	if err != nil {
@@ -99,33 +103,44 @@ func ActivateHostDaemon(
 	}
 
 	defer func() {
-		log.Debug("host agent activation step", "step", "release-lock", "path", opts.LockPath)
+		log.Debug("releasing host agent activation lock", "path", opts.LockPath)
 
 		if err := lock.Close(); err != nil {
 			log.Warn("failed to release host agent activation lock", "error", err)
 		}
 	}()
 
-	log.Debug("host agent activation step", "step", "preflight")
-
-	plan, err := PreflightHostDaemonActivation(ctx, opts, service)
-	if err != nil {
-		return ActivationResult{}, err
-	}
-
-	log.Debug("host agent activation step", "step", "verify-candidate", "path", plan.CandidatePath)
-
-	if err := Verify(ctx, plan.CandidatePath); err != nil {
-		return ActivationResult{}, fmt.Errorf("verify candidate agent binary: %w", err)
-	}
-
 	mode := opts.BinaryMode
 	if mode == 0 {
 		mode = daemonBinaryMode
 	}
 
+	log.Debug("snapshotting host agent activation candidate", "path", opts.CandidatePath)
+
+	candidateSnapshot, removeCandidateSnapshot, err := snapshotActivationCandidate(opts.CandidatePath, mode)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+	defer removeCandidateSnapshot()
+
+	activationOpts := opts
+	activationOpts.CandidatePath = candidateSnapshot
+
+	log.Debug("running host agent activation preflight")
+
+	plan, err := PreflightHostDaemonActivation(ctx, activationOpts, service)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+
+	log.Debug("verifying host agent activation candidate", "path", plan.CandidatePath)
+
+	if err := Verify(ctx, plan.CandidatePath); err != nil {
+		return ActivationResult{}, fmt.Errorf("verify candidate agent binary: %w", err)
+	}
+
 	if plan.InitializeLayout {
-		log.Debug("host agent activation step", "step", "initialize-layout", "active", plan.ActivePath, "target", opts.Layout.BluePath)
+		log.Debug("initializing host agent binary layout", "active", plan.ActivePath, "target", opts.Layout.BluePath)
 
 		if err := installFromFile(plan.ActivePath, opts.Layout.BluePath, mode); err != nil {
 			return ActivationResult{}, fmt.Errorf("preserve active agent binary: %w", err)
@@ -142,36 +157,36 @@ func ActivateHostDaemon(
 
 		lastGoodProtected = protected
 		if protected {
-			log.Debug("host agent activation step", "step", "protect-last-good", "target", plan.RollbackPath)
+			log.Debug("protecting last-good host agent binary", "target", plan.RollbackPath)
 
 			if err := utilio.UpdateSymlink(opts.Layout.LastGoodPath, plan.RollbackPath); err != nil {
 				return ActivationResult{}, fmt.Errorf("protect active agent as last-good: %w", err)
 			}
 		}
 
-		log.Debug("host agent activation step", "step", "install-candidate", "source", plan.CandidatePath, "target", plan.TargetPath)
+		log.Debug("installing host agent activation candidate", "source", plan.CandidatePath, "target", plan.TargetPath)
 
 		if err := installFromFile(plan.CandidatePath, plan.TargetPath, mode); err != nil {
 			return ActivationResult{}, fmt.Errorf("install candidate agent binary: %w", err)
 		}
 
-		log.Debug("host agent activation step", "step", "verify-installed-candidate", "path", plan.TargetPath)
+		log.Debug("verifying installed host agent candidate", "path", plan.TargetPath)
 
 		if err := Verify(ctx, plan.TargetPath); err != nil {
 			return ActivationResult{}, fmt.Errorf("verify installed candidate agent binary: %w", err)
 		}
 	}
 
-	log.Debug("host agent activation step", "step", "prepare-service", "current", opts.Layout.CurrentPath)
+	log.Debug("preparing host agent daemon service", "current", opts.Layout.CurrentPath)
 
 	if err := service.Prepare(ctx, opts.Layout.CurrentPath); err != nil {
 		return ActivationResult{}, fmt.Errorf("prepare daemon service: %w", err)
 	}
 
-	log.Debug("host agent activation step", "step", "switch-links", "current", plan.TargetPath, "last_good", plan.RollbackPath)
+	log.Debug("switching host agent binary links", "current", plan.TargetPath, "last_good", plan.RollbackPath)
 
 	if err := switchActivationLinks(opts.Layout, plan); err != nil {
-		log.Debug("host agent activation step", "step", "restore-links-after-switch-failure")
+		log.Debug("restoring host agent binary links after switch failure")
 
 		currentRollbackErr := utilio.UpdateSymlink(opts.Layout.CurrentPath, plan.RollbackPath)
 		if currentRollbackErr != nil {
@@ -193,29 +208,29 @@ func ActivateHostDaemon(
 		Changed:      plan.CandidateChanged,
 	}
 
-	log.Debug("host agent activation step", "step", "reload-service-manager")
+	log.Debug("reloading host agent service manager")
 
 	if err := service.Reload(ctx); err != nil {
-		result.RolledBack = true
 		rollbackErr := rollbackHostActivation(ctx, log, opts.Layout, plan, service)
+		result.RolledBack = rollbackErr == nil
 
 		return result, errors.Join(fmt.Errorf("reload daemon service: %w", err), rollbackErr)
 	}
 
-	log.Debug("host agent activation step", "step", "restart-service")
+	log.Debug("restarting host agent daemon service")
 
 	if err := service.Restart(ctx); err != nil {
-		result.RolledBack = true
 		rollbackErr := rollbackHostActivation(ctx, log, opts.Layout, plan, service)
+		result.RolledBack = rollbackErr == nil
 
 		return result, errors.Join(fmt.Errorf("restart daemon service: %w", err), rollbackErr)
 	}
 
-	log.Debug("host agent activation step", "step", "wait-for-health", "expected", plan.TargetPath)
+	log.Debug("waiting for activated host agent health", "expected", plan.TargetPath)
 
 	if err := service.WaitHealthy(ctx, plan.TargetPath); err != nil {
-		result.RolledBack = true
 		rollbackErr := rollbackHostActivation(ctx, log, opts.Layout, plan, service)
+		result.RolledBack = rollbackErr == nil
 
 		return result, errors.Join(fmt.Errorf("wait for activated daemon health: %w", err), rollbackErr)
 	}
@@ -230,8 +245,51 @@ func ActivateHostDaemon(
 	return result, nil
 }
 
+func snapshotActivationCandidate(sourcePath string, mode os.FileMode) (snapshotPath string, cleanup func(), retErr error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return "", nil, fmt.Errorf("open host agent activation candidate: %w", err)
+	}
+
+	var snapshotDir string
+
+	defer func() {
+		if retErr != nil && snapshotDir != "" {
+			os.RemoveAll(snapshotDir) //nolint:errcheck // preserve the snapshot error
+		}
+	}()
+	defer func() {
+		if err := source.Close(); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("close host agent activation candidate: %w", err))
+		}
+	}()
+
+	info, err := source.Stat()
+	if err != nil {
+		return "", nil, fmt.Errorf("stat host agent activation candidate: %w", err)
+	}
+
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return "", nil, fmt.Errorf("host agent activation candidate is not a regular executable file")
+	}
+
+	snapshotDir, err = os.MkdirTemp("", "host-agent-activation-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create private host agent activation directory: %w", err)
+	}
+
+	snapshotPath = filepath.Join(snapshotDir, "candidate")
+	if err := utilio.InstallFile(snapshotPath, source, mode); err != nil {
+		return "", nil, fmt.Errorf("snapshot host agent activation candidate: %w", err)
+	}
+
+	return snapshotPath, func() {
+		os.RemoveAll(snapshotDir) //nolint:errcheck // best effort private snapshot cleanup
+	}, nil
+}
+
 func switchActivationLinks(layout Layout, plan ActivationPlan) error {
-	if plan.InitializeLayout || plan.CandidateChanged || plan.RepairLastGood {
+	if plan.UpdateLastGood {
 		if err := utilio.UpdateSymlink(layout.LastGoodPath, plan.RollbackPath); err != nil {
 			return fmt.Errorf("update last-good agent symlink: %w", err)
 		}
@@ -269,21 +327,24 @@ func restoreLastGoodSymlink(path string, plan ActivationPlan) error {
 }
 
 func rollbackHostActivation(ctx context.Context, log *slog.Logger, layout Layout, plan ActivationPlan, service DaemonService) error {
-	log.Debug("host agent activation rollback step", "step", "restore-current-link", "target", plan.RollbackPath)
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), activationRollbackTimeout)
+	defer cancel()
+
+	log.Debug("restoring previous host agent binary link", "target", plan.RollbackPath)
 
 	if err := utilio.UpdateSymlink(layout.CurrentPath, plan.RollbackPath); err != nil {
 		return fmt.Errorf("roll back current agent symlink: %w", err)
 	}
 
-	log.Debug("host agent activation rollback step", "step", "restart-service")
+	log.Debug("restarting rolled-back host agent service")
 
-	if err := service.Restart(ctx); err != nil {
+	if err := service.Restart(rollbackCtx); err != nil {
 		return fmt.Errorf("restart rolled-back daemon service: %w", err)
 	}
 
-	log.Debug("host agent activation rollback step", "step", "wait-for-health", "expected", plan.RollbackPath)
+	log.Debug("waiting for rolled-back host agent health", "expected", plan.RollbackPath)
 
-	if err := service.WaitHealthy(ctx, plan.RollbackPath); err != nil {
+	if err := service.WaitHealthy(rollbackCtx, plan.RollbackPath); err != nil {
 		return fmt.Errorf("wait for rolled-back daemon health: %w", err)
 	}
 

--- a/pkg/agent/agentbinary/activation.go
+++ b/pkg/agent/agentbinary/activation.go
@@ -85,10 +85,6 @@ func ActivateHostDaemon(
 	opts ActivationOptions,
 	service DaemonService,
 ) (ActivationResult, error) {
-	if log == nil {
-		return ActivationResult{}, fmt.Errorf("logger is required")
-	}
-
 	if err := validateActivationOptions(opts); err != nil {
 		return ActivationResult{}, err
 	}

--- a/pkg/agent/agentbinary/activation.go
+++ b/pkg/agent/agentbinary/activation.go
@@ -1,0 +1,456 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentbinary
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/Azure/unbounded/pkg/agent/internal/utilio"
+)
+
+// ErrActivationInProgress indicates that another host agent activation owns
+// the shared activation lock.
+var ErrActivationInProgress = errors.New("host agent activation is already in progress")
+
+// ActivationOptions configures a host-driven daemon binary activation.
+type ActivationOptions struct {
+	Layout        Layout
+	CandidatePath string
+	Mode          os.FileMode
+	LockPath      string
+}
+
+// ServicePlan describes service configuration work needed by an activation.
+type ServicePlan struct {
+	UpdateRequired bool
+	Description    string
+}
+
+// DaemonServiceInspector inspects host-specific service configuration without
+// changing it.
+type DaemonServiceInspector interface {
+	Preflight(context.Context, string) (ServicePlan, error)
+}
+
+// DaemonService adapts host-specific service management to binary activation.
+type DaemonService interface {
+	DaemonServiceInspector
+	Prepare(context.Context, string) error
+	Reload(context.Context) error
+	Restart(context.Context) error
+	WaitHealthy(context.Context, string) error
+}
+
+// ActivationPlan describes a host activation without changing host state.
+type ActivationPlan struct {
+	CandidatePath    string
+	ActivePath       string
+	TargetPath       string
+	CurrentLinkPath  string
+	LastGoodLinkPath string
+	RollbackPath     string
+	InitializeLayout bool
+	CandidateChanged bool
+	Service          ServicePlan
+	Actions          []string
+}
+
+// ActivationResult describes a completed host activation.
+type ActivationResult struct {
+	PreviousPath string
+	CurrentPath  string
+	Initialized  bool
+	Changed      bool
+	RolledBack   bool
+}
+
+// PreflightHostDaemonActivation validates and plans a host-driven activation
+// without changing files, links, services, or locks.
+func PreflightHostDaemonActivation(
+	ctx context.Context,
+	opts ActivationOptions,
+	service DaemonServiceInspector,
+) (ActivationPlan, error) {
+	if service == nil {
+		return ActivationPlan{}, fmt.Errorf("daemon service is required")
+	}
+
+	if err := validateActivationOptions(opts); err != nil {
+		return ActivationPlan{}, err
+	}
+
+	candidatePath, err := executablePath(opts.CandidatePath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("resolve candidate agent binary: %w", err)
+	}
+
+	currentPath, initialized, err := activationCurrentPath(opts.Layout)
+	if err != nil {
+		return ActivationPlan{}, err
+	}
+
+	if !initialized && candidatePath == currentPath {
+		return ActivationPlan{}, fmt.Errorf("candidate must be staged separately from the existing single-path agent binary")
+	}
+
+	changed, err := filesDiffer(candidatePath, currentPath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("compare candidate and active agent binaries: %w", err)
+	}
+
+	plan := ActivationPlan{
+		CandidatePath:    candidatePath,
+		ActivePath:       currentPath,
+		CurrentLinkPath:  opts.Layout.CurrentPath,
+		LastGoodLinkPath: opts.Layout.LastGoodPath,
+		RollbackPath:     currentPath,
+		InitializeLayout: !initialized,
+		CandidateChanged: changed,
+	}
+
+	if !initialized {
+		plan.RollbackPath = opts.Layout.BluePath
+
+		plan.TargetPath = opts.Layout.BluePath
+		if changed {
+			plan.TargetPath = opts.Layout.GreenPath
+		}
+	} else {
+		plan.TargetPath = currentPath
+		if changed {
+			currentIsBlue, resolveErr := pathResolvesTo(opts.Layout.BluePath, currentPath)
+			if resolveErr != nil {
+				return ActivationPlan{}, fmt.Errorf("resolve blue agent binary: %w", resolveErr)
+			}
+
+			plan.TargetPath = opts.Layout.BluePath
+			if currentIsBlue {
+				plan.TargetPath = opts.Layout.GreenPath
+			}
+		}
+	}
+
+	servicePlan, err := service.Preflight(ctx, opts.Layout.CurrentPath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("preflight daemon service: %w", err)
+	}
+
+	plan.Service = servicePlan
+	plan.Actions = activationActions(plan, opts.Layout)
+
+	return plan, nil
+}
+
+// ActivateHostDaemon installs the candidate, switches the daemon entrypoint,
+// restarts the service, verifies health, and rolls back on restart or health
+// failure.
+func ActivateHostDaemon(
+	ctx context.Context,
+	log *slog.Logger,
+	opts ActivationOptions,
+	service DaemonService,
+) (ActivationResult, error) {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	if err := validateActivationOptions(opts); err != nil {
+		return ActivationResult{}, err
+	}
+
+	lock, err := AcquireHostActivationLock(opts.LockPath)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+
+	defer func() {
+		if err := lock.Close(); err != nil {
+			log.Warn("failed to release host agent activation lock", "error", err)
+		}
+	}()
+
+	plan, err := PreflightHostDaemonActivation(ctx, opts, service)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+
+	if err := Verify(ctx, plan.CandidatePath); err != nil {
+		return ActivationResult{}, fmt.Errorf("verify candidate agent binary: %w", err)
+	}
+
+	mode := opts.Mode
+	if mode == 0 {
+		mode = daemonBinaryMode
+	}
+
+	if plan.InitializeLayout {
+		if err := installFromFile(plan.ActivePath, opts.Layout.BluePath, mode); err != nil {
+			return ActivationResult{}, fmt.Errorf("preserve active agent binary: %w", err)
+		}
+	}
+
+	if plan.CandidateChanged {
+		protected, protectErr := symlinkReferencesPath(opts.Layout.LastGoodPath, plan.TargetPath)
+		if protectErr != nil {
+			return ActivationResult{}, fmt.Errorf("resolve last-good agent binary: %w", protectErr)
+		}
+
+		if protected {
+			if err := utilio.UpdateSymlink(opts.Layout.LastGoodPath, plan.RollbackPath); err != nil {
+				return ActivationResult{}, fmt.Errorf("protect active agent as last-good: %w", err)
+			}
+		}
+
+		if err := installFromFile(plan.CandidatePath, plan.TargetPath, mode); err != nil {
+			return ActivationResult{}, fmt.Errorf("install candidate agent binary: %w", err)
+		}
+
+		if err := Verify(ctx, plan.TargetPath); err != nil {
+			return ActivationResult{}, fmt.Errorf("verify installed candidate agent binary: %w", err)
+		}
+	}
+
+	if err := service.Prepare(ctx, opts.Layout.CurrentPath); err != nil {
+		return ActivationResult{}, fmt.Errorf("prepare daemon service: %w", err)
+	}
+
+	if err := switchActivationLinks(opts.Layout, plan); err != nil {
+		return ActivationResult{}, err
+	}
+
+	result := ActivationResult{
+		PreviousPath: plan.ActivePath,
+		CurrentPath:  plan.TargetPath,
+		Initialized:  plan.InitializeLayout,
+		Changed:      plan.CandidateChanged,
+	}
+
+	if err := service.Reload(ctx); err != nil {
+		result.RolledBack = true
+		rollbackErr := rollbackHostActivation(ctx, opts.Layout, plan, service)
+
+		return result, errors.Join(fmt.Errorf("reload daemon service: %w", err), rollbackErr)
+	}
+
+	if err := service.Restart(ctx); err != nil {
+		result.RolledBack = true
+		rollbackErr := rollbackHostActivation(ctx, opts.Layout, plan, service)
+
+		return result, errors.Join(fmt.Errorf("restart daemon service: %w", err), rollbackErr)
+	}
+
+	if err := service.WaitHealthy(ctx, plan.TargetPath); err != nil {
+		result.RolledBack = true
+		rollbackErr := rollbackHostActivation(ctx, opts.Layout, plan, service)
+
+		return result, errors.Join(fmt.Errorf("wait for activated daemon health: %w", err), rollbackErr)
+	}
+
+	log.Info("activated host agent daemon binary",
+		"previous", plan.ActivePath,
+		"current", plan.TargetPath,
+		"initialized", plan.InitializeLayout,
+		"changed", plan.CandidateChanged,
+	)
+
+	return result, nil
+}
+
+func validateActivationOptions(opts ActivationOptions) error {
+	if err := validateLayout(opts.Layout); err != nil {
+		return err
+	}
+
+	if opts.CandidatePath == "" || !filepath.IsAbs(opts.CandidatePath) || filepath.Clean(opts.CandidatePath) != opts.CandidatePath {
+		return fmt.Errorf("invalid candidate agent binary path %q", opts.CandidatePath)
+	}
+
+	if opts.LockPath == "" || !filepath.IsAbs(opts.LockPath) || filepath.Clean(opts.LockPath) != opts.LockPath {
+		return fmt.Errorf("invalid agent activation lock path %q", opts.LockPath)
+	}
+
+	if opts.Mode != 0 && opts.Mode.Perm() != opts.Mode {
+		return fmt.Errorf("agent binary mode must contain permission bits only")
+	}
+
+	return nil
+}
+
+func activationCurrentPath(layout Layout) (string, bool, error) {
+	currentPath, err := executablePath(layout.CurrentPath)
+	if err == nil {
+		currentIsBlue, blueErr := pathResolvesTo(layout.BluePath, currentPath)
+		if blueErr != nil {
+			return "", false, fmt.Errorf("resolve blue agent binary: %w", blueErr)
+		}
+
+		currentIsGreen, greenErr := pathResolvesTo(layout.GreenPath, currentPath)
+		if greenErr != nil {
+			return "", false, fmt.Errorf("resolve green agent binary: %w", greenErr)
+		}
+
+		return currentPath, currentIsBlue || currentIsGreen, nil
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", false, fmt.Errorf("resolve current agent binary: %w", err)
+	}
+
+	legacyPath, legacyErr := executablePath(layout.BinaryPath)
+	if legacyErr != nil {
+		return "", false, fmt.Errorf("resolve existing agent binary: %w", legacyErr)
+	}
+
+	return legacyPath, false, nil
+}
+
+func activationActions(plan ActivationPlan, layout Layout) []string {
+	actions := make([]string, 0, 9)
+	actions = append(actions, "verify candidate binary")
+
+	if plan.InitializeLayout {
+		actions = append(actions, "initialize managed binary layout")
+	}
+
+	if plan.CandidateChanged {
+		actions = append(actions,
+			"install candidate into "+plan.TargetPath,
+			"preserve "+plan.RollbackPath+" as last-good",
+			"switch "+layout.CurrentPath+" to "+plan.TargetPath,
+		)
+	}
+
+	if plan.Service.UpdateRequired {
+		actions = append(actions, "update daemon service configuration")
+	}
+
+	return append(actions,
+		"reload daemon service manager",
+		"restart daemon service",
+		"wait for daemon health",
+		"roll back to "+plan.RollbackPath+" if activation fails",
+	)
+}
+
+func switchActivationLinks(layout Layout, plan ActivationPlan) error {
+	if err := utilio.UpdateSymlink(layout.LastGoodPath, plan.RollbackPath); err != nil {
+		return fmt.Errorf("update last-good agent symlink: %w", err)
+	}
+
+	if err := utilio.UpdateSymlink(layout.CurrentPath, plan.TargetPath); err != nil {
+		return fmt.Errorf("update current agent symlink: %w", err)
+	}
+
+	if err := utilio.UpdateSymlink(layout.BinaryPath, layout.CurrentPath); err != nil {
+		return fmt.Errorf("update compatibility agent symlink: %w", err)
+	}
+
+	return nil
+}
+
+func rollbackHostActivation(ctx context.Context, layout Layout, plan ActivationPlan, service DaemonService) error {
+	if err := utilio.UpdateSymlink(layout.CurrentPath, plan.RollbackPath); err != nil {
+		return fmt.Errorf("roll back current agent symlink: %w", err)
+	}
+
+	if err := service.Restart(ctx); err != nil {
+		return fmt.Errorf("restart rolled-back daemon service: %w", err)
+	}
+
+	if err := service.WaitHealthy(ctx, plan.RollbackPath); err != nil {
+		return fmt.Errorf("wait for rolled-back daemon health: %w", err)
+	}
+
+	return nil
+}
+
+func filesDiffer(firstPath, secondPath string) (bool, error) {
+	first, err := fileSHA256(firstPath)
+	if err != nil {
+		return false, err
+	}
+
+	second, err := fileSHA256(secondPath)
+	if err != nil {
+		return false, err
+	}
+
+	return first != second, nil
+}
+
+func fileSHA256(path string) ([sha256.Size]byte, error) {
+	var digest [sha256.Size]byte
+
+	file, err := os.Open(path)
+	if err != nil {
+		return digest, err
+	}
+	defer file.Close() //nolint:errcheck // read error is authoritative
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return digest, err
+	}
+
+	copy(digest[:], hasher.Sum(nil))
+
+	return digest, nil
+}
+
+// HostActivationLock is an exclusive lock shared by host-driven and
+// MachineOperation-driven agent activation paths.
+type HostActivationLock struct {
+	file *os.File
+}
+
+// AcquireHostActivationLock acquires the shared, nonblocking host activation
+// lock. The caller must close the returned lock.
+func AcquireHostActivationLock(path string) (*HostActivationLock, error) {
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return nil, fmt.Errorf("invalid agent activation lock path %q", path)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return nil, fmt.Errorf("create agent activation lock directory: %w", err)
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open agent activation lock: %w", err)
+	}
+
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		file.Close() //nolint:errcheck // preserve lock acquisition error
+
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, fmt.Errorf("%w: %w", ErrActivationInProgress, err)
+		}
+
+		return nil, fmt.Errorf("acquire host agent activation lock: %w", err)
+	}
+
+	return &HostActivationLock{file: file}, nil
+}
+
+// Close releases the host activation lock.
+func (l *HostActivationLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	unlockErr := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	closeErr := l.file.Close()
+	l.file = nil
+
+	return errors.Join(unlockErr, closeErr)
+}

--- a/pkg/agent/agentbinary/activation.go
+++ b/pkg/agent/agentbinary/activation.go
@@ -64,6 +64,9 @@ type ActivationPlan struct {
 	RepairLastGood   bool
 	Service          ServicePlan
 	Actions          []string
+
+	previousLastGoodExists bool
+	previousLastGoodTarget string
 }
 
 // ActivationResult describes a completed host activation.
@@ -141,6 +144,14 @@ func PreflightHostDaemonActivation(
 		}
 	}
 
+	lastGoodExists, lastGoodTarget, err := readSymlinkState(opts.Layout.LastGoodPath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("inspect last-good agent symlink: %w", err)
+	}
+
+	plan.previousLastGoodExists = lastGoodExists
+	plan.previousLastGoodTarget = lastGoodTarget
+
 	if !plan.InitializeLayout && !plan.CandidateChanged {
 		if _, err := executablePath(opts.Layout.LastGoodPath); errors.Is(err, os.ErrNotExist) {
 			plan.RepairLastGood = true
@@ -208,12 +219,15 @@ func ActivateHostDaemon(
 		}
 	}
 
+	lastGoodProtected := false
+
 	if plan.CandidateChanged {
 		protected, protectErr := symlinkReferencesPath(opts.Layout.LastGoodPath, plan.TargetPath)
 		if protectErr != nil {
 			return ActivationResult{}, fmt.Errorf("resolve last-good agent binary: %w", protectErr)
 		}
 
+		lastGoodProtected = protected
 		if protected {
 			if err := utilio.UpdateSymlink(opts.Layout.LastGoodPath, plan.RollbackPath); err != nil {
 				return ActivationResult{}, fmt.Errorf("protect active agent as last-good: %w", err)
@@ -234,12 +248,17 @@ func ActivateHostDaemon(
 	}
 
 	if err := switchActivationLinks(opts.Layout, plan); err != nil {
-		rollbackErr := utilio.UpdateSymlink(opts.Layout.CurrentPath, plan.RollbackPath)
-		if rollbackErr != nil {
-			rollbackErr = fmt.Errorf("restore current agent symlink after switch failure: %w", rollbackErr)
+		currentRollbackErr := utilio.UpdateSymlink(opts.Layout.CurrentPath, plan.RollbackPath)
+		if currentRollbackErr != nil {
+			currentRollbackErr = fmt.Errorf("restore current agent symlink after switch failure: %w", currentRollbackErr)
 		}
 
-		return ActivationResult{}, errors.Join(err, rollbackErr)
+		var lastGoodRollbackErr error
+		if !lastGoodProtected {
+			lastGoodRollbackErr = restoreLastGoodSymlink(opts.Layout.LastGoodPath, plan)
+		}
+
+		return ActivationResult{}, errors.Join(err, currentRollbackErr, lastGoodRollbackErr)
 	}
 
 	result := ActivationResult{
@@ -384,8 +403,48 @@ func switchActivationLinks(layout Layout, plan ActivationPlan) error {
 		}
 	}
 
-	if err := utilio.UpdateSymlink(layout.BinaryPath, layout.CurrentPath); err != nil {
-		return fmt.Errorf("update compatibility agent symlink: %w", err)
+	if layout.BinaryPath != "" {
+		if err := utilio.UpdateSymlink(layout.BinaryPath, layout.CurrentPath); err != nil {
+			return fmt.Errorf("update compatibility agent symlink: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func readSymlinkState(path string) (bool, string, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, "", nil
+	}
+
+	if err != nil {
+		return false, "", err
+	}
+
+	if info.Mode()&os.ModeSymlink == 0 {
+		return false, "", fmt.Errorf("%s is not a symlink", path)
+	}
+
+	target, err := os.Readlink(path)
+	if err != nil {
+		return false, "", err
+	}
+
+	return true, target, nil
+}
+
+func restoreLastGoodSymlink(path string, plan ActivationPlan) error {
+	if plan.previousLastGoodExists {
+		if err := utilio.UpdateSymlink(path, plan.previousLastGoodTarget); err != nil {
+			return fmt.Errorf("restore last-good agent symlink: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove newly created last-good agent symlink: %w", err)
 	}
 
 	return nil
@@ -463,13 +522,14 @@ func AcquireHostActivationLock(path string) (*HostActivationLock, error) {
 	}
 
 	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
-		file.Close() //nolint:errcheck // preserve lock acquisition error
+		closeErr := file.Close()
+		lockErr := errors.Join(err, closeErr)
 
 		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
-			return nil, fmt.Errorf("%w: %w", ErrActivationInProgress, err)
+			return nil, fmt.Errorf("%w: %w", ErrActivationInProgress, lockErr)
 		}
 
-		return nil, fmt.Errorf("acquire host agent activation lock: %w", err)
+		return nil, fmt.Errorf("acquire host agent activation lock: %w", lockErr)
 	}
 
 	return &HostActivationLock{file: file}, nil

--- a/pkg/agent/agentbinary/activation.go
+++ b/pkg/agent/agentbinary/activation.go
@@ -85,9 +85,13 @@ func ActivateHostDaemon(
 	opts ActivationOptions,
 	service DaemonService,
 ) (ActivationResult, error) {
+	log.Debug("host agent activation step", "step", "validate-options")
+
 	if err := validateActivationOptions(opts); err != nil {
 		return ActivationResult{}, err
 	}
+
+	log.Debug("host agent activation step", "step", "acquire-lock", "path", opts.LockPath)
 
 	lock, err := AcquireHostActivationLock(opts.LockPath)
 	if err != nil {
@@ -95,15 +99,21 @@ func ActivateHostDaemon(
 	}
 
 	defer func() {
+		log.Debug("host agent activation step", "step", "release-lock", "path", opts.LockPath)
+
 		if err := lock.Close(); err != nil {
 			log.Warn("failed to release host agent activation lock", "error", err)
 		}
 	}()
 
+	log.Debug("host agent activation step", "step", "preflight")
+
 	plan, err := PreflightHostDaemonActivation(ctx, opts, service)
 	if err != nil {
 		return ActivationResult{}, err
 	}
+
+	log.Debug("host agent activation step", "step", "verify-candidate", "path", plan.CandidatePath)
 
 	if err := Verify(ctx, plan.CandidatePath); err != nil {
 		return ActivationResult{}, fmt.Errorf("verify candidate agent binary: %w", err)
@@ -115,6 +125,8 @@ func ActivateHostDaemon(
 	}
 
 	if plan.InitializeLayout {
+		log.Debug("host agent activation step", "step", "initialize-layout", "active", plan.ActivePath, "target", opts.Layout.BluePath)
+
 		if err := installFromFile(plan.ActivePath, opts.Layout.BluePath, mode); err != nil {
 			return ActivationResult{}, fmt.Errorf("preserve active agent binary: %w", err)
 		}
@@ -130,25 +142,37 @@ func ActivateHostDaemon(
 
 		lastGoodProtected = protected
 		if protected {
+			log.Debug("host agent activation step", "step", "protect-last-good", "target", plan.RollbackPath)
+
 			if err := utilio.UpdateSymlink(opts.Layout.LastGoodPath, plan.RollbackPath); err != nil {
 				return ActivationResult{}, fmt.Errorf("protect active agent as last-good: %w", err)
 			}
 		}
 
+		log.Debug("host agent activation step", "step", "install-candidate", "source", plan.CandidatePath, "target", plan.TargetPath)
+
 		if err := installFromFile(plan.CandidatePath, plan.TargetPath, mode); err != nil {
 			return ActivationResult{}, fmt.Errorf("install candidate agent binary: %w", err)
 		}
+
+		log.Debug("host agent activation step", "step", "verify-installed-candidate", "path", plan.TargetPath)
 
 		if err := Verify(ctx, plan.TargetPath); err != nil {
 			return ActivationResult{}, fmt.Errorf("verify installed candidate agent binary: %w", err)
 		}
 	}
 
+	log.Debug("host agent activation step", "step", "prepare-service", "current", opts.Layout.CurrentPath)
+
 	if err := service.Prepare(ctx, opts.Layout.CurrentPath); err != nil {
 		return ActivationResult{}, fmt.Errorf("prepare daemon service: %w", err)
 	}
 
+	log.Debug("host agent activation step", "step", "switch-links", "current", plan.TargetPath, "last_good", plan.RollbackPath)
+
 	if err := switchActivationLinks(opts.Layout, plan); err != nil {
+		log.Debug("host agent activation step", "step", "restore-links-after-switch-failure")
+
 		currentRollbackErr := utilio.UpdateSymlink(opts.Layout.CurrentPath, plan.RollbackPath)
 		if currentRollbackErr != nil {
 			currentRollbackErr = fmt.Errorf("restore current agent symlink after switch failure: %w", currentRollbackErr)
@@ -169,23 +193,29 @@ func ActivateHostDaemon(
 		Changed:      plan.CandidateChanged,
 	}
 
+	log.Debug("host agent activation step", "step", "reload-service-manager")
+
 	if err := service.Reload(ctx); err != nil {
 		result.RolledBack = true
-		rollbackErr := rollbackHostActivation(ctx, opts.Layout, plan, service)
+		rollbackErr := rollbackHostActivation(ctx, log, opts.Layout, plan, service)
 
 		return result, errors.Join(fmt.Errorf("reload daemon service: %w", err), rollbackErr)
 	}
 
+	log.Debug("host agent activation step", "step", "restart-service")
+
 	if err := service.Restart(ctx); err != nil {
 		result.RolledBack = true
-		rollbackErr := rollbackHostActivation(ctx, opts.Layout, plan, service)
+		rollbackErr := rollbackHostActivation(ctx, log, opts.Layout, plan, service)
 
 		return result, errors.Join(fmt.Errorf("restart daemon service: %w", err), rollbackErr)
 	}
 
+	log.Debug("host agent activation step", "step", "wait-for-health", "expected", plan.TargetPath)
+
 	if err := service.WaitHealthy(ctx, plan.TargetPath); err != nil {
 		result.RolledBack = true
-		rollbackErr := rollbackHostActivation(ctx, opts.Layout, plan, service)
+		rollbackErr := rollbackHostActivation(ctx, log, opts.Layout, plan, service)
 
 		return result, errors.Join(fmt.Errorf("wait for activated daemon health: %w", err), rollbackErr)
 	}
@@ -238,14 +268,20 @@ func restoreLastGoodSymlink(path string, plan ActivationPlan) error {
 	return nil
 }
 
-func rollbackHostActivation(ctx context.Context, layout Layout, plan ActivationPlan, service DaemonService) error {
+func rollbackHostActivation(ctx context.Context, log *slog.Logger, layout Layout, plan ActivationPlan, service DaemonService) error {
+	log.Debug("host agent activation rollback step", "step", "restore-current-link", "target", plan.RollbackPath)
+
 	if err := utilio.UpdateSymlink(layout.CurrentPath, plan.RollbackPath); err != nil {
 		return fmt.Errorf("roll back current agent symlink: %w", err)
 	}
 
+	log.Debug("host agent activation rollback step", "step", "restart-service")
+
 	if err := service.Restart(ctx); err != nil {
 		return fmt.Errorf("restart rolled-back daemon service: %w", err)
 	}
+
+	log.Debug("host agent activation rollback step", "step", "wait-for-health", "expected", plan.RollbackPath)
 
 	if err := service.WaitHealthy(ctx, plan.RollbackPath); err != nil {
 		return fmt.Errorf("wait for rolled-back daemon health: %w", err)

--- a/pkg/agent/agentbinary/activation_preflight.go
+++ b/pkg/agent/agentbinary/activation_preflight.go
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentbinary
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// PreflightHostDaemonActivation validates and plans a host-driven activation
+// without changing files, links, services, or locks.
+func PreflightHostDaemonActivation(
+	ctx context.Context,
+	opts ActivationOptions,
+	service DaemonServiceInspector,
+) (ActivationPlan, error) {
+	if service == nil {
+		return ActivationPlan{}, fmt.Errorf("daemon service is required")
+	}
+
+	if err := validateActivationOptions(opts); err != nil {
+		return ActivationPlan{}, err
+	}
+
+	candidatePath, err := executablePath(opts.CandidatePath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("resolve candidate agent binary: %w", err)
+	}
+
+	currentPath, initialized, err := activationCurrentPath(opts.Layout)
+	if err != nil {
+		return ActivationPlan{}, err
+	}
+
+	if !initialized && candidatePath == currentPath {
+		return ActivationPlan{}, fmt.Errorf("candidate must be staged separately from the existing single-path agent binary")
+	}
+
+	changed, err := filesDiffer(candidatePath, currentPath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("compare candidate and active agent binaries: %w", err)
+	}
+
+	plan := ActivationPlan{
+		CandidatePath:    candidatePath,
+		ActivePath:       currentPath,
+		CurrentLinkPath:  opts.Layout.CurrentPath,
+		LastGoodLinkPath: opts.Layout.LastGoodPath,
+		RollbackPath:     currentPath,
+		InitializeLayout: !initialized,
+		CandidateChanged: changed,
+	}
+
+	if !initialized {
+		plan.RollbackPath = opts.Layout.BluePath
+
+		plan.TargetPath = opts.Layout.BluePath
+		if changed {
+			plan.TargetPath = opts.Layout.GreenPath
+		}
+	} else {
+		plan.TargetPath = currentPath
+		if changed {
+			currentIsBlue, resolveErr := pathResolvesTo(opts.Layout.BluePath, currentPath)
+			if resolveErr != nil {
+				return ActivationPlan{}, fmt.Errorf("resolve blue agent binary: %w", resolveErr)
+			}
+
+			plan.TargetPath = opts.Layout.BluePath
+			if currentIsBlue {
+				plan.TargetPath = opts.Layout.GreenPath
+			}
+		}
+	}
+
+	lastGoodExists, lastGoodTarget, err := readSymlinkState(opts.Layout.LastGoodPath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("inspect last-good agent symlink: %w", err)
+	}
+
+	plan.previousLastGoodExists = lastGoodExists
+	plan.previousLastGoodTarget = lastGoodTarget
+
+	if !plan.InitializeLayout && !plan.CandidateChanged {
+		if _, err := executablePath(opts.Layout.LastGoodPath); errors.Is(err, os.ErrNotExist) {
+			plan.RepairLastGood = true
+		} else if err != nil {
+			return ActivationPlan{}, fmt.Errorf("resolve last-good agent binary: %w", err)
+		}
+	}
+
+	servicePlan, err := service.Preflight(ctx, opts.Layout.CurrentPath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("preflight daemon service: %w", err)
+	}
+
+	plan.Service = servicePlan
+	plan.Actions = activationActions(plan, opts.Layout)
+
+	return plan, nil
+}
+
+func validateActivationOptions(opts ActivationOptions) error {
+	if err := validateLayout(opts.Layout); err != nil {
+		return err
+	}
+
+	if opts.CandidatePath == "" || !filepath.IsAbs(opts.CandidatePath) || filepath.Clean(opts.CandidatePath) != opts.CandidatePath {
+		return fmt.Errorf("invalid candidate agent binary path %q", opts.CandidatePath)
+	}
+
+	if opts.LockPath == "" || !filepath.IsAbs(opts.LockPath) || filepath.Clean(opts.LockPath) != opts.LockPath {
+		return fmt.Errorf("invalid agent activation lock path %q", opts.LockPath)
+	}
+
+	if opts.BinaryMode != 0 && opts.BinaryMode.Perm() != opts.BinaryMode {
+		return fmt.Errorf("agent binary mode must contain permission bits only")
+	}
+
+	return nil
+}
+
+func activationCurrentPath(layout Layout) (string, bool, error) {
+	currentPath, err := executablePath(layout.CurrentPath)
+	if err == nil {
+		currentIsBlue, blueErr := pathResolvesTo(layout.BluePath, currentPath)
+		if blueErr != nil {
+			return "", false, fmt.Errorf("resolve blue agent binary: %w", blueErr)
+		}
+
+		currentIsGreen, greenErr := pathResolvesTo(layout.GreenPath, currentPath)
+		if greenErr != nil {
+			return "", false, fmt.Errorf("resolve green agent binary: %w", greenErr)
+		}
+
+		return currentPath, currentIsBlue || currentIsGreen, nil
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", false, fmt.Errorf("resolve current agent binary: %w", err)
+	}
+
+	for _, fallbackPath := range []string{
+		layout.LastGoodPath,
+		layout.BluePath,
+		layout.GreenPath,
+		layout.BinaryPath,
+	} {
+		fallback, fallbackErr := executablePath(fallbackPath)
+		if fallbackErr == nil {
+			return fallback, false, nil
+		}
+
+		if !errors.Is(fallbackErr, os.ErrNotExist) {
+			return "", false, fmt.Errorf("resolve fallback agent binary %s: %w", fallbackPath, fallbackErr)
+		}
+	}
+
+	return "", false, fmt.Errorf("no executable existing agent binary found")
+}
+
+func activationActions(plan ActivationPlan, layout Layout) []string {
+	actions := make([]string, 0, 9)
+	actions = append(actions, "verify candidate binary")
+
+	if plan.InitializeLayout {
+		actions = append(actions, "initialize managed binary layout")
+	}
+
+	if plan.CandidateChanged {
+		actions = append(actions,
+			"install candidate into "+plan.TargetPath,
+			"preserve "+plan.RollbackPath+" as last-good",
+			"switch "+layout.CurrentPath+" to "+plan.TargetPath,
+		)
+	}
+
+	if plan.RepairLastGood {
+		actions = append(actions, "repair last-good agent symlink")
+	}
+
+	if plan.Service.UpdateRequired {
+		actions = append(actions, "update daemon service configuration")
+	}
+
+	return append(actions,
+		"reload daemon service manager",
+		"restart daemon service",
+		"wait for daemon health",
+		"roll back to "+plan.RollbackPath+" if activation fails",
+	)
+}
+
+func readSymlinkState(path string) (bool, string, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, "", nil
+	}
+
+	if err != nil {
+		return false, "", err
+	}
+
+	if info.Mode()&os.ModeSymlink == 0 {
+		return false, "", fmt.Errorf("%s is not a symlink", path)
+	}
+
+	target, err := os.Readlink(path)
+	if err != nil {
+		return false, "", err
+	}
+
+	return true, target, nil
+}
+
+func filesDiffer(firstPath, secondPath string) (bool, error) {
+	first, err := fileSHA256(firstPath)
+	if err != nil {
+		return false, err
+	}
+
+	second, err := fileSHA256(secondPath)
+	if err != nil {
+		return false, err
+	}
+
+	return first != second, nil
+}
+
+func fileSHA256(path string) ([sha256.Size]byte, error) {
+	var digest [sha256.Size]byte
+
+	file, err := os.Open(path)
+	if err != nil {
+		return digest, err
+	}
+	defer file.Close() //nolint:errcheck // read error is authoritative
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return digest, err
+	}
+
+	copy(digest[:], hasher.Sum(nil))
+
+	return digest, nil
+}

--- a/pkg/agent/agentbinary/activation_preflight.go
+++ b/pkg/agent/agentbinary/activation_preflight.go
@@ -79,6 +79,30 @@ func PreflightHostDaemonActivation(
 		}
 	}
 
+	targetAliasesActive, err := pathResolvesTo(plan.TargetPath, currentPath)
+	if err != nil {
+		return ActivationPlan{}, fmt.Errorf("resolve selected target agent binary: %w", err)
+	}
+
+	if targetAliasesActive && plan.CandidateChanged {
+		return ActivationPlan{}, fmt.Errorf("selected target agent binary %s resolves to active binary %s", plan.TargetPath, currentPath)
+	}
+
+	for _, destination := range []struct {
+		role string
+		path string
+	}{
+		{role: "binary compatibility path", path: opts.Layout.BinaryPath},
+		{role: "blue slot", path: opts.Layout.BluePath},
+		{role: "green slot", path: opts.Layout.GreenPath},
+		{role: "current link", path: opts.Layout.CurrentPath},
+		{role: "last-good link", path: opts.Layout.LastGoodPath},
+	} {
+		if err := validateReplaceableActivationPath(destination.path); err != nil {
+			return ActivationPlan{}, fmt.Errorf("validate %s: %w", destination.role, err)
+		}
+	}
+
 	lastGoodExists, lastGoodTarget, err := readSymlinkState(opts.Layout.LastGoodPath)
 	if err != nil {
 		return ActivationPlan{}, fmt.Errorf("inspect last-good agent symlink: %w", err)
@@ -94,6 +118,8 @@ func PreflightHostDaemonActivation(
 			return ActivationPlan{}, fmt.Errorf("resolve last-good agent binary: %w", err)
 		}
 	}
+
+	plan.UpdateLastGood = plan.InitializeLayout || plan.CandidateChanged || plan.RepairLastGood
 
 	servicePlan, err := service.Preflight(ctx, opts.Layout.CurrentPath)
 	if err != nil {
@@ -195,6 +221,27 @@ func activationActions(plan ActivationPlan, layout Layout) []string {
 		"wait for daemon health",
 		"roll back to "+plan.RollbackPath+" if activation fails",
 	)
+}
+
+func validateReplaceableActivationPath(path string) error {
+	if path == "" {
+		return nil
+	}
+
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%s is not a replaceable regular file or symlink", path)
 }
 
 func readSymlinkState(path string) (bool, string, error) {

--- a/pkg/agent/agentbinary/activation_test.go
+++ b/pkg/agent/agentbinary/activation_test.go
@@ -4,6 +4,7 @@
 package agentbinary
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -130,7 +131,11 @@ func TestActivateHostDaemonInitializesAndActivatesCandidate(t *testing.T) {
 	require.NoError(t, os.WriteFile(candidatePath, candidate, 0o755))
 
 	service := &fakeDaemonService{}
-	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+
+	var logs bytes.Buffer
+
+	log := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	result, err := ActivateHostDaemon(context.Background(), log, ActivationOptions{
 		Layout:        layout,
 		CandidatePath: candidatePath,
 		LockPath:      filepath.Join(dir, "activation.lock"),
@@ -148,6 +153,24 @@ func TestActivateHostDaemonInitializesAndActivatesCandidate(t *testing.T) {
 	assert.Equal(t, 1, service.reloads)
 	assert.Equal(t, 1, service.restarts)
 	assert.Equal(t, []string{layout.GreenPath}, service.healthTargets)
+
+	for _, step := range []string{
+		"validate-options",
+		"acquire-lock",
+		"preflight",
+		"verify-candidate",
+		"initialize-layout",
+		"install-candidate",
+		"verify-installed-candidate",
+		"prepare-service",
+		"switch-links",
+		"reload-service-manager",
+		"restart-service",
+		"wait-for-health",
+		"release-lock",
+	} {
+		assert.Contains(t, logs.String(), "step="+step)
+	}
 }
 
 func TestActivateHostDaemonAdoptsCurrentLinkToSingleBinary(t *testing.T) {

--- a/pkg/agent/agentbinary/activation_test.go
+++ b/pkg/agent/agentbinary/activation_test.go
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentbinary
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDaemonService struct {
+	plan          ServicePlan
+	prepared      []string
+	reloads       int
+	restarts      int
+	healthTargets []string
+	failHealthFor string
+}
+
+func (s *fakeDaemonService) Preflight(context.Context, string) (ServicePlan, error) {
+	return s.plan, nil
+}
+
+func (s *fakeDaemonService) Prepare(_ context.Context, current string) error {
+	s.prepared = append(s.prepared, current)
+	return nil
+}
+
+func (s *fakeDaemonService) Reload(context.Context) error {
+	s.reloads++
+	return nil
+}
+
+func (s *fakeDaemonService) Restart(context.Context) error {
+	s.restarts++
+	return nil
+}
+
+func (s *fakeDaemonService) WaitHealthy(_ context.Context, target string) error {
+	s.healthTargets = append(s.healthTargets, target)
+	if target == s.failHealthFor {
+		return errors.New("candidate unhealthy")
+	}
+
+	return nil
+}
+
+func TestAcquireHostActivationLockSerializesCallers(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "activation.lock")
+
+	first, err := AcquireHostActivationLock(lockPath)
+	require.NoError(t, err)
+
+	defer first.Close() //nolint:errcheck // test cleanup
+
+	_, err = AcquireHostActivationLock(lockPath)
+	require.ErrorIs(t, err, ErrActivationInProgress)
+
+	require.NoError(t, first.Close())
+
+	second, err := AcquireHostActivationLock(lockPath)
+	require.NoError(t, err)
+	require.NoError(t, second.Close())
+}
+
+func TestPreflightHostDaemonActivationInitialLayoutDoesNotMutate(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	legacy := []byte("#!/bin/sh\nexit 0\n")
+	candidate := []byte("#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	require.NoError(t, os.WriteFile(layout.BinaryPath, legacy, 0o755))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	require.NoError(t, os.WriteFile(candidatePath, candidate, 0o755))
+
+	service := &fakeDaemonService{plan: ServicePlan{UpdateRequired: true, Description: "update unit"}}
+	plan, err := PreflightHostDaemonActivation(context.Background(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.NoError(t, err)
+
+	assert.True(t, plan.InitializeLayout)
+	assert.True(t, plan.CandidateChanged)
+	assert.Equal(t, layout.GreenPath, plan.TargetPath)
+	assert.Equal(t, layout.BluePath, plan.RollbackPath)
+	assert.Equal(t, layout.CurrentPath, plan.CurrentLinkPath)
+	assert.Equal(t, layout.LastGoodPath, plan.LastGoodLinkPath)
+	assert.True(t, plan.Service.UpdateRequired)
+
+	for _, path := range []string{layout.BluePath, layout.GreenPath, layout.CurrentPath, layout.LastGoodPath, filepath.Join(dir, "activation.lock")} {
+		_, err := os.Lstat(path)
+		assert.ErrorIs(t, err, os.ErrNotExist, path)
+	}
+}
+
+func TestPreflightHostDaemonActivationRejectsUnstagedCandidate(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	writeExecutable(t, layout.BinaryPath, "#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	_, err := PreflightHostDaemonActivation(context.Background(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: layout.BinaryPath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, &fakeDaemonService{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "staged separately")
+}
+
+func TestActivateHostDaemonInitializesAndActivatesCandidate(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	legacy := []byte("#!/bin/sh\nexit 0\n")
+	candidate := []byte("#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	require.NoError(t, os.WriteFile(layout.BinaryPath, legacy, 0o755))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	require.NoError(t, os.WriteFile(candidatePath, candidate, 0o755))
+
+	service := &fakeDaemonService{}
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.NoError(t, err)
+
+	assert.True(t, result.Initialized)
+	assert.True(t, result.Changed)
+	assert.Equal(t, layout.GreenPath, result.CurrentPath)
+	assert.Equal(t, layout.GreenPath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
+	assert.Equal(t, layout.GreenPath, mustEvalSymlinks(t, layout.BinaryPath))
+	assert.Equal(t, legacy, mustReadFile(t, layout.BluePath))
+	assert.Equal(t, candidate, mustReadFile(t, layout.GreenPath))
+	assert.Equal(t, 1, service.reloads)
+	assert.Equal(t, 1, service.restarts)
+	assert.Equal(t, []string{layout.GreenPath}, service.healthTargets)
+}
+
+func TestActivateHostDaemonAdoptsCurrentLinkToSingleBinary(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	legacy := []byte("#!/bin/sh\nexit 0\n")
+	candidate := []byte("#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	require.NoError(t, os.WriteFile(layout.BinaryPath, legacy, 0o755))
+	require.NoError(t, os.Symlink(layout.BinaryPath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.BinaryPath, layout.LastGoodPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	require.NoError(t, os.WriteFile(candidatePath, candidate, 0o755))
+
+	service := &fakeDaemonService{}
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.NoError(t, err)
+
+	assert.True(t, result.Initialized)
+	assert.Equal(t, layout.GreenPath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
+	assert.Equal(t, legacy, mustReadFile(t, layout.BluePath))
+	assert.Equal(t, candidate, mustReadFile(t, layout.GreenPath))
+}
+
+func TestActivateHostDaemonSwitchesExistingLayout(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	writeExecutable(t, layout.BluePath, "#!/bin/sh\nexit 0\n")
+	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.BluePath, layout.LastGoodPath))
+	require.NoError(t, os.Symlink(layout.CurrentPath, layout.BinaryPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutable(t, candidatePath, "#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	service := &fakeDaemonService{}
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.NoError(t, err)
+
+	assert.False(t, result.Initialized)
+	assert.Equal(t, layout.GreenPath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
+}
+
+func TestActivateHostDaemonRollsBackUnhealthyCandidate(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	writeExecutable(t, layout.BluePath, "#!/bin/sh\nexit 0\n")
+	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.BluePath, layout.LastGoodPath))
+	require.NoError(t, os.Symlink(layout.CurrentPath, layout.BinaryPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutable(t, candidatePath, "#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	service := &fakeDaemonService{failHealthFor: layout.GreenPath}
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.Error(t, err)
+
+	assert.True(t, result.RolledBack)
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, 2, service.restarts)
+	assert.Equal(t, []string{layout.GreenPath, layout.BluePath}, service.healthTargets)
+}
+
+func testActivationLayout(dir string) Layout {
+	return Layout{
+		BinaryPath:   filepath.Join(dir, "unbounded-agent"),
+		BluePath:     filepath.Join(dir, "unbounded-agent-blue"),
+		GreenPath:    filepath.Join(dir, "unbounded-agent-green"),
+		CurrentPath:  filepath.Join(dir, "unbounded-agent-current"),
+		LastGoodPath: filepath.Join(dir, "unbounded-agent-last-good"),
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+}
+
+func mustEvalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+
+	resolved, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+
+	return resolved
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return data
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/pkg/agent/agentbinary/activation_test.go
+++ b/pkg/agent/agentbinary/activation_test.go
@@ -53,6 +53,12 @@ func (s *fakeDaemonService) WaitHealthy(_ context.Context, target string) error 
 	return nil
 }
 
+func TestActivateHostDaemonRequiresLogger(t *testing.T) {
+	_, err := ActivateHostDaemon(context.Background(), nil, ActivationOptions{}, &fakeDaemonService{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "logger is required")
+}
+
 func TestAcquireHostActivationLockSerializesCallers(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "activation.lock")
 

--- a/pkg/agent/agentbinary/activation_test.go
+++ b/pkg/agent/agentbinary/activation_test.go
@@ -4,7 +4,6 @@
 package agentbinary
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -18,12 +17,15 @@ import (
 )
 
 type fakeDaemonService struct {
-	plan          ServicePlan
-	prepared      []string
-	reloads       int
-	restarts      int
-	healthTargets []string
-	failHealthFor string
+	plan                  ServicePlan
+	prepared              []string
+	reloads               int
+	restarts              int
+	restartErr            error
+	restartContextErrors  []error
+	healthTargets         []string
+	failHealthFor         string
+	healthFailureCallback func()
 }
 
 func (s *fakeDaemonService) Preflight(context.Context, string) (ServicePlan, error) {
@@ -40,18 +42,41 @@ func (s *fakeDaemonService) Reload(context.Context) error {
 	return nil
 }
 
-func (s *fakeDaemonService) Restart(context.Context) error {
+func (s *fakeDaemonService) Restart(ctx context.Context) error {
 	s.restarts++
-	return nil
+	s.restartContextErrors = append(s.restartContextErrors, ctx.Err())
+
+	return s.restartErr
 }
 
 func (s *fakeDaemonService) WaitHealthy(_ context.Context, target string) error {
 	s.healthTargets = append(s.healthTargets, target)
 	if target == s.failHealthFor {
+		if s.healthFailureCallback != nil {
+			s.healthFailureCallback()
+		}
+
 		return errors.New("candidate unhealthy")
 	}
 
 	return nil
+}
+
+func TestSnapshotActivationCandidatePinsOpenedContent(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "candidate")
+	original := []byte("#!/bin/sh\nexit 0\n")
+	replacement := []byte("#!/bin/sh\nexit 42\n")
+
+	require.NoError(t, os.WriteFile(sourcePath, original, 0o755))
+
+	snapshotPath, cleanup, err := snapshotActivationCandidate(sourcePath, 0o755)
+	require.NoError(t, err)
+
+	defer cleanup()
+
+	require.NoError(t, os.WriteFile(sourcePath, replacement, 0o755))
+	assert.Equal(t, original, mustReadFile(t, snapshotPath))
 }
 
 func TestAcquireHostActivationLockSerializesCallers(t *testing.T) {
@@ -98,6 +123,7 @@ func TestPreflightHostDaemonActivationInitialLayoutDoesNotMutate(t *testing.T) {
 	assert.Equal(t, layout.CurrentPath, plan.CurrentLinkPath)
 	assert.Equal(t, layout.LastGoodPath, plan.LastGoodLinkPath)
 	assert.True(t, plan.Service.UpdateRequired)
+	assert.True(t, plan.UpdateLastGood)
 
 	for _, path := range []string{layout.BluePath, layout.GreenPath, layout.CurrentPath, layout.LastGoodPath, filepath.Join(dir, "activation.lock")} {
 		_, err := os.Lstat(path)
@@ -119,6 +145,27 @@ func TestPreflightHostDaemonActivationRejectsUnstagedCandidate(t *testing.T) {
 	assert.Contains(t, err.Error(), "staged separately")
 }
 
+func TestPreflightHostDaemonActivationRejectsAliasedTargetSlot(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	writeExecutable(t, layout.GreenPath, "#!/bin/sh\nexit 0\n")
+	require.NoError(t, os.Symlink(layout.GreenPath, layout.BluePath))
+	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.GreenPath, layout.LastGoodPath))
+	require.NoError(t, os.Symlink(layout.CurrentPath, layout.BinaryPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutable(t, candidatePath, "#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	_, err := PreflightHostDaemonActivation(context.Background(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, &fakeDaemonService{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolves to active binary")
+}
+
 func TestActivateHostDaemonInitializesAndActivatesCandidate(t *testing.T) {
 	dir := t.TempDir()
 	layout := testActivationLayout(dir)
@@ -131,11 +178,7 @@ func TestActivateHostDaemonInitializesAndActivatesCandidate(t *testing.T) {
 	require.NoError(t, os.WriteFile(candidatePath, candidate, 0o755))
 
 	service := &fakeDaemonService{}
-
-	var logs bytes.Buffer
-
-	log := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	result, err := ActivateHostDaemon(context.Background(), log, ActivationOptions{
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
 		Layout:        layout,
 		CandidatePath: candidatePath,
 		LockPath:      filepath.Join(dir, "activation.lock"),
@@ -153,24 +196,6 @@ func TestActivateHostDaemonInitializesAndActivatesCandidate(t *testing.T) {
 	assert.Equal(t, 1, service.reloads)
 	assert.Equal(t, 1, service.restarts)
 	assert.Equal(t, []string{layout.GreenPath}, service.healthTargets)
-
-	for _, step := range []string{
-		"validate-options",
-		"acquire-lock",
-		"preflight",
-		"verify-candidate",
-		"initialize-layout",
-		"install-candidate",
-		"verify-installed-candidate",
-		"prepare-service",
-		"switch-links",
-		"reload-service-manager",
-		"restart-service",
-		"wait-for-health",
-		"release-lock",
-	} {
-		assert.Contains(t, logs.String(), "step="+step)
-	}
 }
 
 func TestActivateHostDaemonAdoptsCurrentLinkToSingleBinary(t *testing.T) {
@@ -253,7 +278,7 @@ func TestActivateHostDaemonSwitchesExistingLayout(t *testing.T) {
 	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
 }
 
-func TestActivateHostDaemonRestoresLinksAfterLinkSwitchFailure(t *testing.T) {
+func TestActivateHostDaemonRejectsDirectoryDestinationDuringPreflight(t *testing.T) {
 	dir := t.TempDir()
 	layout := testActivationLayout(dir)
 	previousLastGood := filepath.Join(dir, "previous-last-good")
@@ -269,13 +294,16 @@ func TestActivateHostDaemonRestoresLinksAfterLinkSwitchFailure(t *testing.T) {
 	candidatePath := filepath.Join(dir, "candidate")
 	writeExecutable(t, candidatePath, "#!/bin/sh\n[ \"$1\" = version ]\n")
 
+	service := &fakeDaemonService{}
 	_, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
 		Layout:        layout,
 		CandidatePath: candidatePath,
 		LockPath:      filepath.Join(dir, "activation.lock"),
-	}, &fakeDaemonService{})
+	}, service)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a replaceable regular file or symlink")
 
+	assert.Empty(t, service.prepared)
 	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.CurrentPath))
 	assert.Equal(t, previousLastGood, mustEvalSymlinks(t, layout.LastGoodPath))
 }
@@ -364,8 +392,12 @@ func TestActivateHostDaemonRollsBackUnhealthyCandidate(t *testing.T) {
 	candidatePath := filepath.Join(dir, "candidate")
 	writeExecutable(t, candidatePath, "#!/bin/sh\n[ \"$1\" = version ]\n")
 
-	service := &fakeDaemonService{failHealthFor: layout.GreenPath}
-	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+	ctx, cancel := context.WithCancel(context.Background())
+	service := &fakeDaemonService{
+		failHealthFor:         layout.GreenPath,
+		healthFailureCallback: cancel,
+	}
+	result, err := ActivateHostDaemon(ctx, discardLogger(), ActivationOptions{
 		Layout:        layout,
 		CandidatePath: candidatePath,
 		LockPath:      filepath.Join(dir, "activation.lock"),
@@ -375,7 +407,32 @@ func TestActivateHostDaemonRollsBackUnhealthyCandidate(t *testing.T) {
 	assert.True(t, result.RolledBack)
 	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.CurrentPath))
 	assert.Equal(t, 2, service.restarts)
+	assert.Equal(t, []error{nil, nil}, service.restartContextErrors)
 	assert.Equal(t, []string{layout.GreenPath, layout.BluePath}, service.healthTargets)
+}
+
+func TestActivateHostDaemonReportsUnsuccessfulRollback(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	writeExecutable(t, layout.BluePath, "#!/bin/sh\nexit 0\n")
+	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.BluePath, layout.LastGoodPath))
+	require.NoError(t, os.Symlink(layout.CurrentPath, layout.BinaryPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutable(t, candidatePath, "#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	service := &fakeDaemonService{restartErr: errors.New("restart failed")}
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.Error(t, err)
+
+	assert.False(t, result.RolledBack)
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, 2, service.restarts)
 }
 
 func testActivationLayout(dir string) Layout {

--- a/pkg/agent/agentbinary/activation_test.go
+++ b/pkg/agent/agentbinary/activation_test.go
@@ -53,12 +53,6 @@ func (s *fakeDaemonService) WaitHealthy(_ context.Context, target string) error 
 	return nil
 }
 
-func TestActivateHostDaemonRequiresLogger(t *testing.T) {
-	_, err := ActivateHostDaemon(context.Background(), nil, ActivationOptions{}, &fakeDaemonService{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "logger is required")
-}
-
 func TestAcquireHostActivationLockSerializesCallers(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "activation.lock")
 

--- a/pkg/agent/agentbinary/activation_test.go
+++ b/pkg/agent/agentbinary/activation_test.go
@@ -178,6 +178,34 @@ func TestActivateHostDaemonAdoptsCurrentLinkToSingleBinary(t *testing.T) {
 	assert.Equal(t, candidate, mustReadFile(t, layout.GreenPath))
 }
 
+func TestActivateHostDaemonRepairsMissingCurrentLink(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	legacy := []byte("#!/bin/sh\nexit 0\n")
+	candidate := []byte("#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	require.NoError(t, os.WriteFile(layout.BluePath, legacy, 0o755))
+	require.NoError(t, os.Symlink(layout.BluePath, layout.LastGoodPath))
+	require.NoError(t, os.Symlink(layout.CurrentPath, layout.BinaryPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	require.NoError(t, os.WriteFile(candidatePath, candidate, 0o755))
+
+	service := &fakeDaemonService{}
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.NoError(t, err)
+
+	assert.True(t, result.Initialized)
+	assert.Equal(t, layout.GreenPath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
+	assert.Equal(t, legacy, mustReadFile(t, layout.BluePath))
+	assert.Equal(t, candidate, mustReadFile(t, layout.GreenPath))
+}
+
 func TestActivateHostDaemonSwitchesExistingLayout(t *testing.T) {
 	dir := t.TempDir()
 	layout := testActivationLayout(dir)
@@ -199,6 +227,80 @@ func TestActivateHostDaemonSwitchesExistingLayout(t *testing.T) {
 
 	assert.False(t, result.Initialized)
 	assert.Equal(t, layout.GreenPath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
+}
+
+func TestActivateHostDaemonRestoresCurrentAfterLinkSwitchFailure(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	writeExecutable(t, layout.BluePath, "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, layout.GreenPath, "#!/bin/sh\nexit 0\n# previous\n")
+	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.GreenPath, layout.LastGoodPath))
+
+	layout.BinaryPath = filepath.Join(dir, "compatibility-directory")
+	require.NoError(t, os.Mkdir(layout.BinaryPath, 0o755))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutable(t, candidatePath, "#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	_, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, &fakeDaemonService{})
+	require.Error(t, err)
+
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.CurrentPath))
+}
+
+func TestActivateHostDaemonIdenticalCandidatePreservesLastGood(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	active := "#!/bin/sh\n[ \"$1\" = version ]\n"
+	writeExecutable(t, layout.BluePath, active)
+	writeExecutable(t, layout.GreenPath, "#!/bin/sh\nexit 0\n")
+	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.GreenPath, layout.LastGoodPath))
+	require.NoError(t, os.Symlink(layout.CurrentPath, layout.BinaryPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutable(t, candidatePath, active)
+
+	service := &fakeDaemonService{}
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.NoError(t, err)
+
+	assert.False(t, result.Changed)
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, layout.GreenPath, mustEvalSymlinks(t, layout.LastGoodPath))
+}
+
+func TestActivateHostDaemonIdenticalCandidateRepairsMissingLastGood(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	active := "#!/bin/sh\n[ \"$1\" = version ]\n"
+	writeExecutable(t, layout.BluePath, active)
+	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.CurrentPath, layout.BinaryPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutable(t, candidatePath, active)
+
+	service := &fakeDaemonService{}
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, service)
+	require.NoError(t, err)
+
+	assert.False(t, result.Changed)
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.CurrentPath))
 	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
 }
 

--- a/pkg/agent/agentbinary/activation_test.go
+++ b/pkg/agent/agentbinary/activation_test.go
@@ -230,13 +230,15 @@ func TestActivateHostDaemonSwitchesExistingLayout(t *testing.T) {
 	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
 }
 
-func TestActivateHostDaemonRestoresCurrentAfterLinkSwitchFailure(t *testing.T) {
+func TestActivateHostDaemonRestoresLinksAfterLinkSwitchFailure(t *testing.T) {
 	dir := t.TempDir()
 	layout := testActivationLayout(dir)
+	previousLastGood := filepath.Join(dir, "previous-last-good")
+
 	writeExecutable(t, layout.BluePath, "#!/bin/sh\nexit 0\n")
-	writeExecutable(t, layout.GreenPath, "#!/bin/sh\nexit 0\n# previous\n")
+	writeExecutable(t, previousLastGood, "#!/bin/sh\nexit 0\n# previous\n")
 	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
-	require.NoError(t, os.Symlink(layout.GreenPath, layout.LastGoodPath))
+	require.NoError(t, os.Symlink(previousLastGood, layout.LastGoodPath))
 
 	layout.BinaryPath = filepath.Join(dir, "compatibility-directory")
 	require.NoError(t, os.Mkdir(layout.BinaryPath, 0o755))
@@ -252,6 +254,30 @@ func TestActivateHostDaemonRestoresCurrentAfterLinkSwitchFailure(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, previousLastGood, mustEvalSymlinks(t, layout.LastGoodPath))
+}
+
+func TestActivateHostDaemonAllowsMissingCompatibilityPath(t *testing.T) {
+	dir := t.TempDir()
+	layout := testActivationLayout(dir)
+	layout.BinaryPath = ""
+	writeExecutable(t, layout.BluePath, "#!/bin/sh\nexit 0\n")
+	require.NoError(t, os.Symlink(layout.BluePath, layout.CurrentPath))
+	require.NoError(t, os.Symlink(layout.BluePath, layout.LastGoodPath))
+
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutable(t, candidatePath, "#!/bin/sh\n[ \"$1\" = version ]\n")
+
+	result, err := ActivateHostDaemon(context.Background(), discardLogger(), ActivationOptions{
+		Layout:        layout,
+		CandidatePath: candidatePath,
+		LockPath:      filepath.Join(dir, "activation.lock"),
+	}, &fakeDaemonService{})
+	require.NoError(t, err)
+
+	assert.True(t, result.Changed)
+	assert.Equal(t, layout.GreenPath, mustEvalSymlinks(t, layout.CurrentPath))
+	assert.Equal(t, layout.BluePath, mustEvalSymlinks(t, layout.LastGoodPath))
 }
 
 func TestActivateHostDaemonIdenticalCandidatePreservesLastGood(t *testing.T) {

--- a/pkg/agent/goalstates/constants.go
+++ b/pkg/agent/goalstates/constants.go
@@ -33,6 +33,7 @@ const (
 	DaemonBinaryLastGoodPath     = "/usr/local/bin/unbounded-agent-last-good"
 	DaemonRecoveryScriptPath     = "/usr/local/bin/unbounded-agent-daemon-recovery.sh"
 	DaemonAgentUpgradeSignalPath = AgentConfigDir + "/agent-upgrade-signal"
+	DaemonAgentUpgradeLockPath   = "/run/unbounded-agent-upgrade.lock"
 
 	EnvDaemonBinary                 = "UNBOUNDED_AGENT_DAEMON_BINARY"
 	EnvDaemonBinaryBlue             = "UNBOUNDED_AGENT_DAEMON_BINARY_BLUE"


### PR DESCRIPTION
## Summary
- add a hidden `unbounded-agent agent-upgrade [--preflight]` host-driven activation command
- expose reusable, lock-coordinated binary activation APIs for node-side consumers
- coordinate direct and MachineOperation upgrades with the shared lock and pending signal
- add unit coverage and a QEMU/Kind host-upgrade E2E scenario

## Validation
- `go test ./pkg/agent/agentbinary ./pkg/agent/goalstates ./cmd/agent/internal/daemon ./cmd/agent/internal/cmd`
- focused `golangci-lint` for changed Go packages
- `go build -o bin/unbounded-agent ./cmd/agent`
- Python syntax and E2E command registration checks
