### PR TITLE
ci: fail fast on image pull errors during deploy rollouts

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -512,35 +512,18 @@ jobs:
             --manage-cni-plugin="${MANAGE_CNI_PLUGIN}"
 
       - name: Wait for rollouts
+        # Shared with release-upgrade.yaml so the two deploy gates cannot drift.
+        # Component workloads are created asynchronously after the operator
+        # reconciles the Site, so the script waits for each to exist before
+        # checking its rollout status, and fails fast naming the image when a pod
+        # cannot pull one.
         run: |
-          set -euo pipefail
-          # Post-redesign, all component workloads are created by the operator in
-          # the unified unbounded-system namespace. They appear asynchronously
-          # after the operator reconciles the Site, so wait for each object to
-          # exist before checking its rollout status.
-          NS=unbounded-system
-
-          wait_exists() {
-            local kind="$1" name="$2" deadline=$((SECONDS + 300))
-            until kubectl -n "$NS" get "$kind" "$name" >/dev/null 2>&1; do
-              if (( SECONDS >= deadline )); then
-                echo "::error::timed out waiting for $kind/$name in $NS to be created"
-                return 1
-              fi
-              sleep 5
-            done
-          }
-
-          for target in \
-            "deploy unbounded-operator" \
-            "deploy unbounded-net-controller" \
-            "ds unbounded-net-node" \
-            "deploy machina-controller" \
-            "ds gantry"; do
-            set -- $target
-            wait_exists "$1" "$2"
-            kubectl -n "$NS" rollout status "$1/$2" --timeout=5m
-          done
+          hack/release/wait-rollouts.sh \
+            deploy/unbounded-operator \
+            deploy/unbounded-net-controller \
+            ds/unbounded-net-node \
+            deploy/machina-controller \
+            ds/gantry
 
       - name: Diagnose failed rollout
         # Runs only when a prior step failed (e.g. the operator never created a

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -388,35 +388,18 @@ jobs:
           fi
 
       - name: Wait for rollouts
+        # Shared with nightly.yaml so the two deploy gates cannot drift.
+        # Component workloads are created asynchronously after the operator
+        # reconciles the Site, so the script waits for each to exist before
+        # checking its rollout status, and fails fast naming the image when a pod
+        # cannot pull one.
         run: |
-          set -euo pipefail
-          # Post-redesign, all component workloads are created by the operator in
-          # the unified unbounded-system namespace. They appear asynchronously
-          # after the operator reconciles the Site, so wait for each object to
-          # exist before checking its rollout status.
-          NS=unbounded-system
-
-          wait_exists() {
-            local kind="$1" name="$2" deadline=$((SECONDS + 300))
-            until kubectl -n "$NS" get "$kind" "$name" >/dev/null 2>&1; do
-              if (( SECONDS >= deadline )); then
-                echo "::error::timed out waiting for $kind/$name in $NS to be created"
-                return 1
-              fi
-              sleep 5
-            done
-          }
-
-          for target in \
-            "deploy unbounded-operator" \
-            "deploy unbounded-net-controller" \
-            "ds unbounded-net-node" \
-            "deploy machina-controller" \
-            "ds gantry"; do
-            set -- $target
-            wait_exists "$1" "$2"
-            kubectl -n "$NS" rollout status "$1/$2" --timeout=5m
-          done
+          hack/release/wait-rollouts.sh \
+            deploy/unbounded-operator \
+            deploy/unbounded-net-controller \
+            ds/unbounded-net-node \
+            deploy/machina-controller \
+            ds/gantry
 
       - name: Diagnose failed rollout
         # Runs only when a prior step failed (e.g. the operator never created a

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# wait-rollouts: wait for operator-managed workloads to become available, and
+# fail fast with a named image when a pod cannot pull its image.
+#
+# Shared by .github/workflows/nightly.yaml and .github/workflows/release-upgrade.yaml.
+# Both deploy gates previously carried a copy of this logic and had already
+# drifted (the gantry DaemonSet was gated in one and not the other), so the
+# single copy lives here next to the smoke tests those workflows also share.
+#
+# Why the image check exists: the operator resolves every component image as
+# <registry>/<repository>:<operator version>. When a pipeline forgets to build
+# one of them the pods sit in ImagePullBackOff, 'kubectl rollout status' simply
+# blocks for its full timeout, and the run reports a bare "pod not ready". That
+# failure mode kept the nightly red for 15 consecutive nights. Detecting the
+# pull error names the missing image in seconds instead.
+#
+# Usage:
+#   hack/release/wait-rollouts.sh deploy/unbounded-operator ds/gantry ...
+#
+# Arguments are kubectl <kind>/<name> references, waited on in order.
+#
+# Contract (provided by the calling workflow):
+#   KUBECONFIG   Path to a kubeconfig for the target cluster.
+#
+# Optional overrides:
+#   NAMESPACE                Namespace to watch (default unbounded-system).
+#   ROLLOUT_TIMEOUT          Per-workload rollout timeout (default 5m).
+#   CREATE_TIMEOUT_SECONDS   How long to wait for a workload to be created by
+#                            the operator before giving up (default 300).
+#   POLL_INTERVAL_SECONDS    Poll cadence for the image check (default 5).
+
+set -euo pipefail
+
+: "${KUBECONFIG:?KUBECONFIG must be set}"
+
+NS="${NAMESPACE:-unbounded-system}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-5m}"
+CREATE_TIMEOUT_SECONDS="${CREATE_TIMEOUT_SECONDS:-300}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
+
+KUBECTL=(kubectl --request-timeout=30s -n "$NS")
+
+if (( $# == 0 )); then
+  echo "::error::wait-rollouts.sh requires at least one <kind>/<name> argument"
+  exit 2
+fi
+
+# Waiting reasons treated as terminal. ImagePullBackOff means the kubelet has
+# already retried and backed off; InvalidImageName means the reference does not
+# parse at all. Both are unambiguous, so neither produces false positives on a
+# merely slow pull. A bare ErrImagePull is the first transient attempt and is
+# deliberately NOT fatal, though it is still reported in the diagnostics below.
+FATAL_WAITING_REASONS='^(ImagePullBackOff|InvalidImageName)$'
+
+# image_pull_failures prints one tab-separated record per container stuck on a
+# fatal image error, and returns 1 when there are none. Init containers are
+# included: a failed init image never lets the main container start.
+image_pull_failures() {
+  local out
+  out="$("${KUBECTL[@]}" get pods -o json 2>/dev/null | jq -r --arg re "$FATAL_WAITING_REASONS" '
+    .items[]
+    | .metadata.name as $pod
+    | ((.status.containerStatuses // []) + (.status.initContainerStatuses // []))[]
+    | select((.state.waiting.reason // "") | test($re))
+    | [$pod, .name, .image, .state.waiting.reason, ((.state.waiting.message // "") | gsub("\t"; " "))]
+    | @tsv
+  ' 2>/dev/null || true)"
+
+  [[ -z "$out" ]] && return 1
+
+  printf '%s\n' "$out"
+}
+
+# report_image_failures turns the records into GitHub error annotations so the
+# missing image is visible in the run summary without opening the log.
+report_image_failures() {
+  local records="$1" pod container image reason message
+
+  while IFS=$'\t' read -r pod container image reason message; do
+    [[ -z "$pod" ]] && continue
+    echo "::error::pod ${NS}/${pod} container ${container} cannot pull ${image} (${reason})"
+    [[ -n "$message" ]] && echo "  ${message}"
+  done <<< "$records"
+
+  echo "::error::image pull failure in ${NS}; the pipeline is missing an image the operator references"
+}
+
+# fail_on_image_pull aborts the whole script when any container is wedged on a
+# fatal image error.
+fail_on_image_pull() {
+  local records
+  if records="$(image_pull_failures)"; then
+    report_image_failures "$records"
+    return 1
+  fi
+
+  return 0
+}
+
+# wait_exists blocks until the operator materializes the workload. Component
+# workloads are created asynchronously after the operator reconciles the Site,
+# so they do not exist the moment the deploy step finishes.
+wait_exists() {
+  local target="$1" deadline=$(( SECONDS + CREATE_TIMEOUT_SECONDS ))
+
+  until "${KUBECTL[@]}" get "$target" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      echo "::error::timed out waiting for ${target} in ${NS} to be created"
+      return 1
+    fi
+
+    fail_on_image_pull || return 1
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+# wait_rollout runs 'kubectl rollout status' in the background and polls for
+# image failures alongside it. Delegating to kubectl keeps the real rollout
+# semantics (observedGeneration, updated/available replicas) rather than
+# reimplementing them; the poll only adds an early exit.
+wait_rollout() {
+  local target="$1" pid rc=0
+
+  "${KUBECTL[@]}" rollout status "$target" --timeout="$ROLLOUT_TIMEOUT" &
+  pid=$!
+
+  while kill -0 "$pid" 2>/dev/null; do
+    if ! fail_on_image_pull; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      echo "::error::aborted waiting for ${target}: image pull failure in ${NS}"
+
+      return 1
+    fi
+
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+
+  wait "$pid" || rc=$?
+
+  return "$rc"
+}
+
+echo "Waiting for rollouts in ${NS}: $*"
+
+for target in "$@"; do
+  echo "::group::${target}"
+  wait_exists "$target"
+  wait_rollout "$target"
+  echo "::endgroup::"
+done
+
+echo "OK: all workloads rolled out in ${NS}"


### PR DESCRIPTION
> **Stacked on #611.** Base is `fix/nightly-gantry-image`; merge that first. This PR rewrites the exact lines #611 touches, so stacking avoids a guaranteed conflict.

## Problem

When a pipeline forgets to build an image the operator references, the pods sit in `ImagePullBackOff` and `kubectl rollout status` simply blocks for its full 5m timeout. The run then reports a bare `pod not ready (phase=Pending)` with no hint that an image is missing.

That is exactly how the gantry omission fixed in #611 went unnoticed for **15 consecutive nights**. The information needed to diagnose it in seconds was one `kubectl get pods` away, but nothing was looking.

This is the durable guard for that whole bug class: it is namespace-wide and needs no list of expected images, so it catches any missing image, including ones added by future components.

## Changes

**New `hack/release/wait-rollouts.sh`.** Keeps the existing wait-for-creation and `rollout status` behaviour, and polls alongside it for containers wedged on a fatal image error, aborting immediately with pod, container, image and reason as GitHub error annotations.

- Fatal reasons are `ImagePullBackOff` and `InvalidImageName`. Both are unambiguous: the kubelet has already retried and backed off, or the reference does not parse. A bare `ErrImagePull` is deliberately **not** fatal, since it is the first and often transient attempt, so a merely slow pull cannot produce a false positive.
- Init containers are included; a failed init image never lets the main container start.
- `kubectl rollout status` still does the real readiness evaluation (`observedGeneration`, updated/available replicas). The poll only adds an early exit, so rollout semantics are unchanged.

**Both workflows now call it.** The rollout wait was copy-pasted between `nightly.yaml` and `release-upgrade.yaml` and had **already drifted** - `release-upgrade` gated `ds/gantry` and `nightly` did not, which is the same failure mode this PR exists to prevent. One copy now lives in `hack/release/`, alongside the `hack/release/smoke/` tests these two workflows already share. Net -56 lines of duplicated shell.

## Before / after

Before, for 15 nights:

```
pod unbounded-system/gantry-dh58w not ready (phase=Pending ready=False)
4 pod(s) not ready across unbounded-system
```

After:

```
pod unbounded-system/gantry-dh58w container gantry cannot pull ghcr.io/azure/gantry:nightly-abc123 (ImagePullBackOff)
  Back-off pulling image "ghcr.io/azure/gantry:nightly-abc123"
image pull failure in unbounded-system; the pipeline is missing an image the operator references
```

## Testing

Verified locally against a stubbed `kubectl` across all four control-flow paths:

| Scenario | Expected | Result |
|---|---|---|
| Container in `ImagePullBackOff` | abort fast, name the image | exit 1, image named |
| Healthy multi-workload rollout | succeed | exit 0, both groups closed |
| Rollout genuinely fails, no image error | propagate kubectl's failure | exit 1 |
| Workload never created by the operator | time out | exit 1 |

The jq selector was also unit-checked against synthetic pod JSON covering a running container, a transient `ErrImagePull`, a failed **init** container, and a `Pending` pod with no `containerStatuses` (no crash on the null path).

## Notes

- `jq` is preinstalled on the runners and already used by `nightly.yaml`'s `smoke-discover` job, so no new dependency.
- The fatal-reason set is a single variable, easy to extend later to `CreateContainerConfigError` and friends. Kept to image errors here to stay scoped.
- The existing `Diagnose failed rollout` step is untouched and still runs on failure.

Part of the release machinery work in #610.