### PR TITLE
feat: add standalone Gantry installer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1037,6 +1037,7 @@ jobs:
           # Upload the additional artifacts to the draft release that
           # GoReleaser created.
           gh release upload "${TAG}" \
+            hack/install-gantry.sh \
             dist/unbounded.yaml \
             dist/unbounded-manifests-*.tar.gz \
             dist/unbounded-manifests-*.tar.gz.bundle.json \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,23 @@ builds:
       - amd64
       - arm64
 
+  - id: gantryctl
+    main: ./cmd/gantryctl
+    binary: gantryctl
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/Azure/unbounded/internal/version.Version={{ .Version }}
+      - -X github.com/Azure/unbounded/internal/version.GitCommit={{ .ShortCommit }}
+      - -X github.com/Azure/unbounded/internal/version.BuildTime={{ .Date }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
   - id: unbounded-agent
     main: ./cmd/agent
     binary: unbounded-agent
@@ -64,6 +81,13 @@ archives:
     formats:
       - tar.gz
     name_template: "kubectl-unbounded-{{ .Os }}-{{ .Arch }}"
+
+  - id: gantryctl
+    ids:
+      - gantryctl
+    formats:
+      - tar.gz
+    name_template: "gantryctl-{{ .Os }}-{{ .Arch }}"
 
   - id: unbounded-agent
     ids:

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ UNBOUNDED_OPERATOR_MANIFEST_RENDERED_DIR  := deploy/unbounded-operator/rendered
 KUBECTL_UNBOUNDED_BIN=bin/kubectl-unbounded
 KUBECTL_UNBOUNDED_CMD=./cmd/kubectl-unbounded
 
+GANTRYCTL_BIN=bin/gantryctl
+GANTRYCTL_CMD=./cmd/gantryctl
+
 # Net binaries
 NET_CONTROLLER_BIN=bin/unbounded-net-controller
 NET_CONTROLLER_CMD=./cmd/unbounded-net-controller
@@ -225,6 +228,7 @@ ORCA_DEV_IMAGE ?= ghcr.io/azure/orca:dev
 ORCA_KIND_CLUSTER ?= orca-dev
 
 KUBECTL_UNBOUNDED_LDFLAGS=$(STAMP_LDFLAGS)
+GANTRYCTL_LDFLAGS=$(STAMP_LDFLAGS)
 
 # --- Net (unbounded-net) configuration -------------------------------------
 # Container images for the net controller and node agent.
@@ -264,7 +268,7 @@ NET_FRONTEND_CACHE_FILE    := $(NET_FRONTEND_DIST_DIR)/.frontend-build-key
 # Frontend build toggle (dev builds produce unminified output with sourcemaps).
 REACT_DEV ?= false
 
-.PHONY: all help fmt lint test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build install-tools install-protoc generate kubectl-unbounded forge agent-artifacts-builder agent-artifacts-builder-build orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push unbounded-operator unbounded-operator-build unbounded-operator-manifests playpen-manifests e2e-playpen gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build gantry-manifests inventory-manifests
+.PHONY: all help fmt lint test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build gantryctl gantryctl-build install-tools install-protoc generate kubectl-unbounded forge agent-artifacts-builder agent-artifacts-builder-build orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push unbounded-operator unbounded-operator-build unbounded-operator-manifests playpen-manifests e2e-playpen gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build gantry-manifests inventory-manifests
 .PHONY: net-frontend net-frontend-clean net-ebpf-build net-ebpf-generate net-ebpf-verify net-manifests release-bom release-manifests unbounded-operator-release-manifest
 .PHONY: image-machina-local image-machine-ops-controller-local image-metalman-local image-unbounded-operator-local image-unbounded-operator-push image-playpen-local image-net-controller-local image-net-node-local image-gantry-local image-gantry-push images-local
 .PHONY: image-net-controller-push image-net-node-push images-net-all images-net-all-push
@@ -273,7 +277,7 @@ REACT_DEV ?= false
 
 ##@ General
 
-all: kubectl-unbounded forge machina machine-ops-controller unbounded-operator unbounded-net-controller unbounded-net-node unbounded-net-routeplan-debug unping unroute gantry ## Build all binaries (default)
+all: kubectl-unbounded gantryctl forge machina machine-ops-controller unbounded-operator unbounded-net-controller unbounded-net-node unbounded-net-routeplan-debug unping unroute gantry ## Build all binaries (default)
 
 help: ## Show this help
 	@echo ""
@@ -300,6 +304,7 @@ help: ## Show this help
 	@echo ""
 	@echo "Build:"
 	@echo "  kubectl-unbounded                Build kubectl-unbounded plugin"
+	@echo "  gantryctl                        Build standalone Gantry management CLI"
 	@echo "  forge                            Build forge dev tool"
 	@echo "  agent-artifacts-builder          Build offline agent artifacts builder"
 	@echo "  agent-artifacts-builder-build    Build offline agent artifacts builder without test"
@@ -557,6 +562,11 @@ kubectl-unbounded-build: machina-manifests net-manifests unbounded-storage-super
 	$(GOBUILD) -ldflags '$(KUBECTL_UNBOUNDED_LDFLAGS)' -o $(KUBECTL_UNBOUNDED_BIN) $(KUBECTL_UNBOUNDED_CMD)/main.go
 
 kubectl-unbounded: test kubectl-unbounded-build ## Build the kubectl-unbounded plugin (implies test)
+
+gantryctl-build: ## Build the standalone Gantry management CLI (no lint/test)
+	$(GOBUILD) -ldflags '$(GANTRYCTL_LDFLAGS)' -o $(GANTRYCTL_BIN) $(GANTRYCTL_CMD)
+
+gantryctl: test gantryctl-build ## Build the standalone Gantry management CLI (implies test)
 
 forge: test ## Build the forge dev tool (implies test)
 	$(GOBUILD) -o $(FORGE_BIN) $(FORGE_CMD)/main.go

--- a/cmd/gantry/main.go
+++ b/cmd/gantry/main.go
@@ -80,6 +80,8 @@ func run(args []string) error {
 		return nil
 	case "agent":
 		return runAgent(args[1:])
+	case "node-config":
+		return runNodeConfig(args[1:])
 	case "help", "-h", "-help", "--help":
 		return runHelp(args[1:])
 	default:
@@ -94,6 +96,7 @@ func printUsage(w *os.File) {
 
 Subcommands:
   agent      run the Gantry P2P agent
+	node-config reconcile standalone containerd registry routes
   version    print build information
   help       print help for the agent subcommand`)
 }

--- a/cmd/gantry/node_config.go
+++ b/cmd/gantry/node_config.go
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/unbounded/internal/gantry/noderoute"
+)
+
+func runNodeConfig(args []string) error {
+	if len(args) == 0 {
+		return errors.New("gantry node-config: command required (reconcile or check)")
+	}
+
+	options := noderoute.DefaultOptions()
+	flags := flag.NewFlagSet("node-config "+args[0], flag.ContinueOnError)
+	flags.StringVar(&options.DesiredPath, "desired", options.DesiredPath, "path to desired registry routes JSON")
+	flags.StringVar(&options.HostCertsDir, "host-certs-dir", options.HostCertsDir, "mounted host containerd certs.d directory")
+	flags.StringVar(&options.HostContainerdConfig, "host-containerd-config", options.HostContainerdConfig, "mounted host containerd config.toml")
+	flags.StringVar(&options.HostStateDir, "host-state-dir", options.HostStateDir, "mounted host route ownership state directory")
+	flags.StringVar(&options.ExpectedContainerdCerts, "expected-certs-dir", options.ExpectedContainerdCerts, "containerd registry config_path expected on the host")
+
+	interval := time.Minute
+	if args[0] == "reconcile" {
+		flags.DurationVar(&interval, "interval", interval, "desired-state reconcile interval")
+	}
+
+	if err := flags.Parse(args[1:]); err != nil {
+		return err
+	}
+
+	if flags.NArg() != 0 {
+		return fmt.Errorf("gantry node-config %s: unexpected arguments: %v", args[0], flags.Args())
+	}
+
+	switch args[0] {
+	case "reconcile":
+		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer cancel()
+
+		return noderoute.Run(ctx, options, interval)
+	case "check":
+		return noderoute.CheckDesired(options)
+	default:
+		return fmt.Errorf("gantry node-config: unknown command %q", args[0])
+	}
+}

--- a/cmd/gantryctl/app/client.go
+++ b/cmd/gantryctl/app/client.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type clusterClients struct {
+	kube      kubernetes.Interface
+	resources client.Client
+	rest      *rest.Config
+}
+
+func (o *rootOptions) clusterClients() (*clusterClients, error) {
+	if o.clients != nil {
+		return o.clients, nil
+	}
+
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if o.kubeconfig != "" {
+		rules.ExplicitPath = o.kubeconfig
+	}
+
+	overrides := &clientcmd.ConfigOverrides{CurrentContext: o.context}
+	deferred := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+
+	restConfig, err := deferred.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load Kubernetes configuration: %w", err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes client: %w", err)
+	}
+
+	resourceClient, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes resource client: %w", err)
+	}
+
+	o.clients = &clusterClients{kube: kubeClient, resources: resourceClient, rest: restConfig}
+
+	return o.clients, nil
+}

--- a/cmd/gantryctl/app/install.go
+++ b/cmd/gantryctl/app/install.go
@@ -1,0 +1,245 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	appstypedv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gantrystandalone "github.com/Azure/unbounded/deploy/gantry-standalone"
+)
+
+const (
+	fieldManager            = "gantryctl"
+	agentDaemonSetName      = "gantry-standalone"
+	nodeConfigDaemonSetName = "gantry-standalone-node-config"
+	agentConfigMapName      = "gantry-standalone-config"
+	nodeRoutesConfigMapName = "gantry-standalone-node-routes"
+	registryCredentialsName = "gantry-standalone-registry-credentials"
+	nodeConfigManifestName  = "03-node-config.yaml.tmpl"
+)
+
+type installOptions struct {
+	root  *rootOptions
+	image string
+	wait  bool
+}
+
+func newInstallCommand(root *rootOptions) *cobra.Command {
+	options := &installOptions{root: root, image: defaultGantryImage(), wait: true}
+	command := &cobra.Command{
+		Use:   "install",
+		Short: "Install a standalone, initially unconfigured Gantry agent",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return options.run(command.Context(), command.OutOrStdout())
+		},
+	}
+	command.Flags().StringVar(&options.image, "image", options.image, "Gantry agent image")
+	command.Flags().BoolVar(&options.wait, "wait", options.wait, "Wait for all Gantry agents to become ready")
+
+	return command
+}
+
+func (o *installOptions) run(ctx context.Context, output io.Writer) error {
+	clients, err := o.root.clusterClients()
+	if err != nil {
+		return err
+	}
+
+	if err := ensureNoCompetingMirror(ctx, clients.resources, o.root.namespace); err != nil {
+		return err
+	}
+
+	manifests, err := gantrystandalone.Render(gantrystandalone.Values{Namespace: o.root.namespace, Image: o.image})
+	if err != nil {
+		return err
+	}
+
+	for _, manifest := range manifests {
+		if !baseInstallManifest(manifest.Name) {
+			continue
+		}
+
+		if err := applyInstallManifest(ctx, clients.resources, manifest.Data); err != nil {
+			return fmt.Errorf("apply %s: %w", manifest.Name, err)
+		}
+	}
+
+	nodeConfigExists := false
+
+	nodeConfig, err := clients.kube.AppsV1().DaemonSets(o.root.namespace).Get(ctx, nodeConfigDaemonSetName, metav1.GetOptions{})
+	if err == nil {
+		if nodeConfig.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+			return fmt.Errorf("DaemonSet %s/%s is not owned by gantryctl", o.root.namespace, nodeConfigDaemonSetName)
+		}
+
+		nodeConfigExists = true
+
+		if err := applyNodeConfigManifest(ctx, clients.resources, o.root.namespace, o.image); err != nil {
+			return fmt.Errorf("update existing node-config DaemonSet: %w", err)
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get existing node-config DaemonSet: %w", err)
+	}
+
+	if o.wait {
+		if err := waitForDaemonSet(ctx, clients.kube, o.root.namespace, agentDaemonSetName, o.root.timeout); err != nil {
+			return err
+		}
+
+		if nodeConfigExists {
+			if err := waitForDaemonSet(ctx, clients.kube, o.root.namespace, nodeConfigDaemonSetName, o.root.timeout); err != nil {
+				return err
+			}
+		}
+	}
+
+	store, err := loadRegistryStore(ctx, clients.kube, o.root.namespace)
+	if err != nil {
+		return err
+	}
+
+	registryCount := len(store.agentConfig.UpstreamRegistries)
+
+	verb := "is ready"
+	if !o.wait {
+		verb = "was applied"
+	}
+
+	if registryCount == 0 {
+		return writeOutputf(output,
+			"Standalone Gantry %s in namespace %s with no registry routes configured.\nNext: gantryctl registry add <registry-host> --auth delegated\n",
+			verb, o.root.namespace,
+		)
+	} else {
+		return writeOutputf(output, "Standalone Gantry %s in namespace %s with %d registry route(s) preserved.\n", verb, o.root.namespace, registryCount)
+	}
+}
+
+func baseInstallManifest(name string) bool {
+	return name != nodeConfigManifestName
+}
+
+func ensureNoCompetingMirror(ctx context.Context, resourceClient client.Client, namespace string) error {
+	var daemonSets appsv1.DaemonSetList
+	if err := resourceClient.List(ctx, &daemonSets); err != nil {
+		return fmt.Errorf("list DaemonSets for Gantry conflict preflight: %w", err)
+	}
+
+	for index := range daemonSets.Items {
+		daemonSet := &daemonSets.Items[index]
+		if daemonSet.Namespace == namespace && daemonSet.Name == agentDaemonSetName {
+			if daemonSet.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+				return fmt.Errorf("DaemonSet %s/%s is not owned by gantryctl", daemonSet.Namespace, daemonSet.Name)
+			}
+
+			continue
+		}
+
+		for _, container := range daemonSet.Spec.Template.Spec.Containers {
+			for _, port := range container.Ports {
+				if port.HostPort == 5000 {
+					return fmt.Errorf("DaemonSet %s/%s already reserves host port 5000; refusing to overlap standalone Gantry", daemonSet.Namespace, daemonSet.Name)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func applyInstallManifest(ctx context.Context, resourceClient client.Client, data []byte) error {
+	decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+	for {
+		object := &unstructured.Unstructured{}
+		if err := decoder.Decode(object); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+
+			return fmt.Errorf("decode manifest: %w", err)
+		}
+
+		if object.Object == nil {
+			continue
+		}
+
+		key := types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()}
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(object.GroupVersionKind())
+
+		err := resourceClient.Get(ctx, key, existing)
+		if err == nil {
+			owned := existing.GetLabels()["app.kubernetes.io/managed-by"] == fieldManager
+			if object.GetKind() == "Namespace" && !owned {
+				continue
+			}
+
+			if !owned {
+				return fmt.Errorf("%s %s is not owned by gantryctl", object.GetKind(), key)
+			}
+
+			if object.GetKind() == "ConfigMap" {
+				continue
+			}
+		} else if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("get %s %s: %w", object.GetKind(), key, err)
+		}
+
+		configuration := client.ApplyConfigurationFromUnstructured(object)
+		if err := resourceClient.Apply(ctx, configuration, client.FieldOwner(fieldManager), client.ForceOwnership); err != nil {
+			return fmt.Errorf("apply %s %s: %w", object.GetKind(), object.GetName(), err)
+		}
+	}
+}
+
+func applyNodeConfigManifest(ctx context.Context, resourceClient client.Client, namespace, image string) error {
+	manifests, err := gantrystandalone.Render(gantrystandalone.Values{Namespace: namespace, Image: image})
+	if err != nil {
+		return err
+	}
+
+	for _, manifest := range manifests {
+		if manifest.Name == nodeConfigManifestName {
+			return applyInstallManifest(ctx, resourceClient, manifest.Data)
+		}
+	}
+
+	return errors.New("standalone node-config manifest is missing")
+}
+
+func waitForDaemonSet(ctx context.Context, kubeClient interface {
+	AppsV1() appstypedv1.AppsV1Interface
+}, namespace, name string, timeout time.Duration,
+) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		daemonSet, err := kubeClient.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("DaemonSet %s/%s not found", namespace, name)
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		return daemonSetReady(daemonSet), nil
+	})
+}

--- a/cmd/gantryctl/app/mutation_lock.go
+++ b/cmd/gantryctl/app/mutation_lock.go
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+const registryMutationLeaseName = "gantryctl-registry-mutation"
+
+const (
+	registryMutationLeaseDuration = 30 * time.Second
+	registryMutationRenewInterval = 10 * time.Second
+)
+
+func withRegistryMutationLock(ctx context.Context, kubeClient kubernetes.Interface, namespace string, timeout time.Duration, run func(context.Context) error) error {
+	holder, err := randomHolderIdentity()
+	if err != nil {
+		return err
+	}
+
+	acquireCtx, acquireCancel := context.WithTimeout(ctx, timeout)
+	defer acquireCancel()
+
+	if err := acquireRegistryMutationLease(acquireCtx, kubeClient, namespace, holder); err != nil {
+		return fmt.Errorf("acquire Gantry registry mutation lock: %w", err)
+	}
+
+	operationCtx, operationCancel := context.WithCancel(ctx)
+
+	var (
+		renewErr error
+		renewMu  sync.Mutex
+	)
+
+	renewDone := make(chan struct{})
+
+	go func() {
+		defer close(renewDone)
+
+		if err := renewRegistryMutationLease(operationCtx, kubeClient, namespace, holder); err != nil && !errors.Is(err, context.Canceled) {
+			renewMu.Lock()
+			renewErr = err
+			renewMu.Unlock()
+			operationCancel()
+		}
+	}()
+
+	runErr := run(operationCtx)
+
+	operationCancel()
+	<-renewDone
+
+	releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	releaseErr := releaseRegistryMutationLease(releaseCtx, kubeClient, namespace, holder)
+
+	releaseCancel()
+
+	renewMu.Lock()
+	defer renewMu.Unlock()
+
+	return errors.Join(runErr, renewErr, releaseErr)
+}
+
+func randomHolderIdentity() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("generate mutation lock identity: %w", err)
+	}
+
+	return "gantryctl-" + hex.EncodeToString(value), nil
+}
+
+func acquireRegistryMutationLease(ctx context.Context, kubeClient kubernetes.Interface, namespace, holder string) error {
+	leases := kubeClient.CoordinationV1().Leases(namespace)
+
+	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+		now := metav1.NewMicroTime(time.Now())
+
+		lease, err := leases.Get(ctx, registryMutationLeaseName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			durationSeconds := int32(registryMutationLeaseDuration / time.Second)
+
+			_, err = leases.Create(ctx, &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      registryMutationLeaseName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": fieldManager,
+					},
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       &holder,
+					LeaseDurationSeconds: &durationSeconds,
+					AcquireTime:          &now,
+					RenewTime:            &now,
+				},
+			}, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(err) {
+				return false, nil
+			}
+
+			return err == nil, err
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		if lease.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+			return false, fmt.Errorf("lease %s/%s is not owned by gantryctl", namespace, registryMutationLeaseName)
+		}
+
+		if leaseHeld(lease, now.Time) {
+			return false, nil
+		}
+
+		durationSeconds := int32(registryMutationLeaseDuration / time.Second)
+		lease.Spec.HolderIdentity = &holder
+		lease.Spec.LeaseDurationSeconds = &durationSeconds
+		lease.Spec.AcquireTime = &now
+		lease.Spec.RenewTime = &now
+
+		_, err = leases.Update(ctx, lease, metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			return false, nil
+		}
+
+		return err == nil, err
+	})
+}
+
+func leaseHeld(lease *coordinationv1.Lease, now time.Time) bool {
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+		return false
+	}
+
+	duration := registryMutationLeaseDuration
+	if lease.Spec.LeaseDurationSeconds != nil {
+		duration = time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second
+	}
+
+	renewed := lease.CreationTimestamp.Time
+	if lease.Spec.RenewTime != nil {
+		renewed = lease.Spec.RenewTime.Time
+	} else if lease.Spec.AcquireTime != nil {
+		renewed = lease.Spec.AcquireTime.Time
+	}
+
+	return now.Before(renewed.Add(duration))
+}
+
+func renewRegistryMutationLease(ctx context.Context, kubeClient kubernetes.Interface, namespace, holder string) error {
+	ticker := time.NewTicker(registryMutationRenewInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := updateRegistryMutationLease(ctx, kubeClient, namespace, holder, false); err != nil {
+				return fmt.Errorf("renew Gantry registry mutation lock: %w", err)
+			}
+		}
+	}
+}
+
+func releaseRegistryMutationLease(ctx context.Context, kubeClient kubernetes.Interface, namespace, holder string) error {
+	if err := updateRegistryMutationLease(ctx, kubeClient, namespace, holder, true); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("release Gantry registry mutation lock: %w", err)
+	}
+
+	return nil
+}
+
+func updateRegistryMutationLease(ctx context.Context, kubeClient kubernetes.Interface, namespace, holder string, release bool) error {
+	leases := kubeClient.CoordinationV1().Leases(namespace)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		lease, err := leases.Get(ctx, registryMutationLeaseName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != holder {
+			return errors.New("gantry registry mutation lock ownership was lost")
+		}
+
+		now := metav1.NewMicroTime(time.Now())
+
+		if release {
+			empty := ""
+			lease.Spec.HolderIdentity = &empty
+		} else {
+			lease.Spec.RenewTime = &now
+		}
+
+		_, err = leases.Update(ctx, lease, metav1.UpdateOptions{})
+
+		return err
+	})
+}

--- a/cmd/gantryctl/app/mutation_lock_test.go
+++ b/cmd/gantryctl/app/mutation_lock_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRegistryMutationLeaseSerializesHolders(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	if err := acquireRegistryMutationLease(t.Context(), client, "gantry-system", "holder-a"); err != nil {
+		t.Fatalf("acquire holder-a: %v", err)
+	}
+
+	blockedCtx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	if err := acquireRegistryMutationLease(blockedCtx, client, "gantry-system", "holder-b"); err == nil {
+		t.Fatal("holder-b acquired a lease still owned by holder-a")
+	}
+
+	if err := releaseRegistryMutationLease(t.Context(), client, "gantry-system", "holder-a"); err != nil {
+		t.Fatalf("release holder-a: %v", err)
+	}
+
+	if err := acquireRegistryMutationLease(t.Context(), client, "gantry-system", "holder-b"); err != nil {
+		t.Fatalf("acquire holder-b after release: %v", err)
+	}
+}
+
+func TestRegistryMutationLeaseRefusesUnownedCollision(t *testing.T) {
+	client := fake.NewSimpleClientset(&coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{
+		Name: registryMutationLeaseName, Namespace: "gantry-system",
+	}})
+
+	err := acquireRegistryMutationLease(t.Context(), client, "gantry-system", "holder")
+	if err == nil || !strings.Contains(err.Error(), "not owned by gantryctl") {
+		t.Fatalf("want ownership refusal, got %v", err)
+	}
+}

--- a/cmd/gantryctl/app/registry.go
+++ b/cmd/gantryctl/app/registry.go
@@ -1,0 +1,527 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coretypedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	gantryconfig "github.com/Azure/unbounded/internal/gantry/config"
+	"github.com/Azure/unbounded/internal/gantry/noderoute"
+)
+
+const (
+	authAnonymous = "anonymous"
+	authDelegated = "delegated"
+	authBasic     = "basic"
+)
+
+func newRegistryCommand(root *rootOptions) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "registry",
+		Short: "Manage standalone Gantry registries",
+	}
+	command.AddCommand(newRegistryAddCommand(root))
+	command.AddCommand(newRegistryListCommand(root))
+	command.AddCommand(newRegistryShowCommand(root))
+	command.AddCommand(newRegistryAuthCommand(root))
+	command.AddCommand(newRegistryRemoveCommand(root))
+	command.AddCommand(newRegistryTestCommand(root))
+
+	return command
+}
+
+type registryAddOptions struct {
+	root                 *rootOptions
+	endpoint             string
+	auth                 string
+	username             string
+	passwordStdin        bool
+	fromSecret           string
+	secretNamespace      string
+	usernameKey          string
+	passwordKey          string
+	replaceExistingRoute bool
+	existingOnly         bool
+}
+
+func newRegistryAddCommand(root *rootOptions) *cobra.Command {
+	options := &registryAddOptions{
+		root:        root,
+		auth:        authDelegated,
+		usernameKey: "username",
+		passwordKey: "password",
+	}
+	command := &cobra.Command{
+		Use:   "add HOST",
+		Short: "Configure and route one upstream registry through Gantry",
+		Example: `  gantryctl registry add myacr.azurecr.io --auth delegated
+  gantryctl registry add registry.k8s.io --auth anonymous
+  printf '%s' "$PASSWORD" | gantryctl registry add registry.example.com --auth basic --username reader --password-stdin
+  gantryctl registry add registry.example.com --auth basic --from-secret registry-reader --secret-namespace team-a`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			return options.run(command.Context(), command, args[0])
+		},
+	}
+	command.Flags().StringVar(&options.endpoint, "endpoint", "", "Origin endpoint (defaults to https://HOST)")
+	addRegistryAuthFlags(command, options)
+	command.Flags().BoolVar(&options.replaceExistingRoute, "replace-existing-route", false, "Approve backing up and replacing a pre-existing hosts.toml during initial setup; later OS replacements are adopted automatically")
+
+	return command
+}
+
+func addRegistryAuthFlags(command *cobra.Command, options *registryAddOptions) {
+	command.Flags().StringVar(&options.auth, "auth", options.auth, "Authentication mode: delegated (kubelet/imagePullSecrets), anonymous, or basic (cluster-wide shared identity)")
+	command.Flags().StringVar(&options.username, "username", "", "Cluster-wide shared authentication username")
+	command.Flags().BoolVar(&options.passwordStdin, "password-stdin", false, "Read the cluster-wide shared authentication password from stdin")
+	command.Flags().StringVar(&options.fromSecret, "from-secret", "", "Copy cluster-wide shared authentication from an existing Kubernetes Secret")
+	command.Flags().StringVar(&options.secretNamespace, "secret-namespace", "", "Namespace of --from-secret (defaults to the Gantry namespace)")
+	command.Flags().StringVar(&options.usernameKey, "username-key", options.usernameKey, "Username key in --from-secret")
+	command.Flags().StringVar(&options.passwordKey, "password-key", options.passwordKey, "Password key in --from-secret")
+}
+
+func (o *registryAddOptions) run(ctx context.Context, command *cobra.Command, rawHost string) error {
+	host, err := noderoute.NormalizeRegistryHost(rawHost)
+	if err != nil {
+		return err
+	}
+
+	clients, err := o.root.clusterClients()
+	if err != nil {
+		return err
+	}
+
+	return withRegistryMutationLock(ctx, clients.kube, o.root.namespace, o.root.timeout, func(lockCtx context.Context) error {
+		return o.runLocked(lockCtx, command, clients, host)
+	})
+}
+
+func (o *registryAddOptions) runLocked(ctx context.Context, command *cobra.Command, clients *clusterClients, host string) error {
+	store, err := loadRegistryStore(ctx, clients.kube, o.root.namespace)
+	if err != nil {
+		return err
+	}
+
+	var existingUpstream *gantryconfig.UpstreamRegistry
+
+	for index := range store.agentConfig.UpstreamRegistries {
+		if store.agentConfig.UpstreamRegistries[index].Name == host {
+			existingUpstream = &store.agentConfig.UpstreamRegistries[index]
+
+			break
+		}
+	}
+
+	if o.existingOnly {
+		if existingUpstream == nil {
+			return fmt.Errorf("registry %s is not configured", host)
+		}
+
+		if !command.Flags().Changed("auth") {
+			return errors.New("--auth is required for registry auth set")
+		}
+	}
+
+	endpoint := strings.TrimSpace(o.endpoint)
+	if endpoint == "" && existingUpstream != nil {
+		endpoint = existingUpstream.Endpoint
+	} else if endpoint == "" {
+		endpoint = "https://" + host
+	}
+
+	snapshot := store.snapshot()
+	routeWasActive := false
+	manageReplacements := false
+	replaceExisting := o.replaceExistingRoute
+
+	for _, route := range store.routes.Registries {
+		if route.Host == host {
+			routeWasActive = true
+			manageReplacements = route.ManageReplacements
+			replaceExisting = replaceExisting || route.ReplaceExisting
+
+			break
+		}
+	}
+
+	previousAuth := store.auth[host]
+	selectedAuth := o.auth
+	authRecord := registryAuthRecord{Mode: selectedAuth}
+	authMode := selectedAuth
+	credentialsPath := ""
+	preserveAuth := existingUpstream != nil && !command.Flags().Changed("auth") && !hasCredentialFlags(o)
+
+	if store.secret != nil {
+		store.secret = store.secret.DeepCopy()
+	}
+
+	if preserveAuth {
+		selectedAuth = previousAuth.Mode
+		authRecord = previousAuth
+		authMode = existingUpstream.AuthMode
+		credentialsPath = existingUpstream.CredentialsPath
+	} else if selectedAuth == authBasic {
+		username, password, err := o.sharedCredential(ctx, command, clients.kube)
+		if err != nil {
+			return err
+		}
+
+		if previousAuth.CredentialKey != "" && store.secret != nil {
+			delete(store.secret.Data, previousAuth.CredentialKey)
+		}
+
+		if store.secret == nil {
+			store.secret = newOwnedSecret(o.root.namespace)
+		}
+
+		key := credentialKey(host)
+		store.secret.Data[key] = []byte(username + ":" + password)
+		authRecord.CredentialKey = key
+		authMode = gantryconfig.UpstreamAuthShared
+		credentialsPath = "/etc/gantry/registry/" + key
+	} else if hasCredentialFlags(o) {
+		return fmt.Errorf("credential flags are only valid with --auth %s", authBasic)
+	} else if previousAuth.CredentialKey != "" && store.secret != nil {
+		delete(store.secret.Data, previousAuth.CredentialKey)
+	}
+
+	if err := validateAuthMode(selectedAuth, endpoint); err != nil {
+		return err
+	}
+
+	if store.secret != nil && len(store.secret.Data) == 0 {
+		store.secret = nil
+	}
+
+	store.upsertRegistry(
+		gantryconfig.UpstreamRegistry{Name: host, Endpoint: endpoint, AuthMode: authMode, CredentialsPath: credentialsPath},
+		authRecord,
+		noderoute.Registry{Host: host, Server: endpoint, ReplaceExisting: replaceExisting, ManageReplacements: manageReplacements},
+	)
+
+	if err := store.agentConfig.Validate(); err != nil {
+		return fmt.Errorf("validate updated Gantry config: %w", err)
+	}
+
+	if err := store.routes.Validate(); err != nil {
+		return fmt.Errorf("validate updated node routes: %w", err)
+	}
+
+	if routeWasActive {
+		store.removeRoute(host)
+
+		if err := applyRouteState(ctx, clients.kube, o.root.namespace, store); err != nil {
+			return errors.Join(fmt.Errorf("temporarily bypass Gantry for registry update: %w", err), rollbackRouteSnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot))
+		}
+
+		if err := waitForDaemonSet(ctx, clients.kube, o.root.namespace, nodeConfigDaemonSetName, o.root.timeout); err != nil {
+			return errors.Join(fmt.Errorf("wait for temporary registry bypass: %w", err), rollbackRouteSnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot))
+		}
+
+		store.upsertRegistry(
+			gantryconfig.UpstreamRegistry{Name: host, Endpoint: endpoint, AuthMode: authMode, CredentialsPath: credentialsPath},
+			authRecord,
+			noderoute.Registry{Host: host, Server: endpoint, ReplaceExisting: replaceExisting, ManageReplacements: manageReplacements},
+		)
+	}
+
+	if err := applyAgentState(ctx, clients.kube, o.root.namespace, store); err != nil {
+		return errors.Join(err, rollbackRegistrySnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot, routeWasActive, routeWasActive))
+	}
+
+	if err := waitForDaemonSet(ctx, clients.kube, o.root.namespace, agentDaemonSetName, o.root.timeout); err != nil {
+		return errors.Join(fmt.Errorf("wait for Gantry agent rollout: %w", err), rollbackRegistrySnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot, routeWasActive, routeWasActive))
+	}
+
+	image, err := installedAgentImage(ctx, clients.kube, o.root.namespace)
+	if err != nil {
+		return errors.Join(err, rollbackRegistrySnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot, routeWasActive, routeWasActive))
+	}
+
+	if err := applyNodeConfigManifest(ctx, clients.resources, o.root.namespace, image); err != nil {
+		return errors.Join(err, rollbackRegistrySnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot, routeWasActive, routeWasActive))
+	}
+
+	if err := applyRouteState(ctx, clients.kube, o.root.namespace, store); err != nil {
+		return errors.Join(fmt.Errorf("enable registry route: %w", err), rollbackRegistrySnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot, true, routeWasActive))
+	}
+
+	if err := waitForDaemonSet(ctx, clients.kube, o.root.namespace, nodeConfigDaemonSetName, o.root.timeout); err != nil {
+		return errors.Join(fmt.Errorf("enable registry route: %w", err), rollbackRegistrySnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot, true, routeWasActive))
+	}
+
+	if store.manageRouteReplacements(host) {
+		if err := applyRouteState(ctx, clients.kube, o.root.namespace, store); err != nil {
+			return errors.Join(fmt.Errorf("enable OS replacement management: %w", err), rollbackRegistrySnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot, true, routeWasActive))
+		}
+
+		if err := waitForDaemonSet(ctx, clients.kube, o.root.namespace, nodeConfigDaemonSetName, o.root.timeout); err != nil {
+			return errors.Join(fmt.Errorf("wait for OS replacement management: %w", err), rollbackRegistrySnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot, true, routeWasActive))
+		}
+	}
+
+	message := fmt.Sprintf("Registry %s configured with %s authentication.\n", host, selectedAuth)
+
+	if selectedAuth == authBasic {
+		message += "Shared authentication depends on Gantry; replacement-node pulls may retry until the node-critical agent is ready.\n"
+	}
+
+	message += fmt.Sprintf("Test it with: gantryctl registry test %s/<repository>:<tag>\n", host)
+
+	return writeOutputf(command.OutOrStdout(), "%s", message)
+}
+
+func validateAuthMode(mode, endpoint string) error {
+	switch mode {
+	case authAnonymous:
+		return nil
+	case authDelegated, authBasic:
+		if !strings.HasPrefix(strings.ToLower(endpoint), "https://") {
+			return fmt.Errorf("--auth %s requires an https endpoint", mode)
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("unsupported authentication mode %q; use anonymous, delegated, or basic", mode)
+	}
+}
+
+func hasCredentialFlags(options *registryAddOptions) bool {
+	return options.username != "" || options.passwordStdin || options.fromSecret != ""
+}
+
+func (o *registryAddOptions) sharedCredential(ctx context.Context, command *cobra.Command, kubeClient interface {
+	CoreV1() coretypedv1.CoreV1Interface
+},
+) (string, string, error) {
+	if o.passwordStdin == (o.fromSecret != "") {
+		return "", "", errors.New("basic authentication requires exactly one of --password-stdin or --from-secret")
+	}
+
+	username := o.username
+	password := ""
+
+	if o.passwordStdin {
+		data, err := io.ReadAll(io.LimitReader(command.InOrStdin(), 64*1024+1))
+		if err != nil {
+			return "", "", fmt.Errorf("read password from stdin: %w", err)
+		}
+
+		if len(data) > 64*1024 {
+			return "", "", errors.New("password from stdin exceeds 64 KiB")
+		}
+
+		password = strings.TrimRight(string(data), "\r\n")
+	} else {
+		namespace := o.secretNamespace
+		if namespace == "" {
+			namespace = o.root.namespace
+		}
+
+		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, o.fromSecret, metav1.GetOptions{})
+		if err != nil {
+			return "", "", fmt.Errorf("read credential Secret %s/%s: %w", namespace, o.fromSecret, err)
+		}
+
+		username = string(secret.Data[o.usernameKey])
+		password = string(secret.Data[o.passwordKey])
+	}
+
+	if username == "" || password == "" {
+		return "", "", errors.New("basic authentication username and password must not be empty")
+	}
+
+	if strings.ContainsAny(username, ":\r\n") || strings.ContainsAny(password, "\r\n") {
+		return "", "", errors.New("basic authentication username must not contain ':' and credentials must be single-line")
+	}
+
+	return username, password, nil
+}
+
+func newRegistryListCommand(root *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured registries",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			clients, err := root.clusterClients()
+			if err != nil {
+				return err
+			}
+
+			store, err := loadRegistryStore(command.Context(), clients.kube, root.namespace)
+			if err != nil {
+				return err
+			}
+
+			writer := tabwriter.NewWriter(command.OutOrStdout(), 0, 4, 2, ' ', 0)
+			if _, err := fmt.Fprintln(writer, "HOST\tENDPOINT\tAUTH"); err != nil {
+				return fmt.Errorf("write registry list header: %w", err)
+			}
+
+			for _, upstream := range store.agentConfig.UpstreamRegistries {
+				if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\n", upstream.Name, upstream.Endpoint, store.auth[upstream.Name].Mode); err != nil {
+					return fmt.Errorf("write registry list row: %w", err)
+				}
+			}
+
+			if err := writer.Flush(); err != nil {
+				return fmt.Errorf("flush registry list: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newRegistryShowCommand(root *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show HOST",
+		Short: "Show one configured registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			host, err := noderoute.NormalizeRegistryHost(args[0])
+			if err != nil {
+				return err
+			}
+
+			clients, err := root.clusterClients()
+			if err != nil {
+				return err
+			}
+
+			store, err := loadRegistryStore(command.Context(), clients.kube, root.namespace)
+			if err != nil {
+				return err
+			}
+
+			for _, upstream := range store.agentConfig.UpstreamRegistries {
+				if upstream.Name == host {
+					return writeOutputf(command.OutOrStdout(), "Host: %s\nEndpoint: %s\nAuthentication: %s\n", host, upstream.Endpoint, store.auth[host].Mode)
+				}
+			}
+
+			return fmt.Errorf("registry %s is not configured", host)
+		},
+	}
+}
+
+func newRegistryAuthCommand(root *rootOptions) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "auth",
+		Short: "Change registry authentication",
+	}
+	command.AddCommand(newRegistryAuthSetCommand(root))
+
+	return command
+}
+
+func newRegistryAuthSetCommand(root *rootOptions) *cobra.Command {
+	options := &registryAddOptions{
+		root:         root,
+		auth:         authDelegated,
+		usernameKey:  "username",
+		passwordKey:  "password",
+		existingOnly: true,
+	}
+	command := &cobra.Command{
+		Use:   "set HOST",
+		Short: "Replace a registry's authentication mechanism",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			return options.run(command.Context(), command, args[0])
+		},
+	}
+	addRegistryAuthFlags(command, options)
+
+	return command
+}
+
+func newRegistryRemoveCommand(root *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove HOST",
+		Short: "Restore the node route and remove a registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			return removeRegistry(command.Context(), command.OutOrStdout(), root, args[0])
+		},
+	}
+}
+
+func removeRegistry(ctx context.Context, output io.Writer, root *rootOptions, rawHost string) error {
+	host, err := noderoute.NormalizeRegistryHost(rawHost)
+	if err != nil {
+		return err
+	}
+
+	clients, err := root.clusterClients()
+	if err != nil {
+		return err
+	}
+
+	return withRegistryMutationLock(ctx, clients.kube, root.namespace, root.timeout, func(lockCtx context.Context) error {
+		return removeRegistryLocked(lockCtx, output, root, clients, host)
+	})
+}
+
+func removeRegistryLocked(ctx context.Context, output io.Writer, root *rootOptions, clients *clusterClients, host string) error {
+	store, err := loadRegistryStore(ctx, clients.kube, root.namespace)
+	if err != nil {
+		return err
+	}
+
+	snapshot := store.snapshot()
+
+	auth, found := store.removeRegistry(host)
+	if !found {
+		return fmt.Errorf("registry %s is not configured", host)
+	}
+
+	store.sort()
+
+	if err := applyRouteState(ctx, clients.kube, root.namespace, store); err != nil {
+		return errors.Join(err, rollbackRouteSnapshot(ctx, clients.kube, root.namespace, root.timeout, snapshot))
+	}
+
+	if err := waitForDaemonSet(ctx, clients.kube, root.namespace, nodeConfigDaemonSetName, root.timeout); err != nil {
+		return errors.Join(fmt.Errorf("wait for node route restoration: %w", err), rollbackRouteSnapshot(ctx, clients.kube, root.namespace, root.timeout, snapshot))
+	}
+
+	if store.secret != nil {
+		store.secret = store.secret.DeepCopy()
+		if auth.CredentialKey != "" {
+			delete(store.secret.Data, auth.CredentialKey)
+		}
+
+		if len(store.secret.Data) == 0 {
+			store.secret = nil
+		}
+	}
+
+	if err := applyAgentState(ctx, clients.kube, root.namespace, store); err != nil {
+		return errors.Join(err, rollbackRegistrySnapshot(ctx, clients.kube, root.namespace, root.timeout, snapshot, true, true))
+	}
+
+	if err := waitForDaemonSet(ctx, clients.kube, root.namespace, agentDaemonSetName, root.timeout); err != nil {
+		return errors.Join(fmt.Errorf("wait for Gantry agent rollout: %w", err), rollbackRegistrySnapshot(ctx, clients.kube, root.namespace, root.timeout, snapshot, true, true))
+	}
+
+	if len(store.routes.Registries) == 0 {
+		if err := clients.kube.AppsV1().DaemonSets(root.namespace).Delete(ctx, nodeConfigDaemonSetName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete idle node-config DaemonSet: %w", err)
+		}
+	}
+
+	return writeOutputf(output, "Registry %s removed and its node route restored.\n", host)
+}

--- a/cmd/gantryctl/app/registry_pull.go
+++ b/cmd/gantryctl/app/registry_pull.go
@@ -1,0 +1,310 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/Azure/unbounded/internal/gantry/noderoute"
+)
+
+type registryTestOptions struct {
+	root              *rootOptions
+	workloadNamespace string
+	serviceAccount    string
+	imagePullSecrets  []string
+	keepPod           bool
+}
+
+func newRegistryTestCommand(root *rootOptions) *cobra.Command {
+	options := &registryTestOptions{root: root, workloadNamespace: "default"}
+	command := &cobra.Command{
+		Use:   "test IMAGE",
+		Short: "Verify a kubelet image pull traverses Gantry",
+		Example: `  gantryctl registry test myacr.azurecr.io/team/image:v1
+  gantryctl registry test registry.example.com/team/image:v1 --workload-namespace team-a --image-pull-secret any-secret-name
+  gantryctl registry test registry.example.com/team/image:v1 --workload-namespace team-a --service-account build-runner`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			return options.run(command.Context(), command.OutOrStdout(), args[0])
+		},
+	}
+	command.Flags().StringVar(&options.workloadNamespace, "workload-namespace", options.workloadNamespace, "Namespace for the temporary pull Pod")
+	command.Flags().StringVar(&options.serviceAccount, "service-account", "", "ServiceAccount used by the temporary pull Pod")
+	command.Flags().StringSliceVar(&options.imagePullSecrets, "image-pull-secret", nil, "Image pull Secret name; may be repeated")
+	command.Flags().BoolVar(&options.keepPod, "keep-pod", false, "Keep the temporary pull Pod after the test")
+
+	return command
+}
+
+func (o *registryTestOptions) run(ctx context.Context, output io.Writer, image string) error {
+	host, err := registryFromImage(image)
+	if err != nil {
+		return err
+	}
+
+	clients, err := o.root.clusterClients()
+	if err != nil {
+		return err
+	}
+
+	store, err := loadRegistryStore(ctx, clients.kube, o.root.namespace)
+	if err != nil {
+		return err
+	}
+
+	auth, configured := store.auth[host]
+	if !configured {
+		return fmt.Errorf("registry %s is not configured; run gantryctl registry add %s first", host, host)
+	}
+
+	agent, err := selectReadyAgent(ctx, clients, o.root.namespace)
+	if err != nil {
+		return err
+	}
+
+	before, err := mirrorBytesServed(ctx, clients, o.root.namespace, agent.Name)
+	if err != nil {
+		return fmt.Errorf("read Gantry metrics before test: %w", err)
+	}
+
+	pullSecrets := make([]corev1.LocalObjectReference, 0, len(o.imagePullSecrets))
+	for _, name := range o.imagePullSecrets {
+		if strings.TrimSpace(name) == "" {
+			return errors.New("--image-pull-secret must not be empty")
+		}
+
+		pullSecrets = append(pullSecrets, corev1.LocalObjectReference{Name: name})
+	}
+
+	pod, err := clients.kube.CoreV1().Pods(o.workloadNamespace).Create(ctx, pullTestPod(
+		o.workloadNamespace,
+		agent.Spec.NodeName,
+		image,
+		o.serviceAccount,
+		pullSecrets,
+	), metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("create pull-test Pod: %w", err)
+	}
+
+	if !o.keepPod {
+		defer func() {
+			grace := int64(0)
+			_ = clients.kube.CoreV1().Pods(o.workloadNamespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}) //nolint:errcheck // test pod cleanup is best effort
+		}()
+	}
+
+	if err := waitForImagePull(ctx, clients, o.workloadNamespace, pod.Name, o.root.timeout); err != nil {
+		return err
+	}
+
+	after, err := waitForMirrorBytes(ctx, clients, o.root.namespace, agent.Name, before, 30*time.Second)
+	if err != nil {
+		return err
+	}
+
+	return writeOutputf(output,
+		"Registry configured      PASS (%s)\nAuthentication           PASS (%s)\nKubelet/containerd pull  PASS (%s)\nRequest traversed Gantry PASS (served bytes %.0f -> %.0f on node %s)\n",
+		host, auth.Mode, image, before, after, agent.Spec.NodeName,
+	)
+}
+
+func pullTestPod(namespace, nodeName, image, serviceAccount string, pullSecrets []corev1.LocalObjectReference) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "gantryctl-pull-",
+			Namespace:    namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "gantryctl-pull-test",
+				"app.kubernetes.io/managed-by": fieldManager,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:           nodeName,
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ServiceAccountName: serviceAccount,
+			ImagePullSecrets:   pullSecrets,
+			Tolerations: []corev1.Toleration{{
+				Operator: corev1.TolerationOpExists,
+			}},
+			Containers: []corev1.Container{{
+				Name:            "pull",
+				Image:           image,
+				ImagePullPolicy: corev1.PullAlways,
+			}},
+		},
+	}
+}
+
+func registryFromImage(image string) (string, error) {
+	image = strings.TrimSpace(image)
+
+	slash := strings.IndexByte(image, '/')
+	if slash <= 0 {
+		return "", fmt.Errorf("image %q must include an explicit registry host", image)
+	}
+
+	prefix := image[:slash]
+	if prefix != "localhost" && !strings.ContainsAny(prefix, ".:") {
+		return "", fmt.Errorf("image %q must include an explicit registry host", image)
+	}
+
+	return noderoute.NormalizeRegistryHost(prefix)
+}
+
+func selectReadyAgent(ctx context.Context, clients *clusterClients, namespace string) (*corev1.Pod, error) {
+	pods, err := clients.kube.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=gantry,app.kubernetes.io/instance=standalone",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list standalone Gantry agents: %w", err)
+	}
+
+	ready := make([]*corev1.Pod, 0, len(pods.Items))
+	for index := range pods.Items {
+		pod := &pods.Items[index]
+		if pod.Spec.NodeName != "" && podReady(pod) {
+			ready = append(ready, pod)
+		}
+	}
+
+	if len(ready) == 0 {
+		return nil, errors.New("no Ready standalone Gantry agent found")
+	}
+
+	sort.Slice(ready, func(i, j int) bool {
+		return ready[i].Spec.NodeName < ready[j].Spec.NodeName
+	})
+
+	return ready[0], nil
+}
+
+func podReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}
+
+func waitForImagePull(ctx context.Context, clients *clusterClients, namespace, name string, timeout time.Duration) error {
+	var lastReason string
+
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		pod, err := clients.kube.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name != "pull" {
+				continue
+			}
+
+			if status.ImageID != "" {
+				return true, nil
+			}
+
+			if status.State.Waiting != nil {
+				lastReason = status.State.Waiting.Reason + ": " + status.State.Waiting.Message
+				if status.State.Waiting.Reason == "ImagePullBackOff" {
+					return false, fmt.Errorf("image pull failed: %s", lastReason)
+				}
+			}
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		if lastReason != "" {
+			return fmt.Errorf("wait for image pull (%s): %w", lastReason, err)
+		}
+
+		return fmt.Errorf("wait for image pull: %w", err)
+	}
+
+	return nil
+}
+
+func waitForMirrorBytes(ctx context.Context, clients *clusterClients, namespace, pod string, before float64, timeout time.Duration) (float64, error) {
+	var current float64
+
+	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		value, err := mirrorBytesServed(ctx, clients, namespace, pod)
+		if err != nil {
+			return false, err
+		}
+
+		current = value
+
+		return current > before, nil
+	})
+	if err != nil {
+		return current, fmt.Errorf("image pulled but Gantry did not complete a response; retry with an uncached image: %w", err)
+	}
+
+	return current, nil
+}
+
+func mirrorBytesServed(ctx context.Context, clients *clusterClients, namespace, pod string) (float64, error) {
+	restClient := clients.kube.CoreV1().RESTClient()
+	if restClient == nil {
+		return 0, errors.New("kubernetes REST client does not support pod proxy requests")
+	}
+
+	body, err := restClient.Get().
+		Namespace(namespace).
+		Resource("pods").
+		Name(pod + ":9095").
+		SubResource("proxy").
+		Suffix("metrics").
+		DoRaw(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return metricSum(body, "gantry_mirror_bytes_served_total"), nil
+}
+
+func metricSum(metrics []byte, name string) float64 {
+	var total float64
+
+	for _, rawLine := range strings.Split(string(metrics), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if !strings.HasPrefix(line, name+" ") && !strings.HasPrefix(line, name+"{") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+
+		value, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err == nil {
+			total += value
+		}
+	}
+
+	return total
+}

--- a/cmd/gantryctl/app/registry_state.go
+++ b/cmd/gantryctl/app/registry_state.go
@@ -1,0 +1,588 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	gantryconfig "github.com/Azure/unbounded/internal/gantry/config"
+	"github.com/Azure/unbounded/internal/gantry/noderoute"
+)
+
+type registryAuthRecord struct {
+	Mode          string `json:"mode"`
+	CredentialKey string `json:"credentialKey,omitempty"`
+}
+
+type registryAuthMetadata map[string]registryAuthRecord
+
+type registryStore struct {
+	agentConfig *gantryconfig.Config
+	auth        registryAuthMetadata
+	routes      noderoute.Config
+	configData  map[string]string
+	routesData  map[string]string
+	secret      *corev1.Secret
+}
+
+type registrySnapshot struct {
+	configData map[string]string
+	routesData map[string]string
+	secret     *corev1.Secret
+}
+
+func loadRegistryStore(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (*registryStore, error) {
+	configMap, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, agentConfigMapName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, errors.New("standalone Gantry is not installed; run gantryctl install first")
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("get standalone Gantry config: %w", err)
+	}
+
+	if configMap.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+		return nil, fmt.Errorf("ConfigMap %s/%s is not owned by gantryctl", namespace, agentConfigMapName)
+	}
+
+	agentConfig := gantryconfig.NewDefault()
+	if err := agentConfig.LoadYAML(strings.NewReader(configMap.Data["config.yaml"])); err != nil {
+		return nil, fmt.Errorf("load standalone Gantry config: %w", err)
+	}
+
+	agentConfig.AllowNoUpstreamRegistries = true
+	if err := agentConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("validate standalone Gantry config: %w", err)
+	}
+
+	auth := registryAuthMetadata{}
+	if raw := configMap.Data["registry-auth.json"]; raw != "" {
+		if err := json.Unmarshal([]byte(raw), &auth); err != nil {
+			return nil, fmt.Errorf("decode registry authentication metadata: %w", err)
+		}
+	}
+
+	routesMap, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, nodeRoutesConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get standalone Gantry node routes: %w", err)
+	}
+
+	if routesMap.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+		return nil, fmt.Errorf("ConfigMap %s/%s is not owned by gantryctl", namespace, nodeRoutesConfigMapName)
+	}
+
+	var routes noderoute.Config
+	if err := json.Unmarshal([]byte(routesMap.Data["registries.json"]), &routes); err != nil {
+		return nil, fmt.Errorf("decode standalone Gantry node routes: %w", err)
+	}
+
+	if err := routes.Validate(); err != nil {
+		return nil, fmt.Errorf("validate standalone Gantry node routes: %w", err)
+	}
+
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, registryCredentialsName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		secret = nil
+	} else if err != nil {
+		return nil, fmt.Errorf("get standalone Gantry registry credentials: %w", err)
+	} else if secret.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+		return nil, fmt.Errorf("secret %s/%s is not owned by gantryctl", namespace, registryCredentialsName)
+	}
+
+	return &registryStore{
+		agentConfig: agentConfig,
+		auth:        auth,
+		routes:      routes,
+		configData:  copyStringMap(configMap.Data),
+		routesData:  copyStringMap(routesMap.Data),
+		secret:      secret,
+	}, nil
+}
+
+func (s *registryStore) snapshot() registrySnapshot {
+	var secret *corev1.Secret
+	if s.secret != nil {
+		secret = s.secret.DeepCopy()
+	}
+
+	return registrySnapshot{
+		configData: copyStringMap(s.configData),
+		routesData: copyStringMap(s.routesData),
+		secret:     secret,
+	}
+}
+
+func (s *registryStore) encode() error {
+	configYAML, err := yaml.Marshal(s.agentConfig)
+	if err != nil {
+		return fmt.Errorf("encode standalone Gantry config: %w", err)
+	}
+
+	authJSON, err := json.MarshalIndent(s.auth, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode registry authentication metadata: %w", err)
+	}
+
+	routesJSON, err := json.Marshal(s.routes)
+	if err != nil {
+		return fmt.Errorf("encode standalone Gantry node routes: %w", err)
+	}
+
+	s.configData["config.yaml"] = string(configYAML)
+	s.configData["registry-auth.json"] = string(append(authJSON, '\n'))
+	s.routesData["registries.json"] = string(routesJSON)
+
+	return nil
+}
+
+func (s *registryStore) sort() {
+	sort.Slice(s.agentConfig.UpstreamRegistries, func(i, j int) bool {
+		return s.agentConfig.UpstreamRegistries[i].Name < s.agentConfig.UpstreamRegistries[j].Name
+	})
+	sort.Slice(s.routes.Registries, func(i, j int) bool {
+		return s.routes.Registries[i].Host < s.routes.Registries[j].Host
+	})
+}
+
+func (s *registryStore) upsertRegistry(upstream gantryconfig.UpstreamRegistry, auth registryAuthRecord, route noderoute.Registry) {
+	upstreamFound := false
+
+	for index := range s.agentConfig.UpstreamRegistries {
+		if s.agentConfig.UpstreamRegistries[index].Name == upstream.Name {
+			s.agentConfig.UpstreamRegistries[index] = upstream
+			upstreamFound = true
+
+			break
+		}
+	}
+
+	if !upstreamFound {
+		s.agentConfig.UpstreamRegistries = append(s.agentConfig.UpstreamRegistries, upstream)
+	}
+
+	routeFound := false
+
+	for index := range s.routes.Registries {
+		if s.routes.Registries[index].Host == route.Host {
+			s.routes.Registries[index] = route
+			routeFound = true
+
+			break
+		}
+	}
+
+	if !routeFound {
+		s.routes.Registries = append(s.routes.Registries, route)
+	}
+
+	s.auth[upstream.Name] = auth
+	s.sort()
+}
+
+func (s *registryStore) removeRegistry(host string) (registryAuthRecord, bool) {
+	auth, found := s.auth[host]
+	if !found {
+		return registryAuthRecord{}, false
+	}
+
+	delete(s.auth, host)
+
+	upstreams := s.agentConfig.UpstreamRegistries[:0]
+	for _, upstream := range s.agentConfig.UpstreamRegistries {
+		if upstream.Name != host {
+			upstreams = append(upstreams, upstream)
+		}
+	}
+
+	s.agentConfig.UpstreamRegistries = upstreams
+
+	routes := s.routes.Registries[:0]
+	for _, route := range s.routes.Registries {
+		if route.Host != host {
+			routes = append(routes, route)
+		}
+	}
+
+	s.routes.Registries = routes
+
+	return auth, true
+}
+
+func (s *registryStore) removeRoute(host string) bool {
+	found := false
+
+	routes := s.routes.Registries[:0]
+	for _, route := range s.routes.Registries {
+		if route.Host == host {
+			found = true
+			continue
+		}
+
+		routes = append(routes, route)
+	}
+
+	s.routes.Registries = routes
+
+	return found
+}
+
+func (s *registryStore) manageRouteReplacements(host string) bool {
+	for index := range s.routes.Registries {
+		if s.routes.Registries[index].Host == host {
+			if s.routes.Registries[index].ManageReplacements {
+				return false
+			}
+
+			s.routes.Registries[index].ManageReplacements = true
+
+			return true
+		}
+	}
+
+	return false
+}
+
+func applyAgentState(ctx context.Context, kubeClient kubernetes.Interface, namespace string, store *registryStore) error {
+	if err := store.encode(); err != nil {
+		return err
+	}
+
+	if err := setAgentPayload(ctx, kubeClient, namespace, store.configData, store.secret); err != nil {
+		return err
+	}
+
+	return rollDaemonSet(ctx, kubeClient, namespace, agentDaemonSetName, "gantryctl.io/config-hash", agentStateHash(store.configData, store.secret))
+}
+
+func setAgentPayload(ctx context.Context, kubeClient kubernetes.Interface, namespace string, configData map[string]string, secret *corev1.Secret) error {
+	if secret != nil {
+		staged, err := stagedSecret(ctx, kubeClient, namespace, secret)
+		if err != nil {
+			return err
+		}
+
+		if err := setSecret(ctx, kubeClient, namespace, staged); err != nil {
+			return err
+		}
+	}
+
+	if err := setConfigMapData(ctx, kubeClient, namespace, agentConfigMapName, configData); err != nil {
+		return err
+	}
+
+	return setSecret(ctx, kubeClient, namespace, secret)
+}
+
+func stagedSecret(ctx context.Context, kubeClient kubernetes.Interface, namespace string, desired *corev1.Secret) (*corev1.Secret, error) {
+	staged := desired.DeepCopy()
+
+	existing, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, registryCredentialsName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return staged, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("get registry credentials for staged update: %w", err)
+	}
+
+	if existing.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+		return nil, fmt.Errorf("secret %s/%s is not owned by gantryctl", namespace, registryCredentialsName)
+	}
+
+	if staged.Data == nil {
+		staged.Data = map[string][]byte{}
+	}
+
+	for key, value := range existing.Data {
+		if _, replaced := staged.Data[key]; !replaced {
+			staged.Data[key] = bytes.Clone(value)
+		}
+	}
+
+	return staged, nil
+}
+
+func applyRouteState(ctx context.Context, kubeClient kubernetes.Interface, namespace string, store *registryStore) error {
+	if err := store.encode(); err != nil {
+		return err
+	}
+
+	if err := setConfigMapData(ctx, kubeClient, namespace, nodeRoutesConfigMapName, store.routesData); err != nil {
+		return err
+	}
+
+	return rollDaemonSet(ctx, kubeClient, namespace, nodeConfigDaemonSetName, "gantryctl.io/routes-hash", stringHash(store.routesData["registries.json"]))
+}
+
+func restoreAgentSnapshot(ctx context.Context, kubeClient kubernetes.Interface, namespace string, snapshot registrySnapshot) error {
+	if err := setAgentPayload(ctx, kubeClient, namespace, snapshot.configData, snapshot.secret); err != nil {
+		return err
+	}
+
+	return rollDaemonSet(ctx, kubeClient, namespace, agentDaemonSetName, "gantryctl.io/config-hash", agentStateHash(snapshot.configData, snapshot.secret))
+}
+
+func restoreRouteSnapshot(ctx context.Context, kubeClient kubernetes.Interface, namespace string, snapshot registrySnapshot) error {
+	if err := setConfigMapData(ctx, kubeClient, namespace, nodeRoutesConfigMapName, snapshot.routesData); err != nil {
+		return err
+	}
+
+	return rollDaemonSet(ctx, kubeClient, namespace, nodeConfigDaemonSetName, "gantryctl.io/routes-hash", stringHash(snapshot.routesData["registries.json"]))
+}
+
+func rollbackAgentSnapshot(ctx context.Context, kubeClient kubernetes.Interface, namespace string, timeout time.Duration, snapshot registrySnapshot) error {
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+
+	if err := restoreAgentSnapshot(rollbackCtx, kubeClient, namespace, snapshot); err != nil {
+		return err
+	}
+
+	return waitForDaemonSet(rollbackCtx, kubeClient, namespace, agentDaemonSetName, timeout)
+}
+
+func rollbackRouteSnapshot(ctx context.Context, kubeClient kubernetes.Interface, namespace string, timeout time.Duration, snapshot registrySnapshot) error {
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+
+	if err := restoreRouteSnapshot(rollbackCtx, kubeClient, namespace, snapshot); err != nil {
+		return err
+	}
+
+	return waitForDaemonSet(rollbackCtx, kubeClient, namespace, nodeConfigDaemonSetName, timeout)
+}
+
+func rollbackRegistrySnapshot(ctx context.Context, kubeClient kubernetes.Interface, namespace string, timeout time.Duration, snapshot registrySnapshot, routeTouched, routeWasActive bool) error {
+	if !routeTouched {
+		return rollbackAgentSnapshot(ctx, kubeClient, namespace, timeout, snapshot)
+	}
+
+	if routeWasActive {
+		if err := rollbackAgentSnapshot(ctx, kubeClient, namespace, timeout, snapshot); err != nil {
+			return err
+		}
+
+		return rollbackRouteSnapshot(ctx, kubeClient, namespace, timeout, snapshot)
+	}
+
+	if err := rollbackRouteSnapshot(ctx, kubeClient, namespace, timeout, snapshot); err != nil {
+		return err
+	}
+
+	return rollbackAgentSnapshot(ctx, kubeClient, namespace, timeout, snapshot)
+}
+
+func setConfigMapData(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, data map[string]string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		configMap, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if configMap.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+			return fmt.Errorf("ConfigMap %s/%s is not owned by gantryctl", namespace, name)
+		}
+
+		configMap.Data = copyStringMap(data)
+		_, err = kubeClient.CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+
+		return err
+	})
+}
+
+func setSecret(ctx context.Context, kubeClient kubernetes.Interface, namespace string, desired *corev1.Secret) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, registryCredentialsName, metav1.GetOptions{})
+		if desired == nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			if err != nil {
+				return err
+			}
+
+			if existing.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+				return fmt.Errorf("secret %s/%s is not owned by gantryctl", namespace, registryCredentialsName)
+			}
+
+			return kubeClient.CoreV1().Secrets(namespace).Delete(ctx, existing.Name, metav1.DeleteOptions{})
+		}
+
+		if apierrors.IsNotFound(err) {
+			copy := desired.DeepCopy()
+			copy.ResourceVersion = ""
+			_, err = kubeClient.CoreV1().Secrets(namespace).Create(ctx, copy, metav1.CreateOptions{})
+
+			return err
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if existing.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+			return fmt.Errorf("secret %s/%s is not owned by gantryctl", namespace, registryCredentialsName)
+		}
+
+		existing.Data = copyByteMap(desired.Data)
+
+		existing.Type = corev1.SecretTypeOpaque
+		if existing.Labels == nil {
+			existing.Labels = map[string]string{}
+		}
+
+		existing.Labels["app.kubernetes.io/managed-by"] = fieldManager
+		_, err = kubeClient.CoreV1().Secrets(namespace).Update(ctx, existing, metav1.UpdateOptions{})
+
+		return err
+	})
+}
+
+func rollDaemonSet(ctx context.Context, kubeClient kubernetes.Interface, namespace, name, annotation, value string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		daemonSet, err := kubeClient.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if daemonSet.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+			return fmt.Errorf("DaemonSet %s/%s is not owned by gantryctl", namespace, name)
+		}
+
+		if daemonSet.Spec.Template.Annotations == nil {
+			daemonSet.Spec.Template.Annotations = map[string]string{}
+		}
+
+		if daemonSet.Spec.Template.Annotations[annotation] == value {
+			return nil
+		}
+
+		daemonSet.Spec.Template.Annotations[annotation] = value
+		_, err = kubeClient.AppsV1().DaemonSets(namespace).Update(ctx, daemonSet, metav1.UpdateOptions{})
+
+		return err
+	})
+}
+
+func installedAgentImage(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (string, error) {
+	daemonSet, err := kubeClient.AppsV1().DaemonSets(namespace).Get(ctx, agentDaemonSetName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get standalone Gantry DaemonSet: %w", err)
+	}
+
+	if daemonSet.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+		return "", fmt.Errorf("DaemonSet %s/%s is not owned by gantryctl", namespace, agentDaemonSetName)
+	}
+
+	for _, container := range daemonSet.Spec.Template.Spec.Containers {
+		if container.Name == "gantry" {
+			return container.Image, nil
+		}
+	}
+
+	return "", errors.New("standalone Gantry DaemonSet has no gantry container")
+}
+
+func newOwnedSecret(namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      registryCredentialsName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": fieldManager,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{},
+	}
+}
+
+func credentialKey(host string) string {
+	digest := sha256.Sum256([]byte(host))
+	return "registry-" + hex.EncodeToString(digest[:8])
+}
+
+func agentStateHash(configData map[string]string, secret *corev1.Secret) string {
+	var buffer bytes.Buffer
+
+	keys := make([]string, 0, len(configData))
+	for key := range configData {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		buffer.WriteString(key)
+		buffer.WriteByte(0)
+		buffer.WriteString(configData[key])
+		buffer.WriteByte(0)
+	}
+
+	if secret != nil {
+		secretKeys := make([]string, 0, len(secret.Data))
+		for key := range secret.Data {
+			secretKeys = append(secretKeys, key)
+		}
+
+		sort.Strings(secretKeys)
+
+		for _, key := range secretKeys {
+			buffer.WriteString(key)
+			buffer.WriteByte(0)
+			buffer.Write(secret.Data[key])
+			buffer.WriteByte(0)
+		}
+	}
+
+	return stringHash(buffer.String())
+}
+
+func stringHash(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
+}
+
+func copyStringMap(source map[string]string) map[string]string {
+	copy := make(map[string]string, len(source))
+	for key, value := range source {
+		copy[key] = value
+	}
+
+	return copy
+}
+
+func copyByteMap(source map[string][]byte) map[string][]byte {
+	copy := make(map[string][]byte, len(source))
+	for key, value := range source {
+		copy[key] = bytes.Clone(value)
+	}
+
+	return copy
+}
+
+func daemonSetReady(daemonSet *appsv1.DaemonSet) bool {
+	return daemonSet.Status.DesiredNumberScheduled > 0 &&
+		daemonSet.Status.ObservedGeneration >= daemonSet.Generation &&
+		daemonSet.Status.UpdatedNumberScheduled == daemonSet.Status.DesiredNumberScheduled &&
+		daemonSet.Status.NumberReady == daemonSet.Status.DesiredNumberScheduled
+}

--- a/cmd/gantryctl/app/registry_test.go
+++ b/cmd/gantryctl/app/registry_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	gantryconfig "github.com/Azure/unbounded/internal/gantry/config"
+	"github.com/Azure/unbounded/internal/gantry/noderoute"
+)
+
+func TestSharedCredentialFromStdin(t *testing.T) {
+	options := &registryAddOptions{
+		root:          &rootOptions{namespace: "gantry-system"},
+		username:      "reader",
+		passwordStdin: true,
+	}
+	command := &cobra.Command{}
+	command.SetIn(strings.NewReader("secret-value\n"))
+
+	username, password, err := options.sharedCredential(t.Context(), command, fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("sharedCredential: %v", err)
+	}
+
+	if username != "reader" || password != "secret-value" {
+		t.Fatalf("credential = %q/%q", username, password)
+	}
+}
+
+func TestBaseInstallExcludesNodeConfigManifest(t *testing.T) {
+	if baseInstallManifest(nodeConfigManifestName) {
+		t.Fatal("base install included the host-routing DaemonSet")
+	}
+
+	for _, name := range []string{"00-rbac.yaml.tmpl", "01-config.yaml.tmpl", "02-agent.yaml.tmpl"} {
+		if !baseInstallManifest(name) {
+			t.Fatalf("base install excluded %s", name)
+		}
+	}
+}
+
+func TestSharedCredentialFromArbitrarilyNamedSecret(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a-pull-auth", Namespace: "workloads"},
+		Data: map[string][]byte{
+			"login": []byte("team-reader"),
+			"token": []byte("team-secret"),
+		},
+	})
+	options := &registryAddOptions{
+		root:            &rootOptions{namespace: "gantry-system"},
+		fromSecret:      "team-a-pull-auth",
+		secretNamespace: "workloads",
+		usernameKey:     "login",
+		passwordKey:     "token",
+	}
+
+	username, password, err := options.sharedCredential(t.Context(), &cobra.Command{}, client)
+	if err != nil {
+		t.Fatalf("sharedCredential: %v", err)
+	}
+
+	if username != "team-reader" || password != "team-secret" {
+		t.Fatalf("credential = %q/%q", username, password)
+	}
+}
+
+func TestPullTestPodPreservesSecretNamesAndServiceAccount(t *testing.T) {
+	pod := pullTestPod(
+		"team-a",
+		"node-a",
+		"registry.example.com/team/image:v1",
+		"build-runner",
+		[]corev1.LocalObjectReference{{Name: "first-secret"}, {Name: "different-name"}},
+	)
+
+	if pod.Namespace != "team-a" || pod.Spec.NodeName != "node-a" || pod.Spec.ServiceAccountName != "build-runner" {
+		t.Fatalf("unexpected pull Pod placement: %#v", pod.Spec)
+	}
+
+	if got := pod.Spec.ImagePullSecrets; len(got) != 2 || got[0].Name != "first-secret" || got[1].Name != "different-name" {
+		t.Fatalf("imagePullSecrets = %#v", got)
+	}
+}
+
+func TestRegistryStoreEncodeKeepsCredentialOutOfConfigMaps(t *testing.T) {
+	config := gantryconfig.NewDefault()
+	config.AllowNoUpstreamRegistries = true
+	secret := newOwnedSecret("gantry-system")
+	secret.Data["registry-key"] = []byte("reader:highly-secret")
+	store := &registryStore{
+		agentConfig: config,
+		auth:        registryAuthMetadata{},
+		routes:      noderoute.Config{},
+		configData:  map[string]string{},
+		routesData:  map[string]string{},
+		secret:      secret,
+	}
+	store.upsertRegistry(
+		gantryconfig.UpstreamRegistry{
+			Name:            "registry.example.com",
+			Endpoint:        "https://registry.example.com",
+			AuthMode:        gantryconfig.UpstreamAuthShared,
+			CredentialsPath: "/etc/gantry/registry/registry-key",
+		},
+		registryAuthRecord{Mode: authBasic, CredentialKey: "registry-key"},
+		noderoute.Registry{Host: "registry.example.com", Server: "https://registry.example.com"},
+	)
+
+	if err := store.encode(); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	for key, value := range store.configData {
+		if strings.Contains(value, "highly-secret") || strings.Contains(value, "reader:") {
+			t.Fatalf("credential leaked into ConfigMap key %s", key)
+		}
+	}
+
+	loaded := gantryconfig.NewDefault()
+	if err := loaded.LoadYAML(strings.NewReader(store.configData["config.yaml"])); err != nil {
+		t.Fatalf("reload generated config: %v", err)
+	}
+
+	loaded.AllowNoUpstreamRegistries = true
+	if err := loaded.Validate(); err != nil {
+		t.Fatalf("validate generated config: %v", err)
+	}
+
+	if got := loaded.UpstreamRegistries[0].AuthMode; got != gantryconfig.UpstreamAuthShared {
+		t.Fatalf("generated auth mode = %q", got)
+	}
+}
+
+func TestRegistryStorePromotesReplacementManagementOnce(t *testing.T) {
+	store := &registryStore{routes: noderoute.Config{Registries: []noderoute.Registry{{
+		Host: "registry.example.com", Server: "https://registry.example.com",
+	}}}}
+
+	if !store.manageRouteReplacements("registry.example.com") {
+		t.Fatal("first promotion reported no change")
+	}
+
+	if !store.routes.Registries[0].ManageReplacements {
+		t.Fatal("route was not promoted")
+	}
+
+	if store.manageRouteReplacements("registry.example.com") {
+		t.Fatal("second promotion reported a change")
+	}
+}
+
+func TestStagedSecretPreservesExistingKeys(t *testing.T) {
+	existing := newOwnedSecret("gantry-system")
+	existing.Data["old-key"] = []byte("old")
+	client := fake.NewSimpleClientset(existing)
+	desired := newOwnedSecret("gantry-system")
+	desired.Data["new-key"] = []byte("new")
+
+	staged, err := stagedSecret(t.Context(), client, "gantry-system", desired)
+	if err != nil {
+		t.Fatalf("stagedSecret: %v", err)
+	}
+
+	if string(staged.Data["old-key"]) != "old" || string(staged.Data["new-key"]) != "new" {
+		t.Fatalf("staged data = %#v", staged.Data)
+	}
+}
+
+func TestMetricSum(t *testing.T) {
+	metrics := []byte(`# HELP p2p_cache_hit_total hits
+p2p_cache_hit_total 2
+p2p_cache_hit_total{source="local"} 3
+p2p_cache_miss_total 4
+unrelated 100
+`)
+	if got := metricSum(metrics, "p2p_cache_hit_total"); got != 5 {
+		t.Fatalf("metricSum = %v, want 5", got)
+	}
+}
+
+func TestRegistryFromImage(t *testing.T) {
+	if got, err := registryFromImage("MyACR.azurecr.io/team/image:v1"); err != nil || got != "myacr.azurecr.io" {
+		t.Fatalf("registryFromImage = %q, %v", got, err)
+	}
+
+	if _, err := registryFromImage("alpine:latest"); err == nil {
+		t.Fatal("registryFromImage accepted an implicit registry")
+	}
+}
+
+func TestDaemonSetReady(t *testing.T) {
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration:     2,
+			DesiredNumberScheduled: 3,
+			UpdatedNumberScheduled: 3,
+			NumberReady:            3,
+		},
+	}
+	if !daemonSetReady(daemonSet) {
+		t.Fatal("complete DaemonSet was not ready")
+	}
+
+	daemonSet.Status.NumberReady = 2
+	if daemonSetReady(daemonSet) {
+		t.Fatal("partial DaemonSet was ready")
+	}
+}

--- a/cmd/gantryctl/app/root.go
+++ b/cmd/gantryctl/app/root.go
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/unbounded/internal/version"
+)
+
+const (
+	defaultNamespace = "gantry-system"
+	defaultTimeout   = 10 * time.Minute
+)
+
+type rootOptions struct {
+	kubeconfig string
+	context    string
+	namespace  string
+	timeout    time.Duration
+	clients    *clusterClients
+}
+
+// NewCommand constructs the independent Gantry management CLI.
+func NewCommand() *cobra.Command {
+	options := &rootOptions{}
+	command := &cobra.Command{
+		Use:           "gantryctl",
+		Short:         "Install and configure standalone Gantry",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	command.PersistentFlags().StringVar(&options.kubeconfig, "kubeconfig", "", "Path to kubeconfig (defaults to standard kubectl loading rules)")
+	command.PersistentFlags().StringVar(&options.context, "context", "", "Kubeconfig context override")
+	command.PersistentFlags().StringVar(&options.namespace, "namespace", defaultNamespace, "Namespace for the standalone Gantry installation")
+	command.PersistentFlags().DurationVar(&options.timeout, "timeout", defaultTimeout, "Timeout for cluster operations")
+
+	command.AddCommand(newInstallCommand(options))
+	command.AddCommand(newRegistryCommand(options))
+	command.AddCommand(newUninstallCommand(options))
+	command.AddCommand(version.Command())
+
+	return command
+}
+
+// Run executes gantryctl and exits nonzero on failure.
+func Run() {
+	command := NewCommand()
+	if err := command.Execute(); err != nil {
+		_, _ = fmt.Fprintln(command.ErrOrStderr(), err) //nolint:errcheck // terminal error reporting is best effort
+
+		os.Exit(1)
+	}
+}
+
+func writeOutputf(output io.Writer, format string, args ...any) error {
+	if _, err := fmt.Fprintf(output, format, args...); err != nil {
+		return fmt.Errorf("write command output: %w", err)
+	}
+
+	return nil
+}
+
+func defaultGantryImage() string {
+	tag := strings.TrimSpace(version.Version)
+	if tag == "" {
+		tag = "dev"
+	}
+
+	if tag != "dev" && !strings.HasPrefix(tag, "v") {
+		tag = "v" + tag
+	}
+
+	return "ghcr.io/azure/gantry:" + tag
+}

--- a/cmd/gantryctl/app/uninstall.go
+++ b/cmd/gantryctl/app/uninstall.go
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type uninstallOptions struct {
+	root            *rootOptions
+	deleteNamespace bool
+}
+
+func newUninstallCommand(root *rootOptions) *cobra.Command {
+	options := &uninstallOptions{root: root}
+	command := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Restore node routes and remove standalone Gantry",
+		Example: `  gantryctl uninstall
+  gantryctl uninstall --delete-namespace`,
+		Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return options.run(command.Context(), command.OutOrStdout())
+		},
+	}
+	command.Flags().BoolVar(&options.deleteNamespace, "delete-namespace", false, "Delete the installation namespace after removing Gantry resources")
+
+	return command
+}
+
+func (o *uninstallOptions) run(ctx context.Context, output io.Writer) error {
+	clients, err := o.root.clusterClients()
+	if err != nil {
+		return err
+	}
+
+	if err := withRegistryMutationLock(ctx, clients.kube, o.root.namespace, o.root.timeout, func(lockCtx context.Context) error {
+		return o.runLocked(lockCtx, output, clients)
+	}); err != nil {
+		return err
+	}
+
+	if err := clients.kube.CoordinationV1().Leases(o.root.namespace).Delete(ctx, registryMutationLeaseName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete registry mutation Lease: %w", err)
+	}
+
+	return nil
+}
+
+func (o *uninstallOptions) runLocked(ctx context.Context, output io.Writer, clients *clusterClients) error {
+	store, err := loadRegistryStore(ctx, clients.kube, o.root.namespace)
+	if err != nil {
+		return err
+	}
+
+	if o.deleteNamespace {
+		namespace, err := clients.kube.CoreV1().Namespaces().Get(ctx, o.root.namespace, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("get standalone namespace: %w", err)
+		}
+
+		if err == nil && namespace.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+			return fmt.Errorf("namespace %s is not owned by gantryctl; refusing --delete-namespace", o.root.namespace)
+		}
+	}
+
+	agent, agentErr := clients.kube.AppsV1().DaemonSets(o.root.namespace).Get(ctx, agentDaemonSetName, metav1.GetOptions{})
+	if agentErr != nil && !apierrors.IsNotFound(agentErr) {
+		return fmt.Errorf("get agent DaemonSet: %w", agentErr)
+	}
+
+	if agentErr == nil && agent.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+		return fmt.Errorf("DaemonSet %s/%s is not owned by gantryctl", o.root.namespace, agentDaemonSetName)
+	}
+
+	nodeConfig, nodeConfigErr := clients.kube.AppsV1().DaemonSets(o.root.namespace).Get(ctx, nodeConfigDaemonSetName, metav1.GetOptions{})
+
+	nodeConfigExists := nodeConfigErr == nil
+	if nodeConfigErr != nil && !apierrors.IsNotFound(nodeConfigErr) {
+		return fmt.Errorf("get node-config DaemonSet: %w", nodeConfigErr)
+	}
+
+	if nodeConfigExists && nodeConfig.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+		return fmt.Errorf("DaemonSet %s/%s is not owned by gantryctl", o.root.namespace, nodeConfigDaemonSetName)
+	}
+
+	if len(store.routes.Registries) > 0 {
+		if !nodeConfigExists {
+			return errors.New("cannot restore node routes because the node-config DaemonSet is unavailable")
+		}
+
+		snapshot := store.snapshot()
+
+		store.routes.Registries = nil
+		if err := applyRouteState(ctx, clients.kube, o.root.namespace, store); err != nil {
+			return errors.Join(err, rollbackRouteSnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot))
+		}
+
+		if err := waitForDaemonSet(ctx, clients.kube, o.root.namespace, nodeConfigDaemonSetName, o.root.timeout); err != nil {
+			return errors.Join(fmt.Errorf("wait for node route restoration: %w", err), rollbackRouteSnapshot(ctx, clients.kube, o.root.namespace, o.root.timeout, snapshot))
+		}
+	}
+
+	if nodeConfigExists {
+		if err := waitForDaemonSet(ctx, clients.kube, o.root.namespace, nodeConfigDaemonSetName, o.root.timeout); err != nil {
+			return fmt.Errorf("verify restored node routes before uninstall: %w", err)
+		}
+	}
+
+	deleteOptions := metav1.DeleteOptions{}
+	for _, name := range []string{nodeConfigDaemonSetName, agentDaemonSetName} {
+		if err := clients.kube.AppsV1().DaemonSets(o.root.namespace).Delete(ctx, name, deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete DaemonSet %s: %w", name, err)
+		}
+	}
+
+	for _, name := range []string{agentConfigMapName, nodeRoutesConfigMapName} {
+		if err := clients.kube.CoreV1().ConfigMaps(o.root.namespace).Delete(ctx, name, deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete ConfigMap %s: %w", name, err)
+		}
+	}
+
+	if err := clients.kube.CoreV1().Secrets(o.root.namespace).Delete(ctx, registryCredentialsName, deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete registry credentials: %w", err)
+	}
+
+	if err := clients.kube.RbacV1().RoleBindings(o.root.namespace).Delete(ctx, "gantry-standalone-agent", deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete standalone RoleBinding: %w", err)
+	}
+
+	if err := clients.kube.RbacV1().Roles(o.root.namespace).Delete(ctx, "gantry-standalone-agent", deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete standalone Role: %w", err)
+	}
+
+	if err := clients.kube.CoreV1().ServiceAccounts(o.root.namespace).Delete(ctx, "gantry-standalone", deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete standalone ServiceAccount: %w", err)
+	}
+
+	if err := clients.kube.RbacV1().ClusterRoleBindings().Delete(ctx, "gantry-standalone-agent", deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete standalone ClusterRoleBinding: %w", err)
+	}
+
+	if err := clients.kube.RbacV1().ClusterRoles().Delete(ctx, "gantry-standalone-agent", deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete standalone ClusterRole: %w", err)
+	}
+
+	if o.deleteNamespace {
+		namespace, err := clients.kube.CoreV1().Namespaces().Get(ctx, o.root.namespace, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("get standalone namespace: %w", err)
+		}
+
+		if err == nil && namespace.Labels["app.kubernetes.io/managed-by"] != fieldManager {
+			return fmt.Errorf("namespace %s is not owned by gantryctl; refusing --delete-namespace", o.root.namespace)
+		}
+
+		if err := clients.kube.CoreV1().Namespaces().Delete(ctx, o.root.namespace, deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete standalone namespace: %w", err)
+		}
+	}
+
+	return writeOutputf(output, "Standalone Gantry removed; all managed containerd routes were restored first.\n")
+}

--- a/cmd/gantryctl/main.go
+++ b/cmd/gantryctl/main.go
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import "github.com/Azure/unbounded/cmd/gantryctl/app"
+
+func main() {
+	app.Run()
+}

--- a/deploy/gantry-standalone/00-rbac.yaml.tmpl
+++ b/deploy/gantry-standalone/00-rbac.yaml.tmpl
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/part-of: gantry-standalone
+    app.kubernetes.io/managed-by: gantryctl
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gantry-standalone
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: gantry
+    app.kubernetes.io/managed-by: gantryctl
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gantry-standalone-agent
+  labels:
+    app.kubernetes.io/managed-by: gantryctl
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gantry-standalone-agent
+  labels:
+    app.kubernetes.io/managed-by: gantryctl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gantry-standalone-agent
+subjects:
+  - kind: ServiceAccount
+    name: gantry-standalone
+    namespace: {{ .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gantry-standalone-agent
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: gantryctl
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gantry-standalone-agent
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: gantryctl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gantry-standalone-agent
+subjects:
+  - kind: ServiceAccount
+    name: gantry-standalone
+    namespace: {{ .Namespace }}

--- a/deploy/gantry-standalone/01-config.yaml.tmpl
+++ b/deploy/gantry-standalone/01-config.yaml.tmpl
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gantry-standalone-config
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: gantry
+    app.kubernetes.io/managed-by: gantryctl
+data:
+  registry-auth.json: "{}"
+  config.yaml: |
+    mirror_listen: "0.0.0.0:5000"
+    mirror_bind_allow_non_loopback: true
+    transfer_listen: "0.0.0.0:5001"
+    metrics_listen: "0.0.0.0:9095"
+    libp2p_listen:
+      - "/ip4/0.0.0.0/tcp/4001"
+      - "/ip4/0.0.0.0/udp/4001/quic-v1"
+    libp2p_identity_path: "/var/lib/gantry-standalone/libp2p/identity.key"
+    members_label_selector: "app.kubernetes.io/name=gantry"
+    storage_mode: "containerd"
+    containerd_socket: "/run/containerd/containerd.sock"
+    containerd_namespace: "k8s.io"
+    upstream_registries: []
+    log_level: "info"
+    log_format: "json"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gantry-standalone-node-routes
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: gantryctl
+data:
+  registries.json: '{"registries":[]}'

--- a/deploy/gantry-standalone/02-agent.yaml.tmpl
+++ b/deploy/gantry-standalone/02-agent.yaml.tmpl
@@ -1,0 +1,165 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gantry-standalone
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: gantry
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: gantryctl
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gantry
+      app.kubernetes.io/instance: standalone
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gantry
+        app.kubernetes.io/instance: standalone
+        app.kubernetes.io/component: agent
+        app.kubernetes.io/managed-by: gantryctl
+      annotations:
+        gantryctl.io/config-hash: initial
+    spec:
+      serviceAccountName: gantry-standalone
+      hostNetwork: false
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      terminationGracePeriodSeconds: 30
+      initContainers:
+        - name: chown-hostpaths
+          image: mcr.microsoft.com/cbl-mariner/busybox:2.0
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "chown -R 65532:65532 /var/lib/gantry-standalone/libp2p && chmod 0700 /var/lib/gantry-standalone/libp2p"]
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "FOWNER", "DAC_OVERRIDE"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - name: libp2p
+              mountPath: /var/lib/gantry-standalone/libp2p
+      containers:
+        - name: gantry
+          image: {{ .Image }}
+          imagePullPolicy: IfNotPresent
+          args: ["agent", "--config=/etc/gantry/config.yaml", "--allow-no-upstream-registries=true"]
+          env:
+            - name: GANTRY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: GANTRY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: GANTRY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: GANTRY_MEMBERS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: mirror
+              containerPort: 5000
+              hostPort: 5000
+              hostIP: 127.0.0.1
+              protocol: TCP
+            - name: transfer
+              containerPort: 5001
+              protocol: TCP
+            - name: libp2p-tcp
+              containerPort: 4001
+              protocol: TCP
+            - name: libp2p-quic
+              containerPort: 4001
+              protocol: UDP
+            - name: metrics
+              containerPort: 9095
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1Gi
+            limits:
+              cpu: "8"
+              memory: 8Gi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: libp2p
+              mountPath: /var/lib/gantry-standalone/libp2p
+            - name: config
+              mountPath: /etc/gantry
+              readOnly: true
+            - name: registry-creds
+              mountPath: /etc/gantry/registry
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            - name: containerd-socket
+              mountPath: /run/containerd/containerd.sock
+      volumes:
+        - name: libp2p
+          hostPath:
+            path: /var/lib/gantry-standalone/libp2p
+            type: DirectoryOrCreate
+        - name: config
+          configMap:
+            name: gantry-standalone-config
+        - name: registry-creds
+          secret:
+            secretName: gantry-standalone-registry-credentials
+            optional: true
+        - name: tmp
+          emptyDir: {}
+        - name: containerd-socket
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket

--- a/deploy/gantry-standalone/03-node-config.yaml.tmpl
+++ b/deploy/gantry-standalone/03-node-config.yaml.tmpl
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gantry-standalone-node-config
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: gantry-standalone-node-config
+    app.kubernetes.io/component: node-config
+    app.kubernetes.io/managed-by: gantryctl
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gantry-standalone-node-config
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gantry-standalone-node-config
+        app.kubernetes.io/component: node-config
+        app.kubernetes.io/managed-by: gantryctl
+    spec:
+      priorityClassName: system-node-critical
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: configure
+          image: {{ .Image }}
+          imagePullPolicy: IfNotPresent
+          args: ["node-config", "reconcile"]
+          readinessProbe:
+            exec:
+              command: ["gantry", "node-config", "check"]
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: desired
+              mountPath: /etc/gantry-node-config
+              readOnly: true
+            - name: host-certs
+              mountPath: /host-certs
+            - name: host-containerd-config
+              mountPath: /host-containerd-config
+              readOnly: true
+            - name: host-state
+              mountPath: /host-state
+      volumes:
+        - name: desired
+          configMap:
+            name: gantry-standalone-node-routes
+        - name: host-certs
+          hostPath:
+            path: /etc/containerd/certs.d
+            type: DirectoryOrCreate
+        - name: host-containerd-config
+          hostPath:
+            path: /etc/containerd
+            type: Directory
+        - name: host-state
+          hostPath:
+            path: /var/lib/gantry-standalone/node-config
+            type: DirectoryOrCreate

--- a/deploy/gantry-standalone/render.go
+++ b/deploy/gantry-standalone/render.go
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package gantrystandalone embeds and renders the manifests owned by gantryctl.
+package gantrystandalone
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+	"text/template"
+)
+
+// Values are the runtime substitutions supported by standalone manifests.
+type Values struct {
+	Namespace string
+	Image     string
+}
+
+// Manifest is one rendered Kubernetes manifest.
+type Manifest struct {
+	Name string
+	Data []byte
+}
+
+//go:embed *.yaml.tmpl
+var templates embed.FS
+
+// Render renders every standalone manifest in stable filename order.
+func Render(values Values) ([]Manifest, error) {
+	if values.Namespace == "" {
+		return nil, fmt.Errorf("standalone manifest namespace is required")
+	}
+
+	if values.Image == "" {
+		return nil, fmt.Errorf("standalone Gantry image is required")
+	}
+
+	paths, err := fs.Glob(templates, "*.yaml.tmpl")
+	if err != nil {
+		return nil, fmt.Errorf("list standalone manifests: %w", err)
+	}
+
+	sort.Strings(paths)
+
+	manifests := make([]Manifest, 0, len(paths))
+	for _, path := range paths {
+		source, err := templates.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read standalone manifest %s: %w", path, err)
+		}
+
+		parsed, err := template.New(path).Option("missingkey=error").Parse(string(source))
+		if err != nil {
+			return nil, fmt.Errorf("parse standalone manifest %s: %w", path, err)
+		}
+
+		var rendered bytes.Buffer
+		if err := parsed.Execute(&rendered, values); err != nil {
+			return nil, fmt.Errorf("render standalone manifest %s: %w", path, err)
+		}
+
+		manifests = append(manifests, Manifest{Name: path, Data: rendered.Bytes()})
+	}
+
+	return manifests, nil
+}

--- a/deploy/gantry-standalone/render_test.go
+++ b/deploy/gantry-standalone/render_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package gantrystandalone
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+
+	gantryconfig "github.com/Azure/unbounded/internal/gantry/config"
+)
+
+func TestRenderProducesIsolatedInertInstallation(t *testing.T) {
+	manifests, err := Render(Values{Namespace: "gantry-test", Image: "ghcr.io/azure/gantry:test"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	if len(manifests) != 4 {
+		t.Fatalf("manifest count = %d, want 4", len(manifests))
+	}
+
+	var (
+		configYAML         string
+		standaloneOptIn    bool
+		criticalAgent      bool
+		criticalNodeConfig bool
+	)
+
+	for _, manifest := range manifests {
+		if manifest.Name == "02-agent.yaml.tmpl" && bytes.Contains(manifest.Data, []byte("--allow-no-upstream-registries=true")) {
+			standaloneOptIn = true
+		}
+
+		if manifest.Name == "02-agent.yaml.tmpl" && bytes.Contains(manifest.Data, []byte("priorityClassName: system-node-critical")) {
+			criticalAgent = true
+		}
+
+		if manifest.Name == "03-node-config.yaml.tmpl" && bytes.Contains(manifest.Data, []byte("priorityClassName: system-node-critical")) {
+			criticalNodeConfig = true
+		}
+
+		decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(manifest.Data), 4096)
+
+		for {
+			var object map[string]any
+			if err := decoder.Decode(&object); err != nil {
+				if err == io.EOF {
+					break
+				}
+
+				t.Fatalf("decode %s: %v", manifest.Name, err)
+			}
+
+			metadata, _ := object["metadata"].(map[string]any)
+
+			name, _ := metadata["name"].(string)
+			if object["kind"] == "DaemonSet" && name == "gantry" {
+				t.Fatal("standalone manifests reused the operator DaemonSet name gantry")
+			}
+
+			if object["kind"] == "ConfigMap" && name == "gantry-standalone-config" {
+				data, _ := object["data"].(map[string]any)
+				configYAML, _ = data["config.yaml"].(string)
+			}
+		}
+	}
+
+	if configYAML == "" {
+		t.Fatal("rendered agent ConfigMap has no config.yaml")
+	}
+
+	if !standaloneOptIn {
+		t.Fatal("standalone agent does not opt into empty-registry mode")
+	}
+
+	if !criticalAgent || !criticalNodeConfig {
+		t.Fatalf("node replacement priorities = agent:%v node-config:%v, want both critical", criticalAgent, criticalNodeConfig)
+	}
+
+	config := gantryconfig.NewDefault()
+	if err := config.LoadYAML(bytes.NewBufferString(configYAML)); err != nil {
+		t.Fatalf("load rendered Gantry config: %v", err)
+	}
+
+	if config.AllowNoUpstreamRegistries || len(config.UpstreamRegistries) != 0 {
+		t.Fatalf("rendered YAML registry state = allowEmpty:%v registries:%v", config.AllowNoUpstreamRegistries, config.UpstreamRegistries)
+	}
+
+	config.AllowNoUpstreamRegistries = true
+	if err := config.Validate(); err != nil {
+		t.Fatalf("validate rendered inert config: %v", err)
+	}
+}

--- a/hack/install-gantry.sh
+++ b/hack/install-gantry.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env sh
+set -eu
+
+repository=${GANTRY_REPOSITORY:-Azure/unbounded}
+version=${GANTRY_VERSION:-}
+: "${HOME:?HOME must be set}"
+install_dir=${GANTRYCTL_INSTALL_DIR:-$HOME/.local/bin}
+action=install
+
+case ${1:-} in
+  install)
+    shift
+    ;;
+  uninstall)
+    action=uninstall
+    shift
+    ;;
+  ""|--*) ;;
+  *)
+    echo "usage: install-gantry.sh [install|uninstall] [gantryctl flags]" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$action" = uninstall ] && [ -z "$version" ] && [ -x "${install_dir}/gantryctl" ]; then
+  "${install_dir}/gantryctl" uninstall "$@"
+  printf '\nStandalone Gantry uninstalled. gantryctl remains at %s/gantryctl.\n' "$install_dir"
+  exit 0
+fi
+
+if [ -z "$version" ]; then
+  latest_url=$(curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/${repository}/releases/latest")
+  version=${latest_url##*/}
+fi
+case "$version" in
+  v*) ;;
+  *) version="v${version}" ;;
+esac
+
+case $(uname -s) in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+  *)
+    echo "unsupported operating system: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case $(uname -m) in
+  x86_64|amd64) arch=amd64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *)
+    echo "unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+archive="gantryctl-${os}-${arch}.tar.gz"
+release_base="https://github.com/${repository}/releases/download/${version}"
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+
+curl -fsSL "${release_base}/${archive}" -o "${temp_dir}/${archive}"
+curl -fsSL "${release_base}/checksums.txt" -o "${temp_dir}/checksums.txt"
+
+expected=$(awk -v name="$archive" '$2 == name || $2 == ("*" name) { print $1; exit }' "${temp_dir}/checksums.txt")
+if [ -z "$expected" ]; then
+  echo "release checksum for ${archive} was not found" >&2
+  exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum "${temp_dir}/${archive}" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  actual=$(shasum -a 256 "${temp_dir}/${archive}" | awk '{print $1}')
+else
+  echo "sha256sum or shasum is required" >&2
+  exit 1
+fi
+if [ "$actual" != "$expected" ]; then
+  echo "checksum verification failed for ${archive}" >&2
+  exit 1
+fi
+
+tar -xzf "${temp_dir}/${archive}" -C "$temp_dir"
+mkdir -p "$install_dir"
+if command -v install >/dev/null 2>&1; then
+  install -m 0755 "${temp_dir}/gantryctl" "${install_dir}/gantryctl"
+else
+  cp "${temp_dir}/gantryctl" "${install_dir}/gantryctl"
+  chmod 0755 "${install_dir}/gantryctl"
+fi
+
+repository_owner=${repository%%/*}
+registry_owner=$(printf '%s' "$repository_owner" | tr '[:upper:]' '[:lower:]')
+if [ "$action" = uninstall ]; then
+  "${install_dir}/gantryctl" uninstall "$@"
+  printf '\nStandalone Gantry uninstalled. gantryctl remains at %s/gantryctl.\n' "$install_dir"
+else
+  image=${GANTRY_IMAGE:-ghcr.io/${registry_owner}/gantry:${version}}
+  "${install_dir}/gantryctl" install --image "$image" "$@"
+
+  printf '\ngantryctl installed at %s/gantryctl\n' "$install_dir"
+  case ":${PATH}:" in
+    *":${install_dir}:"*) ;;
+    *) printf 'Add %s to PATH before running post-install registry commands.\n' "$install_dir" ;;
+  esac
+  printf 'Configure a registry: gantryctl registry add <registry-host> --auth delegated\n'
+  printf 'Uninstall and restore host files: gantryctl uninstall\n'
+fi

--- a/internal/gantry/config/config.go
+++ b/internal/gantry/config/config.go
@@ -249,6 +249,11 @@ type Config struct {
 	// one of these once more than one is configured.
 	UpstreamRegistries []UpstreamRegistry `yaml:"upstream_registries"`
 
+	// AllowNoUpstreamRegistries permits an inert agent with no registry routes.
+	// It is command-line-only so operator-managed YAML remains strict;
+	// standalone installations opt in explicitly on their DaemonSet args.
+	AllowNoUpstreamRegistries bool `yaml:"-"`
+
 	// ---------- HRW / coordination ----------
 
 	// HRWK is the top-K size for HRW probe (the step 3 default 3; the design doc
@@ -418,6 +423,12 @@ type UpstreamRegistry struct {
 	// "https://registry.example.com".
 	Endpoint string `yaml:"endpoint"`
 
+	// AuthMode selects how Gantry authenticates origin requests. Empty keeps
+	// backward compatibility: delegated when CredentialsPath is empty and
+	// legacy shared credentials when it is set. New standalone configuration
+	// writes one of "delegated", "anonymous", or "shared" explicitly.
+	AuthMode string `yaml:"auth_mode,omitempty"`
+
 	// CredentialsPath is an optional fallback file containing registry
 	// credentials. Format: "username:password" (or "_json_key:<json>" for
 	// the well-known GCR pattern). A request-scoped Basic/Bearer credential
@@ -430,6 +441,28 @@ type UpstreamRegistry struct {
 	// NSAlias lets containerd's ?ns= use a different name than Name.
 	// Empty means ?ns= must equal Name.
 	NSAlias string `yaml:"ns_alias"`
+}
+
+const (
+	// UpstreamAuthDelegated forwards request-scoped kubelet/containerd credentials.
+	UpstreamAuthDelegated = "delegated"
+	// UpstreamAuthAnonymous suppresses all registry credentials.
+	UpstreamAuthAnonymous = "anonymous"
+	// UpstreamAuthShared uses the registry's configured cluster-wide credential.
+	UpstreamAuthShared = "shared"
+)
+
+// EffectiveAuthMode resolves the backward-compatible empty AuthMode value.
+func (u UpstreamRegistry) EffectiveAuthMode() string {
+	if u.AuthMode != "" {
+		return u.AuthMode
+	}
+
+	if u.CredentialsPath != "" {
+		return UpstreamAuthShared
+	}
+
+	return UpstreamAuthDelegated
 }
 
 // LegacyDeprecatedConfig captures YAML field names that used to live
@@ -681,6 +714,7 @@ func (c *Config) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.ContainerdNamespace, "containerd-namespace", c.ContainerdNamespace, "containerd namespace cdsub watches (default k8s.io)")
 	fs.DurationVar(&c.ContainerdLeaseTTL, "containerd-lease-ttl", c.ContainerdLeaseTTL, "TTL for containerd content leases attached by Gantry on ingest (storage_mode=containerd only)")
 	fs.DurationVar(&c.ContainerdLeaseCleanupInterval, "containerd-lease-cleanup-interval", c.ContainerdLeaseCleanupInterval, "period of the expired-lease sweep loop (storage_mode=containerd only)")
+	fs.BoolVar(&c.AllowNoUpstreamRegistries, "allow-no-upstream-registries", c.AllowNoUpstreamRegistries, "allow an inert agent with no configured upstream registries (standalone bootstrap only)")
 
 	fs.IntVar(&c.HRWK, "hrw-k", c.HRWK, "HRW top-K size")
 	fs.IntVar(&c.PrefetchPullerReplicas, "prefetch-puller-replicas", c.PrefetchPullerReplicas, "number of HRW-ranked pullers each prefetched layer digest is pulled by (initial seeds); 1 = single puller/tightest dedup, N = N-fold peer fan-out at N origin copies")
@@ -847,7 +881,7 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	if len(c.UpstreamRegistries) == 0 {
+	if len(c.UpstreamRegistries) == 0 && !c.AllowNoUpstreamRegistries {
 		errs = append(errs, errors.New("upstream_registries: at least one entry required"))
 	}
 
@@ -874,6 +908,28 @@ func (c *Config) Validate() error {
 			errs = append(errs, fmt.Errorf("upstream_registries[%d].endpoint: required", i))
 		} else if !strings.HasPrefix(ur.Endpoint, "http://") && !strings.HasPrefix(ur.Endpoint, "https://") {
 			errs = append(errs, fmt.Errorf("upstream_registries[%d].endpoint %q: must start with http:// or https://", i, ur.Endpoint))
+		}
+
+		switch ur.AuthMode {
+		case "":
+		case UpstreamAuthDelegated, UpstreamAuthAnonymous:
+			if ur.CredentialsPath != "" {
+				errs = append(errs, fmt.Errorf("upstream_registries[%d].credentials_path: must be empty when auth_mode is %q", i, ur.AuthMode))
+			}
+
+			if ur.AuthMode == UpstreamAuthDelegated && !strings.HasPrefix(ur.Endpoint, "https://") {
+				errs = append(errs, fmt.Errorf("upstream_registries[%d].endpoint: auth_mode %q requires https", i, ur.AuthMode))
+			}
+		case UpstreamAuthShared:
+			if ur.CredentialsPath == "" {
+				errs = append(errs, fmt.Errorf("upstream_registries[%d].credentials_path: required when auth_mode is %q", i, ur.AuthMode))
+			}
+
+			if !strings.HasPrefix(ur.Endpoint, "https://") {
+				errs = append(errs, fmt.Errorf("upstream_registries[%d].endpoint: auth_mode %q requires https", i, ur.AuthMode))
+			}
+		default:
+			errs = append(errs, fmt.Errorf("upstream_registries[%d].auth_mode %q: must be %q, %q, or %q", i, ur.AuthMode, UpstreamAuthDelegated, UpstreamAuthAnonymous, UpstreamAuthShared))
 		}
 	}
 

--- a/internal/gantry/config/config_test.go
+++ b/internal/gantry/config/config_test.go
@@ -172,6 +172,66 @@ func TestValidate_RequiresUpstream(t *testing.T) {
 	}
 }
 
+func TestValidate_UpstreamAuthenticationModes(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		registry UpstreamRegistry
+		wantErr  string
+	}{
+		{name: "delegated", registry: UpstreamRegistry{Name: "r", Endpoint: "https://r", AuthMode: UpstreamAuthDelegated}},
+		{name: "anonymous https", registry: UpstreamRegistry{Name: "r", Endpoint: "https://r", AuthMode: UpstreamAuthAnonymous}},
+		{name: "anonymous http", registry: UpstreamRegistry{Name: "r", Endpoint: "http://r", AuthMode: UpstreamAuthAnonymous}},
+		{name: "shared", registry: UpstreamRegistry{Name: "r", Endpoint: "https://r", AuthMode: UpstreamAuthShared, CredentialsPath: "/creds"}},
+		{name: "delegated credentials", registry: UpstreamRegistry{Name: "r", Endpoint: "https://r", AuthMode: UpstreamAuthDelegated, CredentialsPath: "/creds"}, wantErr: "credentials_path"},
+		{name: "shared missing credentials", registry: UpstreamRegistry{Name: "r", Endpoint: "https://r", AuthMode: UpstreamAuthShared}, wantErr: "credentials_path"},
+		{name: "delegated http", registry: UpstreamRegistry{Name: "r", Endpoint: "http://r", AuthMode: UpstreamAuthDelegated}, wantErr: "requires https"},
+		{name: "shared http", registry: UpstreamRegistry{Name: "r", Endpoint: "http://r", AuthMode: UpstreamAuthShared, CredentialsPath: "/creds"}, wantErr: "requires https"},
+		{name: "unknown", registry: UpstreamRegistry{Name: "r", Endpoint: "https://r", AuthMode: "mystery"}, wantErr: "auth_mode"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := NewDefault()
+			config.UpstreamRegistries = []UpstreamRegistry{test.registry}
+
+			err := config.Validate()
+			if test.wantErr == "" && err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+
+			if test.wantErr != "" && (err == nil || !strings.Contains(err.Error(), test.wantErr)) {
+				t.Fatalf("want %q error, got %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidate_AllowsExplicitlyUnconfiguredAgent(t *testing.T) {
+	c := NewDefault()
+	c.AllowNoUpstreamRegistries = true
+
+	if err := c.Validate(); err != nil {
+		t.Fatalf("validate explicitly unconfigured agent: %v", err)
+	}
+}
+
+func TestAllowNoUpstreamRegistriesIsFlagOnly(t *testing.T) {
+	c := NewDefault()
+	if err := c.LoadYAML(strings.NewReader("allow_no_upstream_registries: true\n")); err == nil {
+		t.Fatal("standalone empty-registry opt-in was accepted from YAML")
+	}
+
+	c = NewDefault()
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+	c.BindFlags(flags)
+
+	if err := flags.Parse([]string{"--allow-no-upstream-registries=true"}); err != nil {
+		t.Fatalf("parse standalone opt-in: %v", err)
+	}
+
+	if !c.AllowNoUpstreamRegistries {
+		t.Fatal("standalone empty-registry flag did not take effect")
+	}
+}
+
 func TestValidate_MirrorListenMustBeLoopback(t *testing.T) {
 	c := NewDefault()
 	c.UpstreamRegistries = []UpstreamRegistry{{Name: "r", Endpoint: "https://r"}}

--- a/internal/gantry/mirror/mirror.go
+++ b/internal/gantry/mirror/mirror.go
@@ -62,6 +62,10 @@ type AuthenticationChallenger interface {
 	AuthenticationChallenge(ctx context.Context, registry string) (challenge string, required bool, err error)
 }
 
+type tagManifestFetcher interface {
+	FetchManifest(ctx context.Context, method, registry, repository, reference string) (*http.Response, error)
+}
+
 // Server is the mirror HTTP handler.
 type Server struct {
 	cfg     *config.Config
@@ -731,13 +735,6 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request) {
 	rawAuthorization := strings.TrimSpace(r.Header.Get("Authorization"))
 
 	authorization := registryauth.Normalize(rawAuthorization)
-	if rawAuthorization != "" && authorization == "" {
-		http.Error(w, "unsupported registry authorization", http.StatusServiceUnavailable)
-
-		return
-	}
-
-	r = r.WithContext(registryauth.WithAuthorization(r.Context(), authorization))
 
 	path := r.URL.Path
 	if path == "/v2/" || path == "/v2" {
@@ -776,10 +773,32 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	upstreamConfig, found := s.cfg.ResolveUpstream(upstream)
+	if !found {
+		http.Error(w, "registry configuration unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	authMode := upstreamConfig.EffectiveAuthMode()
+	if authMode == config.UpstreamAuthAnonymous || authMode == config.UpstreamAuthShared {
+		authorization = ""
+	} else if rawAuthorization != "" && authorization == "" {
+		http.Error(w, "unsupported registry authorization", http.StatusServiceUnavailable)
+
+		return
+	}
+
+	r = r.WithContext(registryauth.WithAuthorization(r.Context(), authorization))
+
 	if !isDigestRef(ref) {
+		if authMode == config.UpstreamAuthShared {
+			s.serveSharedTagManifest(w, r, upstream, repo, ref)
+			return
+		}
 		// Tag request (the design doc) - fall through to origin via hosts.toml.
 		// 503 (not 404) so containerd retries against the next mirror.
 		w.WriteHeader(http.StatusServiceUnavailable)
+
 		return
 	}
 
@@ -789,7 +808,7 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if authorization == "" && s.auth != nil {
+	if authorization == "" && s.auth != nil && authMode == config.UpstreamAuthDelegated {
 		challengeCtx, cancel := context.WithTimeout(r.Context(), authenticationChallengeTimeout)
 		challenge, required, challengeErr := s.auth.AuthenticationChallenge(challengeCtx, upstream)
 
@@ -814,6 +833,38 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.serveDigest(w, r, upstream, repo, d, kind)
+}
+
+func (s *Server) serveSharedTagManifest(w http.ResponseWriter, r *http.Request, registry, repository, reference string) {
+	fetcher, ok := s.origin.(tagManifestFetcher)
+	if !ok {
+		http.Error(w, "shared registry manifest resolution unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	resp, err := fetcher.FetchManifest(r.Context(), r.Method, registry, repository, reference)
+	if err != nil {
+		writeOriginError(w, err, s.logger)
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // best-effort close
+
+	for _, header := range []string{"Content-Type", "Content-Length", "Docker-Content-Digest", "ETag"} {
+		if value := resp.Header.Get(header); value != "" {
+			w.Header().Set(header, value)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		s.logger.Warn("mirror: shared-auth tag manifest stream failed", slog.Any("err", err))
+	}
 }
 
 func (s *Server) resolveUpstream(r *http.Request) (string, error) {

--- a/internal/gantry/mirror/mirror_test.go
+++ b/internal/gantry/mirror/mirror_test.go
@@ -146,6 +146,45 @@ type authorizationCapturingOrigin struct {
 	seen chan string
 }
 
+type modeCapturingOrigin struct {
+	authorizationCapturingOrigin
+	challengeCalls atomic.Int32
+}
+
+type tagFetchingOrigin struct {
+	authorizationCapturingOrigin
+	methods []string
+}
+
+func (o *tagFetchingOrigin) FetchManifest(_ context.Context, method, registry, repository, reference string) (*http.Response, error) {
+	o.methods = append(o.methods, method)
+
+	if registry != "reg.example.com" || repository != "repo" || reference != "v1" {
+		return nil, fmt.Errorf("unexpected manifest request: %s/%s:%s", registry, repository, reference)
+	}
+
+	body := io.NopCloser(bytes.NewReader(o.body))
+	if method == http.MethodHead {
+		body = io.NopCloser(bytes.NewReader(nil))
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":          []string{"application/vnd.oci.image.manifest.v1+json"},
+			"Content-Length":        []string{fmt.Sprint(len(o.body))},
+			"Docker-Content-Digest": []string{"sha256:" + strings.Repeat("a", 64)},
+		},
+		Body: body,
+	}, nil
+}
+
+func (o *modeCapturingOrigin) AuthenticationChallenge(context.Context, string) (string, bool, error) {
+	o.challengeCalls.Add(1)
+
+	return `Bearer realm="https://auth.example/token"`, true, nil
+}
+
 type authorizationRejectingOrigin struct{}
 
 func (authorizationRejectingOrigin) Pull(_ context.Context, ref ifaces.OriginRef) (io.ReadCloser, int64, error) {
@@ -196,6 +235,130 @@ func TestMirror_CapturesInboundAuthorizationForOrigin(t *testing.T) {
 
 	if got := <-origin.seen; got != "Bearer requester-token" {
 		t.Fatalf("origin authorization = %q, want requester token", got)
+	}
+}
+
+func TestMirror_ExplicitNonDelegatedModesSuppressRequesterAuthorization(t *testing.T) {
+	for _, mode := range []string{config.UpstreamAuthAnonymous, config.UpstreamAuthShared} {
+		t.Run(mode, func(t *testing.T) {
+			body := []byte("origin bytes")
+			d := digestOf(body)
+			origin := &modeCapturingOrigin{authorizationCapturingOrigin: authorizationCapturingOrigin{
+				body: body,
+				seen: make(chan string, 1),
+			}}
+			cfg := &config.Config{UpstreamRegistries: []config.UpstreamRegistry{{
+				Name: "reg.example.com", Endpoint: "https://reg.example.com", AuthMode: mode,
+			}}}
+
+			server := httptest.NewServer(mirror.New(cfg, fakes.NewCache(), origin).Handler())
+			defer server.Close()
+
+			request, err := http.NewRequest(http.MethodGet, server.URL+"/v2/repo/blobs/"+d.String(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			request.Header.Set("Authorization", "Bearer requester-token")
+
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", response.StatusCode)
+			}
+
+			if got := <-origin.seen; got != "" {
+				t.Fatalf("origin authorization = %q, want empty", got)
+			}
+
+			if got := origin.challengeCalls.Load(); got != 0 {
+				t.Fatalf("authentication challenge calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestMirror_SharedAuthIgnoresMalformedRequesterAuthorization(t *testing.T) {
+	body := []byte("origin bytes")
+	d := digestOf(body)
+	origin := &authorizationCapturingOrigin{body: body, seen: make(chan string, 1)}
+	cfg := &config.Config{UpstreamRegistries: []config.UpstreamRegistry{{
+		Name: "reg.example.com", Endpoint: "https://reg.example.com", AuthMode: config.UpstreamAuthShared,
+	}}}
+
+	server := httptest.NewServer(mirror.New(cfg, fakes.NewCache(), origin).Handler())
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/v2/repo/blobs/"+d.String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request.Header.Set("Authorization", "Bearer two tokens")
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.StatusCode)
+	}
+
+	if got := <-origin.seen; got != "" {
+		t.Fatalf("origin authorization = %q, want empty", got)
+	}
+}
+
+func TestMirror_SharedAuthProxiesTagManifest(t *testing.T) {
+	body := []byte(`{"schemaVersion":2}`)
+	origin := &tagFetchingOrigin{authorizationCapturingOrigin: authorizationCapturingOrigin{body: body, seen: make(chan string, 1)}}
+	config := &config.Config{UpstreamRegistries: []config.UpstreamRegistry{{
+		Name: "reg.example.com", Endpoint: "https://reg.example.com", AuthMode: config.UpstreamAuthShared,
+	}}}
+
+	server := httptest.NewServer(mirror.New(config, fakes.NewCache(), origin).Handler())
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/v2/repo/manifests/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := io.ReadAll(response.Body)
+	response.Body.Close()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if response.StatusCode != http.StatusOK || !bytes.Equal(got, body) {
+		t.Fatalf("GET status/body = %d/%q", response.StatusCode, got)
+	}
+
+	if response.Header.Get("Docker-Content-Digest") == "" {
+		t.Fatal("GET Docker-Content-Digest header missing")
+	}
+
+	request, err := http.NewRequest(http.MethodHead, server.URL+"/v2/repo/manifests/v1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response, err = http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response.Body.Close()
+
+	if response.StatusCode != http.StatusOK || len(origin.methods) != 2 || origin.methods[0] != http.MethodGet || origin.methods[1] != http.MethodHead {
+		t.Fatalf("HEAD status/methods = %d/%v", response.StatusCode, origin.methods)
 	}
 }
 

--- a/internal/gantry/noderoute/config.go
+++ b/internal/gantry/noderoute/config.go
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package noderoute safely reconciles standalone Gantry containerd registry routes.
+package noderoute
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const managedMarker = "# Managed by gantryctl."
+
+// Config is the desired set of registry-specific containerd routes on a node.
+type Config struct {
+	Registries []Registry `json:"registries"`
+}
+
+// Registry maps one OCI registry host to its canonical origin server.
+type Registry struct {
+	Host               string `json:"host"`
+	Server             string `json:"server"`
+	ReplaceExisting    bool   `json:"replaceExisting,omitempty"`
+	ManageReplacements bool   `json:"manageReplacements,omitempty"`
+}
+
+// LoadConfig reads and validates a desired node-route configuration.
+func LoadConfig(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("read desired registry routes: %w", err)
+	}
+
+	var config Config
+
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(&config); err != nil {
+		return Config{}, fmt.Errorf("decode desired registry routes: %w", err)
+	}
+
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return Config{}, errors.New("decode desired registry routes: multiple JSON values")
+		}
+
+		return Config{}, fmt.Errorf("decode desired registry routes trailing data: %w", err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return Config{}, err
+	}
+
+	sort.Slice(config.Registries, func(i, j int) bool {
+		return config.Registries[i].Host < config.Registries[j].Host
+	})
+
+	return config, nil
+}
+
+// Validate checks that every route is path-safe, canonical, and unambiguous.
+func (c Config) Validate() error {
+	var errs []error
+
+	seen := make(map[string]struct{}, len(c.Registries))
+
+	for index, registry := range c.Registries {
+		host, err := NormalizeRegistryHost(registry.Host)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("registries[%d].host: %w", index, err))
+		} else if host != registry.Host {
+			errs = append(errs, fmt.Errorf("registries[%d].host %q is not canonical; use %q", index, registry.Host, host))
+		} else if _, ok := seen[host]; ok {
+			errs = append(errs, fmt.Errorf("registries[%d].host %q is duplicated", index, host))
+		} else {
+			seen[host] = struct{}{}
+		}
+
+		if err := validateServer(registry.Server); err != nil {
+			errs = append(errs, fmt.Errorf("registries[%d].server: %w", index, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// NormalizeRegistryHost returns the canonical host[:port] used by OCI image
+// references and containerd's certs.d directory layout.
+func NormalizeRegistryHost(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("required")
+	}
+
+	if raw == "." || raw == ".." || strings.Contains(raw, "://") || strings.ContainsAny(raw, `/\?#@`) {
+		return "", fmt.Errorf("%q must be a registry host with no scheme or path", raw)
+	}
+
+	parsed, err := url.Parse("https://" + raw)
+	if err != nil || parsed.Host == "" || parsed.Hostname() == "" {
+		return "", fmt.Errorf("invalid registry host %q", raw)
+	}
+
+	if parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.User != nil {
+		return "", fmt.Errorf("%q must be a registry host with no path, query, or credentials", raw)
+	}
+
+	return strings.ToLower(parsed.Host), nil
+}
+
+func validateServer(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse %q: %w", raw, err)
+	}
+
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("%q must use http or https", raw)
+	}
+
+	if parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("%q must contain a host and no credentials, query, or fragment", raw)
+	}
+
+	return nil
+}
+
+func renderHosts(registry Registry) []byte {
+	return []byte(strings.Join([]string{
+		managedMarker,
+		"# Registry: " + registry.Host,
+		"server = " + strconv.Quote(strings.TrimRight(registry.Server, "/")),
+		"",
+		`[host."http://127.0.0.1:5000"]`,
+		`  capabilities = ["pull", "resolve"]`,
+		`  dial_timeout = "200ms"`,
+		"",
+	}, "\n"))
+}

--- a/internal/gantry/noderoute/reconciler.go
+++ b/internal/gantry/noderoute/reconciler.go
@@ -1,0 +1,664 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package noderoute
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const stateVersion = 2
+
+// Options identifies the host files managed by the standalone node reconciler.
+type Options struct {
+	DesiredPath             string
+	HostCertsDir            string
+	HostContainerdConfig    string
+	HostStateDir            string
+	ExpectedContainerdCerts string
+}
+
+// DefaultOptions returns paths matching a standard AKS containerd node and the
+// standalone DaemonSet mounts.
+func DefaultOptions() Options {
+	return Options{
+		DesiredPath:             "/etc/gantry-node-config/registries.json",
+		HostCertsDir:            "/host-certs",
+		HostContainerdConfig:    "/host-containerd-config/config.toml",
+		HostStateDir:            "/host-state",
+		ExpectedContainerdCerts: "/etc/containerd/certs.d",
+	}
+}
+
+type routeState struct {
+	Version              int    `json:"version"`
+	Host                 string `json:"host"`
+	OriginalPresent      bool   `json:"originalPresent"`
+	OriginalMode         uint32 `json:"originalMode,omitempty"`
+	OriginalSHA256       string `json:"originalSHA256,omitempty"`
+	OriginalBackup       string `json:"originalBackup,omitempty"`
+	ManagedSHA256        string `json:"managedSHA256"`
+	PendingManagedSHA256 string `json:"pendingManagedSHA256,omitempty"`
+	Applied              bool   `json:"applied"`
+}
+
+// Reconcile converges all desired registry routes and restores routes removed
+// from the desired set.
+func Reconcile(ctx context.Context, options Options, desired Config) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := validateOptions(options); err != nil {
+		return err
+	}
+
+	if err := desired.Validate(); err != nil {
+		return err
+	}
+
+	if len(desired.Registries) > 0 {
+		if err := verifyContainerdConfig(options); err != nil {
+			return err
+		}
+
+		if err := rejectCompetingDefaultRoute(options, desired); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(options.HostStateDir, 0o700); err != nil {
+		return fmt.Errorf("create route state directory: %w", err)
+	}
+
+	states, err := loadStates(options.HostStateDir)
+	if err != nil {
+		return err
+	}
+
+	desiredHosts := make(map[string]struct{}, len(desired.Registries))
+	for _, registry := range desired.Registries {
+		desiredHosts[registry.Host] = struct{}{}
+		if err := ensureTargetDirectory(options, registry.Host); err != nil {
+			return fmt.Errorf("validate registry directory %s: %w", registry.Host, err)
+		}
+
+		if err := ensureRoute(options, registry); err != nil {
+			return fmt.Errorf("configure registry %s: %w", registry.Host, err)
+		}
+	}
+
+	for _, state := range states {
+		if _, ok := desiredHosts[state.Host]; ok {
+			continue
+		}
+
+		if err := restoreRoute(options, state); err != nil {
+			return fmt.Errorf("restore registry %s: %w", state.Host, err)
+		}
+	}
+
+	return nil
+}
+
+// Check verifies that host state exactly matches the desired configuration.
+func Check(options Options, desired Config) error {
+	if err := validateOptions(options); err != nil {
+		return err
+	}
+
+	if err := desired.Validate(); err != nil {
+		return err
+	}
+
+	if len(desired.Registries) > 0 {
+		if err := verifyContainerdConfig(options); err != nil {
+			return err
+		}
+
+		if err := rejectCompetingDefaultRoute(options, desired); err != nil {
+			return err
+		}
+	}
+
+	states, err := loadStates(options.HostStateDir)
+	if err != nil {
+		return err
+	}
+
+	statesByHost := make(map[string]routeState, len(states))
+	for _, state := range states {
+		statesByHost[state.Host] = state
+	}
+
+	desiredHosts := make(map[string]struct{}, len(desired.Registries))
+	for _, registry := range desired.Registries {
+		desiredHosts[registry.Host] = struct{}{}
+
+		state, ok := statesByHost[registry.Host]
+		if !ok {
+			return fmt.Errorf("registry route %s has no ownership state", registry.Host)
+		}
+
+		managedSHA := checksum(renderHosts(registry))
+		if !state.Applied || state.PendingManagedSHA256 != "" || state.ManagedSHA256 != managedSHA {
+			return fmt.Errorf("registry route %s ownership state has not converged", registry.Host)
+		}
+
+		if err := ensureTargetDirectory(options, registry.Host); err != nil {
+			return fmt.Errorf("validate registry directory %s: %w", registry.Host, err)
+		}
+
+		actual, mode, err := readRegularFile(targetPath(options, registry.Host))
+		if err != nil {
+			return fmt.Errorf("read registry route %s: %w", registry.Host, err)
+		}
+
+		if !bytes.Equal(actual, renderHosts(registry)) {
+			return fmt.Errorf("registry route %s has not converged", registry.Host)
+		}
+
+		if mode.Perm() != 0o644 {
+			return fmt.Errorf("registry route %s mode is %o, want 644", registry.Host, mode.Perm())
+		}
+	}
+
+	for _, state := range states {
+		if _, ok := desiredHosts[state.Host]; !ok {
+			return fmt.Errorf("removed registry route %s has not been restored", state.Host)
+		}
+	}
+
+	return nil
+}
+
+func validateOptions(options Options) error {
+	if options.HostCertsDir == "" || options.HostContainerdConfig == "" || options.HostStateDir == "" || options.ExpectedContainerdCerts == "" {
+		return errors.New("node-route paths must not be empty")
+	}
+
+	return nil
+}
+
+func verifyContainerdConfig(options Options) error {
+	data, err := os.ReadFile(options.HostContainerdConfig)
+	if err != nil {
+		return fmt.Errorf("read host containerd config: %w", err)
+	}
+
+	if !containerdUsesCertsDir(data, options.ExpectedContainerdCerts) {
+		return fmt.Errorf("containerd config does not set registry config_path to %q", options.ExpectedContainerdCerts)
+	}
+
+	return nil
+}
+
+func containerdUsesCertsDir(data []byte, expected string) bool {
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(strings.SplitN(rawLine, "#", 2)[0])
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "config_path" {
+			continue
+		}
+
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 && ((value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'')) {
+			value = value[1 : len(value)-1]
+		}
+
+		if value == expected {
+			return true
+		}
+	}
+
+	return false
+}
+
+func rejectCompetingDefaultRoute(options Options, desired Config) error {
+	if len(desired.Registries) == 0 {
+		return nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(options.HostCertsDir, "_default", "hosts.toml"))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("read containerd default registry route: %w", err)
+	}
+
+	if bytes.Contains(data, []byte("127.0.0.1:5000")) {
+		return errors.New("containerd _default/hosts.toml already routes to 127.0.0.1:5000; refusing to overlap another Gantry installation")
+	}
+
+	return nil
+}
+
+func ensureRoute(options Options, registry Registry) error {
+	managed := renderHosts(registry)
+	managedSHA := checksum(managed)
+	statePath := stateFile(options.HostStateDir, registry.Host)
+	state, stateErr := readState(statePath)
+
+	target := targetPath(options, registry.Host)
+	current, currentMode, currentErr := readRegularFile(target)
+
+	currentMissing := errors.Is(currentErr, fs.ErrNotExist)
+	if currentErr != nil && !currentMissing {
+		return currentErr
+	}
+
+	if errors.Is(stateErr, fs.ErrNotExist) {
+		managedWithoutState := !currentMissing && bytes.Equal(current, managed)
+		if !currentMissing && !managedWithoutState && !registry.ReplaceExisting && !registry.ManageReplacements {
+			return fmt.Errorf("unmanaged %s exists; rerun with replacement explicitly enabled", target)
+		}
+
+		state = routeState{
+			Version:         stateVersion,
+			Host:            registry.Host,
+			OriginalPresent: !currentMissing && !managedWithoutState,
+			ManagedSHA256:   managedSHA,
+		}
+		if state.OriginalPresent {
+			state.OriginalMode = uint32(currentMode.Perm())
+
+			state.OriginalSHA256 = checksum(current)
+			if err := writeFileAtomic(originalFile(options.HostStateDir, registry.Host), current, 0o600); err != nil {
+				return fmt.Errorf("back up existing route: %w", err)
+			}
+		}
+
+		if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+			return fmt.Errorf("record route ownership: %w", err)
+		}
+	} else if stateErr != nil {
+		return stateErr
+	} else {
+		if state.Version != stateVersion || state.Host != registry.Host {
+			return fmt.Errorf("invalid ownership state in %s", statePath)
+		}
+
+		originalModeChanged := !currentMissing && state.OriginalPresent && checksum(current) == state.OriginalSHA256 && uint32(currentMode.Perm()) != state.OriginalMode
+		if !currentMatchesState(current, currentMissing, state) || (registry.ManageReplacements && originalModeChanged) {
+			if !registry.ManageReplacements {
+				return fmt.Errorf("refusing to overwrite concurrently changed %s", target)
+			}
+
+			adoptedState, err := adoptReplacementBaseline(options, statePath, state, current, currentMode)
+			if err != nil {
+				return fmt.Errorf("adopt replacement %s: %w", target, err)
+			}
+
+			state = adoptedState
+
+			slog.Warn("adopted replacement containerd hosts file as new uninstall baseline",
+				"registry", registry.Host,
+				"path", target,
+			)
+		}
+	}
+
+	if !currentMissing && bytes.Equal(current, managed) && currentMode.Perm() == 0o644 && state.PendingManagedSHA256 == "" && state.ManagedSHA256 == managedSHA {
+		if !state.Applied {
+			state.Applied = true
+			if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+				return fmt.Errorf("complete route ownership update: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	state.PendingManagedSHA256 = managedSHA
+	if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+		return fmt.Errorf("record pending route update: %w", err)
+	}
+
+	if err := writeFileAtomic(target, managed, 0o644); err != nil {
+		return fmt.Errorf("write managed route: %w", err)
+	}
+
+	state.ManagedSHA256 = managedSHA
+	state.PendingManagedSHA256 = ""
+
+	state.Applied = true
+	if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+		return fmt.Errorf("complete route ownership update: %w", err)
+	}
+
+	return nil
+}
+
+func currentMatchesState(current []byte, missing bool, state routeState) bool {
+	if missing {
+		return true
+	}
+
+	currentSHA := checksum(current)
+
+	return currentSHA == state.ManagedSHA256 ||
+		(state.PendingManagedSHA256 != "" && currentSHA == state.PendingManagedSHA256) ||
+		(state.OriginalPresent && currentSHA == state.OriginalSHA256)
+}
+
+func adoptReplacementBaseline(options Options, statePath string, state routeState, current []byte, mode fs.FileMode) (routeState, error) {
+	state.OriginalPresent = true
+	state.OriginalMode = uint32(mode.Perm())
+	state.OriginalSHA256 = checksum(current)
+	state.OriginalBackup = "original-hosts-" + state.OriginalSHA256 + ".toml"
+
+	backupPath, err := backupFile(options.HostStateDir, state)
+	if err != nil {
+		return routeState{}, err
+	}
+
+	if err := writeFileAtomic(backupPath, current, 0o600); err != nil {
+		return routeState{}, fmt.Errorf("write replacement backup: %w", err)
+	}
+
+	if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+		return routeState{}, fmt.Errorf("record replacement baseline: %w", err)
+	}
+
+	return state, nil
+}
+
+func restoreRoute(options Options, state routeState) error {
+	if err := ensureTargetDirectory(options, state.Host); err != nil {
+		return err
+	}
+
+	target := targetPath(options, state.Host)
+	current, _, err := readRegularFile(target)
+
+	missing := errors.Is(err, fs.ErrNotExist)
+	if err != nil && !missing {
+		return err
+	}
+
+	if !currentMatchesState(current, missing, state) {
+		return fmt.Errorf("refusing to replace concurrently changed %s", target)
+	}
+
+	if state.OriginalPresent {
+		backupPath, pathErr := backupFile(options.HostStateDir, state)
+		if pathErr != nil {
+			return pathErr
+		}
+
+		original, readErr := os.ReadFile(backupPath)
+		if readErr != nil {
+			return fmt.Errorf("read route backup: %w", readErr)
+		}
+
+		if checksum(original) != state.OriginalSHA256 {
+			return errors.New("route backup checksum mismatch")
+		}
+
+		if missing || !bytes.Equal(current, original) {
+			if err := writeFileAtomic(target, original, fs.FileMode(state.OriginalMode)); err != nil {
+				return fmt.Errorf("restore route backup: %w", err)
+			}
+		}
+	} else if !missing {
+		if err := os.Remove(target); err != nil {
+			return fmt.Errorf("remove managed route: %w", err)
+		}
+	}
+
+	if err := os.RemoveAll(stateDirectory(options.HostStateDir, state.Host)); err != nil {
+		return fmt.Errorf("remove route state: %w", err)
+	}
+
+	if !state.OriginalPresent {
+		_ = os.Remove(filepath.Dir(target)) //nolint:errcheck // directory cleanup is best effort when other containerd files remain
+	}
+
+	return nil
+}
+
+func loadStates(root string) ([]routeState, error) {
+	entries, err := os.ReadDir(root)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("read route state directory: %w", err)
+	}
+
+	states := make([]routeState, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		statePath := filepath.Join(root, entry.Name(), "state.json")
+
+		state, err := readState(statePath)
+		if errors.Is(err, fs.ErrNotExist) {
+			if !validHex(entry.Name(), 16) {
+				return nil, fmt.Errorf("unexpected directory in route state: %s", entry.Name())
+			}
+
+			if err := os.RemoveAll(filepath.Join(root, entry.Name())); err != nil {
+				return nil, fmt.Errorf("remove uncommitted route state %s: %w", entry.Name(), err)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if state.Version != stateVersion || !validChecksum(state.ManagedSHA256) ||
+			(state.PendingManagedSHA256 != "" && !validChecksum(state.PendingManagedSHA256)) ||
+			(state.OriginalPresent && !validChecksum(state.OriginalSHA256)) {
+			return nil, fmt.Errorf("route state directory %s has invalid ownership metadata", entry.Name())
+		}
+
+		if state.OriginalPresent {
+			backupPath, err := backupFile(root, state)
+			if err != nil {
+				return nil, fmt.Errorf("resolve route backup for state %s: %w", entry.Name(), err)
+			}
+
+			original, err := os.ReadFile(backupPath)
+			if err != nil {
+				return nil, fmt.Errorf("read route backup for state %s: %w", entry.Name(), err)
+			}
+
+			if checksum(original) != state.OriginalSHA256 {
+				return nil, fmt.Errorf("route backup checksum mismatch for state %s", entry.Name())
+			}
+		}
+
+		normalizedHost, err := NormalizeRegistryHost(state.Host)
+		if err != nil || normalizedHost != state.Host {
+			return nil, fmt.Errorf("route state directory %s has invalid host %q", entry.Name(), state.Host)
+		}
+
+		if routeKey(state.Host) != entry.Name() {
+			return nil, fmt.Errorf("route state directory %s does not match host %s", entry.Name(), state.Host)
+		}
+
+		states = append(states, state)
+	}
+
+	return states, nil
+}
+
+func readState(path string) (routeState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return routeState{}, err
+	}
+
+	var state routeState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return routeState{}, fmt.Errorf("decode route state %s: %w", path, err)
+	}
+
+	return state, nil
+}
+
+func readRegularFile(path string) ([]byte, fs.FileMode, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if !info.Mode().IsRegular() {
+		return nil, 0, fmt.Errorf("%s is not a regular file", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return data, info.Mode(), nil
+}
+
+func ensureTargetDirectory(options Options, host string) error {
+	directory := filepath.Join(options.HostCertsDir, host)
+
+	info, err := os.Lstat(directory)
+	if errors.Is(err, fs.ErrNotExist) {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			return err
+		}
+
+		info, err = os.Lstat(directory)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", directory)
+	}
+
+	return nil
+}
+
+func writeJSONAtomic(path string, value any, mode fs.FileMode) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	data = append(data, '\n')
+
+	return writeFileAtomic(path, data, mode)
+}
+
+func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return err
+	}
+
+	temp, err := os.CreateTemp(directory, ".gantryctl-*")
+	if err != nil {
+		return err
+	}
+
+	tempPath := temp.Name()
+
+	defer func() { _ = os.Remove(tempPath) }() //nolint:errcheck // temporary cleanup is best effort after rename or failure
+
+	if err := temp.Chmod(mode); err != nil {
+		_ = temp.Close() //nolint:errcheck // preserve the original chmod error
+		return err
+	}
+
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close() //nolint:errcheck // preserve the original write error
+		return err
+	}
+
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close() //nolint:errcheck // preserve the original sync error
+		return err
+	}
+
+	if err := temp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tempPath, path)
+}
+
+func targetPath(options Options, host string) string {
+	return filepath.Join(options.HostCertsDir, host, "hosts.toml")
+}
+
+func stateDirectory(root, host string) string {
+	return filepath.Join(root, routeKey(host))
+}
+
+func stateFile(root, host string) string {
+	return filepath.Join(stateDirectory(root, host), "state.json")
+}
+
+func originalFile(root, host string) string {
+	return filepath.Join(stateDirectory(root, host), "original-hosts.toml")
+}
+
+func backupFile(root string, state routeState) (string, error) {
+	name := state.OriginalBackup
+	if name == "" {
+		return originalFile(root, state.Host), nil
+	}
+
+	if filepath.Base(name) != name || name == "." || name == ".." {
+		return "", fmt.Errorf("invalid route backup name %q", name)
+	}
+
+	if name != "original-hosts-"+state.OriginalSHA256+".toml" {
+		return "", fmt.Errorf("route backup name %q does not match its checksum", name)
+	}
+
+	return filepath.Join(stateDirectory(root, state.Host), name), nil
+}
+
+func routeKey(host string) string {
+	digest := sha256.Sum256([]byte(host))
+	return hex.EncodeToString(digest[:16])
+}
+
+func checksum(data []byte) string {
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func validChecksum(value string) bool {
+	return validHex(value, sha256.Size)
+}
+
+func validHex(value string, byteCount int) bool {
+	if len(value) != byteCount*2 {
+		return false
+	}
+
+	_, err := hex.DecodeString(value)
+
+	return err == nil
+}

--- a/internal/gantry/noderoute/reconciler_test.go
+++ b/internal/gantry/noderoute/reconciler_test.go
@@ -1,0 +1,613 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package noderoute
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testOptions(t *testing.T) Options {
+	t.Helper()
+	root := t.TempDir()
+
+	options := Options{
+		HostCertsDir:            filepath.Join(root, "certs.d"),
+		HostContainerdConfig:    filepath.Join(root, "config.toml"),
+		HostStateDir:            filepath.Join(root, "state"),
+		ExpectedContainerdCerts: "/etc/containerd/certs.d",
+	}
+	if err := os.WriteFile(options.HostContainerdConfig, []byte(`[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/certs.d"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return options
+}
+
+func TestReconcileInstallsAndRemovesNewRoute(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "example.azurecr.io", Server: "https://example.azurecr.io"}
+
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("install route: %v", err)
+	}
+
+	if err := Check(options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("check installed route: %v", err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{}); err != nil {
+		t.Fatalf("remove route: %v", err)
+	}
+
+	if _, err := os.Stat(targetPath(options, registry.Host)); !os.IsNotExist(err) {
+		t.Fatalf("route still exists after removal: %v", err)
+	}
+}
+
+func TestReconcileRefusesExistingRouteWithoutReplacement(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com"}
+
+	target := targetPath(options, registry.Host)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, []byte("original\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}})
+	if err == nil || !strings.Contains(err.Error(), "replacement explicitly enabled") {
+		t.Fatalf("want existing-route refusal, got %v", err)
+	}
+}
+
+func TestReconcileReplacesAndRestoresExistingRoute(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{
+		Host:            "registry.example.com",
+		Server:          "https://registry.example.com",
+		ReplaceExisting: true,
+	}
+	target := targetPath(options, registry.Host)
+	original := []byte("server = \"https://old.example.com\"\n")
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, original, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("replace route: %v", err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{}); err != nil {
+		t.Fatalf("restore route: %v", err)
+	}
+
+	restored, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(restored) != string(original) {
+		t.Fatalf("restored content = %q, want %q", restored, original)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("restored mode = %o, want 640", info.Mode().Perm())
+	}
+}
+
+func TestReconcileRefusesConcurrentManagedRouteChange(t *testing.T) {
+	options := testOptions(t)
+
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com"}
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(targetPath(options, registry.Host), []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Reconcile(context.Background(), options, Config{Registries: []Registry{registry}})
+	if err == nil || !strings.Contains(err.Error(), "concurrently changed") {
+		t.Fatalf("want concurrent-change refusal, got %v", err)
+	}
+}
+
+func TestReconcileReinstallsRouteAfterOriginalIsRestored(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com", ReplaceExisting: true}
+	target := targetPath(options, registry.Host)
+	original := []byte("server = \"https://old.example.com\"\n")
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("reinstall route: %v", err)
+	}
+
+	if err := Check(options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("check reinstalled route: %v", err)
+	}
+}
+
+func TestReconcileReinstallsRouteAfterManagedFileIsRemoved(t *testing.T) {
+	options := testOptions(t)
+
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com"}
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(targetPath(options, registry.Host)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("reinstall missing route: %v", err)
+	}
+
+	if err := Check(options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("check reinstalled route: %v", err)
+	}
+}
+
+func TestReconcileRepairsManagedModeAndCheckRejectsSymlink(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com"}
+
+	desired := Config{Registries: []Registry{registry}}
+	if err := Reconcile(t.Context(), options, desired); err != nil {
+		t.Fatal(err)
+	}
+
+	target := targetPath(options, registry.Host)
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Check(options, desired); err == nil || !strings.Contains(err.Error(), "mode is 600") {
+		t.Fatalf("want mode readiness failure, got %v", err)
+	}
+
+	if err := Reconcile(t.Context(), options, desired); err != nil {
+		t.Fatalf("repair mode: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("repaired mode = %o, want 644", info.Mode().Perm())
+	}
+
+	contents, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "hosts.toml")
+	if err := os.WriteFile(outside, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Symlink(outside, target); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Check(options, desired); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("want symlink readiness failure, got %v", err)
+	}
+}
+
+func TestCheckRejectsMissingOrPendingOwnershipState(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com"}
+
+	desired := Config{Registries: []Registry{registry}}
+	if err := Reconcile(t.Context(), options, desired); err != nil {
+		t.Fatal(err)
+	}
+
+	statePath := stateFile(options.HostStateDir, registry.Host)
+
+	state, err := readState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(statePath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Check(options, desired); err == nil || !strings.Contains(err.Error(), "no ownership state") {
+		t.Fatalf("want missing-state readiness failure, got %v", err)
+	}
+
+	state.PendingManagedSHA256 = state.ManagedSHA256
+	if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Check(options, desired); err == nil || !strings.Contains(err.Error(), "has not converged") {
+		t.Fatalf("want pending-state readiness failure, got %v", err)
+	}
+}
+
+func TestReconcileReconstructsStateWithoutBackingUpManagedFile(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com"}
+
+	desired := Config{Registries: []Registry{registry}}
+	if err := Reconcile(t.Context(), options, desired); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.RemoveAll(options.HostStateDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, desired); err != nil {
+		t.Fatalf("reconstruct ownership state: %v", err)
+	}
+
+	state, err := readState(stateFile(options.HostStateDir, registry.Host))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if state.OriginalPresent {
+		t.Fatal("managed file was recorded as the original baseline")
+	}
+
+	if err := Reconcile(t.Context(), options, Config{}); err != nil {
+		t.Fatalf("remove reconstructed route: %v", err)
+	}
+
+	if _, err := os.Stat(targetPath(options, registry.Host)); !os.IsNotExist(err) {
+		t.Fatalf("managed route still exists after removal: %v", err)
+	}
+}
+
+func TestReconcileAdoptsOSReplacementAsNewBaseline(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{
+		Host:            "registry.example.com",
+		Server:          "https://registry.example.com",
+		ReplaceExisting: true,
+	}
+
+	target := targetPath(options, registry.Host)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, []byte("old os hosts\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatal(err)
+	}
+
+	newOSHosts := []byte("new os hosts\n")
+	if err := os.WriteFile(target, newOSHosts, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	registry.ManageReplacements = true
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("adopt OS replacement: %v", err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{}); err != nil {
+		t.Fatalf("restore adopted OS replacement: %v", err)
+	}
+
+	restored, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(restored, newOSHosts) {
+		t.Fatalf("restored content = %q, want %q", restored, newOSHosts)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("restored mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestReconcileAdoptsOSReplacementModeChange(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com", ReplaceExisting: true}
+	target := targetPath(options, registry.Host)
+	original := []byte("os hosts\n")
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, original, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	registry.ManageReplacements = true
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatalf("adopt replacement mode: %v", err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{}); err != nil {
+		t.Fatalf("restore replacement mode: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("restored mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestReconcileReinstallsRouteAfterFullHostStateReset(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com"}
+
+	desired := Config{Registries: []Registry{registry}}
+	if err := Reconcile(t.Context(), options, desired); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.RemoveAll(options.HostCertsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.RemoveAll(options.HostStateDir); err != nil {
+		t.Fatal(err)
+	}
+
+	newOSHosts := []byte("new image hosts\n")
+
+	target := targetPath(options, registry.Host)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, newOSHosts, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	desired.Registries[0].ManageReplacements = true
+
+	if err := Reconcile(t.Context(), options, desired); err != nil {
+		t.Fatalf("reinstall after host reset: %v", err)
+	}
+
+	if err := Check(options, desired); err != nil {
+		t.Fatalf("check reinstalled route: %v", err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{}); err != nil {
+		t.Fatalf("restore new image baseline: %v", err)
+	}
+
+	restored, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(restored, newOSHosts) {
+		t.Fatalf("restored content = %q, want %q", restored, newOSHosts)
+	}
+}
+
+func TestReconcileRejectsSymlinkedRegistryDirectory(t *testing.T) {
+	options := testOptions(t)
+
+	outside := t.TempDir()
+	if err := os.MkdirAll(options.HostCertsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Symlink(outside, filepath.Join(options.HostCertsDir, "registry.example.com")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Reconcile(t.Context(), options, Config{Registries: []Registry{{Host: "registry.example.com", Server: "https://registry.example.com"}}})
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("want symlink refusal, got %v", err)
+	}
+}
+
+func TestReconcileRejectsCompetingDefaultGantryRoute(t *testing.T) {
+	options := testOptions(t)
+
+	path := filepath.Join(options.HostCertsDir, "_default", "hosts.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(path, []byte(`[host."http://127.0.0.1:5000"]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Reconcile(t.Context(), options, Config{Registries: []Registry{{Host: "registry.example.com", Server: "https://registry.example.com"}}})
+	if err == nil || !strings.Contains(err.Error(), "another Gantry installation") {
+		t.Fatalf("want competing-install refusal, got %v", err)
+	}
+}
+
+func TestEmptyDesiredStateRestoresWithoutInstallPreflight(t *testing.T) {
+	options := testOptions(t)
+
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com"}
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(options.HostContainerdConfig, []byte("version = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{}); err != nil {
+		t.Fatalf("restore with failed install preflight: %v", err)
+	}
+
+	if err := Check(options, Config{}); err != nil {
+		t.Fatalf("check restored empty state: %v", err)
+	}
+}
+
+func TestReconcileRemovesUncommittedStateDirectory(t *testing.T) {
+	options := testOptions(t)
+
+	orphan := filepath.Join(options.HostStateDir, strings.Repeat("a", 32))
+	if err := os.MkdirAll(orphan, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(orphan, "original-hosts.toml"), []byte("backup"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan state still exists: %v", err)
+	}
+}
+
+func TestReconcileRejectsInvalidCommittedState(t *testing.T) {
+	options := testOptions(t)
+	host := "registry.example.com"
+
+	directory := stateDirectory(options.HostStateDir, host)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	state := routeState{Version: stateVersion + 1, Host: host, ManagedSHA256: strings.Repeat("a", 64)}
+	if err := writeJSONAtomic(filepath.Join(directory, "state.json"), state, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Reconcile(t.Context(), options, Config{})
+	if err == nil || !strings.Contains(err.Error(), "invalid ownership metadata") {
+		t.Fatalf("want invalid state refusal, got %v", err)
+	}
+}
+
+func TestReconcileRejectsMissingOriginalBackupBeforeMutation(t *testing.T) {
+	options := testOptions(t)
+	registry := Registry{Host: "registry.example.com", Server: "https://registry.example.com", ReplaceExisting: true}
+
+	target := targetPath(options, registry.Host)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(originalFile(options.HostStateDir, registry.Host)); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Reconcile(t.Context(), options, Config{Registries: []Registry{registry}})
+	if err == nil || !strings.Contains(err.Error(), "read route backup") {
+		t.Fatalf("want missing backup refusal, got %v", err)
+	}
+}
+
+func TestNormalizeRegistryHost(t *testing.T) {
+	if got, err := NormalizeRegistryHost("MyACR.azurecr.io:443"); err != nil || got != "myacr.azurecr.io:443" {
+		t.Fatalf("NormalizeRegistryHost = %q, %v", got, err)
+	}
+
+	for _, invalid := range []string{"", ".", "..", "https://registry.example.com", "registry.example.com/repo", `registry.example.com\repo`, "user@registry.example.com"} {
+		if _, err := NormalizeRegistryHost(invalid); err == nil {
+			t.Errorf("NormalizeRegistryHost(%q) unexpectedly succeeded", invalid)
+		}
+	}
+}
+
+func TestContainerdUsesCertsDir(t *testing.T) {
+	data := []byte("config_path = '/etc/containerd/certs.d' # managed\n")
+	if !containerdUsesCertsDir(data, "/etc/containerd/certs.d") {
+		t.Fatal("expected config_path match")
+	}
+
+	if containerdUsesCertsDir(data, "/different") {
+		t.Fatal("unexpected config_path match")
+	}
+}

--- a/internal/gantry/noderoute/run.go
+++ b/internal/gantry/noderoute/run.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package noderoute
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Run continuously reconciles the projected desired-registry file until the
+// context is cancelled. Configuration errors are fatal so Kubernetes surfaces
+// them through the standalone node-config DaemonSet rollout.
+func Run(ctx context.Context, options Options, interval time.Duration) error {
+	if interval <= 0 {
+		return fmt.Errorf("reconcile interval must be positive, got %s", interval)
+	}
+
+	reconcile := func() error {
+		desired, err := LoadConfig(options.DesiredPath)
+		if err != nil {
+			return err
+		}
+
+		return Reconcile(ctx, options, desired)
+	}
+
+	if err := reconcile(); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	return runReconcileLoop(ctx, ticker.C, reconcile, func(err error) {
+		slog.Error("standalone Gantry node-route reconcile failed; retrying",
+			"retry_after", interval,
+			"err", err,
+		)
+	})
+}
+
+func runReconcileLoop(ctx context.Context, ticks <-chan time.Time, reconcile func() error, onError func(error)) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticks:
+			if err := reconcile(); err != nil {
+				onError(err)
+			}
+		}
+	}
+}
+
+// CheckDesired loads the projected desired state and verifies host convergence.
+func CheckDesired(options Options) error {
+	desired, err := LoadConfig(options.DesiredPath)
+	if err != nil {
+		return err
+	}
+
+	return Check(options, desired)
+}

--- a/internal/gantry/noderoute/run_test.go
+++ b/internal/gantry/noderoute/run_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package noderoute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRunReconcileLoopRetriesAfterError(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	ticks := make(chan time.Time, 2)
+	ticks <- time.Now()
+
+	ticks <- time.Now()
+
+	attempts := 0
+	reported := 0
+
+	err := runReconcileLoop(ctx, ticks, func() error {
+		attempts++
+		if attempts == 1 {
+			return errors.New("transient host reset")
+		}
+
+		cancel()
+
+		return nil
+	}, func(error) {
+		reported++
+	})
+	if err != nil {
+		t.Fatalf("runReconcileLoop: %v", err)
+	}
+
+	if attempts != 2 || reported != 1 {
+		t.Fatalf("attempts/reported = %d/%d, want 2/1", attempts, reported)
+	}
+}

--- a/internal/gantry/oci/path.go
+++ b/internal/gantry/oci/path.go
@@ -38,6 +38,17 @@ var repositoryNameRe = func() *regexp.Regexp {
 	return regexp.MustCompile(`^` + component + `(?:/` + component + `)*$`)
 }()
 
+var tagRe = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`)
+
+// ValidateTag reports whether tag matches the OCI/Docker tag grammar.
+func ValidateTag(tag string) error {
+	if !tagRe.MatchString(tag) {
+		return fmt.Errorf("oci: invalid tag %q", tag)
+	}
+
+	return nil
+}
+
 // ValidateRepositoryName reports whether repo is a well-formed OCI
 // Distribution-spec repository name. It rejects empty values, empty path
 // components, names over MaxRepositoryNameLength, and any value outside

--- a/internal/gantry/oci/path_test.go
+++ b/internal/gantry/oci/path_test.go
@@ -132,6 +132,20 @@ func TestParseV2Path(t *testing.T) {
 	}
 }
 
+func TestValidateTag(t *testing.T) {
+	for _, tag := range []string{"latest", "v1.2.3", "_staging", "UPPER"} {
+		if err := oci.ValidateTag(tag); err != nil {
+			t.Errorf("ValidateTag(%q): %v", tag, err)
+		}
+	}
+
+	for _, tag := range []string{"", ".bad", "bad/tag", strings.Repeat("a", 129)} {
+		if err := oci.ValidateTag(tag); err == nil {
+			t.Errorf("ValidateTag(%q) unexpectedly succeeded", tag)
+		}
+	}
+}
+
 func TestValidateRepositoryName(t *testing.T) {
 	valid := []string{
 		"nginx",

--- a/internal/gantry/origin/origin.go
+++ b/internal/gantry/origin/origin.go
@@ -14,9 +14,9 @@
 // credentials, the client discovers the upstream /v2/ challenge for containerd.
 // An optional "username:password" file retains the legacy shared-identity flow.
 // - Failure classification: maps HTTP status and network errors to
-// ifaces.FailureClass for the design doc propagation. Tag-resolution requests are
-// not handled here (the mirror returns 503 on tag manifests so
-// containerd falls through to origin directly - the design doc / the design doc).
+// ifaces.FailureClass for the design doc propagation. Explicit shared-auth
+// registries resolve tag manifests here; delegated and anonymous modes keep
+// containerd's direct-origin tag fallthrough.
 //
 // Out of scope for (lands later):
 //
@@ -118,7 +118,11 @@ func WithByteMetrics(onBytesRead func(kind string, bytes int64)) Option {
 // New builds a Client from the operator config. Returns an error if any
 // upstream credentials file cannot be read.
 func New(cfg *config.Config, opts ...Option) (*Client, error) {
-	if cfg == nil || len(cfg.UpstreamRegistries) == 0 {
+	if cfg == nil {
+		return nil, errors.New("origin: config is nil")
+	}
+
+	if len(cfg.UpstreamRegistries) == 0 && !cfg.AllowNoUpstreamRegistries {
 		return nil, errors.New("origin: at least one upstream registry required")
 	}
 
@@ -304,6 +308,44 @@ func (c *Client) Head(ctx context.Context, ref ifaces.OriginRef) (int64, string,
 	}
 
 	return r.head(ctx, ref)
+}
+
+// FetchManifest fetches a tag-addressed manifest using this registry client's
+// configured identity. It is used only by the mirror's explicit shared-auth
+// mode; delegated and anonymous tag requests continue to fall through to
+// containerd's origin client.
+func (c *Client) FetchManifest(ctx context.Context, method, registryName, repository, reference string) (*http.Response, error) {
+	if method != http.MethodGet && method != http.MethodHead {
+		return nil, fmt.Errorf("origin: unsupported manifest method %q", method)
+	}
+
+	if err := oci.ValidateRepositoryName(repository); err != nil {
+		return nil, &ifaces.OriginError{Ref: ifaces.OriginRef{Registry: registryName, Repository: repository, Kind: ifaces.KindManifest}, Class: ifaces.FailureNotFound, Err: err}
+	}
+
+	if err := oci.ValidateTag(reference); err != nil {
+		return nil, &ifaces.OriginError{Ref: ifaces.OriginRef{Registry: registryName, Repository: repository, Kind: ifaces.KindManifest}, Class: ifaces.FailureNotFound, Err: err}
+	}
+
+	r, ok := c.registries[registryName]
+	if !ok {
+		return nil, &ifaces.OriginError{Ref: ifaces.OriginRef{Registry: registryName, Repository: repository, Kind: ifaces.KindManifest}, Class: ifaces.FailureNotFound, Err: fmt.Errorf("unknown registry %q", registryName)}
+	}
+
+	url := r.base.String() + "/v2/" + repository + "/manifests/" + reference
+
+	resp, err := r.do(ctx, method, url)
+	if err != nil {
+		return nil, &ifaces.OriginError{Ref: ifaces.OriginRef{Registry: registryName, Repository: repository, Kind: ifaces.KindManifest}, Class: classOf(err), Err: err}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		defer func() { _ = resp.Body.Close() }() //nolint:errcheck // best-effort close
+
+		return nil, r.classify(ifaces.OriginRef{Registry: registryName, Repository: repository, Kind: ifaces.KindManifest}, resp)
+	}
+
+	return resp, nil
 }
 
 // Compile-time check.

--- a/internal/gantry/origin/origin_test.go
+++ b/internal/gantry/origin/origin_test.go
@@ -4,6 +4,7 @@
 package origin
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -60,6 +61,21 @@ func newClient(t *testing.T, ur config.UpstreamRegistry) *Client {
 	}
 
 	return c
+}
+
+func TestNewEmptyRegistriesRequiresExplicitOptIn(t *testing.T) {
+	if _, err := New(&config.Config{}); err == nil {
+		t.Fatal("New accepted empty registries without opt-in")
+	}
+
+	c, err := New(&config.Config{AllowNoUpstreamRegistries: true})
+	if err != nil {
+		t.Fatalf("New with empty-registry opt-in: %v", err)
+	}
+
+	if len(c.registries) != 0 {
+		t.Fatalf("registries = %d, want 0", len(c.registries))
+	}
 }
 
 func TestPullBlob_Success(t *testing.T) {
@@ -978,6 +994,70 @@ func TestNewRejectsBadCredentialsFile(t *testing.T) {
 	}}
 	if _, err := New(cfg); err == nil {
 		t.Fatal("expected New() to reject malformed credentials")
+	}
+}
+
+func TestFetchManifestByTagUsesSharedCredentials(t *testing.T) {
+	manifest := []byte(`{"schemaVersion":2}`)
+
+	var requests atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+
+		if r.URL.Path != "/v2/team/image/manifests/v1" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			w.Header().Set("WWW-Authenticate", `Basic realm="registry"`)
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		if username != "reader" || password != "secret" {
+			t.Errorf("credentials = %q/%q", username, password)
+		}
+
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		w.Header().Set("Docker-Content-Digest", "sha256:"+strings.Repeat("a", 64))
+		_, _ = w.Write(manifest)
+	}))
+	defer server.Close()
+
+	credentialsPath := filepath.Join(t.TempDir(), "credentials")
+	if err := os.WriteFile(credentialsPath, []byte("reader:secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := New(&config.Config{UpstreamRegistries: []config.UpstreamRegistry{{
+		Name: "registry.example.com", Endpoint: server.URL, AuthMode: config.UpstreamAuthShared, CredentialsPath: credentialsPath,
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.registries["registry.example.com"].hc = server.Client()
+
+	response, err := client.FetchManifest(t.Context(), http.MethodGet, "registry.example.com", "team/image", "v1")
+	if err != nil {
+		t.Fatalf("FetchManifest: %v", err)
+	}
+	defer response.Body.Close()
+
+	got, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(got, manifest) || requests.Load() != 2 {
+		t.Fatalf("body/requests = %q/%d", got, requests.Load())
+	}
+
+	if response.Header.Get("Docker-Content-Digest") == "" {
+		t.Fatal("Docker-Content-Digest header missing")
 	}
 }
 

--- a/internal/operator/components/gantry/gantry_test.go
+++ b/internal/operator/components/gantry/gantry_test.go
@@ -22,6 +22,7 @@ import (
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	gantrymanifests "github.com/Azure/unbounded/deploy/gantry"
+	gantryconfig "github.com/Azure/unbounded/internal/gantry/config"
 	"github.com/Azure/unbounded/internal/operator/component"
 )
 
@@ -97,6 +98,32 @@ func TestEnsureConfigCreatesDefaultOnlyWhenAbsent(t *testing.T) {
 
 	if got.Data["config.yaml"] == "" || hash != component.ConfigMapPayloadHash(&got) {
 		t.Fatalf("default gantry config/hash missing: hash=%q data=%#v", hash, got.Data)
+	}
+}
+
+func TestOperatorConfigKeepsRegistryRequirement(t *testing.T) {
+	env := testEnv(t)
+	if _, err := ensureConfig(t.Context(), env); err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	var configMap corev1.ConfigMap
+	if err := env.Client.Get(t.Context(), client.ObjectKey{Namespace: component.DefaultNamespace, Name: configName}, &configMap); err != nil {
+		t.Fatalf("get default gantry config: %v", err)
+	}
+
+	config := gantryconfig.NewDefault()
+	if err := config.LoadYAML(strings.NewReader(configMap.Data["config.yaml"])); err != nil {
+		t.Fatalf("load operator Gantry config: %v", err)
+	}
+
+	if config.AllowNoUpstreamRegistries {
+		t.Fatal("operator Gantry config enabled standalone empty-registry mode")
+	}
+
+	config.UpstreamRegistries = nil
+	if err := config.Validate(); err == nil || !strings.Contains(err.Error(), "upstream_registries") {
+		t.Fatalf("operator config no longer requires an upstream registry: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an independent, curl-based installation and management workflow for standalone Gantry deployments on standard Kubernetes and AKS clusters.

- Adds the standalone `gantryctl` CLI and release artifacts.
- Installs Gantry healthy but inert until registries are configured.
- Supports anonymous, delegated, and shared Basic authentication.
- Adds end-to-end registry pull testing, including arbitrary `imagePullSecrets`.
- Safely manages registry-specific containerd `hosts.toml` files.
- Restores previous host configuration during registry removal or uninstall.
- Reconciles host configuration after node replacement and OS upgrades.

## Important Compatibility Note

`gantryctl` is exclusively for standalone Gantry installations.

On clusters where the Unbounded operator manages Gantry:

- `gantryctl install` refuses to install because operator Gantry already reserves host port `5000`.
- Registry and uninstall commands fail because standalone resources are absent.
- `gantryctl` does not read, modify, or remove operator-managed Gantry resources.
- Only local commands such as `gantryctl version` and help are applicable.
