### PR TITLE
Remove forced containerd debug logging

### DIFF
--- a/pkg/agent/phases/nodestart/assets/containerd.toml
+++ b/pkg/agent/phases/nodestart/assets/containerd.toml
@@ -3,9 +3,6 @@ imports = ["/etc/containerd/conf.d/*.toml"]
 oom_score = 0
 version = 2
 
-[debug]
-level = "info"
-
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "{{.SandboxImage}}"
 image_pull_progress_timeout = "15m"

--- a/pkg/agent/phases/nodestart/cri_test.go
+++ b/pkg/agent/phases/nodestart/cri_test.go
@@ -35,7 +35,7 @@ func TestConfigureContainerdWritesGantryHostsConfig(t *testing.T) {
 	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
 }
 
-func TestConfigureContainerdSetsObservabilityDefaults(t *testing.T) {
+func TestConfigureContainerdSetsImagePullProgressTimeout(t *testing.T) {
 	t.Parallel()
 
 	machineDir := t.TempDir()
@@ -49,7 +49,6 @@ func TestConfigureContainerdSetsObservabilityDefaults(t *testing.T) {
 	path := filepath.Join(machineDir, goalstates.ContainerdConfigPath)
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
-	require.Contains(t, string(data), "[debug]\nlevel = \"info\"")
 	require.Contains(t, string(data), "[plugins.\"io.containerd.grpc.v1.cri\"]\n"+
 		"sandbox_image = \""+goalState.Containerd.SandboxImage+"\"\n"+
 		"image_pull_progress_timeout = \"15m\"")


### PR DESCRIPTION
## Summary
- stop forcing containerd debug logging to info level
- keep the image pull progress timeout test focused on the remaining setting

## Testing
- `go test ./pkg/agent/phases/nodestart`