### PR TITLE
build: bump Go to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/unbounded
 
-go 1.26.5
+go 1.26.6
 
 tool (
 	golang.org/x/vuln/cmd/govulncheck

--- a/images/acr-origin-proxy/Containerfile
+++ b/images/acr-origin-proxy/Containerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 WORKDIR /src
 

--- a/images/gantry/Containerfile
+++ b/images/gantry/Containerfile
@@ -4,7 +4,7 @@
 # Build stage
 # Pin the builder to BUILDPLATFORM so the Go toolchain runs natively on the
 # host even when targeting a foreign TARGETPLATFORM.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/images/inventory/aggregator/Containerfile
+++ b/images/inventory/aggregator/Containerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Build stage
-FROM docker.io/library/golang:1.26.5-trixie AS builder
+FROM docker.io/library/golang:1.26.6-trixie AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/images/inventory/inspector/Containerfile
+++ b/images/inventory/inspector/Containerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Build stage
-FROM docker.io/library/golang:1.26.5-trixie AS builder
+FROM docker.io/library/golang:1.26.6-trixie AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/images/inventory/viewer/Containerfile
+++ b/images/inventory/viewer/Containerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Build stage
-FROM docker.io/library/golang:1.26.5-trixie AS builder
+FROM docker.io/library/golang:1.26.6-trixie AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/images/machina/Containerfile
+++ b/images/machina/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/machine-ops-controller/Containerfile
+++ b/images/machine-ops-controller/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/metalman/Containerfile
+++ b/images/metalman/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/net/Containerfile
+++ b/images/net/Containerfile
@@ -15,7 +15,7 @@
 # when targeting a foreign TARGETPLATFORM. ntttcp is the only piece of C code
 # we still build; for cross-arch we use a Debian cross gcc.
 # =============================================================================
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 # Platform args. TARGETOS / TARGETARCH are populated automatically by
 # buildkit/buildah from --platform. BUILDARCH should be too, but podman

--- a/images/orca/Containerfile
+++ b/images/orca/Containerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Build stage
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/images/playpen/Containerfile
+++ b/images/playpen/Containerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/images/unbounded-storage-supervisor/Containerfile
+++ b/images/unbounded-storage-supervisor/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.


### PR DESCRIPTION
## Problem

Go 1.26.6 was published with fixes for seven standard library vulnerabilities. This repo pins `go 1.26.5`, and CI's `Vulnerability Check` resolves its toolchain via `go-version-file: go.mod`, so `govulncheck` now reports all seven as reachable from our code:

| ID | Package |
|---|---|
| GO-2026-6218 | `net/url` |
| GO-2026-6091 | `html/template` |
| GO-2026-6090 | `crypto/tls` |
| GO-2026-6089 | `net/http` |
| GO-2026-6088 | `encoding/xml` |
| GO-2026-5972 | `encoding/asn1` |
| GO-2026-5026 | `net/http` |

All seven report `Found in: @go1.26.5` / `Fixed in: @go1.26.6`.

`make vulncheck` only tolerates a non-zero govulncheck when the output matches `affected by 1 vulnerability` **and** names the known-unfixable `GO-2024-3218`. With eight findings that allowlist misses and the job fails.

**This blocks the entire repo.** `Vulnerability Check` is a required status check, and the `main` ruleset has `bypass_actors: null`, so there is no override. Any PR entering the merge queue is ejected.

It is also purely time-based, which makes it confusing to diagnose: a PR can be green on its own branch and still be rejected by the queue minutes later. #611 hit this twice. Its branch-level run at 22:29 UTC predated the disclosure and passed; the queue runs at 22:43 and 23:06 failed. Main's last green run (20:40) predates it too, and would fail if re-run.

Worth noting for anyone reading queue logs: the ejection also produces a **spurious `Analyze (rust)` failure**. Once the queue drops the PR it deletes the `gh-readonly-queue` ref, and the still-running CodeQL job then fails uploading its SARIF with `ref ... not found`. That is a symptom, not a second problem, and `codeql.yaml` already sets `continue-on-error` for `merge_group` because of it.

## Why nothing fixed this automatically

`.github/dependabot.yml` configures only the `github-actions` and `gomod` ecosystems. `gomod` updates module requirements, not the `go` directive's patch version, and there is no `docker` ecosystem, so the `golang:` base image pins are hand-maintained.

## Changes

- `go.mod`: `go 1.26.5` -> `go 1.26.6`. This alone unblocks the required check.
- Twelve Containerfiles: `golang:1.26.5-trixie` -> `golang:1.26.6-trixie`, so the binaries we actually ship contain the fixes instead of merely passing the scan.

Nothing else in the tree references the patch version. No workflow hardcodes `go-version:` (all use `go-version-file: go.mod`), and the `GO_VERSION` build-arg the workflows compute from `go.mod` is major.minor (`1.26`), so it is unaffected.

There is no chicken-and-egg here: the merge queue builds this PR against main, so the merged result contains the bump and `Vulnerability Check` passes.

## Testing

Verified locally against the new toolchain (`GOTOOLCHAIN=auto` fetches 1.26.6 from the bumped directive):

- `make vulncheck` -> `vulncheck: only known-unfixable GO-2024-3218 found (accepted)`. All seven stdlib advisories are gone; the report is back to `affected by 1 vulnerability from 1 module`.
- `make gomod` leaves the directive intact and produces no `go.sum` change, so the Test job's tidy check is satisfied.
- `go build ./...`, `make lint` (0 issues), `CI=1 make test` (133 packages, all passing).
- Working tree clean afterwards, so `Verify Generated Files` is unaffected.

`golang:1.26.6-trixie` is confirmed published on Docker Hub; `Build Images (amd64)` / `Build Images (arm64)` exercise it.

## Follow-ups (not in this PR)

- `make vulncheck`'s allowlist matches the literal string `affected by 1 vulnerability`, so it is count-based rather than identity-based. Every future Go security release hard-blocks the repo with no escape hatch until someone bumps. An explicit set of accepted advisory IDs would remove that recurring outage.
- `Analyze (go)` has failed the SARIF upload in every recent merge-queue run, for the same ref-deletion reason, so queue-ref Go scanning results are never recorded. Coverage is preserved by the `pull_request` run, but the job is effectively dead weight in the queue.
- CodeQL's Rust extractor reports 172 files extracted with errors versus 41 clean (macro expansion failures in `cmd/unbounded-storage/src/fabric/error.rs`), so Rust scanning of that crate is largely ineffective.