### PR TITLE
agent: retry exec when a just-written binary is still busy

### DIFF
--- a/internal/executil/exec.go
+++ b/internal/executil/exec.go
@@ -38,11 +38,26 @@ import (
 // lifetime of somebody else's fork, so it closes in well under a millisecond;
 // the budget below is generous against a loaded machine rather than sized to
 // any real expectation.
-const (
-	textBusyRetryBudget  = time.Second
-	textBusyInitialDelay = 10 * time.Millisecond
-	textBusyMaxDelay     = 100 * time.Millisecond
-)
+//
+// The budget bounds how long this package keeps retrying, not the total wall
+// time of the call. Sleeps are clamped so none runs past the deadline, but the
+// attempt that follows the last sleep is a command execution and is not
+// bounded here; a caller that needs a hard ceiling should impose it on ctx.
+var defaultTextBusyPolicy = retryPolicy{
+	budget:       time.Second,
+	initialDelay: 10 * time.Millisecond,
+	maxDelay:     100 * time.Millisecond,
+}
+
+// retryPolicy is a parameter so tests can pin the clamping behaviour. With the
+// production values the difference clamping makes is at most one maxDelay,
+// which is too small to distinguish from scheduling noise on a loaded machine;
+// a test policy whose delay dwarfs its budget makes it unmistakable.
+type retryPolicy struct {
+	budget       time.Duration
+	initialDelay time.Duration
+	maxDelay     time.Duration
+}
 
 // IsTextFileBusy reports whether an error is the transient ETXTBSY described
 // above, so callers doing their own exec can make the same allowance.
@@ -52,12 +67,22 @@ func IsTextFileBusy(err error) bool {
 
 // RetryWhileTextFileBusy runs attempt until it does not fail with ETXTBSY.
 //
-// attempt must build a fresh exec.Cmd each time it is called: an exec.Cmd
-// cannot be reused once started, and any pipes it created must be released
-// before the next attempt.
-func RetryWhileTextFileBusy(ctx context.Context, logger *slog.Logger, path string, attempt func() error) error {
-	deadline := time.Now().Add(textBusyRetryBudget)
-	delay := textBusyInitialDelay
+// attempt must build everything it needs each time it is called, including the
+// exec.Cmd: an exec.Cmd cannot be reused once started, and any pipes it created
+// must be released before the next attempt. Nothing outside attempt constructs
+// a command, so a caller-supplied command factory is invoked exactly once per
+// attempt and never merely to inspect it.
+//
+// The path of the binary is deliberately not a parameter. Every error this can
+// return already names it, because a failed start is wrapped with the command
+// path and the underlying os.PathError carries it as well.
+func RetryWhileTextFileBusy(ctx context.Context, logger *slog.Logger, attempt func() error) error {
+	return retryWhileTextFileBusy(ctx, logger, defaultTextBusyPolicy, attempt)
+}
+
+func retryWhileTextFileBusy(ctx context.Context, logger *slog.Logger, policy retryPolicy, attempt func() error) error {
+	deadline := time.Now().Add(policy.budget)
+	delay := policy.initialDelay
 
 	for {
 		err := attempt()
@@ -65,13 +90,20 @@ func RetryWhileTextFileBusy(ctx context.Context, logger *slog.Logger, path strin
 			return err
 		}
 
-		if time.Now().After(deadline) {
-			return fmt.Errorf("%s was still being written after %s: %w", path, textBusyRetryBudget, err)
+		// Clamped to what is left, so a sleep cannot run past the deadline and
+		// buy an extra attempt on the far side of it.
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("still busy after %s: %w", policy.budget, err)
+		}
+
+		if delay > remaining {
+			delay = remaining
 		}
 
 		if logger != nil {
 			logger.Debug("executable is still open for writing; retrying",
-				"path", path, "delay", delay)
+				"delay", delay, "error", err)
 		}
 
 		select {
@@ -80,8 +112,8 @@ func RetryWhileTextFileBusy(ctx context.Context, logger *slog.Logger, path strin
 		case <-time.After(delay):
 		}
 
-		if delay *= 2; delay > textBusyMaxDelay {
-			delay = textBusyMaxDelay
+		if delay *= 2; delay > policy.maxDelay {
+			delay = policy.maxDelay
 		}
 	}
 }
@@ -96,9 +128,10 @@ func RunCmd(ctx context.Context, logger *slog.Logger, newCmd func(context.Contex
 // Use a lower level (e.g. Debug) when stderr output is known to be benign or
 // when a failure is expected and already handled by the caller.
 func RunCmdAt(ctx context.Context, logger *slog.Logger, stderrLevel slog.Level, newCmd func(context.Context) *exec.Cmd, args ...string) error {
-	// The command is rebuilt on every attempt. An exec.Cmd is single use, and
-	// appending args to a reused one would duplicate them.
-	return RetryWhileTextFileBusy(ctx, logger, newCmd(ctx).Path, func() error {
+	// newCmd is called inside the attempt and nowhere else, so it runs exactly
+	// once per attempt. An exec.Cmd is single use, and appending args to a
+	// reused one would duplicate them.
+	return RetryWhileTextFileBusy(ctx, logger, func() error {
 		return runCmdOnce(ctx, logger, stderrLevel, newCmd, args...)
 	})
 }
@@ -163,7 +196,7 @@ func OutputCmd(ctx context.Context, logger *slog.Logger, name string, args ...st
 func OutputCmdAt(ctx context.Context, logger *slog.Logger, stderrLevel slog.Level, name string, args ...string) (string, error) {
 	var output string
 
-	err := RetryWhileTextFileBusy(ctx, logger, name, func() error {
+	err := RetryWhileTextFileBusy(ctx, logger, func() error {
 		var attemptErr error
 
 		output, attemptErr = outputCmdOnce(ctx, logger, stderrLevel, name, args...)

--- a/internal/executil/exec.go
+++ b/internal/executil/exec.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,7 +15,76 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 )
+
+// A binary this process has just written can be transiently unexecutable.
+//
+// fork() duplicates the writing file descriptor into the child, and O_CLOEXEC
+// only closes it at execve, so between the fork and the exec the child holds
+// the inode open for writing. Linux then refuses to execute it: execve returns
+// ETXTBSY, "text file busy". Any concurrent fork anywhere in the process is
+// enough, so installing a binary and running it is unsafe whenever anything
+// else in the process might be starting a command. See golang.org/issue/22315.
+//
+// The agent does exactly this in several places: it downloads kubelet,
+// containerd, runc, the CNI plugins and CoreDNS and immediately runs each one
+// to check its version, and those installers run concurrently with each other
+// under phases.Parallel.
+//
+// Retrying is safe because the error comes from execve, before the process
+// exists: nothing has run and nothing has taken effect. The window is the
+// lifetime of somebody else's fork, so it closes in well under a millisecond;
+// the budget below is generous against a loaded machine rather than sized to
+// any real expectation.
+const (
+	textBusyRetryBudget  = time.Second
+	textBusyInitialDelay = 10 * time.Millisecond
+	textBusyMaxDelay     = 100 * time.Millisecond
+)
+
+// IsTextFileBusy reports whether an error is the transient ETXTBSY described
+// above, so callers doing their own exec can make the same allowance.
+func IsTextFileBusy(err error) bool {
+	return errors.Is(err, syscall.ETXTBSY)
+}
+
+// RetryWhileTextFileBusy runs attempt until it does not fail with ETXTBSY.
+//
+// attempt must build a fresh exec.Cmd each time it is called: an exec.Cmd
+// cannot be reused once started, and any pipes it created must be released
+// before the next attempt.
+func RetryWhileTextFileBusy(ctx context.Context, logger *slog.Logger, path string, attempt func() error) error {
+	deadline := time.Now().Add(textBusyRetryBudget)
+	delay := textBusyInitialDelay
+
+	for {
+		err := attempt()
+		if !IsTextFileBusy(err) {
+			return err
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%s was still being written after %s: %w", path, textBusyRetryBudget, err)
+		}
+
+		if logger != nil {
+			logger.Debug("executable is still open for writing; retrying",
+				"path", path, "delay", delay)
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.Join(ctx.Err(), err)
+		case <-time.After(delay):
+		}
+
+		if delay *= 2; delay > textBusyMaxDelay {
+			delay = textBusyMaxDelay
+		}
+	}
+}
 
 // RunCmd creates a command from the given factory, appends args, streams stdout
 // at Debug and stderr at Info, and waits for it to finish.
@@ -26,6 +96,14 @@ func RunCmd(ctx context.Context, logger *slog.Logger, newCmd func(context.Contex
 // Use a lower level (e.g. Debug) when stderr output is known to be benign or
 // when a failure is expected and already handled by the caller.
 func RunCmdAt(ctx context.Context, logger *slog.Logger, stderrLevel slog.Level, newCmd func(context.Context) *exec.Cmd, args ...string) error {
+	// The command is rebuilt on every attempt. An exec.Cmd is single use, and
+	// appending args to a reused one would duplicate them.
+	return RetryWhileTextFileBusy(ctx, logger, newCmd(ctx).Path, func() error {
+		return runCmdOnce(ctx, logger, stderrLevel, newCmd, args...)
+	})
+}
+
+func runCmdOnce(ctx context.Context, logger *slog.Logger, stderrLevel slog.Level, newCmd func(context.Context) *exec.Cmd, args ...string) error {
 	cmd := newCmd(ctx)
 	cmd.Args = append(cmd.Args, args...)
 
@@ -40,6 +118,10 @@ func RunCmdAt(ctx context.Context, logger *slog.Logger, stderrLevel slog.Level, 
 	}
 
 	if err := cmd.Start(); err != nil {
+		// The pipes were created before the start failed, so they are closed
+		// here rather than leaked once this attempt is retried.
+		closeAll(stdout, stderr)
+
 		return fmt.Errorf("failed to start %s: %w", cmd.Path, err)
 	}
 
@@ -79,6 +161,20 @@ func OutputCmd(ctx context.Context, logger *slog.Logger, name string, args ...st
 // Info. Use a lower level (e.g. Debug) when stderr output is known to be
 // benign or an error exit is expected and already handled by the caller.
 func OutputCmdAt(ctx context.Context, logger *slog.Logger, stderrLevel slog.Level, name string, args ...string) (string, error) {
+	var output string
+
+	err := RetryWhileTextFileBusy(ctx, logger, name, func() error {
+		var attemptErr error
+
+		output, attemptErr = outputCmdOnce(ctx, logger, stderrLevel, name, args...)
+
+		return attemptErr
+	})
+
+	return output, err
+}
+
+func outputCmdOnce(ctx context.Context, logger *slog.Logger, stderrLevel slog.Level, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 
 	stdout, err := cmd.StdoutPipe()
@@ -92,6 +188,10 @@ func OutputCmdAt(ctx context.Context, logger *slog.Logger, stderrLevel slog.Leve
 	}
 
 	if err := cmd.Start(); err != nil {
+		// The pipes were created before the start failed, so they are closed
+		// here rather than leaked once this attempt is retried.
+		closeAll(stdout, stderr)
+
 		return "", fmt.Errorf("failed to start %s: %w", cmd.Path, err)
 	}
 
@@ -134,6 +234,13 @@ func MachineRun(ctx context.Context, log *slog.Logger, machine string, args ...s
 }
 
 // streamLogs reads lines from reader and logs each one at the given level.
+// closeAll releases pipes belonging to a command that never started.
+func closeAll(closers ...io.Closer) {
+	for _, closer := range closers {
+		_ = closer.Close() //nolint:errcheck // nothing can be done about a pipe from a command that never ran
+	}
+}
+
 func streamLogs(ctx context.Context, logger *slog.Logger, reader io.Reader, level slog.Level) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/internal/executil/exec_test.go
+++ b/internal/executil/exec_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -131,7 +132,7 @@ func TestRetryWhileTextFileBusyReturnsOtherErrorsImmediately(t *testing.T) {
 
 	start := time.Now()
 
-	err := RetryWhileTextFileBusy(t.Context(), discardLogger(), "/bin/true", func() error {
+	err := RetryWhileTextFileBusy(t.Context(), discardLogger(), func() error {
 		attempts++
 
 		return wanted
@@ -145,7 +146,7 @@ func TestRetryWhileTextFileBusyReturnsOtherErrorsImmediately(t *testing.T) {
 		t.Fatalf("attempts = %d, want 1: only ETXTBSY may be retried", attempts)
 	}
 
-	if elapsed := time.Since(start); elapsed > textBusyRetryBudget {
+	if elapsed := time.Since(start); elapsed > defaultTextBusyPolicy.budget {
 		t.Fatalf("took %s, want an immediate return", elapsed)
 	}
 }
@@ -155,6 +156,8 @@ func TestRetryWhileTextFileBusyReturnsOtherErrorsImmediately(t *testing.T) {
 func TestRetryWhileTextFileBusyGivesUp(t *testing.T) {
 	path, _ := busyScript(t, "echo never reached")
 
+	start := time.Now()
+
 	_, err := OutputCmd(t.Context(), discardLogger(), path)
 	if err == nil {
 		t.Fatal("a file held open for writing must eventually fail rather than retry forever")
@@ -162,6 +165,51 @@ func TestRetryWhileTextFileBusyGivesUp(t *testing.T) {
 
 	if !IsTextFileBusy(err) {
 		t.Fatalf("err = %v, want it to carry the underlying ETXTBSY", err)
+	}
+
+	// Sleeps are clamped to what is left of the budget, so none can run past
+	// the deadline and buy a further attempt on the far side of it. The slack
+	// covers the attempts themselves, which are fast because execve rejects
+	// the file immediately, and a loaded machine.
+	const slack = 500 * time.Millisecond
+
+	if elapsed := time.Since(start); elapsed > defaultTextBusyPolicy.budget+slack {
+		t.Fatalf("gave up after %s, want no more than %s", elapsed, defaultTextBusyPolicy.budget+slack)
+	}
+
+	// The binary is still named, even though the helper no longer takes a path.
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("err = %v, want it to name %s", err, path)
+	}
+}
+
+// TestRunCmdBuildsOneCommandPerAttempt is a regression test.
+//
+// The command factory is caller-supplied and may be stateful: it can allocate,
+// open files or hand back a different command each time. An earlier revision
+// called it an extra time purely to read the path for an error message, which
+// consumed whatever that factory does and could report a path belonging to a
+// command that never ran. Nothing outside the attempt builds a command now.
+func TestRunCmdBuildsOneCommandPerAttempt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "probe")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write probe: %v", err)
+	}
+
+	built := 0
+
+	factory := func(ctx context.Context) *exec.Cmd {
+		built++
+
+		return exec.CommandContext(ctx, path)
+	}
+
+	if err := RunCmd(t.Context(), discardLogger(), factory); err != nil {
+		t.Fatalf("RunCmd: %v", err)
+	}
+
+	if built != 1 {
+		t.Fatalf("factory was called %d times for a command that succeeded first time, want 1", built)
 	}
 }
 
@@ -172,7 +220,7 @@ func TestRetryWhileTextFileBusyHonoursContext(t *testing.T) {
 
 	attempts := 0
 
-	err := RetryWhileTextFileBusy(ctx, discardLogger(), "/bin/true", func() error {
+	err := RetryWhileTextFileBusy(ctx, discardLogger(), func() error {
 		attempts++
 
 		cancel()
@@ -190,5 +238,48 @@ func TestRetryWhileTextFileBusyHonoursContext(t *testing.T) {
 
 	if attempts != 1 {
 		t.Fatalf("attempts = %d, want the loop to stop once the context is done", attempts)
+	}
+}
+
+// TestRetryClampsSleepToRemainingBudget is the regression test for the budget
+// being a bound rather than a suggestion.
+//
+// The deadline is checked before sleeping, so without clamping a sleep started
+// just inside the budget runs its full length past it and buys a further
+// attempt on the far side. With the production values that overshoot is at most
+// one maxDelay, too small to separate from scheduling noise, so this uses a
+// policy whose delay dwarfs its budget: unclamped it would sleep 500ms against
+// a 50ms budget.
+func TestRetryClampsSleepToRemainingBudget(t *testing.T) {
+	policy := retryPolicy{
+		budget:       50 * time.Millisecond,
+		initialDelay: 500 * time.Millisecond,
+		maxDelay:     time.Second,
+	}
+
+	attempts := 0
+
+	start := time.Now()
+
+	err := retryWhileTextFileBusy(t.Context(), discardLogger(), policy, func() error {
+		attempts++
+
+		return syscall.ETXTBSY
+	})
+	if err == nil {
+		t.Fatal("a permanently busy file must eventually give up")
+	}
+
+	elapsed := time.Since(start)
+
+	// Clamped, the single sleep is cut to the 50ms that remain. Unclamped it
+	// would be the full 500ms.
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("gave up after %s, want the sleep clamped to the %s budget", elapsed, policy.budget)
+	}
+
+	// One sleep, so two attempts: the one that failed and the one after it.
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
 	}
 }

--- a/internal/executil/exec_test.go
+++ b/internal/executil/exec_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package executil
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// commandAt returns a factory for the command runners, which take one rather
+// than a path so they can rebuild the command on every attempt.
+func commandAt(path string) func(context.Context) *exec.Cmd {
+	return func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, path)
+	}
+}
+
+// busyScript writes an executable and returns its path along with an open
+// write handle to it.
+//
+// While that handle is open the kernel refuses to execute the file: execve
+// returns ETXTBSY. That makes the race this package guards against reproducible
+// on demand, rather than something a test has to wait for.
+func busyScript(t *testing.T, body string) (string, *os.File) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "probe")
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("write probe: %v", err)
+	}
+
+	held, err := os.OpenFile(path, os.O_WRONLY, 0o755)
+	if err != nil {
+		t.Fatalf("hold probe open for writing: %v", err)
+	}
+
+	t.Cleanup(func() { _ = held.Close() })
+
+	return path, held
+}
+
+// TestOutputCmdRetriesWhileTextFileBusy is the regression test for the failure
+// this package exists to absorb.
+//
+// A binary the process has just written can transiently refuse to execute:
+// fork() duplicates the writing descriptor into the child, and O_CLOEXEC only
+// closes it at execve, so for the lifetime of somebody else's fork the inode is
+// open for writing and Linux returns ETXTBSY. The agent installs kubelet,
+// containerd, runc, the CNI plugins and CoreDNS and immediately runs each to
+// read its version, and those installers run concurrently under
+// phases.Parallel, so the window is reached in practice.
+func TestOutputCmdRetriesWhileTextFileBusy(t *testing.T) {
+	path, held := busyScript(t, "echo ready")
+
+	// Release the file shortly after the first attempt, so the command can only
+	// succeed if the retry happens.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+
+		_ = held.Close()
+	}()
+
+	output, err := OutputCmd(t.Context(), discardLogger(), path)
+	if err != nil {
+		t.Fatalf("OutputCmd: %v", err)
+	}
+
+	if output != "ready" {
+		t.Fatalf("output = %q, want %q", output, "ready")
+	}
+}
+
+// TestRunCmdRetriesWhileTextFileBusy covers the other entry point, which takes
+// a command factory rather than a path.
+func TestRunCmdRetriesWhileTextFileBusy(t *testing.T) {
+	path, held := busyScript(t, "exit 0")
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+
+		_ = held.Close()
+	}()
+
+	if err := RunCmd(t.Context(), discardLogger(), commandAt(path)); err != nil {
+		t.Fatalf("RunCmd: %v", err)
+	}
+}
+
+// TestRunCmdDoesNotDuplicateArgsAcrossRetries pins the reason the command is
+// rebuilt on every attempt rather than reused.
+//
+// An exec.Cmd cannot be started twice, and RunCmdAt appends the caller's
+// arguments to the factory's command, so retrying a reused command would append
+// them again and run something different from what the caller asked for.
+func TestRunCmdDoesNotDuplicateArgsAcrossRetries(t *testing.T) {
+	// The script fails unless it receives exactly one argument.
+	path, held := busyScript(t, `[ "$#" -eq 1 ] || exit 3`)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+
+		_ = held.Close()
+	}()
+
+	if err := RunCmd(t.Context(), discardLogger(), commandAt(path), "only-one"); err != nil {
+		t.Fatalf("RunCmd: %v; arguments were probably appended more than once", err)
+	}
+}
+
+// TestRetryWhileTextFileBusyReturnsOtherErrorsImmediately confirms the retry is
+// confined to ETXTBSY. Retrying anything else would re-run a command that has
+// already taken effect.
+func TestRetryWhileTextFileBusyReturnsOtherErrorsImmediately(t *testing.T) {
+	wanted := errors.New("the command genuinely failed")
+
+	attempts := 0
+
+	start := time.Now()
+
+	err := RetryWhileTextFileBusy(t.Context(), discardLogger(), "/bin/true", func() error {
+		attempts++
+
+		return wanted
+	})
+
+	if !errors.Is(err, wanted) {
+		t.Fatalf("err = %v, want the original error", err)
+	}
+
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1: only ETXTBSY may be retried", attempts)
+	}
+
+	if elapsed := time.Since(start); elapsed > textBusyRetryBudget {
+		t.Fatalf("took %s, want an immediate return", elapsed)
+	}
+}
+
+// TestRetryWhileTextFileBusyGivesUp bounds the retry, so a file something else
+// holds open forever cannot hang a pass indefinitely.
+func TestRetryWhileTextFileBusyGivesUp(t *testing.T) {
+	path, _ := busyScript(t, "echo never reached")
+
+	_, err := OutputCmd(t.Context(), discardLogger(), path)
+	if err == nil {
+		t.Fatal("a file held open for writing must eventually fail rather than retry forever")
+	}
+
+	if !IsTextFileBusy(err) {
+		t.Fatalf("err = %v, want it to carry the underlying ETXTBSY", err)
+	}
+}
+
+// TestRetryWhileTextFileBusyHonoursContext confirms a cancelled pass stops
+// retrying rather than running out the budget.
+func TestRetryWhileTextFileBusyHonoursContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	attempts := 0
+
+	err := RetryWhileTextFileBusy(ctx, discardLogger(), "/bin/true", func() error {
+		attempts++
+
+		cancel()
+
+		return syscall.ETXTBSY
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want it to report the cancellation", err)
+	}
+
+	if !IsTextFileBusy(err) {
+		t.Fatalf("err = %v, want it to also carry the reason it was retrying", err)
+	}
+
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want the loop to stop once the context is done", attempts)
+	}
+}

--- a/pkg/agent/phases/rootfs/cni.go
+++ b/pkg/agent/phases/rootfs/cni.go
@@ -98,12 +98,14 @@ func cniPluginsVersionMatch(ctx context.Context, log *slog.Logger, cniBinPath, e
 		return false
 	}
 
-	output, err := executil.OutputCmd(ctx, log, loopbackPath, "--version")
+	// Debug rather than the default Info for stderr: some CNI plugin versions
+	// do not support --version, so this failing is expected and the plugin's
+	// own complaint should not be surfaced as though something were wrong.
+	output, err := executil.OutputCmdAt(ctx, log, slog.LevelDebug, loopbackPath, "--version")
 	if err != nil {
-		// Some CNI plugin versions do not support --version, so an error here
-		// is expected and is treated as "not matching". It is logged at Debug
-		// rather than Warn for that reason, but it is logged: without it an
-		// infrastructure failure looks exactly like an old plugin.
+		// Treated as "not matching", which triggers a reinstall. Logged all the
+		// same: without it an infrastructure failure, an ETXTBSY for instance,
+		// looks exactly like an old plugin.
 		log.Debug("could not read the installed CNI plugin version; assuming it needs reinstalling",
 			"path", loopbackPath, "error", err)
 

--- a/pkg/agent/phases/rootfs/cni.go
+++ b/pkg/agent/phases/rootfs/cni.go
@@ -100,7 +100,13 @@ func cniPluginsVersionMatch(ctx context.Context, log *slog.Logger, cniBinPath, e
 
 	output, err := executil.OutputCmd(ctx, log, loopbackPath, "--version")
 	if err != nil {
-		// Some CNI plugin versions don't support --version; treat as not matching.
+		// Some CNI plugin versions do not support --version, so an error here
+		// is expected and is treated as "not matching". It is logged at Debug
+		// rather than Warn for that reason, but it is logged: without it an
+		// infrastructure failure looks exactly like an old plugin.
+		log.Debug("could not read the installed CNI plugin version; assuming it needs reinstalling",
+			"path", loopbackPath, "error", err)
+
 		return false
 	}
 

--- a/pkg/agent/phases/rootfs/cni_test.go
+++ b/pkg/agent/phases/rootfs/cni_test.go
@@ -4,6 +4,10 @@
 package rootfs
 
 import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Azure/unbounded/pkg/agent/goalstates"
@@ -55,5 +59,36 @@ func TestCNIDownloadURL(t *testing.T) {
 				t.Fatalf("got URL %q, want %q", got.String(), testCase.want)
 			}
 		})
+	}
+}
+
+// TestCNIPluginsVersionMatchStaysQuietForOldPlugins pins a claim the code makes
+// about its own logging.
+//
+// Some CNI plugin versions do not support --version, so the probe failing is
+// expected rather than a fault. Reporting it at Info means every provision of
+// such a cluster logs a complaint about a plugin that is working correctly.
+// Logging the operator's own message at Debug is not enough on its own: the
+// default runner streams the command's stderr at Info, so the plugin's
+// complaint arrives through that route before the message is ever reached.
+func TestCNIPluginsVersionMatchStaysQuietForOldPlugins(t *testing.T) {
+	dir := t.TempDir()
+
+	// A plugin that rejects --version the way an older one does.
+	script := "#!/bin/sh\necho 'unknown flag: --version' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "loopback"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake loopback plugin: %v", err)
+	}
+
+	var logged bytes.Buffer
+
+	log := slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	if cniPluginsVersionMatch(t.Context(), log, dir, "v1.5.1") {
+		t.Fatal("a plugin that cannot report its version must not be treated as matching")
+	}
+
+	if logged.Len() != 0 {
+		t.Fatalf("logged at Info or above for an expected failure:\n%s", logged.String())
 	}
 }

--- a/pkg/agent/phases/rootfs/cri.go
+++ b/pkg/agent/phases/rootfs/cri.go
@@ -135,6 +135,12 @@ func containerdVersionMatch(ctx context.Context, log *slog.Logger, destDir, expe
 
 	output, err := executil.OutputCmd(ctx, log, containerdPath, "--version")
 	if err != nil {
+		// Treated as "not the expected version", which triggers a
+		// re-download. Saying why matters: without this an infrastructure
+		// failure is indistinguishable from a genuine version mismatch.
+		log.Warn("could not read the installed containerd version; assuming it needs reinstalling",
+			"path", containerdPath, "error", err)
+
 		return false
 	}
 
@@ -150,6 +156,12 @@ func runcVersionMatch(ctx context.Context, log *slog.Logger, destDir, expectedVe
 
 	output, err := executil.OutputCmd(ctx, log, runcPath, "--version")
 	if err != nil {
+		// Treated as "not the expected version", which triggers a
+		// re-download. Saying why matters: without this an infrastructure
+		// failure is indistinguishable from a genuine version mismatch.
+		log.Warn("could not read the installed runc version; assuming it needs reinstalling",
+			"path", runcPath, "error", err)
+
 		return false
 	}
 

--- a/pkg/agent/phases/rootfs/kube.go
+++ b/pkg/agent/phases/rootfs/kube.go
@@ -201,6 +201,12 @@ func kubeletVersionMatch(ctx context.Context, log *slog.Logger, destDir, expecte
 
 	output, err := executil.OutputCmd(ctx, log, kubeletPath, "--version")
 	if err != nil {
+		// Treated as "not the expected version", which triggers a
+		// re-download. Saying why matters: without this an infrastructure
+		// failure is indistinguishable from a genuine version mismatch.
+		log.Warn("could not read the installed kubelet version; assuming it needs reinstalling",
+			"path", kubeletPath, "error", err)
+
 		return false
 	}
 
@@ -224,6 +230,12 @@ func crictlVersionMatch(ctx context.Context, log *slog.Logger, destDir, expected
 
 	output, err := executil.OutputCmd(ctx, log, crictlPath, "--version")
 	if err != nil {
+		// Treated as "not the expected version", which triggers a
+		// re-download. Saying why matters: without this an infrastructure
+		// failure is indistinguishable from a genuine version mismatch.
+		log.Warn("could not read the installed crictl version; assuming it needs reinstalling",
+			"path", crictlPath, "error", err)
+
 		return false
 	}
 

--- a/pkg/agent/phases/rootfs/localdns.go
+++ b/pkg/agent/phases/rootfs/localdns.go
@@ -15,6 +15,7 @@ import (
 	"text/template"
 
 	"github.com/Azure/unbounded/internal/agentartifacts"
+	"github.com/Azure/unbounded/internal/executil"
 	"github.com/Azure/unbounded/pkg/agent/artifactsource"
 	"github.com/Azure/unbounded/pkg/agent/goalstates"
 	"github.com/Azure/unbounded/pkg/agent/internal/utilio"
@@ -194,13 +195,24 @@ func (c *configureLocalDNS) installCoreDNS(ctx context.Context) error {
 		return fmt.Errorf("download CoreDNS binary: %w", err)
 	}
 
-	output, err := exec.CommandContext(ctx, destination, "-plugins").CombinedOutput()
+	// CoreDNS was written moments ago, so this exec can transiently fail with
+	// ETXTBSY if anything else in the process forked while it was being
+	// written. ConfigureLocalDNS runs under phases.Parallel alongside five
+	// other tasks that fork constantly, so that is not hypothetical.
+	var output string
+
+	err = executil.RetryWhileTextFileBusy(ctx, c.log, destination, func() error {
+		raw, runErr := exec.CommandContext(ctx, destination, "-plugins").CombinedOutput()
+		output = string(raw)
+
+		return runErr
+	})
 	if err != nil {
 		return fmt.Errorf("list CoreDNS plugins: %w", err)
 	}
 
 	plugins := map[string]struct{}{}
-	for _, field := range strings.Fields(string(output)) {
+	for _, field := range strings.Fields(output) {
 		plugins[strings.TrimPrefix(field, "dns.")] = struct{}{}
 	}
 

--- a/pkg/agent/phases/rootfs/localdns.go
+++ b/pkg/agent/phases/rootfs/localdns.go
@@ -201,7 +201,7 @@ func (c *configureLocalDNS) installCoreDNS(ctx context.Context) error {
 	// other tasks that fork constantly, so that is not hypothetical.
 	var output string
 
-	err = executil.RetryWhileTextFileBusy(ctx, c.log, destination, func() error {
+	err = executil.RetryWhileTextFileBusy(ctx, c.log, func() error {
 		raw, runErr := exec.CommandContext(ctx, destination, "-plugins").CombinedOutput()
 		output = string(raw)
 


### PR DESCRIPTION
Fixes a flaky CI failure in `pkg/agent/phases/rootfs`, which turns out to be a real
race in the agent rather than a test problem.

# The problem

A binary this process has just written can transiently refuse to run.

`fork()` duplicates the writing file descriptor into the child. `O_CLOEXEC` only
closes it at `execve`, so between the fork and the exec the child holds the inode
open **for writing**, and Linux refuses to execute it: `execve` returns `ETXTBSY`,
"text file busy". Any concurrent fork anywhere in the process is enough — it does
not have to touch the same file. This is [golang/go#22315](https://github.com/golang/go/issues/22315).

The agent does write-then-exec in six places. It installs kubelet, containerd,
runc, the CNI plugins and CoreDNS, and immediately runs each one to read its
version:

```go
// pkg/agent/phases/rootfs/localdns.go
} else if err := source.DownloadWithSHA256Verification(ctx, expectedHash, destination, 0o755); err != nil {
    return fmt.Errorf("download CoreDNS binary: %w", err)
}

output, err := exec.CommandContext(ctx, destination, "-plugins").CombinedOutput()
```

These installers are not sequential. They run as siblings under `phases.Parallel`
(`provision.go:22-29`), and the others fork constantly for `apt-get`,
`dpkg-query` and `systemctl`. So the window is reached in practice, not just in
theory.

`renameio` does not protect against this. It closes before renaming, but a
descriptor already duplicated into a forked child still refers to the same inode
after the rename.

## It is already failing

Running the `rootfs` package 200 times on `main` fails **4 times**:

```
--- FAIL: TestConfigureLocalDNS
    localdns_test.go:63: ConfigureLocalDNS() error = list CoreDNS plugins:
      fork/exec /tmp/.../usr/local/bin/coredns: text file busy
```

It became reachable when #554 added `localdns_test.go`. Counting tests in that
package that actually fork:

| File | Forking tests |
|---|---|
| `kube_test.go` | 1 (`TestCrictlVersionMatch`) |
| **`localdns_test.go`** (new in #554) | **3** |
| cni, cri, nspawn_render, preflight ×4 | 0 |

Both are `t.Parallel()` and both write an executable then exec it, so each one's
fork can capture the other's write descriptor. With one forking test there is no
window; with two there is.

The same race also surfaces as a **different-looking** failure:

```
--- FAIL: TestCrictlVersionMatch/matching_version
    kube_test.go:310: got match=false, want true
```

because `crictlVersionMatch` turned every error into "does not match".

# The fix

**Retry, confined to `ETXTBSY`.** This is safe because the error comes from
`execve`, before the process exists: nothing has run and nothing has taken
effect. Every other error is returned untouched, so a command that actually ran
and failed is never re-run.

The budget is one second. That is generous against a loaded machine rather than
sized to any real expectation — the window closes as soon as somebody else's
fork reaches its own exec, which is sub-millisecond.

Three parts:

1. **`internal/executil`** gains `RetryWhileTextFileBusy` and `IsTextFileBusy`,
   used by `RunCmdAt` and `OutputCmdAt`. That covers all five version probes,
   since `RunCmd`, `OutputCmd` and `MachineRun` all delegate to those two.

2. **`localdns.go` calls `os/exec` directly**, bypassing this package, so it
   takes the retry explicitly. This is the site the observed failure comes from,
   and an `executil`-only change would not have fixed it.

3. **The five version probes stop discarding the reason they failed.** Each
   treated any error as "not the expected version", which is why this appeared
   as a version mismatch rather than the exec failure it was, and which silently
   forces a redundant re-download.

   The CNI probe additionally runs at `OutputCmdAt(..., slog.LevelDebug, ...)`.
   Logging its own message at Debug is not enough: the default runner streams
   the command's stderr at Info, so an older plugin's complaint about
   `--version` arrives through that route first. The other four stay at Info
   deliberately — all five guard with `IsExecutable`, so for kubelet,
   containerd, runc and crictl a failure means the binary exists and
   misbehaved, which is genuinely unexpected. CNI is the one case the code
   documents as expected.

Three implementation details worth knowing while reading:

- **The command factory is invoked exactly once per attempt**, inside the
  attempt and nowhere else. It is caller-supplied and may be stateful, so this
  package is not entitled to call it merely to inspect the result. The helper
  therefore takes no path parameter: every error it returns already names the
  binary, because a failed start is wrapped with the command path and the
  underlying `os.PathError` carries it too.
- **The command is rebuilt on every attempt.** An `exec.Cmd` cannot be started
  twice, and `RunCmdAt` appends the caller's arguments to the factory's command,
  so reusing it would append them again and run something other than what the
  caller asked for. There is a test for exactly that.
- **Pipes belonging to a failed attempt are closed** rather than leaked, since
  `StdoutPipe`/`StderrPipe` are created before `Start`.

The budget bounds how long the package keeps **retrying**, not total wall time.
Sleeps are clamped so none runs past the deadline, but the attempt after the
last sleep is a command execution and is not bounded here; a caller needing a
hard ceiling should impose it on `ctx`.

# Verification

| | text-file-busy failures |
|---|---|
| Before, 200 runs of the `rootfs` package | **4** |
| After, 200 runs | **0** |

`internal/executil` gains its first test file. It reproduces `ETXTBSY`
**deterministically** rather than waiting for the race: hold a write handle open
across the exec, which makes the kernel return it every time, then close it from
a goroutine and assert the retry succeeds. Also covered: non-`ETXTBSY` errors
return immediately without retrying, the budget is bounded rather than infinite,
a cancelled context stops the loop, arguments are not duplicated across
attempts, the factory is called once per attempt, sleeps are clamped to the
remaining budget, and the CNI probe stays silent at Info for an old plugin.

Every one of those was confirmed to fail with the behaviour it guards against
removed.

The retry policy is a parameter rather than a constant so the clamp can be
tested. With the production values, clamping changes the outcome by at most one
`maxDelay`, which is smaller than the slack any wall-clock assertion needs on a
loaded machine — a first attempt at that test could not fail. The test policy
uses a delay that dwarfs its budget, where the difference is 500ms against
50ms.

# Deliberately not in this PR

- **Removing `t.Parallel()` from the two tests.** It would make CI green while
  leaving the production bug in place. A real agent installs CoreDNS and
  immediately execs it, alongside five other forking tasks.
- **Folding `agentbinary.Verify` onto this helper.** It already carries its own
  `ETXTBSY` retry for the same reason and is correct as it stands. Unifying them
  is worth doing, but it touches upgrade code merged last week and would double
  the review surface here.
- **The systemd-mediated sites** (`nodestart/localdns.go`, `daemon/lifecycle.go`,
  `storagesupervisor`). systemd performs the `execve` there, so `ETXTBSY` is not
  a Go error and cannot be handled in `executil`.

