### PR TITLE
ci: make the release gate and version resolution trustworthy, and document the process

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# actionlint configuration. Run via `make lint-actions`, which `make lint`
+# includes, so a malformed workflow is caught before it is dispatched rather
+# than when someone tries to cut a release with it.
+
+# Labels for self-hosted runners actionlint cannot know about. `pve` is the
+# Proxmox host pool used by aks-ssh-quickstart.yaml.
+self-hosted-runner:
+  labels:
+    - pve

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -405,7 +405,18 @@ jobs:
       SITE_NODE_CIDR: ${{ vars.SITE_NODE_CIDR }}
       SITE_POD_CIDR: ${{ vars.SITE_POD_CIDR }}
       MANAGE_CNI_PLUGIN: ${{ vars.MANAGE_CNI_PLUGIN }}
-      MAX_NOTREADY_NODES: ${{ inputs.max_notready_nodes || '0' }}
+      # Same cap as the release deploy gate. The nightly deploys the same
+      # component images to the same shape of cluster, and a node dropping out
+      # of unbounded-nightly says no more about this snapshot than one dropping
+      # out of unbounded-stable says about a release. A stricter cap here would
+      # only mean the nightly goes permanently red the first time a remote site
+      # goes offline, which is the failure this whole check exists to end.
+      #
+      # `||` relies on expression truthiness, which is safe here only because
+      # the input is typed `string`: a non-empty string, including "0", is
+      # truthy. Retyping it to `number` would silently turn an explicit 0 back
+      # into this default.
+      MAX_NOTREADY_NODES: ${{ inputs.max_notready_nodes || '2' }}
       # The nightly image tag, which is also the version stamped into the
       # operator binary, so it is the tag the operator resolves every component
       # image at. wait-rollouts.sh refuses to excuse a shortfall on a workload

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -388,6 +388,11 @@ jobs:
       # every component image at. wait-rollouts.sh will not excuse a shortfall
       # on a workload that does not carry it yet.
       EXPECTED_IMAGE_TAG: ${{ needs.resolve.outputs.tag }}
+      # Where we publish. The gate needs it to tell the images this release
+      # ships from the third-party ones pinned beside them, such as gantry's
+      # busybox init, which never carries a release tag. Lowercased by the
+      # script, since the owner is not.
+      EXPECTED_IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
     outputs:
       mode: ${{ steps.mode.outputs.mode }}
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -315,14 +315,12 @@ jobs:
 
       - name: Compute per-component build args
         # metalman bakes its default netboot image from CONTAINER_REGISTRY, so
-        # it needs that arg. REGISTRY is lowercased by the step above.
+        # it needs that arg (images/metalman/Containerfile declares it and feeds
+        # it to make). REGISTRY is lowercased by the step above.
         #
-        # The four unbounded-operator args are INERT: images/unbounded-operator/
-        # Containerfile declares only TARGETOS/TARGETARCH/VERSION/GIT_COMMIT/
-        # BUILD_TIME, so docker ignores them. Nothing breaks, because the
-        # operator overwrites every manifest image at reconcile time from its
-        # own compiled version (internal/operator/component/env.go) - which is
-        # also why VERSION is the arg that actually matters.
+        # Nothing else needs one. Which component images the operator deploys is
+        # decided at reconcile time from its own compiled version, so VERSION,
+        # passed to every build below, is what selects them.
         run: |
           set -euo pipefail
           {
@@ -330,12 +328,6 @@ jobs:
             case "${{ matrix.component.name }}" in
               metalman)
                 echo "CONTAINER_REGISTRY=${REGISTRY}"
-                ;;
-              unbounded-operator)
-                echo "NET_CONTROLLER_IMAGE=${REGISTRY}/unbounded-net-controller:${TAG}"
-                echo "NET_NODE_IMAGE=${REGISTRY}/unbounded-net-node:${TAG}"
-                echo "MACHINA_IMAGE=${REGISTRY}/machina:${TAG}"
-                echo "STORAGE_SUPERVISOR_IMAGE=${REGISTRY}/unbounded-storage-supervisor:${TAG}"
                 ;;
             esac
             echo 'EOF'

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -406,6 +406,11 @@ jobs:
       SITE_POD_CIDR: ${{ vars.SITE_POD_CIDR }}
       MANAGE_CNI_PLUGIN: ${{ vars.MANAGE_CNI_PLUGIN }}
       MAX_NOTREADY_NODES: ${{ inputs.max_notready_nodes || '0' }}
+      # The nightly image tag, which is also the version stamped into the
+      # operator binary, so it is the tag the operator resolves every component
+      # image at. wait-rollouts.sh refuses to excuse a shortfall on a workload
+      # that does not carry it yet.
+      EXPECTED_IMAGE_TAG: ${{ needs.resolve.outputs.tag }}
     outputs:
       mode: ${{ steps.mode.outputs.mode }}
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,28 +6,20 @@ name: nightly
 # ---------------------------------------------------------------------------
 # Builds a snapshot of `main` from source every morning and deploys it to the
 # integration cluster (unbounded-nightly) so the tip of the tree gets the same
-# soak treatment that releases get on unbounded-stable.
+# soak treatment releases get on unbounded-stable.
 #
-# Relationship to release-upgrade.yaml
-# ------------------------------------
-# This is the nightly sibling of .github/workflows/release-upgrade.yaml. That
-# workflow deploys a PUBLISHED, signed release (downloaded as a manifests
-# tarball from a GitHub Release) to unbounded-stable. This one has no release
-# and no tag: it builds the current main HEAD from source, pushes images
-# tagged `nightly-<shortsha>`, then bootstraps the operator via
-# `kubectl unbounded install` and lets it reconcile the Site into
-# unbounded-nightly (same operator-driven flow as release-upgrade.yaml). There
-# is deliberately no cosign signing, SBOM, or Trivy gating here: the nightly
-# cluster is a throwaway soak target, not a customer artifact. The full supply
-# chain stays on the release path.
+# The nightly sibling of release-upgrade.yaml, which deploys a published signed
+# release to unbounded-stable. This one has no release and no tag: it builds
+# main HEAD, pushes images tagged `nightly-<shortsha>`, and lets the operator
+# reconcile them in, using the same deploy gate and smoke tests. Deliberately no
+# cosign, SBOM or Trivy: the nightly cluster is a throwaway soak target, and the
+# supply chain stays on the release path.
 #
 # Schedule
 # --------
-# Runs at 06:00 UTC daily. GitHub Actions cron is UTC-only and does not follow
-# US daylight saving, so this lands at 01:00 ET (EST) / 02:00 ET (EDT). We run
-# early on purpose: a from-source build of every component plus a deploy and
-# smoke pass needs to finish well before the US working day, so 06:00 UTC is
-# chosen over a literal 4am-ET cron to leave that headroom.
+# 06:00 UTC daily, which is 01:00/02:00 ET depending on daylight saving (Actions
+# cron is UTC-only). Early on purpose: a from-source build of everything plus a
+# deploy and smoke pass has to finish before the US working day.
 #
 # Target cluster
 # --------------
@@ -41,19 +33,14 @@ name: nightly
 #     values (Azure account key and Garage S3 credentials)
 #
 # First-time setup (run once, out of band):
-#   Run the one-shot provisioner, which creates the AKS cluster with forge,
-#   creates the Orca origin, configures this Environment, pre-creates the
-#   orca-credentials Secret, and triggers the first (force_init) deploy:
 #
 #     hack/scripts/setup-nightly-cluster.sh \
 #       --subscription <sub-id> [--location <loc>]
 #
-#   forge provisions the gateway node pool already labeled
-#   unbounded-cloud.io/unbounded-net-gateway=true, so no manual node
-#   labeling is needed. The cluster node/pod CIDRs are auto-detected from
-#   AKS; the site CIDRs default to constants. See the script's --help for
-#   all flags. This workflow must already be on the default branch for the
-#   trigger step to work.
+#   Creates the AKS cluster with forge (gateway pool already labeled), the Orca
+#   origin and the orca-credentials Secret, configures this Environment, and
+#   triggers the first force_init deploy. CIDRs are auto-detected. This workflow
+#   must already be on the default branch for the trigger step to work.
 #
 # Customization points (search for "CUSTOMIZE:" in this file)
 # ------------------------------------------------------------
@@ -266,31 +253,25 @@ jobs:
   # ---------------------------------------------------------------------------
   # Build and push the remaining images the deploy needs (amd64).
   #
-  # The operator deploys every component workload when it reconciles the Site,
-  # so each image the operator references must exist at the nightly tag:
+  # The operator resolves EVERY component image as
+  # <registry>/<repository>:<its own compiled version>, so all of them have to
+  # exist at the nightly tag or the workload stalls in ImagePullBackOff:
   #   - machina                       : machina-controller Deployment
-  #   - unbounded-operator            : the operator itself, bootstrapped by
-  #                                     'kubectl unbounded install'. Its embedded
-  #                                     net/machina/storage manifests are pinned
-  #                                     to the nightly images via the
-  #                                     NET_*/MACHINA/STORAGE build-args below.
-  #   - metalman                      : synthesized per-Site Deployment; its
-  #                                     binary bakes the nightly netboot image,
-  #                                     so it is built with CONTAINER_REGISTRY.
+  #   - unbounded-operator            : bootstrapped by 'kubectl unbounded
+  #                                     install'; its VERSION build-arg is what
+  #                                     picks the tag for everything else
+  #   - metalman                      : synthesized per-Site Deployment; bakes
+  #                                     the netboot image from CONTAINER_REGISTRY
   #   - netboot                       : PXE artifact referenced by metalman
   #   - unbounded-storage-supervisor  : per-Site storage supervisor DaemonSet
-  #   - gantry                        : cluster-wide gantry DaemonSet. The
-  #                                     operator resolves its image as
-  #                                     <registry>/gantry:<operator version>, so
-  #                                     it must be built at the nightly tag or
-  #                                     the DaemonSet stalls in ImagePullBackOff.
-  #   - orca                          : deployed separately by the deploy-orca job
+  #   - gantry                        : cluster-wide gantry DaemonSet
+  #   - orca                          : deployed separately by deploy-orca
   #
-  # machine-ops-controller is intentionally omitted: the operator synthesizes
+  # machine-ops-controller is omitted on purpose: the operator synthesizes
   # metalman per Site instead, so machine-ops is never rolled out here.
   #
-  # Anything added to internal/operator/reconciler.go's component list needs a
-  # matching entry here and in the deploy job's rollout wait.
+  # Anything added to internal/operator/reconciler.go's component list needs an
+  # entry here and in the deploy job's rollout wait.
   # ---------------------------------------------------------------------------
   component-images:
     needs: resolve
@@ -333,12 +314,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compute per-component build args
-        # Some images need extra build-args beyond VERSION/GIT_COMMIT so the
-        # references they bake in point at THIS snapshot's nightly images:
-        #   - metalman bakes the default netboot image from CONTAINER_REGISTRY.
-        #   - unbounded-operator embeds the net/machina/storage manifests; pin
-        #     each to the nightly tag so the operator rolls out nightly images.
-        # REGISTRY is already lowercased by the step above; TAG is the job env.
+        # metalman bakes its default netboot image from CONTAINER_REGISTRY, so
+        # it needs that arg. REGISTRY is lowercased by the step above.
+        #
+        # The four unbounded-operator args are INERT: images/unbounded-operator/
+        # Containerfile declares only TARGETOS/TARGETARCH/VERSION/GIT_COMMIT/
+        # BUILD_TIME, so docker ignores them. Nothing breaks, because the
+        # operator overwrites every manifest image at reconcile time from its
+        # own compiled version (internal/operator/component/env.go) - which is
+        # also why VERSION is the arg that actually matters.
         run: |
           set -euo pipefail
           {
@@ -377,20 +361,17 @@ jobs:
   # Deploy the snapshot to unbounded-nightly.
   #
   # Operator-driven, matching release-upgrade.yaml: 'kubectl unbounded install'
-  # bootstraps the CRDs and the operator, then the operator reconciles the Site
-  # and rolls out every component workload (net, machina, metalman, storage) in
-  # the unbounded-system namespace. The reaper migrates any legacy split-namespace
-  # state. We never render or apply component manifests directly here.
+  # bootstraps the CRDs and the operator, the operator reconciles the Site and
+  # rolls out every component into unbounded-system, and the reaper migrates any
+  # legacy split-namespace state. Component manifests are never applied here.
   #
-  #   MODE=init     -> 'install' then 'site init' (creates the Site the operator
-  #                    reconciles). Used for the first bootstrap.
+  #   MODE=init     -> 'install' then 'site init', creating the Site. First
+  #                    bootstrap only.
   #   MODE=upgrade  -> 'install' only; the operator reconciles the existing Site.
   #
-  # The plugin is built from the snapshot checkout (no tarball download, no cosign
-  # verify): there is no release artifact for a nightly. Building it stamps the
-  # embedded operator manifests with this snapshot's nightly operator/metalman
-  # tags, and the operator image itself was built pinned to the nightly component
-  # images (see component-images).
+  # The plugin is built from the snapshot checkout rather than downloaded and
+  # cosign-verified, because a nightly has no release artifact. Building it
+  # stamps the embedded operator manifests with this snapshot's tags.
   # ---------------------------------------------------------------------------
   deploy:
     needs: [resolve, net-images, component-images]
@@ -405,22 +386,15 @@ jobs:
       SITE_NODE_CIDR: ${{ vars.SITE_NODE_CIDR }}
       SITE_POD_CIDR: ${{ vars.SITE_POD_CIDR }}
       MANAGE_CNI_PLUGIN: ${{ vars.MANAGE_CNI_PLUGIN }}
-      # Same cap as the release deploy gate. The nightly deploys the same
-      # component images to the same shape of cluster, and a node dropping out
-      # of unbounded-nightly says no more about this snapshot than one dropping
-      # out of unbounded-stable says about a release. A stricter cap here would
-      # only mean the nightly goes permanently red the first time a remote site
-      # goes offline, which is the failure this whole check exists to end.
-      #
-      # `||` relies on expression truthiness, which is safe here only because
-      # the input is typed `string`: a non-empty string, including "0", is
-      # truthy. Retyping it to `number` would silently turn an explicit 0 back
-      # into this default.
+      # Same cap as the release gate: a node dropping out of unbounded-nightly
+      # says no more about this snapshot than one dropping out of
+      # unbounded-stable says about a release, and a stricter cap would only
+      # mean a permanently red nightly the first time a site goes offline. `||`
+      # is safe only because the input is typed `string`, where "0" is truthy.
       MAX_NOTREADY_NODES: ${{ inputs.max_notready_nodes || '2' }}
-      # The nightly image tag, which is also the version stamped into the
-      # operator binary, so it is the tag the operator resolves every component
-      # image at. wait-rollouts.sh refuses to excuse a shortfall on a workload
-      # that does not carry it yet.
+      # Stamped into the operator binary, so it is the tag the operator resolves
+      # every component image at. wait-rollouts.sh will not excuse a shortfall
+      # on a workload that does not carry it yet.
       EXPECTED_IMAGE_TAG: ${{ needs.resolve.outputs.tag }}
     outputs:
       mode: ${{ steps.mode.outputs.mode }}
@@ -479,17 +453,13 @@ jobs:
             MODE=init
             echo "force_init=true; selecting init mode"
           elif kubectl get crd sites.net.unbounded-cloud.io >/dev/null 2>&1 && ! kubectl get crd sites.unbounded-cloud.io >/dev/null 2>&1; then
-            # First upgrade from the pre-redesign (v0.1) split-namespace layout:
-            # the old net-group Site CRD (sites.net.unbounded-cloud.io) exists but
-            # the new sites.unbounded-cloud.io CRD has not been bootstrapped yet.
-            # That CRD is created by the operator itself during the later
-            # 'Bootstrap CRDs and operator' step (kubectl unbounded install), so
-            # its absence here is expected for a first upgrade. Deploy in upgrade
-            # mode: install brings up the operator, whose always-on LegacyReaper
-            # translates the old Site into the new Site and migrates the split
-            # layout into unbounded-system automatically. Do NOT run 'site init'
-            # here; that would create a fresh Site instead of migrating the
-            # existing one.
+            # First upgrade from the pre-redesign (v0.1) split-namespace
+            # layout: the old net-group Site CRD exists, and the new one is
+            # absent because the operator creates it during the later
+            # 'Bootstrap CRDs and operator' step. Upgrade mode is correct: the
+            # operator's always-on LegacyReaper migrates the old Site and the
+            # split layout into unbounded-system. 'site init' would create a
+            # fresh Site instead of migrating the existing one.
             MODE=upgrade
             echo "Legacy Site CRD present and new Site CRD absent; first v0.1->v0.2 upgrade. Operator migrates automatically. Selecting upgrade mode"
           elif ! kubectl get crd sites.unbounded-cloud.io >/dev/null 2>&1; then

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -714,15 +714,15 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Discover smoke tests (shared with release-upgrade.yaml: hack/release/smoke).
-  # Runs from the snapshot checkout. Emits a JSON matrix; skips cleanly if the
-  # directory is absent or empty (GitHub errors on an empty matrix).
+  # Runs from the snapshot checkout and emits a JSON matrix. Finding none fails:
+  # a snapshot with no smoke tests is a repository regression, and it used to
+  # produce a green nightly that had validated nothing.
   # ---------------------------------------------------------------------------
   smoke-discover:
     needs: [resolve, deploy]
     runs-on: ubuntu-latest
     outputs:
       tasks: ${{ steps.list.outputs.tasks }}
-      has_tasks: ${{ steps.list.outputs.has_tasks }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -732,11 +732,11 @@ jobs:
         id: list
         run: |
           set -euo pipefail
+          # `find` exits non-zero on a missing path, so the directory is checked
+          # first to give the real reason rather than a find error.
           if [[ ! -d hack/release/smoke ]]; then
-            echo "has_tasks=false" >> "$GITHUB_OUTPUT"
-            echo "tasks=[]" >> "$GITHUB_OUTPUT"
-            echo "hack/release/smoke does not exist at this ref; skipping smoke tests"
-            exit 0
+            echo "::error::hack/release/smoke does not exist at this snapshot; the nightly has no smoke tests"
+            exit 1
           fi
           tasks=$(
             find hack/release/smoke -maxdepth 1 -type f -name '*.sh' \
@@ -745,15 +745,12 @@ jobs:
                   map({name: (. | sub(".*/"; "") | sub(".sh$"; "")), script: .})'
           )
           if [[ -z "$tasks" || "$tasks" == "[]" ]]; then
-            echo "has_tasks=false" >> "$GITHUB_OUTPUT"
-            echo "tasks=[]" >> "$GITHUB_OUTPUT"
-            echo "No smoke tasks found in hack/release/smoke/"
-          else
-            echo "has_tasks=true" >> "$GITHUB_OUTPUT"
-            echo "tasks=${tasks}" >> "$GITHUB_OUTPUT"
-            echo "Discovered smoke tasks:"
-            echo "${tasks}" | jq .
+            echo "::error::no smoke tasks found in hack/release/smoke/; the nightly has no smoke tests"
+            exit 1
           fi
+          echo "tasks=${tasks}" >> "$GITHUB_OUTPUT"
+          echo "Discovered smoke tasks:"
+          echo "${tasks}" | jq .
 
   # ---------------------------------------------------------------------------
   # Smoke tests. Runs once per deploy, after core + Orca deploys complete. Each
@@ -762,7 +759,6 @@ jobs:
   # ---------------------------------------------------------------------------
   smoke-tests:
     needs: [resolve, deploy, deploy-orca, smoke-discover]
-    if: needs.smoke-discover.outputs.has_tasks == 'true'
     runs-on: ubuntu-latest
     environment: unbounded-nightly
     strategy:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -79,6 +79,10 @@ on:
         description: "Run 'site init' instead of upgrade-apply (use for first-ever bootstrap)"
         type: boolean
         default: false
+      max_notready_nodes:
+        description: "Override how many NotReady nodes may be tolerated (blank = workflow default)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -401,6 +405,7 @@ jobs:
       SITE_NODE_CIDR: ${{ vars.SITE_NODE_CIDR }}
       SITE_POD_CIDR: ${{ vars.SITE_POD_CIDR }}
       MANAGE_CNI_PLUGIN: ${{ vars.MANAGE_CNI_PLUGIN }}
+      MAX_NOTREADY_NODES: ${{ inputs.max_notready_nodes || '0' }}
     outputs:
       mode: ${{ steps.mode.outputs.mode }}
     steps:
@@ -564,6 +569,17 @@ jobs:
           kubectl get sites.unbounded-cloud.io -o wide 2>&1
           kubectl get sites.unbounded-cloud.io -o yaml 2>&1
           kubectl get sites.net.unbounded-cloud.io -A -o wide 2>&1
+          echo "::endgroup::"
+          echo "::group::Node readiness"
+          # A DaemonSet counts every node toward desiredNumberScheduled, so a
+          # single unreachable node stalls a rollout indefinitely. This is the
+          # first thing to check when a rollout times out, and its absence is
+          # why one such stall went unexplained for weeks.
+          kubectl get nodes -o wide 2>&1
+          echo "--- not Ready ---"
+          kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.metadata.labels.unbounded-cloud\.io/site}{"\n"}{end}' 2>&1 \
+            | awk -F'\t' '$2 != "True" { printf "%s (site=%s, Ready=%s)\n", $1, ($3 == "" ? "none" : $3), $2 }'
           echo "::endgroup::"
           echo "::group::Workloads in ${NS}"
           kubectl -n "$NS" get deploy,ds,pods -o wide 2>&1

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -82,6 +82,7 @@ on:
         description: "promote only: explicit final version to cut (e.g. v0.2.0); blank = the single live prerelease train"
         required: false
         type: string
+        default: ""
       dry_run:
         description: "Compute the version and print it without pushing a tag"
         type: boolean
@@ -90,7 +91,6 @@ on:
         description: "Permit starting a second live prerelease train alongside an existing one"
         type: boolean
         default: false
-        default: ""
 
 # The tag push authenticates via the SSH deploy key, not GITHUB_TOKEN, so no
 # contents:write is needed here.

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -4,60 +4,31 @@
 name: unbounded release prepare
 
 # ---------------------------------------------------------------------------
-# Phase 1 of the two-phase release. This workflow ONLY computes the next
-# version and pushes the git tag. It does not build, sign, or publish
-# anything.
+# Phase 1 of the two-phase release: computes the next version and pushes the
+# tag. It builds, signs and publishes nothing. See RELEASING.md for the process
+# and for what each mode does.
 #
-# Why split it out: the build/sign workflow (release.yaml) must run in the
-# context of the version tag so that keyless cosign signatures carry the
-# identity `release.yaml@refs/tags/vX.Y.Z`. That identity is what the deploy
-# workflow verifies. A tag created mid-run by a workflow dispatched on a
-# branch would instead sign as `@refs/heads/main` and fail verification.
+# Why split it out: release.yaml must run in the tag's context so its keyless
+# cosign signatures carry the identity `release.yaml@refs/tags/vX.Y.Z`, which
+# the deploy workflow verifies. A tag created mid-run by a workflow dispatched
+# on a branch would sign as `@refs/heads/main` and fail that check. For the same
+# reason release.yaml has deliberately NO workflow_dispatch fallback: if a tag
+# lands without triggering a build, delete it and re-run this workflow.
 #
-# The tag is pushed using an SSH deploy key (RELEASE_TAG_DEPLOY_KEY) rather
-# than the default GITHUB_TOKEN. GitHub deliberately suppresses workflow
-# triggers for tags pushed with GITHUB_TOKEN (loop prevention); a deploy-key
-# push is exempt, so it triggers release.yaml's `on: push: tags` in the
-# correct tag context.
+# The tag is pushed with an SSH deploy key (RELEASE_TAG_DEPLOY_KEY), not
+# GITHUB_TOKEN, because GitHub suppresses workflow triggers for tags pushed with
+# the default token. A deploy-key push is exempt.
 #
-# Modes (the `mode` input):
-#   release     Bump the latest FINAL tag by `bump` and cut vX.Y.Z.
-#   prerelease  Cut vX.Y.Z-rc.N. With a train already in flight it continues
-#               that train and takes the next rc automatically, so iterating is
-#               just re-running with no input changes. With none in flight it
-#               starts one, bumped from the latest final by `bump`.
-#   promote     Finalize a prerelease train to its release version, with NO
-#               bump. Resolves automatically when exactly one train is in
-#               flight; set `version` to choose between several. The tag is
-#               created on the LAST CANDIDATE's commit, not on HEAD, so the
-#               tree that was soaked is the tree that ships.
+# Version resolution lives in hack/release/next-version.sh, covered by
+# next-version-test.sh via next_version_test.go. It used to be inline here,
+# where the only way to test a change was to push a real tag, and where it grew
+# three sharp edges: `bump` silently forking a train, `pre` accepting a value
+# that went backwards, and `promote` guessing at the highest prerelease in the
+# repository - which is what orphaned v0.1.24.
 #
-# A train counts as IN FLIGHT when its core version has prerelease tags, no
-# final tag, and is newer than the latest final. That last clause is what keeps
-# an abandoned train from being offered: v0.1.24 still has twelve candidates and
-# no final, but v0.2.4 has since shipped, so it is stale rather than pending.
-#
-# The version resolution lives in hack/release/next-version.sh, tested by
-# hack/release/next-version-test.sh (run by hack/release/next_version_test.go,
-# so CI covers it). It used to be inline here, where the only way to test a
-# change was to push a real tag and see what happened, and where it grew three
-# sharp edges: `bump` silently forking a train, `pre` accepting any value
-# including one that went backwards, and `promote` guessing at the highest
-# prerelease in the whole repository. That last one orphaned v0.1.24.
-#
-# NOTE: the script is read from the checkout below, which is pinned to the
-# default branch. Changes to it therefore only take effect once merged; they
-# cannot be exercised by dispatching this workflow from a branch, dry_run
-# included.
-#
-# Use `dry_run` to see the computed version and commit without pushing anything.
-#
-# Recovery: if a tag is pushed but no release.yaml run is triggered (for
-# example a misconfigured deploy key or disabled Actions), delete the tag
-# (`git push origin :refs/tags/<tag>`) and re-run this workflow. There is
-# deliberately NO workflow_dispatch fallback on release.yaml: a dispatched
-# run would sign as `@refs/heads/main` and fail deploy verification, which is
-# the exact problem this two-phase split exists to avoid.
+# NOTE: the script comes from the checkout below, pinned to the default branch,
+# so changes to it take effect only once merged. They cannot be rehearsed by
+# dispatching this workflow from a branch, `dry_run` included.
 # ---------------------------------------------------------------------------
 
 on:
@@ -145,17 +116,13 @@ jobs:
           echo "Deploy key authenticates to origin."
 
       - name: Compute tag
-        # Inputs are bound to env vars rather than interpolated into the script,
-        # so they arrive as data. `pre` and `version` are free-form: a `${{ }}`
-        # inlined in a run block is template-expanded before bash parses it, so
-        # a shell metacharacter would become script syntax.
+        # Inputs arrive as env vars, not interpolated into the script: `pre`
+        # and `version` are free-form, and a `${{ }}` inlined in a run block is
+        # expanded before bash parses it, so a shell metacharacter would become
+        # script syntax.
         #
-        # The resolution itself lives in hack/release/next-version.sh so it can
-        # be tested against synthetic tag sets. While it was inline here the
-        # only way to test a change was to push a real tag and find out.
-        #
-        # It emits `key=value` lines, so its output goes straight to
-        # $GITHUB_OUTPUT: `tag` and `base`, the commit the tag belongs on.
+        # The resolver emits `key=value`, so its output goes straight to
+        # $GITHUB_OUTPUT: `tag`, and `base`, the commit the tag belongs on.
         id: compute
         env:
           MODE: ${{ inputs.mode }}
@@ -175,11 +142,9 @@ jobs:
           hack/release/next-version.sh >> "$GITHUB_OUTPUT"
 
       - name: Push tag
-        # Compared explicitly rather than relying on truthiness. The REST API,
-        # and so `gh workflow run -f dry_run=false`, submits inputs as strings,
-        # and a NON-EMPTY STRING IS TRUTHY: `!inputs.dry_run` would evaluate
-        # false for the string "false" and silently skip the push on an
-        # ordinary run. Same reasoning as force_publish in release-upgrade.yaml.
+        # Compared explicitly, not by truthiness: `gh workflow run -f
+        # dry_run=false` submits a string, and a NON-EMPTY STRING IS TRUTHY, so
+        # `!inputs.dry_run` would skip the push on an ordinary run.
         if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         env:
           TAG: ${{ steps.compute.outputs.tag }}

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -22,12 +22,27 @@ name: unbounded release prepare
 #
 # Modes (the `mode` input):
 #   release     Bump the latest FINAL tag by `bump` and cut vX.Y.Z.
-#   prerelease  Bump the latest FINAL tag by `bump` and cut vX.Y.Z-<pre>
-#               (e.g. pre=rc.1). Iterate a train by re-running with the same
-#               `bump` and an incremented `pre` (rc.1 -> rc.2 -> ...).
-#   promote     Finalize an in-flight prerelease to its release version, with
-#               NO bump. By default this promotes the highest prerelease
-#               train; set `version` (e.g. v0.2.0) to promote a specific one.
+#   prerelease  Cut vX.Y.Z-rc.N. With a train already in flight it continues
+#               that train and takes the next rc automatically, so iterating is
+#               just re-running with no input changes. With none in flight it
+#               starts one, bumped from the latest final by `bump`.
+#   promote     Finalize a prerelease train to its release version, with NO
+#               bump. Resolves automatically when exactly one train is in
+#               flight; set `version` to choose between several.
+#
+# A train counts as IN FLIGHT when its core version has prerelease tags, no
+# final tag, and is newer than the latest final. That last clause is what keeps
+# an abandoned train from being offered: v0.1.24 still has twelve candidates and
+# no final, but v0.2.4 has since shipped, so it is stale rather than pending.
+#
+# The version resolution lives in hack/release/next-version.sh, tested by
+# hack/release/next-version-test.sh. It used to be inline here, where the only
+# way to test a change was to push a real tag and see what happened, and where
+# it grew three sharp edges: `bump` silently forking a train, `pre` accepting
+# any value including one that went backwards, and `promote` guessing at the
+# highest prerelease in the whole repository. That last one orphaned v0.1.24.
+#
+# Use `dry_run` to see the computed version without pushing anything.
 #
 # Recovery: if a tag is pushed but no release.yaml run is triggered (for
 # example a misconfigured deploy key or disabled Actions), delete the tag
@@ -50,7 +65,7 @@ on:
           - promote
         default: release
       bump:
-        description: "Version bump level (release/prerelease)"
+        description: "Bump level. Only used to START a train or cut a final; ignored while continuing a live train."
         required: true
         type: choice
         options:
@@ -59,14 +74,22 @@ on:
           - major
         default: patch
       pre:
-        description: "Prerelease suffix for prerelease mode (e.g. rc.1)"
+        description: "Prerelease suffix (e.g. rc.3). Blank takes the next rc automatically, which is almost always what you want."
         required: false
         type: string
         default: ""
       version:
-        description: "promote only: explicit final version to cut (e.g. v0.2.0); blank = highest in-flight prerelease"
+        description: "promote only: explicit final version to cut (e.g. v0.2.0); blank = the single live prerelease train"
         required: false
         type: string
+      dry_run:
+        description: "Compute the version and print it without pushing a tag"
+        type: boolean
+        default: false
+      allow_concurrent_trains:
+        description: "Permit starting a second live prerelease train alongside an existing one"
+        type: boolean
+        default: false
         default: ""
 
 # The tag push authenticates via the SSH deploy key, not GITHUB_TOKEN, so no
@@ -113,16 +136,22 @@ jobs:
 
           echo "Deploy key authenticates to origin."
 
-      - name: Compute and push tag
-        # Bind inputs to env vars so they enter the shell as data, not as
-        # code. `pre` and `version` are free-form user input; inlining
-        # `${{ ... }}` in a run block is template-expanded before bash parses
-        # it, so any shell metacharacter would become script syntax.
+      - name: Compute tag
+        # Inputs are bound to env vars rather than interpolated into the script,
+        # so they arrive as data. `pre` and `version` are free-form: a `${{ }}`
+        # inlined in a run block is template-expanded before bash parses it, so
+        # a shell metacharacter would become script syntax.
+        #
+        # The resolution itself lives in hack/release/next-version.sh so it can
+        # be tested against synthetic tag sets. While it was inline here the
+        # only way to test a change was to push a real tag and find out.
+        id: compute
         env:
           MODE: ${{ inputs.mode }}
           BUMP: ${{ inputs.bump }}
           PRE: ${{ inputs.pre }}
           VERSION: ${{ inputs.version }}
+          ALLOW_CONCURRENT_TRAINS: ${{ inputs.allow_concurrent_trains }}
         run: |
           set -euo pipefail
 
@@ -132,83 +161,21 @@ jobs:
             exit 1
           fi
 
-          # Latest FINAL (non-prerelease) tag, used as the bump base. Excluding
-          # prerelease tags avoids git's version sort ranking e.g. v0.2.0-rc.1
-          # above v0.2.0.
-          latest_final() {
-            git tag --list 'v*' --sort=-version:refname | grep -v -- '-' | head -n1
-          }
+          TAG="$(hack/release/next-version.sh)"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-          bump_version() {
-            local base="$1" level="$2"
-            local semver="${base#v}"
-            local major minor patch
-            IFS='.' read -r major minor patch <<< "$semver"
-            case "$level" in
-              major) major=$((major + 1)); minor=0; patch=0 ;;
-              minor) minor=$((minor + 1)); patch=0 ;;
-              patch) patch=$((patch + 1)) ;;
-              *) echo "::error::unexpected bump level: ${level}"; exit 1 ;;
-            esac
-            echo "v${major}.${minor}.${patch}"
-          }
-
-          case "$MODE" in
-            release)
-              FINAL="$(latest_final)"
-              [[ -z "$FINAL" ]] && FINAL="v0.0.0"
-              TAG="$(bump_version "$FINAL" "$BUMP")"
-              ;;
-
-            prerelease)
-              if [[ -z "$PRE" ]]; then
-                echo "::error::mode=prerelease requires a non-empty pre suffix"
-                exit 1
-              fi
-              FINAL="$(latest_final)"
-              [[ -z "$FINAL" ]] && FINAL="v0.0.0"
-              CORE="$(bump_version "$FINAL" "$BUMP")"
-              TAG="${CORE}-${PRE}"
-              ;;
-
-            promote)
-              if [[ -n "$VERSION" ]]; then
-                # Normalize a leading v and reject any prerelease suffix.
-                NORM="v${VERSION#v}"
-                if [[ ! "$NORM" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                  echo "::error::version must be a final vX.Y.Z (no suffix), got: ${VERSION}"
-                  exit 1
-                fi
-                if [[ -z "$(git tag --list "${NORM}-*")" ]]; then
-                  echo "::error::no prerelease train found for ${NORM} (no ${NORM}-* tags); use mode=release to cut it directly"
-                  exit 1
-                fi
-                TAG="$NORM"
-              else
-                PRELATEST="$(git tag --list 'v*-*' --sort=-version:refname | head -n1)"
-                if [[ -z "$PRELATEST" ]]; then
-                  echo "::error::mode=promote found no prerelease tags to finalize"
-                  exit 1
-                fi
-                TAG="${PRELATEST%%-*}"
-              fi
-              ;;
-
-            *)
-              echo "::error::unexpected mode: ${MODE}"
-              exit 1
-              ;;
-          esac
-
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Tag must be in vX.Y.Z[-suffix] format, got: ${TAG}"
-            exit 1
-          fi
-
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "::error::Tag ${TAG} already exists"
-            exit 1
-          fi
+      - name: Push tag
+        # Compared explicitly rather than relying on truthiness. The REST API,
+        # and so `gh workflow run -f dry_run=false`, submits inputs as strings,
+        # and a NON-EMPTY STRING IS TRUTHY: `!inputs.dry_run` would evaluate
+        # false for the string "false" and silently skip the push on an
+        # ordinary run. Same reasoning as force_publish in release-upgrade.yaml.
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
+        env:
+          TAG: ${{ steps.compute.outputs.tag }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -217,3 +184,17 @@ jobs:
 
           echo "Pushed ${TAG} (mode=${MODE}); release.yaml will build and sign it in tag context."
           echo "### Prepared release ${TAG}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report dry run
+        if: ${{ inputs.dry_run == true || inputs.dry_run == 'true' }}
+        env:
+          TAG: ${{ steps.compute.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          echo "Dry run: would have pushed ${TAG}. Nothing was created."
+          {
+            echo "### Dry run: would prepare ${TAG}"
+            echo
+            echo "No tag was pushed. Re-run with dry_run unchecked to cut it."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -28,7 +28,9 @@ name: unbounded release prepare
 #               starts one, bumped from the latest final by `bump`.
 #   promote     Finalize a prerelease train to its release version, with NO
 #               bump. Resolves automatically when exactly one train is in
-#               flight; set `version` to choose between several.
+#               flight; set `version` to choose between several. The tag is
+#               created on the LAST CANDIDATE's commit, not on HEAD, so the
+#               tree that was soaked is the tree that ships.
 #
 # A train counts as IN FLIGHT when its core version has prerelease tags, no
 # final tag, and is newer than the latest final. That last clause is what keeps
@@ -36,13 +38,19 @@ name: unbounded release prepare
 # no final, but v0.2.4 has since shipped, so it is stale rather than pending.
 #
 # The version resolution lives in hack/release/next-version.sh, tested by
-# hack/release/next-version-test.sh. It used to be inline here, where the only
-# way to test a change was to push a real tag and see what happened, and where
-# it grew three sharp edges: `bump` silently forking a train, `pre` accepting
-# any value including one that went backwards, and `promote` guessing at the
-# highest prerelease in the whole repository. That last one orphaned v0.1.24.
+# hack/release/next-version-test.sh (run by hack/release/next_version_test.go,
+# so CI covers it). It used to be inline here, where the only way to test a
+# change was to push a real tag and see what happened, and where it grew three
+# sharp edges: `bump` silently forking a train, `pre` accepting any value
+# including one that went backwards, and `promote` guessing at the highest
+# prerelease in the whole repository. That last one orphaned v0.1.24.
 #
-# Use `dry_run` to see the computed version without pushing anything.
+# NOTE: the script is read from the checkout below, which is pinned to the
+# default branch. Changes to it therefore only take effect once merged; they
+# cannot be exercised by dispatching this workflow from a branch, dry_run
+# included.
+#
+# Use `dry_run` to see the computed version and commit without pushing anything.
 #
 # Recovery: if a tag is pushed but no release.yaml run is triggered (for
 # example a misconfigured deploy key or disabled Actions), delete the tag
@@ -145,6 +153,9 @@ jobs:
         # The resolution itself lives in hack/release/next-version.sh so it can
         # be tested against synthetic tag sets. While it was inline here the
         # only way to test a change was to push a real tag and find out.
+        #
+        # It emits `key=value` lines, so its output goes straight to
+        # $GITHUB_OUTPUT: `tag` and `base`, the commit the tag belongs on.
         id: compute
         env:
           MODE: ${{ inputs.mode }}
@@ -161,8 +172,7 @@ jobs:
             exit 1
           fi
 
-          TAG="$(hack/release/next-version.sh)"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          hack/release/next-version.sh >> "$GITHUB_OUTPUT"
 
       - name: Push tag
         # Compared explicitly rather than relying on truthiness. The REST API,
@@ -173,28 +183,36 @@ jobs:
         if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         env:
           TAG: ${{ steps.compute.outputs.tag }}
+          BASE: ${{ steps.compute.outputs.base }}
           MODE: ${{ inputs.mode }}
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG"
+          # BASE is HEAD for release and prerelease, and the last candidate's
+          # commit for promote, so promoting ships the tree that was soaked
+          # rather than everything merged since.
+          git tag "$TAG" "$BASE"
           git push origin "$TAG"
 
-          echo "Pushed ${TAG} (mode=${MODE}); release.yaml will build and sign it in tag context."
+          echo "Pushed ${TAG} at ${BASE} (mode=${MODE}); release.yaml will build and sign it in tag context."
           echo "### Prepared release ${TAG}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report dry run
         if: ${{ inputs.dry_run == true || inputs.dry_run == 'true' }}
         env:
           TAG: ${{ steps.compute.outputs.tag }}
+          BASE: ${{ steps.compute.outputs.base }}
         run: |
           set -euo pipefail
 
-          echo "Dry run: would have pushed ${TAG}. Nothing was created."
+          echo "Dry run: would have pushed ${TAG} at ${BASE}. Nothing was created."
           {
             echo "### Dry run: would prepare ${TAG}"
+            echo
+            echo "- Commit: \`${BASE}\`"
+            echo "- Commits on HEAD not included: $(git rev-list --count "${BASE}..HEAD")"
             echo
             echo "No tag was pushed. Re-run with dry_run unchecked to cut it."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -273,6 +273,12 @@ jobs:
             --dir dist/
           ls -la dist/
 
+          # What the release actually carries, so the verifier can compare it
+          # against what the BOM says it should. Names only; the assets the
+          # deploy does not consume are not downloaded.
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets -q '.assets[].name' > dist/release-assets.txt
+
       - name: Fetch deploy tooling from the workflow's own commit
         # The primary checkout is pinned to the DEPLOYED TAG, but the rollout
         # gate is tooling, not a release artifact: it validates the deployed
@@ -301,6 +307,7 @@ jobs:
         # checksums.txt rather than by a bundle of its own.
         env:
           CHECKSUM_FILES: kubectl-unbounded-linux-amd64.tar.gz
+          RELEASE_ASSETS_FILE: dist/release-assets.txt
         run: |
           set -euo pipefail
           _deploy-tools/hack/release/verify-release-artifacts.sh "$TAG" "$(git rev-parse HEAD)" dist
@@ -904,10 +911,19 @@ jobs:
             --pattern "unbounded-release-bom-${TAG}.json.bundle.json" \
             --dir dist/
 
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets -q '.assets[].name' > dist/release-assets.txt
+
       - name: Verify release signatures and BOM
         # Deliberately NOT skipped when forcing. Provenance is not what is being
         # bypassed, and this needs no cluster, so it still works in exactly the
         # outage this job exists for.
+        #
+        # It matters most here: this path publishes without a deploy having
+        # touched the release, so nothing else would notice a draft that had
+        # lost assets.
+        env:
+          RELEASE_ASSETS_FILE: dist/release-assets.txt
         run: |
           set -euo pipefail
           _deploy-tools/hack/release/verify-release-artifacts.sh "$TAG" "$(git rev-parse HEAD)" dist

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -883,6 +883,9 @@ jobs:
       DEPLOY_RESULT: ${{ needs.deploy.result }}
       ORCA_RESULT: ${{ needs.deploy-orca.result }}
       SMOKE_RESULT: ${{ needs.smoke-tests.result }}
+      # Marks the notice this job appends to the release body, so re-running it
+      # for the same tag does not stack up a second copy.
+      MARKER: "<!-- unbounded:forced-publish -->"
     steps:
       - name: Require a reason
         # Checked before anything else so a forced run cannot get partway and
@@ -940,6 +943,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          # A forced dispatch always lands on this job, even when the gates
+          # happened to pass, so that forcing is always recorded as forcing.
+          # That makes the headline conditional: claiming an unsoaked release
+          # when the soak in fact went green would be its own kind of
+          # misleading record.
+          if [[ "$DEPLOY_RESULT" == "success" && "$ORCA_RESULT" == "success" \
+                && ( "$SMOKE_RESULT" == "success" || "$SMOKE_RESULT" == "skipped" ) ]]; then
+            headline="Published through the forced path, though the soak did pass."
+            caveat="The gates this run bypasses all reported success; the bypass is recorded because it was requested."
+          else
+            headline="Published without a successful soak."
+            caveat="Release artifact signatures and the release BOM were verified; the deployment soak on unbounded-stable was not completed."
+          fi
+
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false
 
           # Written through a file rather than an argument: release bodies carry
@@ -948,13 +965,21 @@ jobs:
           notes="$(mktemp)"
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body -q .body > "$notes"
 
-          printf '\n\n---\n\n> **Published without a successful soak.**\n> Forced by @%s. Deploy: %s, Orca: %s, smoke: %s.\n> Reason: %s\n>\n> Release artifact signatures and the release BOM were verified; the\n> deployment soak on unbounded-stable was not completed.\n' \
-            "$ACTOR" "$DEPLOY_RESULT" "$ORCA_RESULT" "$SMOKE_RESULT" "$REASON" >> "$notes"
+          # Re-running this job for the same tag must not stack up a second
+          # notice. The marker is an HTML comment so it is invisible on the
+          # rendered release page but reliable to match on.
+          if grep -qF "$MARKER" "$notes"; then
+            echo "::notice::${TAG} already carries a forced-publish notice; leaving the release body alone"
+          else
+            printf '\n\n---\n\n%s\n> **%s**\n> Forced by @%s. Deploy: %s, Orca: %s, smoke: %s.\n> Reason: %s\n>\n> %s\n' \
+              "$MARKER" "$headline" "$ACTOR" "$DEPLOY_RESULT" "$ORCA_RESULT" "$SMOKE_RESULT" "$REASON" "$caveat" >> "$notes"
 
-          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$notes"
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$notes"
+          fi
+
           rm -f "$notes"
 
-          echo "::warning::${TAG} was published WITHOUT a successful soak, forced by ${ACTOR}: ${REASON}"
+          echo "::warning::${TAG} was published through the break-glass path by ${ACTOR}: ${REASON}"
 
           {
             echo "### Published ${TAG} via break glass"

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -253,6 +253,8 @@ jobs:
             --pattern "unbounded-release-bom-${TAG}.json" \
             --pattern "unbounded-release-bom-${TAG}.json.bundle.json" \
             --pattern 'kubectl-unbounded-linux-amd64.tar.gz' \
+            --pattern 'checksums.txt' \
+            --pattern 'checksums.txt.bundle.json' \
             --dir dist/
           ls -la dist/
 
@@ -278,6 +280,12 @@ jobs:
         # Shared with the forced-publish job so the two paths that can publish a
         # release cannot drift into verifying different things. The checkout
         # above is at the tag, so HEAD is the commit the BOM must record.
+        #
+        # CHECKSUM_FILES names the plugin because this job EXECUTES it against
+        # the cluster a few steps below. It is covered by the signed
+        # checksums.txt rather than by a bundle of its own.
+        env:
+          CHECKSUM_FILES: kubectl-unbounded-linux-amd64.tar.gz
         run: |
           set -euo pipefail
           _deploy-tools/hack/release/verify-release-artifacts.sh "$TAG" "$(git rev-parse HEAD)" dist
@@ -300,6 +308,8 @@ jobs:
           echo "MANIFESTS_DIR=${MANIFESTS_DIR}" >> "$GITHUB_ENV"
 
       - name: Install kubectl-unbounded plugin
+        # Safe to execute because the verify step above checked this tarball
+        # against the signed checksums.txt.
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/bin"

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -792,15 +792,26 @@ jobs:
     # always() so the job still evaluates when smoke-tests is SKIPPED (no
     # smoke scripts at this ref); the explicit result checks enforce the gate.
     #
-    # `inputs.force_publish != true` keeps this job and publish-forced mutually
+    # The force_publish comparisons keep this job and publish-forced mutually
     # exclusive, so a forced run is always recorded by the forced path even if
-    # the gates happened to pass anyway. On the workflow_run trigger there are
-    # no inputs at all, so the expression is '' != true, which is true: the
-    # automatic path always takes this normal gate and can never be forced.
+    # the gates happened to pass anyway.
+    #
+    # Both the boolean and the string are tested on purpose. `inputs` respects
+    # the declared type when dispatched from the UI, but the REST API (and so
+    # `gh workflow run -f force_publish=true`) submits inputs as strings. A
+    # string compared against a boolean casts to a number, so 'true' != true is
+    # TRUE, and a forced run would silently fall through to this job and publish
+    # without recording the bypass. This path is only ever exercised in an
+    # emergency, so it is not somewhere to rely on a coercion subtlety.
+    #
+    # On the workflow_run trigger there are no inputs at all, so both
+    # comparisons are against '', which keeps the automatic path on this normal
+    # gate and means it can never be forced.
     if: >
       always() &&
       github.repository == 'Azure/unbounded' &&
       inputs.force_publish != true &&
+      inputs.force_publish != 'true' &&
       needs.deploy.result == 'success' &&
       needs.deploy-orca.result == 'success' &&
       (needs.smoke-tests.result == 'success' || needs.smoke-tests.result == 'skipped')
@@ -842,10 +853,12 @@ jobs:
   # ---------------------------------------------------------------------------
   publish-forced:
     needs: [resolve, deploy, deploy-orca, smoke-discover, smoke-tests]
+    # Accepts the boolean and the string form for the reason given on the
+    # publish job above: the REST API submits dispatch inputs as strings.
     if: >
       always() &&
       github.repository == 'Azure/unbounded' &&
-      inputs.force_publish == true
+      (inputs.force_publish == true || inputs.force_publish == 'true')
     environment: release-force-publish
     permissions:
       contents: write

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -197,6 +197,11 @@ jobs:
       # /env.go). wait-rollouts.sh will not excuse a shortfall on a workload
       # that does not carry it yet.
       EXPECTED_IMAGE_TAG: ${{ needs.resolve.outputs.tag }}
+      # Where we publish. The gate needs it to tell the images this release
+      # ships from the third-party ones pinned beside them, such as gantry's
+      # busybox init, which never carries a release tag. Lowercased by the
+      # script, since the owner is not.
+      EXPECTED_IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
     outputs:
       mode: ${{ steps.mode.outputs.mode }}
     steps:

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -606,21 +606,23 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # Discover smoke tests: lists hack/release/smoke/*.sh into a JSON matrix. An
-  # absent or empty directory sets has_tasks false and skips smoke-tests, which
-  # has to be explicit because Actions errors on an empty matrix.
+  # Discover smoke tests: lists hack/release/smoke/*.sh into a JSON matrix.
   #
   # Checked out from the DEFAULT BRANCH, not the deployed tag: smoke tests
   # validate the deployed cluster, not the artifacts, so backfilling an old tag
   # should still get today's checks. A test that must be tied to one release
   # belongs with the release artifacts instead.
+  #
+  # Finding none is therefore a repository regression, not a property of the
+  # release being deployed, and it FAILS. It used to emit has_tasks=false and
+  # skip the smoke job, which publish then accepted: deleting or renaming this
+  # directory would have turned smoke off for every release, silently.
   # ---------------------------------------------------------------------------
   smoke-discover:
     needs: [resolve, deploy]
     runs-on: ubuntu-latest
     outputs:
       tasks: ${{ steps.list.outputs.tasks }}
-      has_tasks: ${{ steps.list.outputs.has_tasks }}
       smoke_sha: ${{ steps.pin.outputs.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -643,15 +645,11 @@ jobs:
         id: list
         run: |
           set -euo pipefail
-          # Bail out cleanly if the smoke directory does not exist (older
-          # checkouts, accidentally removed directory). `find` exits
-          # non-zero on a missing path even with stderr suppressed, which
-          # would abort under `set -e`.
+          # `find` exits non-zero on a missing path, so the directory is checked
+          # first to give the real reason rather than a find error.
           if [[ ! -d hack/release/smoke ]]; then
-            echo "has_tasks=false" >> "$GITHUB_OUTPUT"
-            echo "tasks=[]" >> "$GITHUB_OUTPUT"
-            echo "hack/release/smoke does not exist at this ref; skipping smoke tests"
-            exit 0
+            echo "::error::hack/release/smoke does not exist on the default branch; the release soak has no smoke tests"
+            exit 1
           fi
           tasks=$(
             find hack/release/smoke -maxdepth 1 -type f -name '*.sh' \
@@ -660,15 +658,12 @@ jobs:
                   map({name: (. | sub(".*/"; "") | sub(".sh$"; "")), script: .})'
           )
           if [[ -z "$tasks" || "$tasks" == "[]" ]]; then
-            echo "has_tasks=false" >> "$GITHUB_OUTPUT"
-            echo "tasks=[]" >> "$GITHUB_OUTPUT"
-            echo "No smoke tasks found in hack/release/smoke/"
-          else
-            echo "has_tasks=true" >> "$GITHUB_OUTPUT"
-            echo "tasks=${tasks}" >> "$GITHUB_OUTPUT"
-            echo "Discovered smoke tasks:"
-            echo "${tasks}" | jq .
+            echo "::error::no smoke tasks found in hack/release/smoke/; the release soak has no smoke tests"
+            exit 1
           fi
+          echo "tasks=${tasks}" >> "$GITHUB_OUTPUT"
+          echo "Discovered smoke tasks:"
+          echo "${tasks}" | jq .
 
   # ---------------------------------------------------------------------------
   # Smoke tests. Runs ONCE per deploy, after both deploys complete. Ongoing
@@ -689,7 +684,6 @@ jobs:
   # ---------------------------------------------------------------------------
   smoke-tests:
     needs: [resolve, deploy, deploy-orca, smoke-discover]
-    if: needs.smoke-discover.outputs.has_tasks == 'true'
     runs-on: ubuntu-latest
     environment: unbounded-stable
     strategy:
@@ -753,8 +747,15 @@ jobs:
   # ---------------------------------------------------------------------------
   publish:
     needs: [resolve, deploy, deploy-orca, smoke-discover, smoke-tests]
-    # always() so the job still evaluates when smoke-tests is SKIPPED (no smoke
-    # scripts at this ref); the explicit result checks enforce the gate.
+    # EVERY gate has to have succeeded, smoke-discover included. Accepting a
+    # skipped smoke matrix used to publish a release that ran no smoke tests at
+    # all, either because the directory had gone missing on the default branch
+    # or because discovery itself failed - and a failed discovery skips the
+    # matrix, so this job never even saw it. Publishing without smoke is
+    # available, but only through publish-forced, where it is recorded.
+    #
+    # always() keeps the job evaluating so the force_publish comparisons below
+    # still run; the result checks are what enforce the gate.
     #
     # The force_publish comparisons keep this job and publish-forced mutually
     # exclusive, so a forced run is recorded as forced even if the gates passed.
@@ -771,7 +772,8 @@ jobs:
       inputs.force_publish != 'true' &&
       needs.deploy.result == 'success' &&
       needs.deploy-orca.result == 'success' &&
-      (needs.smoke-tests.result == 'success' || needs.smoke-tests.result == 'skipped')
+      needs.smoke-discover.result == 'success' &&
+      needs.smoke-tests.result == 'success'
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -481,7 +481,9 @@ jobs:
           exit 0
 
       - name: Summarize deploy
-        if: always()
+        # !cancelled() rather than always(): a cancelled run has nothing worth
+        # summarizing, and always() delays the cancellation to write it.
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           {
@@ -599,7 +601,7 @@ jobs:
             --azure-endpoint "${ORCA_AZURE_ENDPOINT}"
 
       - name: Summarize Orca deploy
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           {
@@ -764,8 +766,10 @@ jobs:
     # matrix, so this job never even saw it. Publishing without smoke is
     # available, but only through publish-forced, where it is recorded.
     #
-    # always() keeps the job evaluating so the force_publish comparisons below
-    # still run; the result checks are what enforce the gate.
+    # Deliberately NOT always(): that runs a job even when the run has been
+    # CANCELLED, so hitting cancel after the gates went green still published.
+    # The result checks below say exactly what default job semantics already
+    # enforce, and keeping them explicit is what lets the function go.
     #
     # The force_publish comparisons keep this job and publish-forced mutually
     # exclusive, so a forced run is recorded as forced even if the gates passed.
@@ -776,7 +780,6 @@ jobs:
     # On workflow_run there are no inputs at all, so both comparisons are
     # against '' and the automatic path can never be forced.
     if: >
-      always() &&
       github.repository == 'Azure/unbounded' &&
       inputs.force_publish != true &&
       inputs.force_publish != 'true' &&
@@ -818,8 +821,12 @@ jobs:
     needs: [resolve, deploy, deploy-orca, smoke-discover, smoke-tests]
     # Accepts the boolean and the string form for the reason given on the
     # publish job above: the REST API submits dispatch inputs as strings.
+    #
+    # !cancelled() rather than always(): this job has to run when deploy or
+    # smoke FAILED, which is its whole purpose, but cancelling the run must
+    # still stop it. always() would publish through a cancellation.
     if: >
-      always() &&
+      !cancelled() &&
       github.repository == 'Azure/unbounded' &&
       (inputs.force_publish == true || inputs.force_publish == 'true')
     environment: release-force-publish
@@ -944,7 +951,7 @@ jobs:
   #
   # notify:
   #   needs: [resolve, deploy, smoke-tests]
-  #   if: always() && needs.resolve.result == 'success'
+  #   if: ${{ !cancelled() && needs.resolve.result == 'success' }}
   #   runs-on: ubuntu-latest
   #   environment: unbounded-stable
   #   steps:

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -40,7 +40,8 @@ name: release upgrade
 # ------------------------------------------------------------
 #   - Add a smoke test       -> drop a script in hack/release/smoke/
 #                               (see the smoke-tests job for the contract)
-#   - Change target cluster  -> change `environment:` on the relevant jobs
+#   - Change target cluster  -> change `environment:` on the relevant jobs AND
+#                               the concurrency group
 #   - Add Teams/Slack notify -> see commented-out notify job at the bottom
 #   - Exclude prereleases    -> tighten the resolve job's tag regex
 # ---------------------------------------------------------------------------
@@ -84,12 +85,21 @@ on:
 permissions:
   contents: read
 
-# Prevent two deploys for the same tag from racing. We key on the upstream
-# workflow_run's head_branch (the tag name for tag-push triggers) or the
-# manual input. Different tags can deploy concurrently; the same tag
-# serializes.
+# One deploy at a time, because the CLUSTER is the shared resource, not the tag.
+# Keying on the tag let two releases deploy to unbounded-stable at once, and
+# they then invalidate each other: one waits for its own image tag to appear,
+# the other replaces the workloads underneath it, and `rollout status` reports
+# the second one's rollout as the first one's success. Both would publish
+# claiming a soak that never happened.
+#
+# Queued rather than cancelled: an in-flight deploy is soaking a real cluster
+# and its result is worth having. A second tag waits for it.
+#
+# CUSTOMIZE: retargeting this workflow at another cluster means changing this
+# group as well as `environment:` on the jobs, or the two clusters will
+# serialize against each other for no reason.
 concurrency:
-  group: deploy-stable-${{ github.event.workflow_run.head_branch || inputs.tag }}
+  group: deploy-unbounded-stable
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -7,57 +7,34 @@ name: release upgrade
 # Deploys an Unbounded release to the integration cluster (unbounded-stable)
 # so it can soak before being published to end users.
 #
-# Lifecycle this workflow is part of:
-#
-#   1. Cut a release. Push a tag (or use the `unbounded release` workflow's
-#      workflow_dispatch). That workflow (release.yaml) builds binaries,
-#      container images, the manifests tarball, signs everything, and
-#      creates a DRAFT GitHub Release with all assets attached.
-#
-#   2. Auto-deploy to integration. As soon as `unbounded release` finishes
-#      successfully, THIS workflow fires via `workflow_run` and deploys
-#      the release onto the `unbounded-stable` cluster.
-#
-#   3. Smoke. Immediately after deploy, the `smoke-tests` job runs an
-#      extensible matrix of fast post-deploy validation tasks against the
-#      freshly deployed cluster (see hack/release/smoke/).
-#
-#   4. Publish. Once deploy (core + Orca) and smoke succeed, the `publish`
-#      job flips the GitHub Release from draft to published automatically -
-#      a clean deploy plus green smoke is the soak gate. Prereleases are
-#      published too but keep their prerelease flag, so they are never
-#      marked "Latest". An operator can still publish or unpublish manually
-#      (`gh release edit <tag> --draft=false` / `--draft=true`). The
-#      `released` event fires but nothing listens to it. Ongoing soak
-#      observation relies on the cluster's existing monitoring/alerts and
-#      is not this workflow's responsibility.
+# The process this is part of is documented in RELEASING.md. In short:
+# release.yaml builds and signs a tag into a DRAFT release, this workflow fires
+# on that run completing, deploys it, smokes it, and publishes the draft.
 #
 # Why workflow_run and not `release: [released]`?
-#   The previous trigger fired on draft -> published, which made the
-#   deploy race the asset uploads in release.yaml. If the operator
-#   published the draft before release.yaml's `finalize` job attached the
-#   manifests, the deploy would fail with "no assets to download". Every
-#   release from v0.1.3 onward failed that way. workflow_run fires only
-#   after release.yaml has uploaded everything to the draft, which by
-#   construction means assets are present.
+#   The previous trigger fired on draft -> published, which raced the asset
+#   uploads in release.yaml: if the draft was published before its `finalize`
+#   job attached the manifests, the deploy failed with "no assets to download".
+#   Every release from v0.1.3 onward failed that way. workflow_run fires only
+#   after release.yaml has uploaded everything.
+#
+# Nothing observes the soak after publish; that is the cluster's monitoring,
+# not this workflow's job.
 #
 # Target cluster
 # --------------
-# The target cluster is configured via the `unbounded-stable` GitHub
-# Environment, which provides:
+# Configured via the `unbounded-stable` GitHub Environment:
 #   - secret KUBECONFIG                 (raw kubeconfig file contents)
 #   - vars   SITE_NAME, CLUSTER_NODE_CIDR, CLUSTER_POD_CIDR,
 #            SITE_NODE_CIDR, SITE_POD_CIDR, MANAGE_CNI_PLUGIN,
-#            ORCA_AZURE_ACCOUNT, ORCA_AZURE_CONTAINER,
-#            ORCA_AZURE_ENDPOINT
-#   - cluster Secret unbounded-system/orca-credentials for confidential
-#     Orca values (Azure account key and Garage S3 credentials)
+#            ORCA_AZURE_ACCOUNT, ORCA_AZURE_CONTAINER, ORCA_AZURE_ENDPOINT
+#   - cluster Secret unbounded-system/orca-credentials for confidential Orca
+#     values (Azure account key and Garage S3 credentials)
 #
-# To redirect this workflow at a different cluster: create a new
-# Environment (e.g. `unbounded-canary`), set its secrets/vars, change
-# `environment:` on the deploy and smoke-tests jobs, and update the
-# concurrency group key if you want the new cluster to deploy in parallel
-# with stable. See hack/scripts/setup-deploy-environment.sh.
+# To retarget: create an Environment, set its secrets/vars, change
+# `environment:` on the deploy and smoke-tests jobs, and update the concurrency
+# group if the new cluster should deploy in parallel with stable. See
+# hack/scripts/setup-deploy-environment.sh.
 #
 # Customization points (search for "CUSTOMIZE:" in this file)
 # ------------------------------------------------------------
@@ -117,26 +94,15 @@ concurrency:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Resolve the release tag we are deploying.
+  # Resolve the release tag we are deploying: from the upstream run's
+  # head_branch on workflow_run (GitHub puts the bare tag name there for tag
+  # pushes), or from the dispatch input.
   #
-  #   workflow_run triggers: read the tag from the upstream run's
-  #     head_branch. For tag pushes, GitHub puts the bare tag name there
-  #     (no refs/tags/ prefix). We filter to:
-  #       - this repo (safety on forks)
-  #       - successful upstream runs
-  #       - upstream runs triggered by tag push (excludes workflow_dispatch
-  #         and dry_run runs of release.yaml, whose head_branch is a branch
-  #         name)
-  #       - tags starting with `v` (cheap pre-filter; full semver regex
-  #         below)
+  # The `event == 'push'` filter excludes workflow_dispatch and dry_run runs of
+  # release.yaml, whose head_branch is a branch name rather than a tag.
   #
-  #   workflow_dispatch: read the tag from the user's input.
-  #
-  # The full semver regex allows prerelease suffixes (e.g. v1.2.3-rc1).
-  # Prerelease tags ARE deployed to unbounded-stable by design - the
-  # integration cluster is where we exercise prereleases.
-  #
-  # CUSTOMIZE: to exclude prereleases, drop the `(-[0-9A-Za-z.-]+)?`
+  # Prerelease tags ARE deployed by design; the integration cluster is where we
+  # exercise them. CUSTOMIZE: to exclude them, drop the `(-[0-9A-Za-z.-]+)?`
   # group from the regex below.
   # ---------------------------------------------------------------------------
   resolve:
@@ -187,15 +153,13 @@ jobs:
   # ---------------------------------------------------------------------------
   # Deploy the release to the target cluster.
   #
-  #   MODE=init     -> bootstrap CRDs/operator, then run 'kubectl unbounded site init'.
-  #                    Used for the very first bootstrap of a cluster.
-  #   MODE=upgrade  -> server-side apply CRDs/operator from the rendered
-  #                    manifests that were attached to the GitHub Release.
+  #   MODE=init     -> bootstrap CRDs/operator, then 'kubectl unbounded site
+  #                    init'. The very first bootstrap of a cluster.
+  #   MODE=upgrade  -> server-side apply CRDs/operator from the release's
+  #                    rendered manifests.
   #
-  # Note: this job downloads assets from the DRAFT GitHub Release (the
-  # release soaks as a draft before it is published to end users). Draft
-  # releases are only visible to tokens with push access, so this job
-  # overrides the workflow's read-only default with `contents: write`.
+  # `contents: write` because the assets come from the DRAFT release, and drafts
+  # are only visible to tokens with push access.
   # ---------------------------------------------------------------------------
   deploy:
     needs: resolve
@@ -213,21 +177,15 @@ jobs:
       SITE_POD_CIDR: ${{ vars.SITE_POD_CIDR }}
       MANAGE_CNI_PLUGIN: ${{ vars.MANAGE_CNI_PLUGIN }}
       # Absorbs an isolated unreachable node without letting a broad outage
-      # through. Override on a manual dispatch when an outage is known and
-      # accepted; the automatic workflow_run path has no inputs, so it always
-      # uses this default.
-      #
-      # `||` relies on expression truthiness, which is safe here only because
-      # the input is typed `string`: a non-empty string, including "0", is
-      # truthy. Retyping it to `number` would silently turn an explicit 0 back
-      # into this default.
+      # through. Overridable on a manual dispatch; workflow_run has no inputs,
+      # so the automatic path always takes this default. `||` is safe only
+      # because the input is typed `string`, where "0" is truthy; a `number`
+      # input would turn an explicit 0 back into this default.
       MAX_NOTREADY_NODES: ${{ inputs.max_notready_nodes || '2' }}
-      # The version the operator will resolve every component image at:
-      # <registry>/<repository>:<operator version>, and the operator's version
-      # is the tag it was built from (internal/operator/component/env.go).
-      # wait-rollouts.sh refuses to excuse a shortfall on a workload that does
-      # not carry this tag yet, so a rollout cannot be declared done while the
-      # operator is still reconciling the PREVIOUS release.
+      # The tag the operator resolves every component image at, since it is the
+      # version the operator itself was built from (internal/operator/component
+      # /env.go). wait-rollouts.sh will not excuse a shortfall on a workload
+      # that does not carry it yet.
       EXPECTED_IMAGE_TAG: ${{ needs.resolve.outputs.tag }}
     outputs:
       mode: ${{ steps.mode.outputs.mode }}
@@ -299,21 +257,16 @@ jobs:
           ls -la dist/
 
       - name: Fetch deploy tooling from the workflow's own commit
-        # The job's primary checkout is pinned to the DEPLOYED TAG, but the
-        # rollout gate is tooling, not a release artifact: it validates the
-        # deployed cluster, exactly like hack/release/smoke/ does. Older tags do
-        # not contain it, so invoking it from the tag checkout would break every
-        # documented rollback and backfill ("re-run this workflow's
-        # workflow_dispatch with the previous tag") with "No such file or
-        # directory" before the cluster is ever contacted.
+        # The primary checkout is pinned to the DEPLOYED TAG, but the rollout
+        # gate is tooling, not a release artifact: it validates the deployed
+        # cluster, exactly like hack/release/smoke/ does. Older tags do not
+        # contain it, so running it from the tag checkout would break every
+        # documented rollback and backfill on "No such file or directory".
         #
         # github.workflow_sha is the commit of the workflow FILE now executing,
-        # so the gate is always the exact sibling of the workflow that calls it.
-        # That holds identically for workflow_run (which runs the default
-        # branch's definition against an old tag) and for workflow_dispatch from
-        # a branch, and unlike resolving a branch name it cannot drift if the
-        # default branch advances mid-run. See "check out its own source code"
-        # in the Actions contexts reference.
+        # so the gate is always its exact sibling - on workflow_run, on dispatch
+        # from a branch, and without drifting if the default branch advances
+        # mid-run, which resolving a branch name would.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.workflow_sha }}
@@ -364,17 +317,13 @@ jobs:
             MODE=init
             echo "force_init=true; selecting init mode"
           elif kubectl get crd sites.net.unbounded-cloud.io >/dev/null 2>&1 && ! kubectl get crd sites.unbounded-cloud.io >/dev/null 2>&1; then
-            # First upgrade from the pre-redesign (v0.1) split-namespace layout:
-            # the old net-group Site CRD (sites.net.unbounded-cloud.io) exists but
-            # the new sites.unbounded-cloud.io CRD has not been bootstrapped yet.
-            # That CRD is created by the operator itself during the later
-            # 'Bootstrap CRDs and operator' step (kubectl unbounded install), so
-            # its absence here is expected for a first upgrade. Deploy in upgrade
-            # mode: install brings up the operator, whose always-on LegacyReaper
-            # translates the old Site into the new Site and migrates the split
-            # layout into unbounded-system automatically. Do NOT run 'site init'
-            # here; that would create a fresh Site instead of migrating the
-            # existing one.
+            # First upgrade from the pre-redesign (v0.1) split-namespace
+            # layout: the old net-group Site CRD exists, and the new one is
+            # absent because the operator creates it during the later
+            # 'Bootstrap CRDs and operator' step. Upgrade mode is correct: the
+            # operator's always-on LegacyReaper migrates the old Site and the
+            # split layout into unbounded-system. 'site init' would create a
+            # fresh Site instead of migrating the existing one.
             MODE=upgrade
             echo "Legacy Site CRD present and new Site CRD absent; first v0.1->v0.2 upgrade. Operator migrates automatically. Selecting upgrade mode"
           elif ! kubectl get crd sites.unbounded-cloud.io >/dev/null 2>&1; then
@@ -512,23 +461,17 @@ jobs:
   # ---------------------------------------------------------------------------
   # Deploy Orca (the origin cache) to the integration cluster.
   #
-  # Orca is deployed separately from the core net/machina manifests: on
-  # unbounded-stable it is a long-running integration-test workload, not
-  # part of the shippable release tarball. release.yaml DOES build and
-  # push the Orca image (<registry>/orca:<tag>), but its manifests plus
-  # the test-only Garage cachestore are deployed here from hack/orca via
-  # hack/orca/deploy-integration.sh.
+  # Separate from the core manifests: on unbounded-stable Orca is a
+  # long-running integration workload, not part of the shippable tarball.
+  # release.yaml does build and push its image, but its manifests and the
+  # test-only Garage cachestore are deployed here from hack/orca.
   #
-  # Origin is real Azure Blob storage; cachestore is an in-cluster
-  # single-node Garage backed by a PVC. Confidential values (Azure
-  # account key, Garage S3 keys) come from a pre-created orca-credentials
-  # Secret that this workflow never creates or overwrites; the
-  # non-confidential Azure account details come from Environment vars.
+  # Origin is real Azure Blob; cachestore is an in-cluster single-node Garage on
+  # a PVC. Confidential values come from a pre-created orca-credentials Secret
+  # this workflow never writes; the rest come from Environment vars.
   #
-  # Unlike the deploy job's rollout gate, this job reads its tooling from the
-  # deployed TAG checkout (no sparse-checkout of the workflow's own commit).
-  # Re-deploying Orca onto a tag that predates this tooling is not supported -
-  # acceptable for a forward-looking integration cluster.
+  # Unlike the rollout gate, this reads its tooling from the deployed TAG, so
+  # re-deploying Orca onto a tag that predates the tooling is unsupported.
   # ---------------------------------------------------------------------------
   deploy-orca:
     needs: [resolve, deploy]
@@ -628,21 +571,14 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # Discover smoke tests to run after deploy. Lists hack/release/smoke/*.sh
-  # and emits a JSON matrix. If the directory is absent or has no scripts,
-  # has_tasks is false and the smoke-tests job is skipped (GitHub Actions
-  # errors on an empty matrix, so we have to gate it explicitly).
+  # Discover smoke tests: lists hack/release/smoke/*.sh into a JSON matrix. An
+  # absent or empty directory sets has_tasks false and skips smoke-tests, which
+  # has to be explicit because Actions errors on an empty matrix.
   #
-  # Why check out the default branch instead of the deployed tag?
-  #   Smoke tests are validation of the *deployed cluster*, not of the
-  #   release artifacts. They are intentionally version-agnostic (they
-  #   check generic cluster health), and we want backfill deploys of older
-  #   tags to still benefit from the latest smoke checks. Without this,
-  #   backfilling a tag that predates hack/release/smoke/ would skip
-  #   smoke entirely; new smoke tests added on main would also never run
-  #   against old releases. If a smoke test ever needs to be tied to a
-  #   specific release, that's a signal it should live with the release
-  #   artifacts (e.g. as an integration test in CI), not here.
+  # Checked out from the DEFAULT BRANCH, not the deployed tag: smoke tests
+  # validate the deployed cluster, not the artifacts, so backfilling an old tag
+  # should still get today's checks. A test that must be tied to one release
+  # belongs with the release artifacts instead.
   # ---------------------------------------------------------------------------
   smoke-discover:
     needs: [resolve, deploy]
@@ -700,36 +636,21 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
-  # Smoke tests. Runs ONCE per deploy, after the core release deploy and
-  # Orca integration deploy have both completed. Each task must complete
-  # within the per-task timeout (15 minutes by default below). Long-running
-  # validation is NOT this job's responsibility - rely on the cluster's
-  # monitoring for that.
-  #
-  # Not to be confused with hack/smoke-metalman.py / hack/smoke-storage.py,
-  # which are component-level smoke tests used by CI workflows. Those run
-  # against ephemeral test environments; this runs against the deployed
-  # unbounded-stable cluster.
+  # Smoke tests. Runs ONCE per deploy, after both deploys complete. Ongoing
+  # validation is the cluster's monitoring, not this job's. Not to be confused
+  # with hack/smoke-metalman.py and hack/smoke-storage.py, which are
+  # component-level checks CI runs against ephemeral environments.
   #
   # CUSTOMIZE: ADD A SMOKE TEST
-  #   1. Drop an executable script in hack/release/smoke/ named
-  #      hack/release/smoke/<name>.sh. The basename (minus .sh) becomes
-  #      the matrix task name and shows up as its own job in the Actions
-  #      UI.
-  #   2. The script must complete within 15 minutes (see timeout-minutes
-  #      below).
-  #   3. The script runs from the repo root at the commit the default
-  #      branch pointed to when smoke-discover ran (NOT the deployed tag -
-  #      see smoke-discover's rationale) with the following env exported:
-  #        TAG          - the deployed tag (e.g. v0.1.12)
-  #        KUBECONFIG   - path to the cluster's kubeconfig
-  #        SITE_NAME    - the configured site name on this cluster
-  #      Anything from the `unbounded-stable` environment is also in scope.
-  #   4. Exit 0 for pass, non-zero for fail. Failures do NOT roll back the
-  #      deploy - rollback during soak is a human decision (re-run this
-  #      workflow's workflow_dispatch with the previous tag).
+  #   Drop an executable hack/release/smoke/<name>.sh. The basename becomes the
+  #   matrix task name and its own job in the Actions UI. It runs from the repo
+  #   root at the commit smoke-discover checked out (NOT the deployed tag), must
+  #   finish inside timeout-minutes below, and exits 0 for pass. Exported: TAG,
+  #   KUBECONFIG, SITE_NAME, plus anything from the unbounded-stable
+  #   environment. A failure does NOT roll back the deploy; rollback during soak
+  #   is a human decision (re-dispatch with the previous tag).
   #
-  # See hack/release/smoke/core-namespaces-ready.sh as a template.
+  #   Use hack/release/smoke/core-namespaces-ready.sh as a template.
   # ---------------------------------------------------------------------------
   smoke-tests:
     needs: [resolve, deploy, deploy-orca, smoke-discover]
@@ -788,37 +709,26 @@ jobs:
           "$SMOKE_SCRIPT"
 
   # ---------------------------------------------------------------------------
-  # Publish the GitHub Release once the soak succeeds. Releases are built as
-  # drafts and soak on unbounded-stable; a clean deploy (core + Orca) plus
-  # green smoke tests is the gate that flips the draft to published. This
-  # applies to prereleases too: they keep their `--prerelease` flag, so they
-  # become visible but are never marked "Latest" nor returned by
-  # /releases/latest. If deploy or smoke fails, the job does not run and the
-  # release stays a draft.
+  # Publish the GitHub Release once the soak succeeds: a clean deploy (core +
+  # Orca) plus green smoke. If any of them fails the release stays a draft.
   #
-  # `gh release edit --draft=false` is idempotent, so re-deploys of an
-  # already-published tag are a no-op.
+  # Prereleases publish too, keeping their `--prerelease` flag, so they are
+  # visible but never "Latest". `--draft=false` is idempotent, so re-deploying
+  # an already-published tag is a no-op.
   # ---------------------------------------------------------------------------
   publish:
     needs: [resolve, deploy, deploy-orca, smoke-discover, smoke-tests]
-    # always() so the job still evaluates when smoke-tests is SKIPPED (no
-    # smoke scripts at this ref); the explicit result checks enforce the gate.
+    # always() so the job still evaluates when smoke-tests is SKIPPED (no smoke
+    # scripts at this ref); the explicit result checks enforce the gate.
     #
     # The force_publish comparisons keep this job and publish-forced mutually
-    # exclusive, so a forced run is always recorded by the forced path even if
-    # the gates happened to pass anyway.
-    #
-    # Both the boolean and the string are tested on purpose. `inputs` respects
-    # the declared type when dispatched from the UI, but the REST API (and so
-    # `gh workflow run -f force_publish=true`) submits inputs as strings. A
-    # string compared against a boolean casts to a number, so 'true' != true is
-    # TRUE, and a forced run would silently fall through to this job and publish
-    # without recording the bypass. This path is only ever exercised in an
-    # emergency, so it is not somewhere to rely on a coercion subtlety.
-    #
-    # On the workflow_run trigger there are no inputs at all, so both
-    # comparisons are against '', which keeps the automatic path on this normal
-    # gate and means it can never be forced.
+    # exclusive, so a forced run is recorded as forced even if the gates passed.
+    # BOTH forms are tested because the REST API, and so `gh workflow run -f
+    # force_publish=true`, submits inputs as strings: a string compared against
+    # a boolean casts to a number, so 'true' != true is TRUE and a forced run
+    # would fall through to here and publish without recording the bypass.
+    # On workflow_run there are no inputs at all, so both comparisons are
+    # against '' and the automatic path can never be forced.
     if: >
       always() &&
       github.repository == 'Azure/unbounded' &&
@@ -842,26 +752,20 @@ jobs:
           echo "### Published ${TAG}" >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # BREAK GLASS: publish without a green soak.
+  # BREAK GLASS: publish without a green soak. Documented in RELEASING.md.
   #
-  # This exists because the alternative is worse. Before it, a release that
-  # could not pass the gate got published by hand with 'gh release edit
-  # --draft=false' and left no trace, which is how the gate quietly stopped
-  # meaning anything. A sanctioned bypass is only an improvement over that if it
-  # is harder to reach and leaves a durable record, so this job:
+  # This exists because the alternative was worse: a release that could not pass
+  # the gate got published by hand with 'gh release edit --draft=false' and left
+  # no trace, which is how the gate quietly stopped meaning anything. A
+  # sanctioned bypass only improves on that if it is harder to reach and leaves
+  # a durable record, so this job runs on manual dispatch only, refuses to run
+  # without a written reason, still verifies signatures and the BOM, and writes
+  # the bypass into the RELEASE BODY rather than just the run log - CI logs age
+  # out, release notes do not.
   #
-  #   - only runs on a manual dispatch (workflow_run carries no inputs);
-  #   - refuses to run without a written reason;
-  #   - still verifies artifact signatures and the release BOM, because the
-  #     soak is the only thing forcing is allowed to skip;
-  #   - writes the bypass into the RELEASE BODY, not just the run log. CI logs
-  #     age out; the release notes do not. If forcing ever becomes routine it
-  #     shows up in the release history where everyone can see it.
-  #
-  # It carries its own environment so a repo admin can require reviewers on the
-  # forced path alone, leaving normal releases fully automatic. GitHub creates
-  # the environment on first reference, so this works before it is configured;
-  # it simply has no protection rules until someone adds them.
+  # Its own environment lets an admin require reviewers on the forced path
+  # alone. GitHub creates it on first reference, so this works before anyone
+  # configures it; it simply has no protection rules until they do.
   # ---------------------------------------------------------------------------
   publish-forced:
     needs: [resolve, deploy, deploy-orca, smoke-discover, smoke-tests]

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -90,6 +90,14 @@ on:
         description: "Override how many NotReady nodes may be tolerated (blank = workflow default)"
         required: false
         type: string
+      force_publish:
+        description: "BREAK GLASS: publish even if deploy or smoke failed. Requires a reason. Artifact signatures are still verified."
+        type: boolean
+        default: false
+      reason:
+        description: "Why the gate is being bypassed (required with force_publish; recorded on the release)"
+        required: false
+        type: string
 
 # workflow_run-triggered workflows default to read-only. Most jobs only need
 # read access for checkout. Two jobs override this with `contents: write`:
@@ -278,31 +286,36 @@ jobs:
             --dir dist/
           ls -la dist/
 
+      - name: Fetch deploy tooling from the workflow's own commit
+        # The job's primary checkout is pinned to the DEPLOYED TAG, but the
+        # rollout gate is tooling, not a release artifact: it validates the
+        # deployed cluster, exactly like hack/release/smoke/ does. Older tags do
+        # not contain it, so invoking it from the tag checkout would break every
+        # documented rollback and backfill ("re-run this workflow's
+        # workflow_dispatch with the previous tag") with "No such file or
+        # directory" before the cluster is ever contacted.
+        #
+        # github.workflow_sha is the commit of the workflow FILE now executing,
+        # so the gate is always the exact sibling of the workflow that calls it.
+        # That holds identically for workflow_run (which runs the default
+        # branch's definition against an old tag) and for workflow_dispatch from
+        # a branch, and unlike resolving a branch name it cannot drift if the
+        # default branch advances mid-run. See "check out its own source code"
+        # in the Actions contexts reference.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: _deploy-tools
+          sparse-checkout: hack/release
+          sparse-checkout-cone-mode: true
+
       - name: Verify release signatures and BOM
+        # Shared with the forced-publish job so the two paths that can publish a
+        # release cannot drift into verifying different things. The checkout
+        # above is at the tag, so HEAD is the commit the BOM must record.
         run: |
           set -euo pipefail
-          IDENTITY="^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yaml@refs/tags/${TAG}$"
-          ARCHIVE="dist/unbounded-manifests-${TAG}.tar.gz"
-          OPERATOR_MANIFEST="dist/unbounded-operator-${TAG}.yaml"
-          BOM="dist/unbounded-release-bom-${TAG}.json"
-
-          for artifact in "${ARCHIVE}" "${OPERATOR_MANIFEST}" "${BOM}"; do
-            cosign verify-blob \
-              --bundle "${artifact}.bundle.json" \
-              --certificate-identity-regexp "${IDENTITY}" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-              "${artifact}"
-          done
-
-          test "$(jq -r '.release.tag' "${BOM}")" = "${TAG}"
-          test "$(jq -r '.release.gitCommit' "${BOM}")" = "$(git rev-parse HEAD)"
-
-          jq -r '.images[] | (.reference | sub(":[^/]+$"; "")) + "@" + .digest' "${BOM}" | while IFS= read -r image; do
-            cosign verify \
-              --certificate-identity-regexp "${IDENTITY}" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-              "${image}" >/dev/null
-          done
+          _deploy-tools/hack/release/verify-release-artifacts.sh "$TAG" "$(git rev-parse HEAD)" dist
 
       - name: Extract manifests
         run: |
@@ -395,29 +408,6 @@ jobs:
             echo "::error::Release tarball contains operator-owned CRs; refusing to upgrade-apply."
             exit 1
           fi
-
-      - name: Fetch deploy tooling from the workflow's own commit
-        # The job's primary checkout is pinned to the DEPLOYED TAG, but the
-        # rollout gate is tooling, not a release artifact: it validates the
-        # deployed cluster, exactly like hack/release/smoke/ does. Older tags do
-        # not contain it, so invoking it from the tag checkout would break every
-        # documented rollback and backfill ("re-run this workflow's
-        # workflow_dispatch with the previous tag") with "No such file or
-        # directory" before the cluster is ever contacted.
-        #
-        # github.workflow_sha is the commit of the workflow FILE now executing,
-        # so the gate is always the exact sibling of the workflow that calls it.
-        # That holds identically for workflow_run (which runs the default
-        # branch's definition against an old tag) and for workflow_dispatch from
-        # a branch, and unlike resolving a branch name it cannot drift if the
-        # default branch advances mid-run. See "check out its own source code"
-        # in the Actions contexts reference.
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.workflow_sha }}
-          path: _deploy-tools
-          sparse-checkout: hack/release
-          sparse-checkout-cone-mode: true
 
       - name: Wait for rollouts
         # Shared with nightly.yaml so the two deploy gates cannot drift.
@@ -801,9 +791,16 @@ jobs:
     needs: [resolve, deploy, deploy-orca, smoke-discover, smoke-tests]
     # always() so the job still evaluates when smoke-tests is SKIPPED (no
     # smoke scripts at this ref); the explicit result checks enforce the gate.
+    #
+    # `inputs.force_publish != true` keeps this job and publish-forced mutually
+    # exclusive, so a forced run is always recorded by the forced path even if
+    # the gates happened to pass anyway. On the workflow_run trigger there are
+    # no inputs at all, so the expression is '' != true, which is true: the
+    # automatic path always takes this normal gate and can never be forced.
     if: >
       always() &&
       github.repository == 'Azure/unbounded' &&
+      inputs.force_publish != true &&
       needs.deploy.result == 'success' &&
       needs.deploy-orca.result == 'success' &&
       (needs.smoke-tests.result == 'success' || needs.smoke-tests.result == 'skipped')
@@ -820,6 +817,129 @@ jobs:
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false
           echo "Published ${TAG}."
           echo "### Published ${TAG}" >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # BREAK GLASS: publish without a green soak.
+  #
+  # This exists because the alternative is worse. Before it, a release that
+  # could not pass the gate got published by hand with 'gh release edit
+  # --draft=false' and left no trace, which is how the gate quietly stopped
+  # meaning anything. A sanctioned bypass is only an improvement over that if it
+  # is harder to reach and leaves a durable record, so this job:
+  #
+  #   - only runs on a manual dispatch (workflow_run carries no inputs);
+  #   - refuses to run without a written reason;
+  #   - still verifies artifact signatures and the release BOM, because the
+  #     soak is the only thing forcing is allowed to skip;
+  #   - writes the bypass into the RELEASE BODY, not just the run log. CI logs
+  #     age out; the release notes do not. If forcing ever becomes routine it
+  #     shows up in the release history where everyone can see it.
+  #
+  # It carries its own environment so a repo admin can require reviewers on the
+  # forced path alone, leaving normal releases fully automatic. GitHub creates
+  # the environment on first reference, so this works before it is configured;
+  # it simply has no protection rules until someone adds them.
+  # ---------------------------------------------------------------------------
+  publish-forced:
+    needs: [resolve, deploy, deploy-orca, smoke-discover, smoke-tests]
+    if: >
+      always() &&
+      github.repository == 'Azure/unbounded' &&
+      inputs.force_publish == true
+    environment: release-force-publish
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ needs.resolve.outputs.tag }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REASON: ${{ inputs.reason }}
+      ACTOR: ${{ github.actor }}
+      DEPLOY_RESULT: ${{ needs.deploy.result }}
+      ORCA_RESULT: ${{ needs.deploy-orca.result }}
+      SMOKE_RESULT: ${{ needs.smoke-tests.result }}
+    steps:
+      - name: Require a reason
+        # Checked before anything else so a forced run cannot get partway and
+        # leave the release in an ambiguous state.
+        run: |
+          set -euo pipefail
+          if [[ -z "${REASON// /}" ]]; then
+            echo "::error::force_publish requires a non-empty reason; it is recorded on the release"
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Fetch verification tooling from the workflow's own commit
+        # Same reasoning as the deploy job: the checkout above is the DEPLOYED
+        # TAG, which for a backfill predates this script entirely. The tooling
+        # has to come from the workflow's own commit or forcing a publish of an
+        # older release would fail on a missing file.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: _deploy-tools
+          sparse-checkout: hack/release
+          sparse-checkout-cone-mode: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Download release artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'unbounded-manifests-*.tar.gz' \
+            --pattern 'unbounded-manifests-*.tar.gz.bundle.json' \
+            --pattern 'unbounded-operator-*.yaml' \
+            --pattern 'unbounded-operator-*.yaml.bundle.json' \
+            --pattern "unbounded-release-bom-${TAG}.json" \
+            --pattern "unbounded-release-bom-${TAG}.json.bundle.json" \
+            --dir dist/
+
+      - name: Verify release signatures and BOM
+        # Deliberately NOT skipped when forcing. Provenance is not what is being
+        # bypassed, and this needs no cluster, so it still works in exactly the
+        # outage this job exists for.
+        run: |
+          set -euo pipefail
+          _deploy-tools/hack/release/verify-release-artifacts.sh "$TAG" "$(git rev-parse HEAD)" dist
+
+      - name: Publish release and record the bypass
+        run: |
+          set -euo pipefail
+
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false
+
+          # Written through a file rather than an argument: release bodies carry
+          # the whole generated changelog and can comfortably exceed the command
+          # line length limit.
+          notes="$(mktemp)"
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body -q .body > "$notes"
+
+          printf '\n\n---\n\n> **Published without a successful soak.**\n> Forced by @%s. Deploy: %s, Orca: %s, smoke: %s.\n> Reason: %s\n>\n> Release artifact signatures and the release BOM were verified; the\n> deployment soak on unbounded-stable was not completed.\n' \
+            "$ACTOR" "$DEPLOY_RESULT" "$ORCA_RESULT" "$SMOKE_RESULT" "$REASON" >> "$notes"
+
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$notes"
+          rm -f "$notes"
+
+          echo "::warning::${TAG} was published WITHOUT a successful soak, forced by ${ACTOR}: ${REASON}"
+
+          {
+            echo "### Published ${TAG} via break glass"
+            echo
+            echo "- Forced by: @${ACTOR}"
+            echo "- Reason: ${REASON}"
+            echo "- deploy: \`${DEPLOY_RESULT}\`, deploy-orca: \`${ORCA_RESULT}\`, smoke-tests: \`${SMOKE_RESULT}\`"
+            echo "- Artifact signatures and BOM: verified"
+          } >> "$GITHUB_STEP_SUMMARY"
+
 
   # ---------------------------------------------------------------------------
   # CUSTOMIZE: Teams notification (NOT YET ENABLED)

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -370,19 +370,54 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve metalman workloads
+        # Metalman is a per-SITE component: the operator creates one
+        # Deployment/metalman-controller-<site> for every Site that enables it.
+        # They are discovered rather than derived from SITE_NAME, because on
+        # this cluster the two differ - the cluster's own Site is `stable`,
+        # while metalman runs for a remote site.
+        #
+        # From _deploy-tools for the same reason as the rollout gate: the
+        # primary checkout is the deployed tag, which for a backfill predates
+        # this script.
+        id: metalman
+        run: |
+          set -euo pipefail
+
+          # Nothing has joined a fresh cluster yet, so an empty result is only a
+          # regression on an upgrade of an existing one.
+          if [[ "$MODE" == "init" ]]; then
+            export REQUIRE_METALMAN=false
+          fi
+
+          # Assigned in its own step rather than substituted into the gate
+          # invocation below: a command substitution that fails inside a larger
+          # command does not trip `set -e`, so the gate would silently lose its
+          # metalman targets.
+          targets="$(_deploy-tools/hack/release/metalman-targets.sh | tr '\n' ' ')"
+
+          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
+          echo "Gating metalman: ${targets:-<none>}"
+
       - name: Wait for rollouts
         # Shared with nightly.yaml so the two deploy gates cannot drift.
         # Component workloads are created asynchronously after the operator
         # reconciles the Site, so the script waits for each to exist before
         # checking its rollout status, and fails fast naming the image when a pod
         # cannot pull one.
+        env:
+          METALMAN_TARGETS: ${{ steps.metalman.outputs.targets }}
         run: |
+          # METALMAN_TARGETS is deliberately unquoted: it carries one argument
+          # per discovered Deployment, and Site names are RFC 1123 object names.
+          # shellcheck disable=SC2086
           _deploy-tools/hack/release/wait-rollouts.sh \
             deploy/unbounded-operator \
             deploy/unbounded-net-controller \
             ds/unbounded-net-node \
             deploy/machina-controller \
-            ds/gantry
+            ds/gantry \
+            ${METALMAN_TARGETS}
 
       - name: Diagnose failed rollout
         # Runs only when a prior step failed (e.g. the operator never created a

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -216,7 +216,19 @@ jobs:
       # through. Override on a manual dispatch when an outage is known and
       # accepted; the automatic workflow_run path has no inputs, so it always
       # uses this default.
+      #
+      # `||` relies on expression truthiness, which is safe here only because
+      # the input is typed `string`: a non-empty string, including "0", is
+      # truthy. Retyping it to `number` would silently turn an explicit 0 back
+      # into this default.
       MAX_NOTREADY_NODES: ${{ inputs.max_notready_nodes || '2' }}
+      # The version the operator will resolve every component image at:
+      # <registry>/<repository>:<operator version>, and the operator's version
+      # is the tag it was built from (internal/operator/component/env.go).
+      # wait-rollouts.sh refuses to excuse a shortfall on a workload that does
+      # not carry this tag yet, so a rollout cannot be declared done while the
+      # operator is still reconciling the PREVIOUS release.
+      EXPECTED_IMAGE_TAG: ${{ needs.resolve.outputs.tag }}
     outputs:
       mode: ${{ steps.mode.outputs.mode }}
     steps:

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -86,6 +86,10 @@ on:
         description: "Run 'site init' instead of upgrade-apply (use for first-ever bootstrap)"
         type: boolean
         default: false
+      max_notready_nodes:
+        description: "Override how many NotReady nodes may be tolerated (blank = workflow default)"
+        required: false
+        type: string
 
 # workflow_run-triggered workflows default to read-only. Most jobs only need
 # read access for checkout. Two jobs override this with `contents: write`:
@@ -200,6 +204,11 @@ jobs:
       SITE_NODE_CIDR: ${{ vars.SITE_NODE_CIDR }}
       SITE_POD_CIDR: ${{ vars.SITE_POD_CIDR }}
       MANAGE_CNI_PLUGIN: ${{ vars.MANAGE_CNI_PLUGIN }}
+      # Absorbs an isolated unreachable node without letting a broad outage
+      # through. Override on a manual dispatch when an outage is known and
+      # accepted; the automatic workflow_run path has no inputs, so it always
+      # uses this default.
+      MAX_NOTREADY_NODES: ${{ inputs.max_notready_nodes || '2' }}
     outputs:
       mode: ${{ steps.mode.outputs.mode }}
     steps:
@@ -443,6 +452,17 @@ jobs:
           kubectl get sites.unbounded-cloud.io -o wide 2>&1
           kubectl get sites.unbounded-cloud.io -o yaml 2>&1
           kubectl get sites.net.unbounded-cloud.io -A -o wide 2>&1
+          echo "::endgroup::"
+          echo "::group::Node readiness"
+          # A DaemonSet counts every node toward desiredNumberScheduled, so a
+          # single unreachable node stalls a rollout indefinitely. This is the
+          # first thing to check when a rollout times out, and its absence is
+          # why one such stall went unexplained for weeks.
+          kubectl get nodes -o wide 2>&1
+          echo "--- not Ready ---"
+          kubectl get nodes \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.metadata.labels.unbounded-cloud\.io/site}{"\n"}{end}' 2>&1 \
+            | awk -F'\t' '$2 != "True" { printf "%s (site=%s, Ready=%s)\n", $1, ($3 == "" ? "none" : $3), $2 }'
           echo "::endgroup::"
           echo "::group::Workloads in ${NS}"
           kubectl -n "$NS" get deploy,ds,pods -o wide 2>&1

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -851,7 +851,7 @@ jobs:
       !cancelled() &&
       github.repository == 'Azure/unbounded' &&
       (inputs.force_publish == true || inputs.force_publish == 'true')
-    environment: release-force-publish
+    environment: unbounded-reviewers
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -823,10 +823,10 @@ jobs:
       ACTOR: ${{ github.actor }}
       DEPLOY_RESULT: ${{ needs.deploy.result }}
       ORCA_RESULT: ${{ needs.deploy-orca.result }}
+      # Both smoke jobs, because a failed discovery skips the matrix: without
+      # this, "smoke: skipped" would be recorded as a soak that passed.
+      DISCOVER_RESULT: ${{ needs.smoke-discover.result }}
       SMOKE_RESULT: ${{ needs.smoke-tests.result }}
-      # Marks the notice this job appends to the release body, so re-running it
-      # for the same tag does not stack up a second copy.
-      MARKER: "<!-- unbounded:forced-publish -->"
     steps:
       - name: Require a reason
         # Checked before anything else so a forced run cannot get partway and
@@ -881,44 +881,34 @@ jobs:
           _deploy-tools/hack/release/verify-release-artifacts.sh "$TAG" "$(git rev-parse HEAD)" dist
 
       - name: Publish release and record the bypass
+        # The notice is composed BEFORE anything is published, and applied in
+        # the same call that clears the draft flag. Publishing first and
+        # recording second left a window where a failed second call produced a
+        # public release with no audit record - the one thing this path exists
+        # to prevent. Now a failure leaves the release a draft.
         run: |
           set -euo pipefail
 
-          # A forced dispatch always lands on this job, even when the gates
-          # happened to pass, so that forcing is always recorded as forcing.
-          # That makes the headline conditional: claiming an unsoaked release
-          # when the soak in fact went green would be its own kind of
-          # misleading record.
-          if [[ "$DEPLOY_RESULT" == "success" && "$ORCA_RESULT" == "success" \
-                && ( "$SMOKE_RESULT" == "success" || "$SMOKE_RESULT" == "skipped" ) ]]; then
-            headline="Published through the forced path, though the soak did pass."
-            caveat="The gates this run bypasses all reported success; the bypass is recorded because it was requested."
-          else
-            headline="Published without a successful soak."
-            caveat="Release artifact signatures and the release BOM were verified; the deployment soak on unbounded-stable was not completed."
-          fi
-
-          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false
-
-          # Written through a file rather than an argument: release bodies carry
+          # Written through files rather than arguments: release bodies carry
           # the whole generated changelog and can comfortably exceed the command
           # line length limit.
-          notes="$(mktemp)"
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body -q .body > "$notes"
+          current="$(mktemp)"
+          updated="$(mktemp)"
+          trap 'rm -f "$current" "$updated"' EXIT
 
-          # Re-running this job for the same tag must not stack up a second
-          # notice. The marker is an HTML comment so it is invisible on the
-          # rendered release page but reliable to match on.
-          if grep -qF "$MARKER" "$notes"; then
-            echo "::notice::${TAG} already carries a forced-publish notice; leaving the release body alone"
-          else
-            printf '\n\n---\n\n%s\n> **%s**\n> Forced by @%s. Deploy: %s, Orca: %s, smoke: %s.\n> Reason: %s\n>\n> %s\n' \
-              "$MARKER" "$headline" "$ACTOR" "$DEPLOY_RESULT" "$ORCA_RESULT" "$SMOKE_RESULT" "$REASON" "$caveat" >> "$notes"
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body -q .body > "$current"
 
-            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$notes"
-          fi
+          rc=0
+          _deploy-tools/hack/release/forced-publish-notes.sh "$current" > "$updated" || rc=$?
 
-          rm -f "$notes"
+          case "$rc" in
+            0) ;;
+            3) echo "::notice::${TAG} already carries a forced-publish notice; leaving the body as it is" ;;
+            *) exit "$rc" ;;
+          esac
+
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --notes-file "$updated" --draft=false
 
           echo "::warning::${TAG} was published through the break-glass path by ${ACTOR}: ${REASON}"
 
@@ -927,7 +917,7 @@ jobs:
             echo
             echo "- Forced by: @${ACTOR}"
             echo "- Reason: ${REASON}"
-            echo "- deploy: \`${DEPLOY_RESULT}\`, deploy-orca: \`${ORCA_RESULT}\`, smoke-tests: \`${SMOKE_RESULT}\`"
+            echo "- deploy: \`${DEPLOY_RESULT}\`, deploy-orca: \`${ORCA_RESULT}\`, smoke-discover: \`${DISCOVER_RESULT}\`, smoke-tests: \`${SMOKE_RESULT}\`"
             echo "- Artifact signatures and BOM: verified"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,9 @@ detail as possible: steps to reproduce, expected behavior, actual behavior, and 
 
 ### Testing the Release Pipeline Locally
 
+Cutting an actual release is documented separately in
+[RELEASING.md](RELEASING.md).
+
 Before pushing a tag, you can rehearse the GitHub Actions release workflow on
 your workstation with:
 

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ NET_FRONTEND_CACHE_FILE    := $(NET_FRONTEND_DIST_DIR)/.frontend-build-key
 # Frontend build toggle (dev builds produce unminified output with sourcemaps).
 REACT_DEV ?= false
 
-.PHONY: all help fmt lint test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build install-tools install-protoc generate kubectl-unbounded forge agent-artifacts-builder agent-artifacts-builder-build orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push unbounded-operator unbounded-operator-build unbounded-operator-manifests playpen-manifests e2e-playpen gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build gantry-manifests inventory-manifests
+.PHONY: all help fmt lint lint-actions test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build install-tools install-protoc generate kubectl-unbounded forge agent-artifacts-builder agent-artifacts-builder-build orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push unbounded-operator unbounded-operator-build unbounded-operator-manifests playpen-manifests e2e-playpen gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build gantry-manifests inventory-manifests
 .PHONY: net-frontend net-frontend-clean net-ebpf-build net-ebpf-generate net-ebpf-verify net-manifests release-bom release-manifests unbounded-operator-release-manifest
 .PHONY: image-machina-local image-machine-ops-controller-local image-metalman-local image-unbounded-operator-local image-unbounded-operator-push image-playpen-local image-net-controller-local image-net-node-local image-gantry-local image-gantry-push images-local
 .PHONY: image-net-controller-push image-net-node-push images-net-all images-net-all-push
@@ -287,12 +287,13 @@ help: ## Show this help
 	@echo "General:"
 	@echo "  all                              Build all Go binaries (default)"
 	@echo "  help                             Show this help"
-	@echo "  install-tools                    Install gofumpt, golangci-lint, protoc-gen-go, protoc-gen-go-grpc, controller-gen"
+	@echo "  install-tools                    Install gofumpt, golangci-lint, protoc-gen-go, protoc-gen-go-grpc, controller-gen, actionlint"
 	@echo "  install-protoc                   Download pinned protoc into bin/protoc/"
 	@echo ""
 	@echo "Development:"
 	@echo "  fmt                              Format Go source (gofumpt + wsl_v5)"
-	@echo "  lint                             Run golangci-lint"
+	@echo "  lint                             Run golangci-lint and actionlint"
+	@echo "  lint-actions                     Run actionlint over .github/workflows"
 	@echo "  test                             Run all tests"
 	@echo "  build                            Compile all Go packages"
 	@echo "  generate                         Run go generate (deepcopy, CRDs, protobuf)"
@@ -425,6 +426,7 @@ GOLANGCI_LINT_VERSION ?= v2.11.4
 PROTOC_GEN_GO_VERSION ?= v1.36.11
 PROTOC_GEN_GO_GRPC_VERSION ?= v1.6.1
 CONTROLLER_GEN_VERSION ?= v0.21.0
+ACTIONLINT_VERSION ?= v1.7.12
 
 # Pinned protoc for deterministic .pb.go output across environments.
 # Downloaded from the upstream protobuf GitHub releases.
@@ -451,12 +453,13 @@ else
   PROTOC_ARCH ?= $(PROTOC_UNAME_M)
 endif
 
-install-tools: ## Install development tools (gofumpt, golangci-lint, protoc-gen-go, protoc-gen-go-grpc, controller-gen)
+install-tools: ## Install development tools (gofumpt, golangci-lint, protoc-gen-go, protoc-gen-go-grpc, controller-gen, actionlint)
 	go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GEN_GO_GRPC_VERSION)
 	go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
+	go install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
 
 install-protoc: $(PROTOC) ## Download pinned protoc into bin/protoc/
 
@@ -488,8 +491,25 @@ fmt: check-deps ## Format all Go source files (gofumpt + wsl_v5 whitespace)
 
 # lint runs the same checks locally and in CI and does NOT auto-fix. Run
 # `make fmt` to apply fixes. wsl_v5 is enforced via .golangci.yaml.
-lint: ## Run golangci-lint (matches CI; run `make fmt` to auto-fix)
+lint: ## Run golangci-lint and actionlint (matches CI; run `make fmt` to auto-fix)
 	$(GOLINT) $(GO_PACKAGE_PATTERNS)
+	@$(MAKE) --no-print-directory lint-actions
+
+# lint-actions is part of `lint` because a workflow file is only ever parsed
+# when it is dispatched. A duplicate `default:` key made release-prepare.yaml
+# undispatchable while every check in CI stayed green, and the workflow that
+# mints release tags is the worst possible place to find that out by hand.
+#
+# The shellcheck and pyflakes integrations are disabled explicitly rather than
+# left at their defaults: GitHub-hosted runners ship shellcheck and most
+# workstations do not, so leaving them on would make `make lint` mean something
+# different in CI than it does locally. Enabling shellcheck over every `run:`
+# block is worth doing on its own terms, with its own findings list.
+lint-actions: ## Run actionlint over .github/workflows
+	@command -v actionlint >/dev/null 2>&1 || \
+		{ echo "error: actionlint not found. Install it with:"; \
+		  echo "  go install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)"; exit 1; }
+	actionlint -shellcheck= -pyflakes=
 
 ifdef CI
 # In CI each job is independent; skip chained prerequisites.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,241 @@
+# Releasing Unbounded Kubernetes
+
+How to cut, soak, and publish a release, and what to do when one of those goes
+wrong. Maintainer-facing; for using a release, see the
+[documentation site](https://unbounded-cloud.io/).
+
+Releases are cut from `main` only. There are no maintenance branches today (see
+[Hotfixes](#hotfixes)).
+
+## At a glance
+
+Three workflows, in order. Only the first is started by a human.
+
+| Phase | Workflow | Trigger | Result |
+|---|---|---|---|
+| 1. Prepare | `release-prepare.yaml` | manual dispatch | pushes a `vX.Y.Z` tag, nothing else |
+| 2. Build | `release.yaml` | the tag push | builds, signs, attests, creates a **draft** release |
+| 3. Soak and publish | `release-upgrade.yaml` | automatic, on phase 2 completing | deploys to `unbounded-stable`, smokes it, flips the draft to published |
+
+The split exists so phase 2 runs in the tag's context. Keyless cosign signatures
+carry the identity `release.yaml@refs/tags/vX.Y.Z`, and phase 3 verifies exactly
+that. A build dispatched from a branch would sign as `@refs/heads/main` and fail
+verification, which is why `release.yaml` deliberately has **no** manual
+trigger.
+
+The tag is pushed with an SSH deploy key rather than `GITHUB_TOKEN`, because
+GitHub suppresses workflow triggers for tags pushed with the default token.
+
+## 1. Is `main` releasable?
+
+There is no single dashboard. Check these before cutting:
+
+```sh
+# The nightly deploys main to a real cluster and smoke-tests it. This is the
+# strongest signal we have. It should be green, and green recently.
+gh run list --repo Azure/unbounded --workflow nightly.yaml --limit 5
+
+# CI on the commit you intend to release.
+gh run list --repo Azure/unbounded --workflow ci.yaml --branch main --limit 5
+```
+
+A red nightly is a release blocker until it is understood. It deploys the same
+component images the release will, to the same shape of cluster, so a nightly
+failure is a release failure you have not had yet.
+
+Note that a nightly failure caused solely by unreachable nodes is tolerated and
+reported rather than failing the run; see
+[Degraded clusters](#degraded-clusters).
+
+## 2. Choosing a version
+
+The project is pre-1.0, so semver's compatibility guarantees are not yet in
+force and breaking changes can land in a minor bump. In practice:
+
+- **patch** (`v0.2.4` to `v0.2.5`) for fixes and incremental work with no
+  behaviour change for existing users.
+- **minor** (`v0.2.4` to `v0.3.0`) for new capabilities, breaking changes,
+  removed flags, or CRD field changes.
+- **major** is reserved for 1.0.
+
+### Prereleases use `rc` only
+
+The prerelease suffix is `rc.N`. `alpha` and `beta` were previously used
+interchangeably with no defined meaning; do not add new ones.
+
+Iterate a train by re-running prepare with the **same** `bump` and an
+incremented `pre`: `rc.1`, then `rc.2`, and so on. Promote when it is good.
+
+### Every component shares one version
+
+The operator resolves each component image as
+`<registry>/<repository>:<operator version>`, where the version is the one
+compiled into the operator binary. So `machina`, `gantry`, `metalman`,
+`unbounded-storage-supervisor` and the two `unbounded-net-*` images are all
+deployed at the release tag. There is no per-component versioning, and a
+component's image must be built by the release pipeline or its workload will not
+start. `internal/operator/imagecoverage_test.go` enforces that.
+
+## 3. Preparing a release
+
+Everything is `release-prepare.yaml`. It only computes a version and pushes a
+tag; it builds nothing, so a mistake here is cheap to undo.
+
+```sh
+# Cut a release candidate. Bump is relative to the latest FINAL tag.
+gh workflow run release-prepare.yaml --repo Azure/unbounded \
+  -f mode=prerelease -f bump=patch -f pre=rc.1
+
+# Iterate the train. Same bump, next rc.
+gh workflow run release-prepare.yaml --repo Azure/unbounded \
+  -f mode=prerelease -f bump=patch -f pre=rc.2
+
+# Promote the train to its final version. No bump: v0.2.5-rc.2 becomes v0.2.5.
+gh workflow run release-prepare.yaml --repo Azure/unbounded \
+  -f mode=promote -f version=v0.2.5
+
+# Cut a final release directly, with no candidate.
+gh workflow run release-prepare.yaml --repo Azure/unbounded \
+  -f mode=release -f bump=patch
+```
+
+### Three things that bite
+
+**`bump` is relative to the latest final tag, every time.** It is not
+remembered across a train. If you cut `v0.2.5-rc.1` with `bump=patch` and then
+run `rc.2` with `bump=minor`, you get `v0.3.0-rc.2` and now have two live
+trains.
+
+**`pre` is not validated.** Nothing checks that `rc.2` follows `rc.1`. Skipping
+or repeating a number is accepted silently.
+
+**`promote` with a blank `version` picks the highest prerelease in the whole
+repository, not the train you were working on.** If two trains are live it will
+silently finalise the wrong one and orphan the other. This has happened: the
+`v0.1.24` train reached `rc.18` and was abandoned when a `v0.2.0` train started
+alongside it. **Always pass `version` explicitly.**
+
+## 4. What the build does
+
+`release.yaml` needs no input. It validates the tag shape, then builds the
+binaries via GoReleaser, the frontend, every container image, the offline agent
+artifacts, the manifests tarball and the storage tarballs. Everything is signed
+with keyless cosign, images carry SPDX SBOM attestations, and a digest-pinned
+release BOM records exactly what shipped.
+
+It always creates the release as a **draft**. Prerelease is inferred from a `-`
+in the tag.
+
+## 5. Soaking and publishing
+
+`release-upgrade.yaml` starts automatically when the build finishes. It:
+
+1. downloads the draft release's artifacts,
+2. verifies their signatures and the BOM against the tag's cosign identity,
+3. deploys to the `unbounded-stable` cluster,
+4. waits for every component workload to roll out,
+5. runs the smoke tests in `hack/release/smoke/`,
+6. and only then flips the draft to published.
+
+A clean deploy plus green smoke is the soak gate. **Publishing is not a manual
+step.** If you find yourself running `gh release edit --draft=false` by hand,
+use the [break-glass path](#break-glass) instead so the bypass is recorded.
+
+Prereleases are published too, but stay flagged as prereleases and never become
+"Latest".
+
+### Degraded clusters
+
+A DaemonSet counts every node toward its desired count, including nodes the
+cluster has lost contact with, so one dead node would otherwise block every
+release forever. The gate tolerates a shortfall when it is caused **only** by
+NotReady nodes and everything on a reachable node is healthy.
+
+`MAX_NOTREADY_NODES` caps how much is excusable: **2** for the release deploy,
+**0** for the nightly. Beyond the cap the shortfall is not excused and the
+rollout fails, with the offending nodes named and grouped by site.
+
+## Break glass
+
+Two sanctioned overrides. Both are manual-dispatch only: the automatic path
+carries no inputs and cannot be relaxed.
+
+### Tolerate more unreachable nodes
+
+When a known outage takes out more nodes than the cap allows:
+
+```sh
+gh workflow run release-upgrade.yaml --repo Azure/unbounded \
+  -f tag=v0.2.5 -f max_notready_nodes=7
+```
+
+This raises the ceiling only. A shortfall must still be entirely explained by
+NotReady nodes, and anything unhealthy on a reachable node still fails. State
+the number deliberately; it is a claim someone can review.
+
+### Publish without a soak
+
+For when the soak cluster itself is the problem and the release must ship:
+
+```sh
+gh workflow run release-upgrade.yaml --repo Azure/unbounded \
+  -f tag=v0.2.5 -f force_publish=true \
+  -f reason="unbounded-stable unreachable during DC maintenance"
+```
+
+- The reason is **required** and is written into the release body, where it
+  stays visible long after the CI logs expire.
+- Artifact signatures and the release BOM are **still verified**. Forcing means
+  "we accept an unsoaked release", never "we accept an unverified one".
+- The deploy and smoke jobs still run, so their diagnostics are preserved.
+- The forced path uses the `release-force-publish` environment, so it can be
+  gated on reviewer approval independently of normal releases.
+
+If you use this, file a follow-up to fix whatever made it necessary.
+
+## Recovery
+
+**A tag was pushed but no build started.** Usually a deploy-key problem. Delete
+the tag and re-run prepare. There is no manual trigger on `release.yaml` by
+design: a dispatched build would sign with the wrong identity and fail
+verification downstream.
+
+```sh
+git push origin :refs/tags/v0.2.5
+```
+
+**The build failed partway.** Fix the cause, delete the tag, and cut it again.
+The draft release and any uploaded assets should be deleted first so the retry
+starts clean.
+
+**The soak failed.** Read the failure before reaching for the override. The
+deploy job's `Diagnose failed rollout` step dumps node readiness, Sites,
+workloads, applied images and operator logs. A missing image is named
+explicitly; so is a rollout blocked by unreachable nodes.
+
+**A release was published by mistake.** Re-draft it:
+
+```sh
+gh release edit v0.2.5 --repo Azure/unbounded --draft=true
+```
+
+**Stale drafts.** Abandoned candidates linger as drafts and should be deleted
+once their train is promoted, otherwise the release list becomes misleading.
+
+## Hotfixes
+
+**Not currently supported.** `release-prepare.yaml` always cuts from `main`, so
+there is no way to patch an older release without shipping everything merged
+since. The agreed model, not yet implemented, is a `release-X.Y` branch created
+on demand from the release tag, with fixes cherry-picked from `main` and patch
+releases cut from the branch. Tracked in
+[#610](https://github.com/Azure/unbounded/issues/610).
+
+Until then the only supported remedy is rolling forward, which matches the
+support policy in [SECURITY.md](SECURITY.md): fixes land on the latest release
+and `main`, and older releases are not routinely supported.
+
+## Rehearsing locally
+
+`./hack/test-release-local.sh` rehearses the build phase on a workstation. See
+[CONTRIBUTING.md](CONTRIBUTING.md#testing-the-release-pipeline-locally).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ wrong. Maintainer-facing; for using a release, see the
 [documentation site](https://unbounded-cloud.io/).
 
 Releases are cut from `main` only. There are no maintenance branches today (see
-[Hotfixes](#hotfixes)).
+[Maintenance lines](#maintenance-lines)).
 
 ## At a glance
 
@@ -27,6 +27,105 @@ trigger.
 
 The tag is pushed with an SSH deploy key rather than `GITHUB_TOKEN`, because
 GitHub suppresses workflow triggers for tags pushed with the default token.
+
+## Cutting a release
+
+One dispatch, then waiting. Nothing between the tag and the published release
+needs a human.
+
+### Patch release
+
+The common case: fixes and incremental work with no behaviour change for
+existing users.
+
+```sh
+# 1. Is main releasable? The nightly deploys it to a real cluster, so this is
+#    the strongest signal available. It should be green, and green recently.
+gh run list --repo Azure/unbounded --workflow nightly.yaml --limit 5
+
+# 2. What would ship? Everything on main since the last final tag.
+git fetch --tags origin
+git log --oneline \
+  "$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' origin/main)..origin/main"
+
+# 3. Confirm the version without cutting anything. The run log prints the tag
+#    it would create and the commit it would tag.
+gh workflow run release-prepare.yaml --repo Azure/unbounded \
+  -f mode=release -f bump=patch -f dry_run=true
+
+# 4. Cut it. Same command, without dry_run.
+gh workflow run release-prepare.yaml --repo Azure/unbounded \
+  -f mode=release -f bump=patch
+
+# 5. Watch it through. The tag push starts the build, which drafts the release;
+#    finishing that starts the soak, which publishes it.
+gh run list --repo Azure/unbounded --workflow release.yaml --limit 3
+gh run list --repo Azure/unbounded --workflow release-upgrade.yaml --limit 3
+
+# 6. Confirm. isDraft false means it shipped.
+gh release view v0.2.5 --repo Azure/unbounded --json tagName,isDraft,url
+```
+
+If a step fails, see [Recovery](#recovery). If the soak cluster is the problem
+rather than the release, see [Break glass](#break-glass).
+
+### Minor release
+
+The same, with `-f bump=minor`. Use it for new capabilities, breaking changes,
+removed flags or CRD field changes; see [Choosing a version](#2-choosing-a-version).
+Consider cutting a candidate first.
+
+### With a release candidate first
+
+Worth it for anything you would not want to publish blind. Each candidate is
+built, signed and soaked on `unbounded-stable` exactly like a final release, and
+published as a prerelease, so it never becomes "Latest".
+
+```sh
+# 1. Start the train. bump is relative to the latest final tag.
+gh workflow run release-prepare.yaml --repo Azure/unbounded \
+  -f mode=prerelease -f bump=minor
+
+# 2. Iterate. Same command with NO input changes: the train in flight is
+#    detected and the next rc taken automatically.
+gh workflow run release-prepare.yaml --repo Azure/unbounded -f mode=prerelease
+
+# 3. Promote when it is good.
+gh workflow run release-prepare.yaml --repo Azure/unbounded -f mode=promote
+```
+
+`promote` tags the **last candidate's commit**, so anything merged to `main`
+after that candidate is not in the release. That is a feature as much as a
+constraint: cut a candidate as soon as your change lands and you hold that exact
+tree, whatever merges afterwards.
+
+## Shipping an urgent fix
+
+There are no maintenance branches yet, so an urgent fix rolls forward: land it
+on `main` and cut a patch release. What that costs depends on what else is
+sitting on `main`.
+
+**`main` is clean.** Land the fix, cut a patch release as above. Nothing
+special.
+
+**`main` carries work you are not ready to ship.** A release from `main` takes
+all of it, and there is no way to exclude it. Read the list first (step 2
+above), then pick:
+
+- cut a candidate the moment your fix lands and promote that. `promote` ships
+  the candidate's tree, so anything merged afterwards is excluded;
+- revert the unready work on `main`, cut the patch, re-land it after;
+- ship it anyway, having read the list.
+
+**The fix is for an older line**, e.g. a `v0.2.x` user after `v0.3.0` shipped.
+Not supported today: `release-prepare` cuts from `main` only. See
+[Maintenance lines](#maintenance-lines).
+
+## Reference
+
+The rest of this document is what the guides above are built on: what each phase
+of the pipeline does, what to do when one of them goes wrong, and the two
+sanctioned overrides.
 
 ## 1. Is `main` releasable?
 
@@ -80,29 +179,10 @@ start. `internal/operator/imagecoverage_test.go` enforces that.
 ## 3. Preparing a release
 
 Everything is `release-prepare.yaml`. It only computes a version and pushes a
-tag; it builds nothing, so a mistake here is cheap to undo.
+tag; it builds nothing, so a mistake here is cheap to undo. The commands are in
+[Cutting a release](#cutting-a-release); what follows is what they mean.
 
-```sh
-# Start a candidate train. Bump is relative to the latest final tag.
-gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=prerelease -f bump=patch
-
-# Iterate it. Same command, no changes: the train is detected and the next
-# rc is taken automatically.
-gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=prerelease
-
-# Promote it. Resolves on its own when one train is in flight, and tags the
-# last candidate's commit.
-gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=promote
-
-# Cut a final release directly, with no candidate.
-gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=release -f bump=patch
-```
-
-Add `-f dry_run=true` to any of these to see the version and commit it would
+`-f dry_run=true` works with any mode and prints the version and commit it would
 cut without pushing anything.
 
 Note that `release-prepare` runs the resolver from `main`, so a change to it
@@ -282,18 +362,31 @@ gh release edit v0.2.5 --repo Azure/unbounded --draft=true
 **Stale drafts.** Abandoned candidates linger as drafts and should be deleted
 once their train is promoted, otherwise the release list becomes misleading.
 
-## Hotfixes
+## Maintenance lines
 
-**Not currently supported.** `release-prepare.yaml` always cuts from `main`, so
-there is no way to patch an older release without shipping everything merged
-since. The agreed model, not yet implemented, is a `release-X.Y` branch created
-on demand from the release tag, with fixes cherry-picked from `main` and patch
-releases cut from the branch. Tracked in
-[#610](https://github.com/Azure/unbounded/issues/610).
+**Not yet implemented**, tracked in
+[#627](https://github.com/Azure/unbounded/issues/627). `release-prepare.yaml`
+cuts from `main` only, so an older release cannot be patched without shipping
+everything merged since.
 
-Until then the only supported remedy is rolling forward, which matches the
-support policy in [SECURITY.md](SECURITY.md): fixes land on the latest release
-and `main`, and older releases are not routinely supported.
+The agreed model is a **lazy** `release-X.Y` branch, created on demand from a
+tag or commit the first time an older line needs a fix, with every subsequent
+release on that line cut from it:
+
+- version resolution scoped to the line, so `release-0.2` cuts `v0.2.5` while
+  `main` is on `v0.3.x` and neither can mint the other's numbers;
+- fixes cherry-picked onto the branch through a PR, with CI and code scanning
+  extended to `release-*` - today both run on `main` only, so a cherry-pick
+  would be tested by nothing;
+- a maintenance release **skips the soak**, because deploying an older line to
+  `unbounded-stable` would downgrade it, and stays a draft until someone
+  publishes it deliberately through the recorded
+  [break-glass path](#publish-without-a-soak).
+
+Until that lands, the remedy is rolling forward, which matches the support
+policy in [SECURITY.md](SECURITY.md): fixes land on the latest release and
+`main`, and older releases are not routinely supported. See
+[Shipping an urgent fix](#shipping-an-urgent-fix).
 
 ## Rehearsing locally
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,11 +60,12 @@ force and breaking changes can land in a minor bump. In practice:
 
 ### Prereleases use `rc` only
 
-The prerelease suffix is `rc.N`. `alpha` and `beta` were previously used
-interchangeably with no defined meaning; do not add new ones.
+The prerelease suffix is `rc.N`, and `release-prepare` rejects anything else.
+`alpha` and `beta` were previously used interchangeably with no defined
+meaning.
 
-Iterate a train by re-running prepare with the **same** `bump` and an
-incremented `pre`: `rc.1`, then `rc.2`, and so on. Promote when it is good.
+Iterate a train by re-running prepare in `prerelease` mode with no input
+changes; the next `rc` is chosen for you. Promote when it is good.
 
 ### Every component shares one version
 
@@ -82,38 +83,50 @@ Everything is `release-prepare.yaml`. It only computes a version and pushes a
 tag; it builds nothing, so a mistake here is cheap to undo.
 
 ```sh
-# Cut a release candidate. Bump is relative to the latest FINAL tag.
+# Start a candidate train. Bump is relative to the latest final tag.
 gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=prerelease -f bump=patch -f pre=rc.1
+  -f mode=prerelease -f bump=patch
 
-# Iterate the train. Same bump, next rc.
+# Iterate it. Same command, no changes: the train is detected and the next
+# rc is taken automatically.
 gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=prerelease -f bump=patch -f pre=rc.2
+  -f mode=prerelease
 
-# Promote the train to its final version. No bump: v0.2.5-rc.2 becomes v0.2.5.
+# Promote it. Resolves on its own when one train is in flight.
 gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=promote -f version=v0.2.5
+  -f mode=promote
 
 # Cut a final release directly, with no candidate.
 gh workflow run release-prepare.yaml --repo Azure/unbounded \
   -f mode=release -f bump=patch
 ```
 
-### Three things that bite
+Add `-f dry_run=true` to any of these to see the version it would cut without
+pushing anything.
 
-**`bump` is relative to the latest final tag, every time.** It is not
-remembered across a train. If you cut `v0.2.5-rc.1` with `bump=patch` and then
-run `rc.2` with `bump=minor`, you get `v0.3.0-rc.2` and now have two live
-trains.
+### How trains work
 
-**`pre` is not validated.** Nothing checks that `rc.2` follows `rc.1`. Skipping
-or repeating a number is accepted silently.
+A train is **in flight** when its core version has prerelease tags, no final
+tag, and is newer than the latest final tag.
 
-**`promote` with a blank `version` picks the highest prerelease in the whole
-repository, not the train you were working on.** If two trains are live it will
-silently finalise the wrong one and orphan the other. This has happened: the
-`v0.1.24` train reached `rc.18` and was abandoned when a `v0.2.0` train started
-alongside it. **Always pass `version` explicitly.**
+- `prerelease` continues the train in flight and takes the next `rc.N`. `bump`
+  is only consulted when there is no train to continue, so it cannot fork a
+  train halfway through.
+- `pre` is almost never needed. Leave it blank. An explicit value must be
+  `rc.N` and must be ahead of the current highest.
+- `promote` resolves on its own when exactly one train is in flight. With
+  several it refuses and asks which, rather than guessing.
+
+Starting a second train while one is in flight requires
+`-f allow_concurrent_trains=true`, and once two exist, `promote` requires an
+explicit `version`.
+
+That guard exists because of a real incident: the `v0.1.24` train reached
+`rc.18` and was silently orphaned when a `v0.2.0` train started beside it.
+Promote picked the newer train, `v0.1.24` was never cut, and its twelve
+candidate tags are still in the repository. Those older candidates are now
+classified as **stale** rather than in flight, so they are reported for cleanup
+and never offered as something to continue or promote.
 
 ## 4. What the build does
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -164,7 +164,8 @@ in the tag.
 3. deploys to the `unbounded-stable` cluster,
 4. waits for the gated component workloads to roll out,
 5. deploys Orca, the origin cache, as an integration workload,
-6. runs the smoke tests in `hack/release/smoke/`,
+6. runs the smoke tests in `hack/release/smoke/`, taken from the default branch
+   so an old tag still gets today's checks,
 7. and only then flips the draft to published.
 
 Step 4 gates on `unbounded-operator`, `unbounded-net-controller`,
@@ -184,9 +185,10 @@ A clean deploy, a clean Orca deploy and green smoke are the soak gate.
 `gh release edit --draft=false` by hand, use the
 [break-glass path](#break-glass) instead so the bypass is recorded.
 
-Smoke tests that are *skipped* also satisfy the gate. That is deliberate and
-only happens when the deployed ref has no `hack/release/smoke/` directory, which
-means backfilling a tag old enough to predate smoke tests still publishes.
+Smoke tests cannot be skipped. Discovery fails if `hack/release/smoke/` is empty
+on the default branch, and publishing requires both discovery and every task to
+succeed, so a release that ran no smoke tests stays a draft. Shipping one anyway
+is the [break-glass path](#break-glass), where it is recorded.
 
 This is also why `promote` tags the last candidate's commit: the soak is
 evidence about one specific tree, and it is only worth anything if that is the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,7 +92,8 @@ gh workflow run release-prepare.yaml --repo Azure/unbounded \
 gh workflow run release-prepare.yaml --repo Azure/unbounded \
   -f mode=prerelease
 
-# Promote it. Resolves on its own when one train is in flight.
+# Promote it. Resolves on its own when one train is in flight, and tags the
+# last candidate's commit.
 gh workflow run release-prepare.yaml --repo Azure/unbounded \
   -f mode=promote
 
@@ -101,8 +102,13 @@ gh workflow run release-prepare.yaml --repo Azure/unbounded \
   -f mode=release -f bump=patch
 ```
 
-Add `-f dry_run=true` to any of these to see the version it would cut without
-pushing anything.
+Add `-f dry_run=true` to any of these to see the version and commit it would
+cut without pushing anything.
+
+Note that `release-prepare` runs the resolver from `main`, so a change to it
+takes effect only once merged. It cannot be rehearsed by dispatching the
+workflow from a branch, `dry_run` included; `hack/release/next-version-test.sh`
+is how you test it before that.
 
 ### How trains work
 
@@ -116,6 +122,16 @@ tag, and is newer than the latest final tag.
   `rc.N` and must be ahead of the current highest.
 - `promote` resolves on its own when exactly one train is in flight. With
   several it refuses and asks which, rather than guessing.
+
+`promote` creates the tag on **the last candidate's commit**, not on `main`
+HEAD. The point of a candidate is that it was built, deployed to
+`unbounded-stable` and smoke-tested; tagging HEAD would ship a different tree,
+including everything merged since, under a version whose only claim to being
+trustworthy is that soak. Anything merged after the last `rc` is therefore
+**not** in the release. `dry_run` prints the commit and how many commits are
+being left out.
+
+If you want those commits, cut another candidate first and promote that one.
 
 Starting a second train while one is in flight requires
 `-f allow_concurrent_trains=true`, and once two exist, `promote` requires an
@@ -154,6 +170,10 @@ A clean deploy plus green smoke is the soak gate. **Publishing is not a manual
 step.** If you find yourself running `gh release edit --draft=false` by hand,
 use the [break-glass path](#break-glass) instead so the bypass is recorded.
 
+This is also why `promote` tags the last candidate's commit: the soak is
+evidence about one specific tree, and it is only worth anything if that is the
+tree that ships.
+
 Prereleases are published too, but stay flagged as prereleases and never become
 "Latest".
 
@@ -164,9 +184,13 @@ cluster has lost contact with, so one dead node would otherwise block every
 release forever. The gate tolerates a shortfall when it is caused **only** by
 NotReady nodes and everything on a reachable node is healthy.
 
-`MAX_NOTREADY_NODES` caps how much is excusable: **2** for the release deploy,
-**0** for the nightly. Beyond the cap the shortfall is not excused and the
+`MAX_NOTREADY_NODES` caps how much is excusable: **2**, for both the release
+deploy and the nightly. Beyond the cap the shortfall is not excused and the
 rollout fails, with the offending nodes named and grouped by site.
+
+Tolerance is not a way to skip the upgrade. A shortfall is only excusable on a
+workload that already carries the release's image tag, so a rollout cannot be
+declared done while the operator is still reconciling the previous version.
 
 ## Break glass
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -325,7 +325,7 @@ gh workflow run release-upgrade.yaml --repo Azure/unbounded \
 - Artifact signatures and the release BOM are **still verified**. Forcing means
   "we accept an unsoaked release", never "we accept an unverified one".
 - The deploy and smoke jobs still run, so their diagnostics are preserved.
-- The forced path uses the `release-force-publish` environment, so it can be
+- The forced path uses the `unbounded-reviewers` environment, so it can be
   gated on reviewer approval independently of normal releases.
 
 If you use this, file a follow-up to fix whatever made it necessary.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -168,9 +168,15 @@ in the tag.
 7. and only then flips the draft to published.
 
 Step 4 gates on `unbounded-operator`, `unbounded-net-controller`,
-`unbounded-net-node`, `machina-controller` and `gantry`. **`metalman` and
-`unbounded-storage-supervisor` are not gated**, so a release can publish with
-either of them failing to start; tracked in
+`unbounded-net-node`, `machina-controller`, `gantry`, and on
+`metalman-controller-<site>` for every Site that enables metalman. Metalman is a
+per-Site component, so those targets are discovered from the cluster rather than
+assumed: on `unbounded-stable` the cluster's own Site is `stable` while metalman
+runs for a remote site. A cluster where **no** Site enables it fails the deploy,
+because this one is expected to run it.
+
+**`unbounded-storage-supervisor` is still not gated**, so a release can publish
+with it failing to start; tracked in
 [#625](https://github.com/Azure/unbounded/issues/625).
 
 A clean deploy, a clean Orca deploy and green smoke are the soak gate.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,9 @@ Releases are cut from `main` only. There are no maintenance branches today (see
 
 ## At a glance
 
-Three workflows, in order. Only the first is started by a human.
+Three workflows, in order. In the normal flow only the first is started by a
+human; `release-upgrade` is also dispatchable by hand for backfills, rollbacks
+and the [break-glass paths](#break-glass).
 
 | Phase | Workflow | Trigger | Result |
 |---|---|---|---|
@@ -41,10 +43,8 @@ gh run list --repo Azure/unbounded --workflow ci.yaml --branch main --limit 5
 
 A red nightly is a release blocker until it is understood. It deploys the same
 component images the release will, to the same shape of cluster, so a nightly
-failure is a release failure you have not had yet.
-
-Note that a nightly failure caused solely by unreachable nodes is tolerated and
-reported rather than failing the run; see
+failure is a release failure you have not had yet - unless it is only
+unreachable nodes, which the rollout gate tolerates. See
 [Degraded clusters](#degraded-clusters).
 
 ## 2. Choosing a version
@@ -162,13 +162,25 @@ in the tag.
 1. downloads the draft release's artifacts,
 2. verifies their signatures and the BOM against the tag's cosign identity,
 3. deploys to the `unbounded-stable` cluster,
-4. waits for every component workload to roll out,
-5. runs the smoke tests in `hack/release/smoke/`,
-6. and only then flips the draft to published.
+4. waits for the gated component workloads to roll out,
+5. deploys Orca, the origin cache, as an integration workload,
+6. runs the smoke tests in `hack/release/smoke/`,
+7. and only then flips the draft to published.
 
-A clean deploy plus green smoke is the soak gate. **Publishing is not a manual
-step.** If you find yourself running `gh release edit --draft=false` by hand,
-use the [break-glass path](#break-glass) instead so the bypass is recorded.
+Step 4 gates on `unbounded-operator`, `unbounded-net-controller`,
+`unbounded-net-node`, `machina-controller` and `gantry`. **`metalman` and
+`unbounded-storage-supervisor` are not gated**, so a release can publish with
+either of them failing to start; tracked in
+[#625](https://github.com/Azure/unbounded/issues/625).
+
+A clean deploy, a clean Orca deploy and green smoke are the soak gate.
+**Publishing is not a manual step.** If you find yourself running
+`gh release edit --draft=false` by hand, use the
+[break-glass path](#break-glass) instead so the bypass is recorded.
+
+Smoke tests that are *skipped* also satisfy the gate. That is deliberate and
+only happens when the deployed ref has no `hack/release/smoke/` directory, which
+means backfilling a tag old enough to predate smoke tests still publishes.
 
 This is also why `promote` tags the last candidate's commit: the soak is
 evidence about one specific tree, and it is only worth anything if that is the
@@ -243,7 +255,10 @@ git push origin :refs/tags/v0.2.5
 
 **The build failed partway.** Fix the cause, delete the tag, and cut it again.
 The draft release and any uploaded assets should be deleted first so the retry
-starts clean.
+starts clean. If the tag came from `promote`, note that re-promoting resolves
+the same candidate commit again, so a fix that is a code change needs a new `rc`
+cut first - only a fix outside the tagged tree (a secret, a runner, a registry)
+can be retried by re-promoting.
 
 **The soak failed.** Read the failure before reaching for the override. The
 deploy job's `Diagnose failed rollout` step dumps node readiness, Sites,

--- a/hack/release/forced-publish-notes.sh
+++ b/hack/release/forced-publish-notes.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# forced-publish-notes: compose the release body for a forced publish.
+#
+# Called by the publish-forced job in .github/workflows/release-upgrade.yaml.
+# It exists as a script, rather than inline in that job, because the bypass
+# notice is the durable record of a release that skipped its soak: it is read
+# long after the run log has expired, and it is the one artefact nobody
+# exercises until an emergency. Two defects lived in it undetected precisely
+# because it could not be tested - a skipped smoke matrix was described as a
+# successful soak, and a re-run stacked a second notice onto the body.
+#
+# Usage:
+#   forced-publish-notes.sh <body-file>
+#
+# The current release body is read from <body-file>; the new body is written to
+# stdout. The caller then applies it and flips the draft in ONE `gh release
+# edit`, so a failure cannot leave a published release with no record.
+#
+# Contract (provided by the calling workflow):
+#   ACTOR            who dispatched the forced run
+#   REASON           why, recorded verbatim on the release
+#   DEPLOY_RESULT    needs.deploy.result
+#   ORCA_RESULT      needs.deploy-orca.result
+#   DISCOVER_RESULT  needs.smoke-discover.result
+#   SMOKE_RESULT     needs.smoke-tests.result
+#
+# Exit codes:
+#   0  a notice was appended; stdout is the new body
+#   2  usage: a required input is missing
+#   3  the body already carries a notice; stdout is the body unchanged
+
+set -euo pipefail
+
+BODY_FILE="${1:?usage: forced-publish-notes.sh <body-file>}"
+
+: "${ACTOR:?ACTOR must be set}"
+: "${DEPLOY_RESULT:?DEPLOY_RESULT must be set}"
+: "${ORCA_RESULT:?ORCA_RESULT must be set}"
+: "${DISCOVER_RESULT:?DISCOVER_RESULT must be set}"
+: "${SMOKE_RESULT:?SMOKE_RESULT must be set}"
+
+REASON="${REASON:-}"
+
+# An HTML comment: invisible on the rendered release page, reliable to match on.
+MARKER="<!-- unbounded:forced-publish -->"
+
+if [[ -z "${REASON// /}" ]]; then
+  echo "::error::force_publish requires a non-empty reason; it is recorded on the release" >&2
+  exit 2
+fi
+
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "::error::no release body at ${BODY_FILE}" >&2
+  exit 2
+fi
+
+cat "$BODY_FILE"
+
+# Guarantee the body ends with a newline so the notice is separated the same way
+# every time, whether or not the generated changelog ended cleanly.
+if [[ ! -s "$BODY_FILE" || -n "$(tail -c 1 "$BODY_FILE")" ]]; then
+  echo
+fi
+
+if grep -qF "$MARKER" "$BODY_FILE"; then
+  exit 3
+fi
+
+# A forced dispatch lands on this path even when every gate passed, so that
+# forcing is always recorded as forcing. The headline therefore has to describe
+# what actually happened rather than assume the worst.
+#
+# `skipped` is NOT a pass. Since smoke discovery fails rather than emitting an
+# empty matrix, a skipped smoke job means something upstream failed and the
+# tests never ran at all - which is exactly when this notice matters most.
+if [[ "$DEPLOY_RESULT" == "success" && "$ORCA_RESULT" == "success" \
+      && "$DISCOVER_RESULT" == "success" && "$SMOKE_RESULT" == "success" ]]; then
+  headline="Published through the forced path, though the soak did pass."
+  caveat="The gates this run bypasses all reported success; the bypass is recorded because it was requested."
+else
+  headline="Published without a successful soak."
+  caveat="Release artifact signatures and the release BOM were verified; the deployment soak on unbounded-stable was not completed."
+fi
+
+printf '\n\n---\n\n%s\n> **%s**\n> Forced by @%s. Deploy: %s, Orca: %s, smoke discovery: %s, smoke: %s.\n> Reason: %s\n>\n> %s\n' \
+  "$MARKER" "$headline" "$ACTOR" \
+  "$DEPLOY_RESULT" "$ORCA_RESULT" "$DISCOVER_RESULT" "$SMOKE_RESULT" \
+  "$REASON" "$caveat"

--- a/hack/release/forced_publish_notes_test.go
+++ b/hack/release/forced_publish_notes_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package release
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for forced-publish-notes.sh.
+//
+// The notice it composes is the durable record of a release that skipped its
+// soak: read long after the run log expires, and never exercised until an
+// emergency. Two defects lived in it undetected while it was inline YAML - a
+// skipped smoke matrix described as a successful soak, and a re-run appending a
+// second copy - so both have a case here.
+
+// results is one combination of upstream job outcomes.
+type results struct {
+	deploy   string
+	orca     string
+	discover string
+	smoke    string
+}
+
+var allPassed = results{deploy: "success", orca: "success", discover: "success", smoke: "success"}
+
+// composeNotes runs the script over a body and returns stdout+stderr and the
+// exit code.
+func composeNotes(t *testing.T, body string, r results, env map[string]string) (string, int) {
+	t.Helper()
+
+	script, err := filepath.Abs("forced-publish-notes.sh")
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+
+	dir := t.TempDir()
+	bodyFile := filepath.Join(dir, "body.md")
+
+	if err := os.WriteFile(bodyFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+
+	base := map[string]string{
+		"PATH":            os.Getenv("PATH"),
+		"ACTOR":           "someone",
+		"REASON":          "stable cluster unreachable during DC maintenance",
+		"DEPLOY_RESULT":   r.deploy,
+		"ORCA_RESULT":     r.orca,
+		"DISCOVER_RESULT": r.discover,
+		"SMOKE_RESULT":    r.smoke,
+	}
+	for key, value := range env {
+		base[key] = value
+	}
+
+	environ := make([]string, 0, len(base))
+	for key, value := range base {
+		environ = append(environ, key+"="+value)
+	}
+
+	command := exec.Command("bash", script, bodyFile)
+	command.Env = environ
+
+	out, err := command.CombinedOutput()
+
+	code := 0
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run script: %v", err)
+	}
+
+	return string(out), code
+}
+
+func TestForcedNotesRecordAnUnsoakedRelease(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	output, code := composeNotes(t, "Original notes.\n",
+		results{deploy: "failure", orca: "success", discover: "success", smoke: "skipped"}, nil)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "Original notes.")
+	requireContains(t, output, "Published without a successful soak.")
+	requireContains(t, output, "Forced by @someone")
+	requireContains(t, output, "Reason: stable cluster unreachable during DC maintenance")
+	requireContains(t, output, "<!-- unbounded:forced-publish -->")
+}
+
+// TestForcedNotesDoNotClaimASoakThatWasSkipped is the regression guard: a
+// failed smoke-discover skips the matrix, and `skipped` was being treated as a
+// pass. Since discovery now fails rather than emitting an empty matrix, a
+// skipped smoke job means the tests never ran.
+func TestForcedNotesDoNotClaimASoakThatWasSkipped(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	for _, r := range []results{
+		{deploy: "success", orca: "success", discover: "failure", smoke: "skipped"},
+		{deploy: "success", orca: "success", discover: "success", smoke: "skipped"},
+		{deploy: "success", orca: "success", discover: "success", smoke: "failure"},
+		{deploy: "success", orca: "skipped", discover: "skipped", smoke: "skipped"},
+	} {
+		output, code := composeNotes(t, "Notes.\n", r, nil)
+
+		requireCode(t, code, 0, output)
+		requireContains(t, output, "Published without a successful soak.")
+		requireNotContains(t, output, "the soak did pass")
+	}
+}
+
+// TestForcedNotesAdmitWhenTheSoakPassed covers the other direction: a forced
+// dispatch lands here even when every gate was green, and claiming otherwise
+// would be its own false record.
+func TestForcedNotesAdmitWhenTheSoakPassed(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	output, code := composeNotes(t, "Notes.\n", allPassed, nil)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "though the soak did pass")
+	requireNotContains(t, output, "Published without a successful soak.")
+}
+
+// TestForcedNotesAreIdempotent keeps a re-run from stacking a second notice
+// onto the release body.
+func TestForcedNotesAreIdempotent(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	first, code := composeNotes(t, "Notes.\n", allPassed, nil)
+	requireCode(t, code, 0, first)
+
+	second, code := composeNotes(t, first, allPassed, nil)
+
+	if code != 3 {
+		t.Errorf("expected exit 3 for an already-recorded body, got %d\n%s", code, second)
+	}
+
+	if strings.Count(second, "<!-- unbounded:forced-publish -->") != 1 {
+		t.Errorf("expected exactly one marker, got %d\n%s",
+			strings.Count(second, "<!-- unbounded:forced-publish -->"), second)
+	}
+
+	// The body still has to be emitted, because the caller applies stdout and
+	// clears the draft flag in one call.
+	requireContains(t, second, "Notes.")
+}
+
+func TestForcedNotesRequireAReason(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	for _, reason := range []string{"", "   "} {
+		output, code := composeNotes(t, "Notes.\n", allPassed, map[string]string{"REASON": reason})
+
+		requireCode(t, code, 2, output)
+		requireContains(t, output, "requires a non-empty reason")
+	}
+}
+
+// TestForcedNotesHandleABodyWithoutATrailingNewline covers a release whose
+// generated notes do not end cleanly, which must not run the marker onto the
+// last line of the changelog.
+func TestForcedNotesHandleABodyWithoutATrailingNewline(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	output, code := composeNotes(t, "No trailing newline", allPassed, nil)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "No trailing newline\n\n\n---")
+}
+
+func TestForcedNotesRejectAMissingBody(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	script, err := filepath.Abs("forced-publish-notes.sh")
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+
+	command := exec.Command("bash", script, filepath.Join(t.TempDir(), "absent.md"))
+	command.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"ACTOR=someone", "REASON=why",
+		"DEPLOY_RESULT=success", "ORCA_RESULT=success",
+		"DISCOVER_RESULT=success", "SMOKE_RESULT=success",
+	}
+
+	out, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected a failure for a missing body file\n%s", out)
+	}
+
+	requireContains(t, string(out), "no release body")
+}

--- a/hack/release/metalman-targets.sh
+++ b/hack/release/metalman-targets.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# metalman-targets: print the rollout-gate targets for the metalman component.
+#
+# Called by .github/workflows/release-upgrade.yaml, which appends the output to
+# hack/release/wait-rollouts.sh's argument list.
+#
+# Metalman is a per-SITE component: the operator creates one
+# Deployment/metalman-controller-<site> in the operator namespace for every Site
+# that enables it, and none at all for a Site that does not. The targets are
+# therefore discovered rather than assumed. On unbounded-stable in particular
+# they are NOT derived from SITE_NAME: the cluster's own Site is `stable`, while
+# metalman runs for a remote site.
+#
+# Contract (provided by the calling workflow):
+#   KUBECONFIG        Path to a kubeconfig for the target cluster.
+#
+# Optional overrides:
+#   REQUIRE_METALMAN  "false" to allow an empty result (default true). The
+#                     workflow sets it on a first bootstrap, where no Site has
+#                     joined yet; on an existing cluster, nothing enabling
+#                     metalman is a regression rather than a configuration.
+#   NAMESPACE         Only used in messages; the gate scopes the namespace.
+#
+# Output contract:
+#   stdout  zero or more `deploy/metalman-controller-<site>` lines
+#   stderr  notices, warnings and errors
+#   exit    0 resolved, or empty and not required
+#           1 no Site enables metalman while it is required
+#           2 usage: missing tooling or KUBECONFIG
+#           3 the query or its evaluation failed
+#
+# Exit 3 is deliberately distinct from exit 1. A malformed payload, an
+# unreachable apiserver or a jq error must never read as "no Site enables
+# metalman", which is the answer that would quietly drop metalman out of the
+# release gate. Anything this script cannot positively determine is a failure.
+
+set -euo pipefail
+
+REQUIRE_METALMAN="${REQUIRE_METALMAN:-true}"
+
+# The CRD is cluster-scoped, so no namespace flag. --request-timeout keeps a
+# stuck apiserver from consuming the job's budget, matching the smoke tests.
+SITE_RESOURCE="sites.unbounded-cloud.io"
+KUBECTL=(kubectl --request-timeout=30s)
+
+# Deployment name pattern, from internal/operator/components/metalman.
+TARGET_PREFIX="deploy/metalman-controller-"
+
+# A Site with no components block, no spec, or `metalman: {}` is simply not
+# selected; only an explicit `enabled: true` counts.
+SITE_FILTER='
+  .items[]
+  | select(.spec.components.metalman.enabled == true)
+  | .metadata.name
+'
+
+if [[ -z "${KUBECONFIG:-}" ]]; then
+  echo "::error::metalman-targets.sh requires KUBECONFIG" >&2
+  exit 2
+fi
+
+for tool in kubectl jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "::error::metalman-targets.sh requires ${tool} on PATH" >&2
+    exit 2
+  fi
+done
+
+err="$(mktemp)"
+trap 'rm -f "$err"' EXIT
+
+if ! sites_json="$("${KUBECTL[@]}" get "$SITE_RESOURCE" -o json 2>"$err")"; then
+  echo "::error::could not list ${SITE_RESOURCE}: $(tr -d '\r' <"$err" | tr '\n' ' ')" >&2
+  exit 3
+fi
+
+if ! sites="$(printf '%s' "$sites_json" | jq -r "$SITE_FILTER" 2>"$err")"; then
+  echo "::error::could not evaluate ${SITE_RESOURCE}: $(tr -d '\r' <"$err" | tr '\n' ' ')" >&2
+  exit 3
+fi
+
+if [[ -z "$sites" ]]; then
+  if [[ "$REQUIRE_METALMAN" == "false" ]]; then
+    echo "::warning::no Site enables metalman; not gating on it for this run" >&2
+    exit 0
+  fi
+
+  echo "::error::no Site enables metalman, but this cluster is expected to run it" >&2
+  echo "::error::enable it with 'kubectl patch ${SITE_RESOURCE} <site> --type=merge -p '{\"spec\":{\"components\":{\"metalman\":{\"enabled\":true}}}}'', or see RELEASING.md" >&2
+
+  exit 1
+fi
+
+while read -r site; do
+  [[ -n "$site" ]] || continue
+
+  echo "${TARGET_PREFIX}${site}"
+done <<<"$sites"

--- a/hack/release/metalman_targets_test.go
+++ b/hack/release/metalman_targets_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for metalman-targets.sh.
+//
+// The script decides which metalman Deployments the release gate waits on. Its
+// answer is derived from cluster state, so the interesting cases are the ones
+// where that state is missing, partial or unreadable: an empty answer removes
+// metalman from the gate entirely, and it must only ever be reached
+// deliberately.
+
+// siteList renders a Site list in the shape kubectl returns. A nil components
+// map produces a Site with no `.spec.components` at all.
+func siteList(sites ...site) string {
+	items := make([]map[string]any, 0, len(sites))
+
+	for _, s := range sites {
+		item := map[string]any{"metadata": map[string]any{"name": s.name}}
+
+		switch {
+		case s.noSpec:
+		case s.noComponents:
+			item["spec"] = map[string]any{}
+		case s.emptyMetalman:
+			item["spec"] = map[string]any{"components": map[string]any{"metalman": map[string]any{}}}
+		default:
+			item["spec"] = map[string]any{
+				"components": map[string]any{"metalman": map[string]any{"enabled": s.metalman}},
+			}
+		}
+
+		items = append(items, item)
+	}
+
+	return marshal(map[string]any{"items": items})
+}
+
+// site describes one fake Site. The shapes below are all reachable: a Site
+// created without --enable-metalman writes `enabled: false`, one migrated by
+// the reaper may predate the components block entirely.
+type site struct {
+	name          string
+	metalman      bool
+	emptyMetalman bool
+	noComponents  bool
+	noSpec        bool
+}
+
+// runTargets executes the script and returns stdout+stderr and the exit code.
+func runTargets(t *testing.T, reply string, env map[string]string) (string, int) {
+	t.Helper()
+
+	f := newFake(t)
+	if reply != "" {
+		f.set("getjson-sites.unbounded-cloud.io", replyOf(reply))
+	}
+
+	return f.runScript("metalman-targets.sh", env)
+}
+
+func replyOf(stdout string) reply { return reply{stdout: stdout} }
+
+func TestMetalmanTargetsListsEveryEnabledSite(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runTargets(t, siteList(
+		site{name: "stable"},
+		site{name: "boulderlab", metalman: true},
+		site{name: "edge", metalman: true},
+	), nil)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "deploy/metalman-controller-boulderlab")
+	requireContains(t, output, "deploy/metalman-controller-edge")
+	// The cluster's own Site does not enable it; unbounded-stable runs metalman
+	// for a remote site, which is why the targets are not built from SITE_NAME.
+	requireNotContains(t, output, "metalman-controller-stable")
+}
+
+// TestMetalmanTargetsIgnoresPartialSites covers the Site shapes that exist
+// alongside a properly configured one. None of them may error, and none may be
+// mistaken for an enabled Site.
+func TestMetalmanTargetsIgnoresPartialSites(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runTargets(t, siteList(
+		site{name: "disabled"},
+		site{name: "empty-block", emptyMetalman: true},
+		site{name: "no-components", noComponents: true},
+		site{name: "no-spec", noSpec: true},
+		site{name: "boulderlab", metalman: true},
+	), nil)
+
+	requireCode(t, code, 0, output)
+
+	targets := 0
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if strings.HasPrefix(line, "deploy/") {
+			targets++
+		}
+	}
+
+	if targets != 1 {
+		t.Errorf("expected exactly one target, got %d\n--- output ---\n%s", targets, output)
+	}
+
+	requireContains(t, output, "deploy/metalman-controller-boulderlab")
+}
+
+func TestMetalmanTargetsFailsWhenNoSiteEnablesIt(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runTargets(t, siteList(
+		site{name: "stable"},
+		site{name: "edge", emptyMetalman: true},
+	), nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "expected to run it")
+	requireNotContains(t, output, "deploy/")
+}
+
+// TestMetalmanTargetsAllowsNoneOnFirstBootstrap covers the one state where an
+// empty answer is legitimate: nothing has joined the cluster yet.
+func TestMetalmanTargetsAllowsNoneOnFirstBootstrap(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runTargets(t, siteList(site{name: "stable"}),
+		map[string]string{"REQUIRE_METALMAN": "false"})
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "not gating on it")
+	requireNotContains(t, output, "deploy/")
+}
+
+func TestMetalmanTargetsHandlesAnEmptySiteList(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runTargets(t, `{"items":[]}`, nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "expected to run it")
+}
+
+// TestMetalmanTargetsFailsWhenTheQueryFails is the fail-closed case: an
+// unreachable apiserver must not read as "no Site enables metalman", which
+// would silently drop metalman from the release gate.
+func TestMetalmanTargetsFailsWhenTheQueryFails(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-sites.unbounded-cloud.io", reply{
+		stderr: "error: You must be logged in to the server (Unauthorized)",
+		exit:   1,
+	})
+
+	output, code := f.runScript("metalman-targets.sh", nil)
+
+	requireCode(t, code, 3, output)
+	requireContains(t, output, "could not list")
+	requireContains(t, output, "Unauthorized")
+	requireNotContains(t, output, "deploy/")
+}
+
+// TestMetalmanTargetsFailsOnAMalformedPayload is the same discipline one layer
+// up: a payload jq cannot walk is exit 3, never a silent empty answer.
+func TestMetalmanTargetsFailsOnAMalformedPayload(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runTargets(t, `{"unexpected":"shape"}`, nil)
+
+	requireCode(t, code, 3, output)
+	requireContains(t, output, "could not evaluate")
+	requireNotContains(t, output, "deploy/")
+}
+
+func TestMetalmanTargetsRequiresKubeconfig(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runTargets(t, siteList(site{name: "boulderlab", metalman: true}),
+		map[string]string{"KUBECONFIG": ""})
+
+	requireCode(t, code, 2, output)
+	requireContains(t, output, "KUBECONFIG")
+}

--- a/hack/release/next-version-test.sh
+++ b/hack/release/next-version-test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Tests for next-version.sh.
+#
+# Each case builds a throwaway git repository containing only tags, runs the
+# resolver against it, and checks the computed tag or the error. Tags are the
+# only input the resolver has, so a synthetic tag set is a complete fixture.
+#
+# This exists because the logic it covers mints version tags. Before it was
+# extracted from the workflow the only way to test a change was to push a real
+# tag to the real repository and see what happened.
+#
+# Usage: hack/release/next-version-test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVER="${SCRIPT_DIR}/next-version.sh"
+
+PASS=0
+FAIL=0
+
+# fixture creates a repository whose tags are exactly the arguments.
+fixture() {
+  local dir
+  dir="$(mktemp -d)"
+
+  git -C "$dir" init -q
+  git -C "$dir" config user.email test@example.com
+  git -C "$dir" config user.name test
+  git -C "$dir" commit -q --allow-empty -m base
+
+  local tag
+  for tag in "$@"; do
+    git -C "$dir" tag "$tag"
+  done
+
+  echo "$dir"
+}
+
+# expect_tag <name> <expected> <tags...> -- <env assignments...>
+expect() {
+  local name="$1" mode="$2" expected="$3"
+  shift 3
+
+  local -a tags=() env=()
+  local seen_sep=0 arg
+  for arg in "$@"; do
+    if [[ "$arg" == "--" ]]; then seen_sep=1; continue; fi
+    if (( seen_sep )); then env+=("$arg"); else tags+=("$arg"); fi
+  done
+
+  local dir out rc=0
+  dir="$(fixture ${tags[@]+"${tags[@]}"})"
+  out="$(cd "$dir" && env MODE="$mode" ${env[@]+"${env[@]}"} "$RESOLVER" 2>/dev/null)" || rc=$?
+  rm -rf "$dir"
+
+  local got
+  if [[ "$expected" == "ERROR" ]]; then
+    got=$([[ $rc -ne 0 ]] && echo ERROR || echo "$out")
+  else
+    got="$out"
+  fi
+
+  if [[ "$got" == "$expected" ]]; then
+    printf 'PASS  %-46s %s\n' "$name" "$got"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL  %-46s got=%q want=%q\n' "$name" "$got" "$expected"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== bootstrap ==="
+expect "no tags, release" release "v0.0.1" -- BUMP=patch
+expect "no tags, prerelease" prerelease "v0.0.1-rc.1" -- BUMP=patch
+
+echo
+echo "=== starting a train ==="
+expect "final only, prerelease patch" prerelease "v0.2.5-rc.1" v0.2.4 -- BUMP=patch
+expect "final only, prerelease minor" prerelease "v0.3.0-rc.1" v0.2.4 -- BUMP=minor
+expect "final only, prerelease major" prerelease "v1.0.0-rc.1" v0.2.4 -- BUMP=major
+expect "final only, release patch" release "v0.2.5" v0.2.4 -- BUMP=patch
+
+echo
+echo "=== continuing a train ==="
+expect "live train auto-increments" prerelease "v0.2.5-rc.2" \
+  v0.2.4 v0.2.5-rc.1 -- BUMP=patch
+expect "live train ignores conflicting bump" prerelease "v0.2.5-rc.2" \
+  v0.2.4 v0.2.5-rc.1 -- BUMP=minor
+# rc.18 must beat rc.9: a lexical max would hand out rc.10 a second time.
+expect "rc numbering is numeric, not lexical" prerelease "v0.2.5-rc.19" \
+  v0.2.4 v0.2.5-rc.7 v0.2.5-rc.8 v0.2.5-rc.9 v0.2.5-rc.10 v0.2.5-rc.18 -- BUMP=patch
+
+echo
+echo "=== stale trains are invisible ==="
+# The real v0.1.24 shape: abandoned at rc.18, superseded by v0.2.4.
+expect "stale train ignored when starting" prerelease "v0.2.5-rc.1" \
+  v0.1.24-rc.17 v0.1.24-rc.18 v0.2.0 v0.2.4 -- BUMP=patch
+expect "stale train not promotable" promote "ERROR" \
+  v0.1.24-rc.17 v0.1.24-rc.18 v0.2.0 v0.2.4 --
+expect "stale train ignored, release" release "v0.2.5" \
+  v0.1.24-rc.18 v0.2.4 -- BUMP=patch
+
+echo
+echo "=== concurrent trains ==="
+expect "second train refused by default" prerelease "ERROR" \
+  v0.2.4 v0.2.5-rc.1 v0.3.0-rc.1 -- BUMP=patch
+expect "second train allowed with opt-in" prerelease "v0.3.0-rc.1" \
+  v0.2.4 v0.2.5-rc.1 -- BUMP=minor ALLOW_CONCURRENT_TRAINS=true
+expect "opt-in continues matching train" prerelease "v0.2.5-rc.2" \
+  v0.2.4 v0.2.5-rc.1 -- BUMP=patch ALLOW_CONCURRENT_TRAINS=true
+
+echo
+echo "=== promote ==="
+expect "promote the only live train" promote "v0.2.5" \
+  v0.2.4 v0.2.5-rc.1 v0.2.5-rc.2 --
+expect "promote refuses to guess" promote "ERROR" \
+  v0.2.4 v0.2.5-rc.1 v0.3.0-rc.1 --
+expect "promote with explicit version" promote "v0.3.0" \
+  v0.2.4 v0.2.5-rc.1 v0.3.0-rc.1 -- VERSION=v0.3.0
+expect "promote accepts bare version" promote "v0.3.0" \
+  v0.2.4 v0.3.0-rc.1 -- VERSION=0.3.0
+expect "promote with no train at all" promote "ERROR" v0.2.4 --
+expect "promote rejects a suffixed version" promote "ERROR" \
+  v0.2.4 v0.2.5-rc.1 -- VERSION=v0.2.5-rc.1
+expect "promote rejects a version with no train" promote "ERROR" \
+  v0.2.4 -- VERSION=v0.9.9
+
+echo
+echo "=== suffix policy ==="
+expect "explicit rc accepted" prerelease "v0.2.5-rc.4" \
+  v0.2.4 v0.2.5-rc.1 -- BUMP=patch PRE=rc.4
+expect "beta rejected" prerelease "ERROR" \
+  v0.2.4 -- BUMP=patch PRE=beta.1
+expect "alpha rejected" prerelease "ERROR" \
+  v0.2.4 -- BUMP=patch PRE=alpha.0
+expect "rc must move forward" prerelease "ERROR" \
+  v0.2.4 v0.2.5-rc.5 -- BUMP=patch PRE=rc.2
+expect "rc equal to current rejected" prerelease "ERROR" \
+  v0.2.4 v0.2.5-rc.5 -- BUMP=patch PRE=rc.5
+
+echo
+echo "=== misuse ==="
+expect "pre rejected with release" release "ERROR" v0.2.4 -- BUMP=patch PRE=rc.1
+expect "pre rejected with promote" promote "ERROR" \
+  v0.2.4 v0.2.5-rc.1 -- PRE=rc.1
+# Promoting a train whose final already shipped. This is the shape the old
+# "highest prerelease in the repository" heuristic would land on today.
+expect "existing tag refused" promote "ERROR" \
+  v0.2.4 v0.2.4-rc.1 -- VERSION=v0.2.4
+expect "unknown mode" nonsense "ERROR" v0.2.4 --
+expect "unknown bump" release "ERROR" v0.2.4 -- BUMP=sideways
+
+echo
+echo "passed=${PASS} failed=${FAIL}"
+exit $(( FAIL > 0 ))

--- a/hack/release/next-version-test.sh
+++ b/hack/release/next-version-test.sh
@@ -263,6 +263,22 @@ expect "four-part tag ignored" release "v0.2.5" \
 # A malformed prerelease tag must not invent a train.
 expect "malformed prerelease tag ignored" prerelease "v0.2.5-rc.1" \
   v0.2.4 v1.2-rc.1 -- BUMP=patch
+expect "bare prerelease suffix ignored" prerelease "v0.2.5-rc.1" \
+  v0.2.4 v9.0.0- -- BUMP=patch
+expect "unknown prerelease suffix ignored" prerelease "v0.2.5-rc.1" \
+  v0.2.4 v9.0.0-junk -- BUMP=patch
+expect "legacy alpha suffix ignored" prerelease "v0.2.5-rc.1" \
+  v0.2.4 v9.0.0-alpha.1 -- BUMP=patch
+expect "non-numeric rc ignored" prerelease "v0.2.5-rc.1" \
+  v0.2.4 v9.0.0-rc.x -- BUMP=patch
+expect "zero rc ignored" prerelease "v0.2.5-rc.1" \
+  v0.2.4 v9.0.0-rc.0 -- BUMP=patch
+expect "leading-zero rc creates no train" prerelease "v0.2.5-rc.1" \
+  v0.2.4 v9.0.0-rc.01 -- BUMP=patch
+expect "canonical rc creates a train" prerelease "v9.0.0-rc.2" \
+  v0.2.4 v9.0.0-rc.1 -- BUMP=patch
+expect "promote rejects only malformed candidates" promote "ERROR" \
+  v0.2.4 v9.0.0-junk v9.0.0-rc.x -- VERSION=v9.0.0
 
 echo
 echo "=== tags off the branch being released ==="

--- a/hack/release/next-version-test.sh
+++ b/hack/release/next-version-test.sh
@@ -23,6 +23,10 @@ PASS=0
 FAIL=0
 
 # fixture creates a repository whose tags are exactly the arguments.
+#
+# A bare `<tag>` is placed on the current commit. `<tag>@new` creates a fresh
+# commit first, so a fixture can express a train whose candidates are behind
+# HEAD, which is the shape promote has to get right.
 fixture() {
   local dir
   dir="$(mktemp -d)"
@@ -34,13 +38,23 @@ fixture() {
 
   local tag
   for tag in "$@"; do
+    if [[ "$tag" == *@new ]]; then
+      tag="${tag%@new}"
+      git -C "$dir" commit -q --allow-empty -m "work before ${tag}"
+    fi
+
     git -C "$dir" tag "$tag"
   done
 
   echo "$dir"
 }
 
-# expect_tag <name> <expected> <tags...> -- <env assignments...>
+# field extracts one `key=value` line from the resolver's stdout.
+field() {
+  sed -n "s/^$1=//p" <<<"$2"
+}
+
+# expect <name> <mode> <expected-tag|ERROR> <tags...> -- <env assignments...>
 expect() {
   local name="$1" mode="$2" expected="$3"
   shift 3
@@ -59,9 +73,9 @@ expect() {
 
   local got
   if [[ "$expected" == "ERROR" ]]; then
-    got=$([[ $rc -ne 0 ]] && echo ERROR || echo "$out")
+    got=$([[ $rc -ne 0 ]] && echo ERROR || field tag "$out")
   else
-    got="$out"
+    got="$(field tag "$out")"
   fi
 
   if [[ "$got" == "$expected" ]]; then
@@ -69,6 +83,47 @@ expect() {
     PASS=$((PASS + 1))
   else
     printf 'FAIL  %-46s got=%q want=%q\n' "$name" "$got" "$expected"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# expect_base <name> <mode> <expected-ref> <tags...> -- <env assignments...>
+#
+# expected-ref is HEAD, or the name of a tag whose commit the base must equal.
+# This is what says the version being minted points at the tree that was soaked
+# rather than at whatever has landed since.
+expect_base() {
+  local name="$1" mode="$2" expected="$3"
+  shift 3
+
+  local -a tags=() env=()
+  local seen_sep=0 arg
+  for arg in "$@"; do
+    if [[ "$arg" == "--" ]]; then seen_sep=1; continue; fi
+    if (( seen_sep )); then env+=("$arg"); else tags+=("$arg"); fi
+  done
+
+  local dir out rc=0
+  dir="$(fixture ${tags[@]+"${tags[@]}"})"
+  out="$(cd "$dir" && env MODE="$mode" ${env[@]+"${env[@]}"} "$RESOLVER" 2>/dev/null)" || rc=$?
+
+  local got want
+  got="$(field base "$out")"
+  want="$(git -C "$dir" rev-parse "${expected}^{commit}" 2>/dev/null)"
+  rm -rf "$dir"
+
+  if (( rc != 0 )); then
+    printf 'FAIL  %-46s resolver exited %d\n' "$name" "$rc"
+    FAIL=$((FAIL + 1))
+
+    return
+  fi
+
+  if [[ -n "$got" && "$got" == "$want" ]]; then
+    printf 'PASS  %-46s base=%s (%s)\n' "$name" "${got:0:8}" "$expected"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL  %-46s base=%q want=%q (%s)\n' "$name" "$got" "$want" "$expected"
     FAIL=$((FAIL + 1))
   fi
 }
@@ -128,6 +183,32 @@ expect "promote rejects a suffixed version" promote "ERROR" \
   v0.2.4 v0.2.5-rc.1 -- VERSION=v0.2.5-rc.1
 expect "promote rejects a version with no train" promote "ERROR" \
   v0.2.4 -- VERSION=v0.9.9
+# The abandoned v0.1.24 train is not a back door: naming it explicitly must not
+# mint a final release below the latest final out of months-old candidates.
+expect "promote rejects a stale train by name" promote "ERROR" \
+  v0.1.24-rc.17 v0.1.24-rc.18 v0.2.4 -- VERSION=v0.1.24
+
+echo
+echo "=== which commit gets tagged ==="
+# promote finalises a candidate that has already been built, deployed and
+# smoke-tested. Tagging HEAD would ship every commit merged since, under a
+# version whose only claim to being trustworthy is that soak.
+expect_base "promote tags the last candidate" promote "v0.2.5-rc.2" \
+  v0.2.4 v0.2.5-rc.1@new v0.2.5-rc.2@new --
+expect_base "promote ignores commits merged since" promote "v0.2.5-rc.1" \
+  v0.2.4 v0.2.5-rc.1@new v9.9.9-marker@new -- VERSION=v0.2.5
+# rc.18 must beat rc.9 here too: a lexical maximum would tag the wrong tree,
+# which is far harder to notice than a wrong version number.
+expect_base "promote picks rc.18 over rc.9" promote "v0.2.5-rc.18" \
+  v0.2.4 v0.2.5-rc.9@new v0.2.5-rc.18@new --
+expect_base "prerelease tags HEAD" prerelease "HEAD" \
+  v0.2.4 v0.2.5-rc.1@new -- BUMP=patch
+expect_base "release tags HEAD" release "HEAD" \
+  v0.2.4 -- BUMP=patch
+# A train with prerelease tags but no rc has no candidate to point at, so
+# there is nothing to promote rather than a HEAD to fall back on.
+expect "promote refuses a train with no rc" promote "ERROR" \
+  v0.2.4 v0.2.5-beta.1 --
 
 echo
 echo "=== suffix policy ==="

--- a/hack/release/next-version-test.sh
+++ b/hack/release/next-version-test.sh
@@ -279,12 +279,25 @@ expect "off-branch train not promotable" promote "ERROR" \
 expect "off-branch rc name still refused" prerelease "ERROR" \
   v0.2.4 v0.2.5-rc.1@off -- BUMP=patch PRE=rc.1
 
+expect "off-branch final blocks a new train" prerelease "ERROR" \
+  v0.2.4 v0.2.5@off -- BUMP=patch
+expect "off-branch final blocks a second train" prerelease "ERROR" \
+  v0.2.4 v0.2.5-rc.1 v0.3.0@off -- BUMP=minor ALLOW_CONCURRENT_TRAINS=true
+
 echo
 echo "=== absurd numbers ==="
 expect "twenty-digit component ignored" release "v0.2.5" \
   v0.2.4 v99999999999999999999.0.0 -- BUMP=patch
 expect "ten-digit rc rejected" prerelease "ERROR" \
   v0.2.4 -- BUMP=patch PRE=rc.9999999999
+# The bump itself overflows rather than minting a ten-digit version that
+# discovery would then ignore.
+expect "bump that overflows refused" release "ERROR" \
+  v999999999.0.0 -- BUMP=major
+expect "leading zeros rejected in a version input" promote "ERROR" \
+  v0.2.4 v0.2.5-rc.1 -- VERSION=v01.2.3
+expect "unbounded version input rejected" promote "ERROR" \
+  v0.2.4 v0.2.5-rc.1 -- VERSION=v99999999999.0.0
 
 echo
 echo "=== misuse ==="

--- a/hack/release/next-version-test.sh
+++ b/hack/release/next-version-test.sh
@@ -224,6 +224,31 @@ expect "rc equal to current rejected" prerelease "ERROR" \
   v0.2.4 v0.2.5-rc.5 -- BUMP=patch PRE=rc.5
 
 echo
+echo "=== malformed input ==="
+# rc.08 is an octal literal to bash. The "is it ahead" comparison used to be an
+# arithmetic error inside an `if`, which set -e exempts, so the guard silently
+# did not fire and rc.08 was accepted behind rc.5.
+expect "leading zero rejected" prerelease "ERROR" \
+  v0.2.4 v0.2.5-rc.5 -- BUMP=patch PRE=rc.08
+expect "leading zero rejected even when ahead" prerelease "ERROR" \
+  v0.2.4 v0.2.5-rc.1 -- BUMP=patch PRE=rc.09
+# An rc.08 tag already in the repository must not poison the maximum: base-ten
+# arithmetic keeps rc.9 the highest, so the next one is rc.10.
+expect "existing leading-zero tag does not poison max_rc" prerelease "v0.2.5-rc.10" \
+  v0.2.4 v0.2.5-rc.08 v0.2.5-rc.9 -- BUMP=patch
+# A stray two-part tag used to be selected as the latest final and bumped to
+# v1.2.1, which passes every later check because it looks well formed.
+expect "two-part tag ignored" release "v0.2.5" \
+  v0.2.4 v1.2 -- BUMP=patch
+expect "date-shaped tag ignored" release "v0.2.5" \
+  v0.2.4 v20260710 -- BUMP=patch
+expect "four-part tag ignored" release "v0.2.5" \
+  v0.2.4 v1.2.3.4 -- BUMP=patch
+# A malformed prerelease tag must not invent a train.
+expect "malformed prerelease tag ignored" prerelease "v0.2.5-rc.1" \
+  v0.2.4 v1.2-rc.1 -- BUMP=patch
+
+echo
 echo "=== misuse ==="
 expect "pre rejected with release" release "ERROR" v0.2.4 -- BUMP=patch PRE=rc.1
 expect "pre rejected with promote" promote "ERROR" \

--- a/hack/release/next-version-test.sh
+++ b/hack/release/next-version-test.sh
@@ -26,7 +26,9 @@ FAIL=0
 #
 # A bare `<tag>` is placed on the current commit. `<tag>@new` creates a fresh
 # commit first, so a fixture can express a train whose candidates are behind
-# HEAD, which is the shape promote has to get right.
+# HEAD, which is the shape promote has to get right. `<tag>@off` places the tag
+# on a commit that is NOT an ancestor of HEAD, as a tag cut on someone else's
+# branch would be.
 fixture() {
   local dir
   dir="$(mktemp -d)"
@@ -36,12 +38,26 @@ fixture() {
   git -C "$dir" config user.name test
   git -C "$dir" commit -q --allow-empty -m base
 
+  local branch
+  branch="$(git -C "$dir" rev-parse --abbrev-ref HEAD)"
+
   local tag
   for tag in "$@"; do
-    if [[ "$tag" == *@new ]]; then
-      tag="${tag%@new}"
-      git -C "$dir" commit -q --allow-empty -m "work before ${tag}"
-    fi
+    case "$tag" in
+      *@new)
+        tag="${tag%@new}"
+        git -C "$dir" commit -q --allow-empty -m "work before ${tag}"
+        ;;
+      *@off)
+        tag="${tag%@off}"
+        git -C "$dir" checkout -q -b "side-${tag}"
+        git -C "$dir" commit -q --allow-empty -m "off-branch work for ${tag}"
+        git -C "$dir" tag "$tag"
+        git -C "$dir" checkout -q "$branch"
+
+        continue
+        ;;
+    esac
 
     git -C "$dir" tag "$tag"
   done
@@ -247,6 +263,28 @@ expect "four-part tag ignored" release "v0.2.5" \
 # A malformed prerelease tag must not invent a train.
 expect "malformed prerelease tag ignored" prerelease "v0.2.5-rc.1" \
   v0.2.4 v1.2-rc.1 -- BUMP=patch
+
+echo
+echo "=== tags off the branch being released ==="
+# A v9.0.0 cut on someone's feature branch used to become the latest final, so
+# the next release from main was v9.0.1.
+expect "off-branch final ignored" release "v0.2.5" \
+  v0.2.4 v9.0.0@off -- BUMP=patch
+expect "off-branch prerelease starts no train" prerelease "v0.2.5-rc.1" \
+  v0.2.4 v9.0.0-rc.1@off -- BUMP=patch
+expect "off-branch train not promotable" promote "ERROR" \
+  v0.2.4 v9.0.0-rc.1@off --
+# An rc cut on a branch that was never merged must not be handed out again
+# either, since the tag name is taken wherever it lives.
+expect "off-branch rc name still refused" prerelease "ERROR" \
+  v0.2.4 v0.2.5-rc.1@off -- BUMP=patch PRE=rc.1
+
+echo
+echo "=== absurd numbers ==="
+expect "twenty-digit component ignored" release "v0.2.5" \
+  v0.2.4 v99999999999999999999.0.0 -- BUMP=patch
+expect "ten-digit rc rejected" prerelease "ERROR" \
+  v0.2.4 -- BUMP=patch PRE=rc.9999999999
 
 echo
 echo "=== misuse ==="

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -64,19 +64,26 @@ version_gt() {
   [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" == "$1" ]]
 }
 
+# SEMVER_TAG matches a tag this project cuts. The glob passed to `git tag` is
+# only a prefix filter, so discovery is anchored here instead: a stray `v1.2`
+# would otherwise be selected as the latest final and bumped to `v1.2.1`, which
+# passes every later check because it looks perfectly well formed.
+SEMVER_TAG='^v[0-9]+\.[0-9]+\.[0-9]+$'
+SEMVER_PRERELEASE_TAG='^v[0-9]+\.[0-9]+\.[0-9]+-'
+
 # latest_final prints the highest final (non-prerelease) tag, or v0.0.0 when the
 # repository has none yet.
 latest_final() {
   local tag
 
-  tag="$(git tag --list 'v[0-9]*' | grep -vE -- '-' | sort -V | tail -n1 || true)"
+  tag="$(git tag --list 'v[0-9]*' | grep -E -- "$SEMVER_TAG" | sort -V | tail -n1 || true)"
 
   echo "${tag:-v0.0.0}"
 }
 
 # train_cores prints every core version that has prerelease tags.
 train_cores() {
-  git tag --list 'v[0-9]*-*' | sed 's/-.*//' | sort -uV
+  git tag --list 'v[0-9]*-*' | grep -E -- "$SEMVER_PRERELEASE_TAG" | sed 's/-.*//' | sort -uV || true
 }
 
 # has_final reports whether a core has been released.
@@ -139,18 +146,23 @@ bump_version() {
 # max_rc prints the highest rc number already cut for a core, or 0. Compared
 # numerically on purpose: v0.1.24 ran to rc.18, and a lexical maximum reports
 # rc.9, which would hand out rc.10 a second time.
+#
+# 10# forces base ten. Bash reads a leading zero as octal, so a stray rc.08 tag
+# makes `(( n > max ))` an arithmetic error - and because that sits in an `if`
+# condition, which set -e exempts, the comparison silently evaluates false and
+# the tag is skipped rather than the run failing.
 max_rc() {
   local core="$1" max=0 n
 
   while read -r n; do
     [[ -n "$n" ]] || continue
 
-    if (( n > max )); then
+    if (( 10#$n > 10#$max )); then
       max="$n"
     fi
   done < <(git tag --list "${core}-rc.*" | sed "s|^${core}-rc\.||" | grep -E '^[0-9]+$' || true)
 
-  echo "$max"
+  echo "$((10#$max))"
 }
 
 # candidate_commit prints the commit of the highest rc tag for a core: the tree
@@ -223,12 +235,17 @@ case "$MODE" in
     if [[ -n "$PRE" ]]; then
       # rc is the only suffix in use; see RELEASING.md. alpha and beta were
       # previously used interchangeably with no defined meaning.
-      [[ "$PRE" =~ ^rc\.[0-9]+$ ]] || fail "pre must look like rc.N (got '${PRE}'); rc is the only prerelease suffix"
+      #
+      # Leading zeros are rejected rather than normalised. rc.08 is an octal
+      # literal to bash, so the "is it ahead" test below became an arithmetic
+      # error - silently false inside an `if`, which set -e exempts - and the
+      # guard did not fire. The tag it then minted poisoned max_rc the same way.
+      [[ "$PRE" =~ ^rc\.[1-9][0-9]*$ ]] || fail "pre must look like rc.N with no leading zeros (got '${PRE}'); rc is the only prerelease suffix"
 
       want="${PRE#rc.}"
       have="$(max_rc "$CORE")"
 
-      if (( want <= have )); then
+      if (( 10#$want <= 10#$have )); then
         fail "pre=${PRE} is not ahead of ${CORE}-rc.${have}; leave pre blank to take the next one automatically"
       fi
     else

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -34,20 +34,15 @@
 #   VERSION                  optional explicit final version for promote
 #   ALLOW_CONCURRENT_TRAINS  "true" to permit a second live train
 #
-# Definition of a LIVE train, which everything below turns on: a core version
-# vX.Y.Z that has prerelease tags, has no final tag of its own, AND is newer
-# than the latest final tag. That last clause is what makes an abandoned train
-# invisible. v0.1.24 still has twelve candidates and no final, but the project
-# has since shipped v0.2.4, so it is stale rather than in flight and must never
-# be offered as something to continue or promote.
+# A LIVE train, which everything below turns on: a core vX.Y.Z with prerelease
+# tags, no final tag of its own, AND newer than the latest final. That last
+# clause makes an abandoned train invisible - v0.1.24 has twelve candidates and
+# no final, but v0.2.4 has since shipped, so it is stale rather than in flight.
 #
-# Why `base` exists: `promote` finalises a candidate that has already been built,
-# deployed to unbounded-stable and smoke-tested. Tagging HEAD would ship a
-# DIFFERENT tree - every commit merged since that candidate was cut, none of
-# which the soak ever saw - under a version number whose only claim to being
-# trustworthy is that soak. So promote resolves the commit of the candidate it
-# is finalising, and release and prerelease resolve HEAD, which is what they
-# have always used.
+# Why `base` exists: promote finalises a candidate that was already built,
+# deployed and smoke-tested, so tagging HEAD would ship a DIFFERENT tree under a
+# version whose only claim to being trustworthy is that soak. promote resolves
+# the candidate's commit; release and prerelease resolve HEAD as always.
 
 set -euo pipefail
 
@@ -141,11 +136,9 @@ bump_version() {
   echo "v${major}.${minor}.${patch}"
 }
 
-# max_rc prints the highest rc number already cut for a core, or 0.
-#
-# The numbers are compared numerically on purpose. The v0.1.24 train ran to
-# rc.18, and a lexical comparison reports rc.9 as its maximum, which would hand
-# out rc.10 a second time.
+# max_rc prints the highest rc number already cut for a core, or 0. Compared
+# numerically on purpose: v0.1.24 ran to rc.18, and a lexical maximum reports
+# rc.9, which would hand out rc.10 a second time.
 max_rc() {
   local core="$1" max=0 n
 
@@ -160,12 +153,9 @@ max_rc() {
   echo "$max"
 }
 
-# candidate_commit prints the commit of the highest rc tag for a core, which is
-# the tree that was actually built, deployed and smoke-tested.
-#
-# Reuses max_rc rather than asking git for the "highest" tag, because git's
-# version sort is exactly the kind of ordering this train got wrong before:
-# rc.18 must beat rc.9.
+# candidate_commit prints the commit of the highest rc tag for a core: the tree
+# that was actually built, deployed and smoke-tested. Reuses max_rc rather than
+# git's version sort, because rc.18 must beat rc.9.
 candidate_commit() {
   local core="$1" highest
 
@@ -279,9 +269,8 @@ case "$MODE" in
       note "Promoting the only live train: ${TAG}"
     fi
 
-    # Ship the tree that was soaked, not whatever has landed since. The explicit
-    # `|| exit` matters: fail's exit only leaves the command substitution's
-    # subshell, so without it a resolution failure would depend on set -e alone.
+    # Ship the tree that was soaked. The explicit `|| exit` matters: fail's exit
+    # only leaves the command substitution's subshell.
     BASE="$(candidate_commit "$TAG")" || exit 1
     ;;
 
@@ -296,8 +285,8 @@ if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
   fail "tag ${TAG} already exists"
 fi
 
-# A candidate cut from a branch that was never merged, or that a force-push has
-# since orphaned, would ship a tree nobody reviewed on the default branch.
+# A candidate cut from an unmerged branch, or orphaned by a force-push, would
+# ship a tree nobody reviewed on the default branch.
 if ! git merge-base --is-ancestor "$BASE" HEAD 2>/dev/null; then
   fail "${BASE} is not an ancestor of HEAD; refusing to tag a commit that is not on the branch being released from"
 fi

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -2,12 +2,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# next-version: work out which tag a release-prepare run should mint.
+# next-version: work out which tag a release-prepare run should mint, and which
+# commit to mint it at.
 #
 # Called by .github/workflows/release-prepare.yaml, which owns pushing the tag.
 # This script only decides what the tag should be, which is the part that used
-# to be inline in the workflow where the only way to test it was to push a tag
-# and see what happened. Three real problems came out of that:
+# to be inline in the workflow where the only way to test a change was to push a
+# tag and see what happened. Three real problems came out of that:
 #
 #   - `bump` was applied to the latest FINAL tag on every run, so it was never
 #     remembered across a candidate train. Re-running with a different bump
@@ -20,7 +21,9 @@
 #     still no v0.1.24 tag.
 #
 # Output contract:
-#   stdout  the computed tag, and nothing else, so the caller can capture it
+#   stdout  `key=value` lines, ready to append to $GITHUB_OUTPUT:
+#             tag=vX.Y.Z[-rc.N]
+#             base=<commit the tag should be created at>
 #   stderr  the state report and any notices
 #   exit    non-zero on anything ambiguous or invalid
 #
@@ -37,6 +40,14 @@
 # invisible. v0.1.24 still has twelve candidates and no final, but the project
 # has since shipped v0.2.4, so it is stale rather than in flight and must never
 # be offered as something to continue or promote.
+#
+# Why `base` exists: `promote` finalises a candidate that has already been built,
+# deployed to unbounded-stable and smoke-tested. Tagging HEAD would ship a
+# DIFFERENT tree - every commit merged since that candidate was cut, none of
+# which the soak ever saw - under a version number whose only claim to being
+# trustworthy is that soak. So promote resolves the commit of the candidate it
+# is finalising, and release and prerelease resolve HEAD, which is what they
+# have always used.
 
 set -euo pipefail
 
@@ -149,9 +160,30 @@ max_rc() {
   echo "$max"
 }
 
+# candidate_commit prints the commit of the highest rc tag for a core, which is
+# the tree that was actually built, deployed and smoke-tested.
+#
+# Reuses max_rc rather than asking git for the "highest" tag, because git's
+# version sort is exactly the kind of ordering this train got wrong before:
+# rc.18 must beat rc.9.
+candidate_commit() {
+  local core="$1" highest
+
+  highest="$(max_rc "$core")"
+
+  (( highest > 0 )) || fail "no rc tag found for ${core} (tags: $(git tag --list "${core}-*" | tr '\n' ' ')); nothing to promote, use mode=release to cut it directly"
+
+  git rev-list -n1 "${core}-rc.${highest}" 2>/dev/null \
+    || fail "could not resolve the commit of ${core}-rc.${highest}"
+}
+
 FINAL="$(latest_final)"
 mapfile -t LIVE < <(live_trains "$FINAL")
 mapfile -t STALE < <(stale_trains "$FINAL")
+
+# Every mode but promote cuts from wherever the workflow checked out, which it
+# pins to the default branch.
+BASE="$(git rev-parse HEAD)"
 
 note "Latest final: ${FINAL}"
 note "Live trains:  $( ((${#LIVE[@]})) && echo "${LIVE[*]}" || echo "(none)" )"
@@ -164,11 +196,15 @@ case "$MODE" in
   release)
     [[ -z "$PRE" ]] || fail "pre is only valid with mode=prerelease"
 
-    if ((${#LIVE[@]})); then
-      note "::warning::cutting a final release while ${LIVE[*]} is still in flight; that train will be stranded"
-    fi
-
     TAG="$(bump_version "$FINAL" "$BUMP")"
+
+    # Cutting the version a live train is heading for is not a fork, it is that
+    # train being finalised the long way round, so only warn when they differ.
+    if ((${#LIVE[@]})) && [[ " ${LIVE[*]} " != *" ${TAG} "* ]]; then
+      note "::warning::cutting ${TAG} while ${LIVE[*]} is still in flight; that train will be stranded"
+    elif ((${#LIVE[@]})); then
+      note "::warning::${TAG} is the version ${TAG} candidates were building toward; this cuts it from HEAD rather than from the last candidate, use mode=promote to ship the tree that was soaked"
+    fi
     ;;
 
   prerelease)
@@ -225,6 +261,13 @@ case "$MODE" in
         fail "no prerelease train found for ${NORM}; use mode=release to cut it directly"
       fi
 
+      # An explicit version must not be a way back to a train the resolver has
+      # just reported as stale. Promoting v0.1.24 today would mint a final
+      # release below v0.2.4 out of a candidate abandoned months ago.
+      if ! version_gt "$NORM" "$FINAL"; then
+        fail "${NORM} is older than the latest final ${FINAL}; its candidates were abandoned, delete them rather than promoting them"
+      fi
+
       TAG="$NORM"
     elif ((${#LIVE[@]} == 0)); then
       fail "no live prerelease train to promote; use mode=release to cut a final version directly"
@@ -235,6 +278,9 @@ case "$MODE" in
       TAG="${LIVE[0]}"
       note "Promoting the only live train: ${TAG}"
     fi
+
+    # Ship the tree that was soaked, not whatever has landed since.
+    BASE="$(candidate_commit "$TAG")"
     ;;
 
   *)
@@ -248,6 +294,20 @@ if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
   fail "tag ${TAG} already exists"
 fi
 
+# A candidate cut from a branch that was never merged, or that a force-push has
+# since orphaned, would ship a tree nobody reviewed on the default branch.
+if ! git merge-base --is-ancestor "$BASE" HEAD 2>/dev/null; then
+  fail "${BASE} is not an ancestor of HEAD; refusing to tag a commit that is not on the branch being released from"
+fi
+
+if [[ "$BASE" != "$(git rev-parse HEAD)" ]]; then
+  note "Base commit: ${BASE} ($(git log -1 --format=%s "$BASE"))"
+  note "Excluding $(git rev-list --count "${BASE}..HEAD") commit(s) merged since that candidate was cut"
+else
+  note "Base commit: ${BASE} (HEAD)"
+fi
+
 note "Computed tag: ${TAG}"
 
-echo "$TAG"
+echo "tag=${TAG}"
+echo "base=${BASE}"

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -68,25 +68,47 @@ version_gt() {
 # only a prefix filter, so discovery is anchored here instead: a stray `v1.2`
 # would otherwise be selected as the latest final and bumped to `v1.2.1`, which
 # passes every later check because it looks perfectly well formed.
-SEMVER_TAG='^v[0-9]+\.[0-9]+\.[0-9]+$'
-SEMVER_PRERELEASE_TAG='^v[0-9]+\.[0-9]+\.[0-9]+-'
+#
+# Components are capped at nine digits. Bash arithmetic is signed 64-bit and
+# wraps in silence - 9999999999999999999 + 1 is negative - so an absurd tag
+# could otherwise produce an absurd version rather than an error.
+SEMVER_TAG='^v[0-9]{1,9}\.[0-9]{1,9}\.[0-9]{1,9}$'
+SEMVER_PRERELEASE_TAG='^v[0-9]{1,9}\.[0-9]{1,9}\.[0-9]{1,9}-'
+
+# reachable_tags prints the tags that are ancestors of HEAD, which is the branch
+# this run is releasing from.
+#
+# Tags anywhere else in the repository must not influence the numbering: a
+# `v9.0.0` cut on someone's feature branch would otherwise become the latest
+# final and make the next release from main v9.0.1. The workflow checks out the
+# default branch, so "reachable from HEAD" is "released from this line".
+#
+# The cost is that a tag whose commit later leaves the branch's history stops
+# being seen. That fails safe - the resolver would recompute a version whose tag
+# already exists, and refuse it - and is the correct reading anyway: a tag on a
+# commit that is no longer on the branch is not part of its history.
+reachable_tags() {
+  git tag --merged HEAD --list "$1" 2>/dev/null || true
+}
 
 # latest_final prints the highest final (non-prerelease) tag, or v0.0.0 when the
 # repository has none yet.
 latest_final() {
   local tag
 
-  tag="$(git tag --list 'v[0-9]*' | grep -E -- "$SEMVER_TAG" | sort -V | tail -n1 || true)"
+  tag="$(reachable_tags 'v[0-9]*' | grep -E -- "$SEMVER_TAG" | sort -V | tail -n1 || true)"
 
   echo "${tag:-v0.0.0}"
 }
 
 # train_cores prints every core version that has prerelease tags.
 train_cores() {
-  git tag --list 'v[0-9]*-*' | grep -E -- "$SEMVER_PRERELEASE_TAG" | sed 's/-.*//' | sort -uV || true
+  reachable_tags 'v[0-9]*-*' | grep -E -- "$SEMVER_PRERELEASE_TAG" | sed 's/-.*//' | sort -uV || true
 }
 
-# has_final reports whether a core has been released.
+# has_final reports whether a core has been released. Deliberately global, not
+# reachability-scoped: the question is whether the name is already taken, and it
+# is taken wherever the tag exists.
 has_final() {
   git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1
 }
@@ -160,7 +182,7 @@ max_rc() {
     if (( 10#$n > 10#$max )); then
       max="$n"
     fi
-  done < <(git tag --list "${core}-rc.*" | sed "s|^${core}-rc\.||" | grep -E '^[0-9]+$' || true)
+  done < <(reachable_tags "${core}-rc.*" | sed "s|^${core}-rc\.||" | grep -E '^[0-9]{1,9}$' || true)
 
   echo "$((10#$max))"
 }
@@ -240,7 +262,7 @@ case "$MODE" in
       # literal to bash, so the "is it ahead" test below became an arithmetic
       # error - silently false inside an `if`, which set -e exempts - and the
       # guard did not fire. The tag it then minted poisoned max_rc the same way.
-      [[ "$PRE" =~ ^rc\.[1-9][0-9]*$ ]] || fail "pre must look like rc.N with no leading zeros (got '${PRE}'); rc is the only prerelease suffix"
+      [[ "$PRE" =~ ^rc\.[1-9][0-9]{0,8}$ ]] || fail "pre must look like rc.N with no leading zeros and at most nine digits (got '${PRE}'); rc is the only prerelease suffix"
 
       want="${PRE#rc.}"
       have="$(max_rc "$CORE")"
@@ -264,7 +286,7 @@ case "$MODE" in
 
       [[ "$NORM" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "version must be a final vX.Y.Z with no suffix, got: ${VERSION}"
 
-      if [[ -z "$(git tag --list "${NORM}-*")" ]]; then
+      if [[ -z "$(reachable_tags "${NORM}-*")" ]]; then
         fail "no prerelease train found for ${NORM}; use mode=release to cut it directly"
       fi
 

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -203,7 +203,7 @@ case "$MODE" in
     if ((${#LIVE[@]})) && [[ " ${LIVE[*]} " != *" ${TAG} "* ]]; then
       note "::warning::cutting ${TAG} while ${LIVE[*]} is still in flight; that train will be stranded"
     elif ((${#LIVE[@]})); then
-      note "::warning::${TAG} is the version ${TAG} candidates were building toward; this cuts it from HEAD rather than from the last candidate, use mode=promote to ship the tree that was soaked"
+      note "::warning::${TAG} is the version its candidates were building toward, but mode=release cuts it from HEAD; use mode=promote to ship the tree that was soaked"
     fi
     ;;
 
@@ -279,8 +279,10 @@ case "$MODE" in
       note "Promoting the only live train: ${TAG}"
     fi
 
-    # Ship the tree that was soaked, not whatever has landed since.
-    BASE="$(candidate_commit "$TAG")"
+    # Ship the tree that was soaked, not whatever has landed since. The explicit
+    # `|| exit` matters: fail's exit only leaves the command substitution's
+    # subshell, so without it a resolution failure would depend on set -e alone.
+    BASE="$(candidate_commit "$TAG")" || exit 1
     ;;
 
   *)

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -6,8 +6,8 @@
 # commit to mint it at.
 #
 # Called by .github/workflows/release-prepare.yaml, which owns pushing the tag.
-# This script only decides what the tag should be, which is the part that used
-# to be inline in the workflow where the only way to test a change was to push a
+# This script only decides what to tag and where, which is the part that used to
+# be inline in the workflow where the only way to test a change was to push a
 # tag and see what happened. Three real problems came out of that:
 #
 #   - `bump` was applied to the latest FINAL tag on every run, so it was never

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -64,16 +64,21 @@ version_gt() {
   [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" == "$1" ]]
 }
 
-# SEMVER_TAG matches a tag this project cuts. The glob passed to `git tag` is
-# only a prefix filter, so discovery is anchored here instead: a stray `v1.2`
-# would otherwise be selected as the latest final and bumped to `v1.2.1`, which
-# passes every later check because it looks perfectly well formed.
+# What a version looks like, in one place. Every pattern below is built from
+# SEMVER_COMPONENT, because three of them used to differ: discovery bounded the
+# digits, the promote input did not, and the final check on the computed tag did
+# not either - so a bump could mint a ten-digit version that passed on the way
+# out and was invisible to discovery on the way back in.
 #
-# Components are capped at nine digits. Bash arithmetic is signed 64-bit and
-# wraps in silence - 9999999999999999999 + 1 is negative - so an absurd tag
-# could otherwise produce an absurd version rather than an error.
-SEMVER_TAG='^v[0-9]{1,9}\.[0-9]{1,9}\.[0-9]{1,9}$'
-SEMVER_PRERELEASE_TAG='^v[0-9]{1,9}\.[0-9]{1,9}\.[0-9]{1,9}-'
+# Nine digits: bash arithmetic is signed 64-bit and wraps in silence
+# (9999999999999999999 + 1 is negative), and below a billion nothing can.
+#
+# No leading zeros: v01.2.3 is not a version, and `sort -V` does not order it
+# where a reader would expect.
+SEMVER_COMPONENT='(0|[1-9][0-9]{0,8})'
+SEMVER_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\$"
+SEMVER_PRERELEASE_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}-"
+SEMVER_ANY_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}(-[0-9A-Za-z.-]+)?\$"
 
 # reachable_tags prints the tags that are ancestors of HEAD, which is the branch
 # this run is releasing from.
@@ -161,6 +166,13 @@ bump_version() {
     patch) patch=$((patch + 1)) ;;
     *) fail "unexpected bump level: ${level}" ;;
   esac
+
+  # Said here rather than left to the pattern check at the end, which would
+  # report "not vX.Y.Z" for a version that is plainly vX.Y.Z and merely too big
+  # for the arithmetic that produced it.
+  if (( ${#major} > 9 || ${#minor} > 9 || ${#patch} > 9 )); then
+    fail "bumping ${base} by ${level} overflows a version component; nine digits is the limit"
+  fi
 
   echo "v${major}.${minor}.${patch}"
 }
@@ -254,6 +266,15 @@ case "$MODE" in
       note "Starting a new train at ${CORE} (bump=${BUMP} from ${FINAL})"
     fi
 
+    # has_final is repository-wide on purpose, and that has a consequence here:
+    # a core whose final exists somewhere off this branch is excluded from LIVE,
+    # so nothing stopped a new train being started on it. Every run then
+    # reported "Starting a new train" and minted another rc, and promote could
+    # never finish any of them, because the tag it would create is taken.
+    if has_final "$CORE"; then
+      fail "${CORE} already exists as a tag, though not on this branch; a train for it could never be promoted, so pick another bump or delete that tag"
+    fi
+
     if [[ -n "$PRE" ]]; then
       # rc is the only suffix in use; see RELEASING.md. alpha and beta were
       # previously used interchangeably with no defined meaning.
@@ -284,7 +305,7 @@ case "$MODE" in
     if [[ -n "$VERSION" ]]; then
       NORM="v${VERSION#v}"
 
-      [[ "$NORM" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "version must be a final vX.Y.Z with no suffix, got: ${VERSION}"
+      [[ "$NORM" =~ $SEMVER_TAG ]] || fail "version must be a final vX.Y.Z with no suffix, no leading zeros and at most nine digits per component, got: ${VERSION}"
 
       if [[ -z "$(reachable_tags "${NORM}-*")" ]]; then
         fail "no prerelease train found for ${NORM}; use mode=release to cut it directly"
@@ -318,7 +339,7 @@ case "$MODE" in
     ;;
 esac
 
-[[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || fail "computed tag is not vX.Y.Z[-suffix]: ${TAG}"
+[[ "$TAG" =~ $SEMVER_ANY_TAG ]] || fail "computed tag is not vX.Y.Z[-suffix]: ${TAG}"
 
 if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
   fail "tag ${TAG} already exists"

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -76,9 +76,10 @@ version_gt() {
 # No leading zeros: v01.2.3 is not a version, and `sort -V` does not order it
 # where a reader would expect.
 SEMVER_COMPONENT='(0|[1-9][0-9]{0,8})'
+RC_NUMBER='[1-9][0-9]{0,8}'
 SEMVER_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\$"
-SEMVER_PRERELEASE_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}-"
-SEMVER_ANY_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}(-[0-9A-Za-z.-]+)?\$"
+SEMVER_RC_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}-rc\.${RC_NUMBER}\$"
+SEMVER_ANY_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}(-rc\.${RC_NUMBER})?\$"
 
 # reachable_tags prints the tags that are ancestors of HEAD, which is the branch
 # this run is releasing from.
@@ -96,6 +97,15 @@ reachable_tags() {
   git tag --merged HEAD --list "$1" 2>/dev/null || true
 }
 
+# reachable_rc_tags prints the canonical candidates for one core. Release train
+# discovery, numbering and promotion must agree on this definition: a stray
+# alpha, malformed rc or bare suffix is repository metadata, not a live train.
+reachable_rc_tags() {
+  local core="$1"
+
+  reachable_tags "${core}-rc.*" | grep -E -- "^${core}-rc\.${RC_NUMBER}\$" || true
+}
+
 # latest_final prints the highest final (non-prerelease) tag, or v0.0.0 when the
 # repository has none yet.
 latest_final() {
@@ -106,9 +116,9 @@ latest_final() {
   echo "${tag:-v0.0.0}"
 }
 
-# train_cores prints every core version that has prerelease tags.
+# train_cores prints every core version that has canonical rc tags.
 train_cores() {
-  reachable_tags 'v[0-9]*-*' | grep -E -- "$SEMVER_PRERELEASE_TAG" | sed 's/-.*//' | sort -uV || true
+  reachable_tags 'v[0-9]*-rc.*' | grep -E -- "$SEMVER_RC_TAG" | sed 's/-rc\.[0-9]*$//' | sort -uV || true
 }
 
 # has_final reports whether a core has been released. Deliberately global, not
@@ -194,7 +204,7 @@ max_rc() {
     if (( 10#$n > 10#$max )); then
       max="$n"
     fi
-  done < <(reachable_tags "${core}-rc.*" | sed "s|^${core}-rc\.||" | grep -E '^[0-9]{1,9}$' || true)
+  done < <(reachable_rc_tags "$core" | sed "s|^${core}-rc\.||")
 
   echo "$((10#$max))"
 }
@@ -307,7 +317,7 @@ case "$MODE" in
 
       [[ "$NORM" =~ $SEMVER_TAG ]] || fail "version must be a final vX.Y.Z with no suffix, no leading zeros and at most nine digits per component, got: ${VERSION}"
 
-      if [[ -z "$(reachable_tags "${NORM}-*")" ]]; then
+      if [[ -z "$(reachable_rc_tags "$NORM")" ]]; then
         fail "no prerelease train found for ${NORM}; use mode=release to cut it directly"
       fi
 

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# next-version: work out which tag a release-prepare run should mint.
+#
+# Called by .github/workflows/release-prepare.yaml, which owns pushing the tag.
+# This script only decides what the tag should be, which is the part that used
+# to be inline in the workflow where the only way to test it was to push a tag
+# and see what happened. Three real problems came out of that:
+#
+#   - `bump` was applied to the latest FINAL tag on every run, so it was never
+#     remembered across a candidate train. Re-running with a different bump
+#     silently forked the version.
+#   - `pre` was hand-written and unvalidated, so nothing noticed rc.2 skipping
+#     to rc.6, or an alpha appearing in an rc train.
+#   - `promote` with no version finalised the highest prerelease in the whole
+#     repository rather than the train being worked on. v0.1.24 reached rc.18
+#     and was orphaned that way when a v0.2.0 train started beside it; there is
+#     still no v0.1.24 tag.
+#
+# Output contract:
+#   stdout  the computed tag, and nothing else, so the caller can capture it
+#   stderr  the state report and any notices
+#   exit    non-zero on anything ambiguous or invalid
+#
+# Inputs (environment, matching how the workflow binds its dispatch inputs):
+#   MODE                     release | prerelease | promote
+#   BUMP                     patch | minor | major (only used to START a train)
+#   PRE                      optional explicit prerelease suffix, e.g. rc.3
+#   VERSION                  optional explicit final version for promote
+#   ALLOW_CONCURRENT_TRAINS  "true" to permit a second live train
+#
+# Definition of a LIVE train, which everything below turns on: a core version
+# vX.Y.Z that has prerelease tags, has no final tag of its own, AND is newer
+# than the latest final tag. That last clause is what makes an abandoned train
+# invisible. v0.1.24 still has twelve candidates and no final, but the project
+# has since shipped v0.2.4, so it is stale rather than in flight and must never
+# be offered as something to continue or promote.
+
+set -euo pipefail
+
+MODE="${MODE:?MODE must be set}"
+BUMP="${BUMP:-patch}"
+PRE="${PRE:-}"
+VERSION="${VERSION:-}"
+ALLOW_CONCURRENT_TRAINS="${ALLOW_CONCURRENT_TRAINS:-false}"
+
+# Everything the human needs to see goes to stderr so stdout stays parseable.
+note() { echo "$*" >&2; }
+fail() { echo "::error::$*" >&2; exit 1; }
+
+# version_gt compares two vX.Y.Z strings. sort -V understands the leading v and
+# orders 1.10 above 1.9, which a lexical comparison does not.
+version_gt() {
+  [[ "$1" != "$2" ]] || return 1
+
+  [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" == "$1" ]]
+}
+
+# latest_final prints the highest final (non-prerelease) tag, or v0.0.0 when the
+# repository has none yet.
+latest_final() {
+  local tag
+
+  tag="$(git tag --list 'v[0-9]*' | grep -vE -- '-' | sort -V | tail -n1 || true)"
+
+  echo "${tag:-v0.0.0}"
+}
+
+# train_cores prints every core version that has prerelease tags.
+train_cores() {
+  git tag --list 'v[0-9]*-*' | sed 's/-.*//' | sort -uV
+}
+
+# has_final reports whether a core has been released.
+has_final() {
+  git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1
+}
+
+# live_trains prints cores that are still in flight: prereleases exist, no final
+# was cut, and the core is newer than the latest final.
+live_trains() {
+  local final="$1" core
+
+  while read -r core; do
+    [[ -n "$core" ]] || continue
+
+    if has_final "$core"; then
+      continue
+    fi
+
+    if version_gt "$core" "$final"; then
+      echo "$core"
+    fi
+  done < <(train_cores)
+}
+
+# stale_trains prints cores whose prereleases were abandoned. Reported so the
+# leftover tags eventually get cleaned up rather than accumulating unexplained.
+stale_trains() {
+  local final="$1" core
+
+  while read -r core; do
+    [[ -n "$core" ]] || continue
+
+    if has_final "$core"; then
+      continue
+    fi
+
+    if ! version_gt "$core" "$final"; then
+      echo "$core"
+    fi
+  done < <(train_cores)
+}
+
+bump_version() {
+  local base="$1" level="$2" semver major minor patch
+
+  semver="${base#v}"
+  IFS='.' read -r major minor patch <<<"$semver"
+
+  case "$level" in
+    major) major=$((major + 1)); minor=0; patch=0 ;;
+    minor) minor=$((minor + 1)); patch=0 ;;
+    patch) patch=$((patch + 1)) ;;
+    *) fail "unexpected bump level: ${level}" ;;
+  esac
+
+  echo "v${major}.${minor}.${patch}"
+}
+
+# max_rc prints the highest rc number already cut for a core, or 0.
+#
+# The numbers are compared numerically on purpose. The v0.1.24 train ran to
+# rc.18, and a lexical comparison reports rc.9 as its maximum, which would hand
+# out rc.10 a second time.
+max_rc() {
+  local core="$1" max=0 n
+
+  while read -r n; do
+    [[ -n "$n" ]] || continue
+
+    if (( n > max )); then
+      max="$n"
+    fi
+  done < <(git tag --list "${core}-rc.*" | sed "s|^${core}-rc\.||" | grep -E '^[0-9]+$' || true)
+
+  echo "$max"
+}
+
+FINAL="$(latest_final)"
+mapfile -t LIVE < <(live_trains "$FINAL")
+mapfile -t STALE < <(stale_trains "$FINAL")
+
+note "Latest final: ${FINAL}"
+note "Live trains:  $( ((${#LIVE[@]})) && echo "${LIVE[*]}" || echo "(none)" )"
+
+if ((${#STALE[@]})); then
+  note "Stale trains: ${STALE[*]} (superseded by ${FINAL}; their tags can be deleted)"
+fi
+
+case "$MODE" in
+  release)
+    [[ -z "$PRE" ]] || fail "pre is only valid with mode=prerelease"
+
+    if ((${#LIVE[@]})); then
+      note "::warning::cutting a final release while ${LIVE[*]} is still in flight; that train will be stranded"
+    fi
+
+    TAG="$(bump_version "$FINAL" "$BUMP")"
+    ;;
+
+  prerelease)
+    if [[ "$ALLOW_CONCURRENT_TRAINS" == "true" ]]; then
+      # Explicit intent wins: bump decides the target even if that means a
+      # second train.
+      CORE="$(bump_version "$FINAL" "$BUMP")"
+
+      if ((${#LIVE[@]})) && [[ " ${LIVE[*]} " != *" ${CORE} "* ]]; then
+        note "::warning::starting a SECOND live train ${CORE} alongside ${LIVE[*]}; promote will now require an explicit version"
+      fi
+    elif ((${#LIVE[@]} > 1)); then
+      fail "multiple live trains (${LIVE[*]}); promote or delete one, or set allow_concurrent_trains to add another"
+    elif ((${#LIVE[@]} == 1)); then
+      # Continue the train in flight. bump is deliberately ignored rather than
+      # validated: it is a required input with a default, so there is no way to
+      # tell "the user chose patch" from "the user left the default", and
+      # erroring would fire on the most ordinary invocation there is.
+      CORE="${LIVE[0]}"
+      note "Continuing live train ${CORE} (bump=${BUMP} ignored; it only applies when starting a train)"
+    else
+      CORE="$(bump_version "$FINAL" "$BUMP")"
+      note "Starting a new train at ${CORE} (bump=${BUMP} from ${FINAL})"
+    fi
+
+    if [[ -n "$PRE" ]]; then
+      # rc is the only suffix in use; see RELEASING.md. alpha and beta were
+      # previously used interchangeably with no defined meaning.
+      [[ "$PRE" =~ ^rc\.[0-9]+$ ]] || fail "pre must look like rc.N (got '${PRE}'); rc is the only prerelease suffix"
+
+      want="${PRE#rc.}"
+      have="$(max_rc "$CORE")"
+
+      if (( want <= have )); then
+        fail "pre=${PRE} is not ahead of ${CORE}-rc.${have}; leave pre blank to take the next one automatically"
+      fi
+    else
+      PRE="rc.$(( $(max_rc "$CORE") + 1 ))"
+      note "Auto-selected ${PRE} for ${CORE}"
+    fi
+
+    TAG="${CORE}-${PRE}"
+    ;;
+
+  promote)
+    [[ -z "$PRE" ]] || fail "pre is only valid with mode=prerelease"
+
+    if [[ -n "$VERSION" ]]; then
+      NORM="v${VERSION#v}"
+
+      [[ "$NORM" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "version must be a final vX.Y.Z with no suffix, got: ${VERSION}"
+
+      if [[ -z "$(git tag --list "${NORM}-*")" ]]; then
+        fail "no prerelease train found for ${NORM}; use mode=release to cut it directly"
+      fi
+
+      TAG="$NORM"
+    elif ((${#LIVE[@]} == 0)); then
+      fail "no live prerelease train to promote; use mode=release to cut a final version directly"
+    elif ((${#LIVE[@]} > 1)); then
+      # The v0.1.24 orphan came from guessing here. It no longer guesses.
+      fail "multiple live trains (${LIVE[*]}); pass version to say which one to promote"
+    else
+      TAG="${LIVE[0]}"
+      note "Promoting the only live train: ${TAG}"
+    fi
+    ;;
+
+  *)
+    fail "unexpected mode: ${MODE}"
+    ;;
+esac
+
+[[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || fail "computed tag is not vX.Y.Z[-suffix]: ${TAG}"
+
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+  fail "tag ${TAG} already exists"
+fi
+
+note "Computed tag: ${TAG}"
+
+echo "$TAG"

--- a/hack/release/next_version_test.go
+++ b/hack/release/next_version_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package release
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNextVersionResolver runs hack/release/next-version-test.sh.
+//
+// The cases live in shell rather than here on purpose: they are read during an
+// incident, by someone deciding whether a version is safe to cut, and running
+// them by hand then must not require a Go toolchain. This wrapper exists so CI
+// runs them at all. Without it the suite was executed by nothing, which for
+// logic that mints version tags is barely better than having none.
+func TestNextVersionResolver(t *testing.T) {
+	requireBash4(t)
+	requireGit(t)
+	t.Parallel()
+
+	script, err := filepath.Abs("next-version-test.sh")
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+
+	command := exec.Command("bash", script)
+
+	// The fixtures create throwaway repositories and tag them, so the ambient
+	// git configuration has to be neutralised: a maintainer with
+	// tag.gpgSign=true, or a commit template, or a hook path, would otherwise
+	// fail every case for reasons that have nothing to do with the resolver.
+	command.Env = append(os.Environ(),
+		"TMPDIR="+t.TempDir(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+
+	output, err := command.CombinedOutput()
+
+	// Always logged: on a failure the per-case PASS/FAIL lines are the whole
+	// diagnosis, and `go test` only shows them when something went wrong.
+	t.Logf("next-version-test.sh output:\n%s", output)
+
+	if err != nil {
+		t.Fatalf("next-version-test.sh failed: %v", err)
+	}
+
+	// Guards against the suite reporting success without running: a typo that
+	// left every case unreachable would otherwise pass here silently.
+	if !strings.Contains(string(output), "failed=0") {
+		t.Errorf("expected the resolver suite to report failed=0")
+	}
+
+	if strings.Contains(string(output), "passed=0") {
+		t.Errorf("the resolver suite ran no cases")
+	}
+}

--- a/hack/release/smoke/core-namespaces-ready.sh
+++ b/hack/release/smoke/core-namespaces-ready.sh
@@ -30,10 +30,9 @@
 #     https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
 #   - Do not fail on workloads stranded by an unreachable node. Sites go
 #     offline; that is the premise of the project, not a release regression.
-#     Report them and judge only what is running on a Ready node. The release
-#     gate already decides how many NotReady nodes are acceptable, in
-#     hack/release/wait-rollouts.sh, and smoke only runs once it has passed, so
-#     that policy deliberately lives in exactly one place.
+#     How many NotReady nodes are acceptable is decided once, by the deploy
+#     gate in hack/release/wait-rollouts.sh, which has already passed by the
+#     time smoke runs.
 
 set -euo pipefail
 
@@ -57,14 +56,14 @@ for ns in "${NAMESPACES[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
-# 2. Collect nodes that are not Ready. Pods on these are reported but never
-#    counted as failures: the kubelet has stopped reporting, so their pods can
-#    sit Terminating or unready indefinitely through no fault of the release.
+# 2. Collect nodes that are not Ready. Their pods are reported, never counted:
+#    with the kubelet gone they can sit Terminating indefinitely through no
+#    fault of the release.
 # ---------------------------------------------------------------------------
 notready_nodes=""
-# Emitted as "<name>\t<ready>" and filtered here rather than with a jsonpath
-# predicate on .items: kubectl cannot evaluate a nested filter inside an item
-# selector, and silently returns nothing when asked to.
+# Filtered here rather than with a jsonpath predicate on .items: kubectl cannot
+# evaluate a nested filter inside an item selector, and silently returns nothing
+# when asked to.
 if node_readiness="$("${KUBECTL[@]}" get nodes \
   -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null)"; then
   notready_nodes="$(awk -F'\t' '$2 != "True" { print $1 }' <<<"${node_readiness}")"
@@ -93,10 +92,9 @@ stranded=0
 for ns in "${NAMESPACES[@]}"; do
   echo "Checking pod readiness in ${ns}"
 
-  # Captured before the loop rather than piped into it. A process substitution
-  # that fails is invisible to `set -e`, so a query that errored would feed the
-  # loop nothing and this check would report success having examined no pods at
-  # all - the one outcome a smoke test must never produce.
+  # Captured before the loop, not piped into it: a failing process substitution
+  # is invisible to `set -e`, so an errored query would feed the loop nothing
+  # and this check would pass having examined no pods at all.
   if ! pods="$("${KUBECTL[@]}" -n "${ns}" get pods \
       -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.spec.nodeName}{"\n"}{end}')"; then
     echo "::error::could not list pods in ${ns}"

--- a/hack/release/smoke/core-namespaces-ready.sh
+++ b/hack/release/smoke/core-namespaces-ready.sh
@@ -5,7 +5,9 @@
 # release-smoke: core-namespaces-ready
 #
 # Verifies that the core Unbounded namespaces exist on the deployed cluster
-# and that every pod in those namespaces is Running and Ready.
+# and that every pod on a REACHABLE node in those namespaces is Running and
+# Ready. Pods stranded on a node the kubelet has stopped reporting for are
+# reported and not counted; see the convention on that below.
 #
 # This script is the canonical TEMPLATE for release smoke tests. Copy it
 # as the starting point for new smoke checks under hack/release/smoke/.

--- a/hack/release/smoke/core-namespaces-ready.sh
+++ b/hack/release/smoke/core-namespaces-ready.sh
@@ -26,6 +26,12 @@
 #   - Use GitHub Actions workflow commands ("::error::msg") to surface
 #     failures as red annotations in the run summary. See
 #     https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+#   - Do not fail on workloads stranded by an unreachable node. Sites go
+#     offline; that is the premise of the project, not a release regression.
+#     Report them and judge only what is running on a Ready node. The release
+#     gate already decides how many NotReady nodes are acceptable, in
+#     hack/release/wait-rollouts.sh, and smoke only runs once it has passed, so
+#     that policy deliberately lives in exactly one place.
 
 set -euo pipefail
 
@@ -49,31 +55,69 @@ for ns in "${NAMESPACES[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
-# 2. Every pod in the target namespaces is Running and Ready.
+# 2. Collect nodes that are not Ready. Pods on these are reported but never
+#    counted as failures: the kubelet has stopped reporting, so their pods can
+#    sit Terminating or unready indefinitely through no fault of the release.
+# ---------------------------------------------------------------------------
+notready_nodes=""
+# Emitted as "<name>\t<ready>" and filtered here rather than with a jsonpath
+# predicate on .items: kubectl cannot evaluate a nested filter inside an item
+# selector, and silently returns nothing when asked to.
+if node_readiness="$("${KUBECTL[@]}" get nodes \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null)"; then
+  notready_nodes="$(awk -F'\t' '$2 != "True" { print $1 }' <<<"${node_readiness}")"
+else
+  # Fail closed: if node readiness cannot be established, judge every pod.
+  echo "::warning::could not list node readiness; every unready pod will be treated as a failure"
+fi
+
+if [[ -n "${notready_nodes}" ]]; then
+  echo "::warning::NotReady nodes (pods on these are excluded from this check): $(tr '\n' ' ' <<<"${notready_nodes}")"
+fi
+
+is_notready_node() {
+  [[ -n "$1" && -n "${notready_nodes}" ]] || return 1
+
+  grep -qxF "$1" <<<"${notready_nodes}"
+}
+
+# ---------------------------------------------------------------------------
+# 3. Every pod on a Ready node is Running and Ready.
 #    Completed pods (Job-style workloads in phase Succeeded) are ignored;
 #    they are not a failure even though they are not Running.
 # ---------------------------------------------------------------------------
 failures=0
+stranded=0
 for ns in "${NAMESPACES[@]}"; do
   echo "Checking pod readiness in ${ns}"
-  # Emit "<name>\t<phase>\t<ready_status>" per pod. ready_status is the
+  # Emit "<name>\t<phase>\t<ready_status>\t<node>" per pod. ready_status is the
   # status of the Ready condition (True/False/<empty> if missing).
-  while IFS=$'\t' read -r name phase ready; do
+  while IFS=$'\t' read -r name phase ready node; do
     [[ -z "${name}" ]] && continue
     if [[ "${phase}" == "Succeeded" ]]; then
       continue
     fi
-    if [[ "${phase}" != "Running" || "${ready}" != "True" ]]; then
-      echo "::error::pod ${ns}/${name} not ready (phase=${phase} ready=${ready:-<none>})"
-      failures=$((failures + 1))
+    if [[ "${phase}" == "Running" && "${ready}" == "True" ]]; then
+      continue
     fi
+    if is_notready_node "${node}"; then
+      echo "  stranded: ${ns}/${name} on NotReady node ${node} (phase=${phase})"
+      stranded=$((stranded + 1))
+      continue
+    fi
+    echo "::error::pod ${ns}/${name} not ready (phase=${phase} ready=${ready:-<none>} node=${node:-<unscheduled>})"
+    failures=$((failures + 1))
   done < <("${KUBECTL[@]}" -n "${ns}" get pods \
-            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}')
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.spec.nodeName}{"\n"}{end}')
 done
 
 if (( failures > 0 )); then
-  echo "::error::${failures} pod(s) not ready across ${NAMESPACES[*]}"
+  echo "::error::${failures} pod(s) not ready on Ready nodes across ${NAMESPACES[*]}"
   exit 1
 fi
 
-echo "OK: namespaces present and all pods Running+Ready"
+if (( stranded > 0 )); then
+  echo "::warning::${stranded} pod(s) stranded on NotReady nodes were not validated by this release"
+fi
+
+echo "OK: namespaces present and every pod on a Ready node is Running+Ready"

--- a/hack/release/smoke/core-namespaces-ready.sh
+++ b/hack/release/smoke/core-namespaces-ready.sh
@@ -92,6 +92,17 @@ failures=0
 stranded=0
 for ns in "${NAMESPACES[@]}"; do
   echo "Checking pod readiness in ${ns}"
+
+  # Captured before the loop rather than piped into it. A process substitution
+  # that fails is invisible to `set -e`, so a query that errored would feed the
+  # loop nothing and this check would report success having examined no pods at
+  # all - the one outcome a smoke test must never produce.
+  if ! pods="$("${KUBECTL[@]}" -n "${ns}" get pods \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.spec.nodeName}{"\n"}{end}')"; then
+    echo "::error::could not list pods in ${ns}"
+    exit 1
+  fi
+
   # Emit "<name>\t<phase>\t<ready_status>\t<node>" per pod. ready_status is the
   # status of the Ready condition (True/False/<empty> if missing).
   while IFS=$'\t' read -r name phase ready node; do
@@ -109,8 +120,7 @@ for ns in "${NAMESPACES[@]}"; do
     fi
     echo "::error::pod ${ns}/${name} not ready (phase=${phase} ready=${ready:-<none>} node=${node:-<unscheduled>})"
     failures=$((failures + 1))
-  done < <("${KUBECTL[@]}" -n "${ns}" get pods \
-            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.spec.nodeName}{"\n"}{end}')
+  done <<<"${pods}"
 done
 
 if (( failures > 0 )); then

--- a/hack/release/verify-release-artifacts.sh
+++ b/hack/release/verify-release-artifacts.sh
@@ -106,12 +106,36 @@ if [[ "$bom_commit" != "$EXPECTED_COMMIT" ]]; then
   exit 1
 fi
 
-# Read into an array first: piping into a while loop runs the body in a
-# subshell, where a cosign failure could not fail this script.
-mapfile -t images < <(jq -r '.images[] | (.reference | sub(":[^/]+$"; "")) + "@" + .digest' "${BOM}")
+# Captured, not piped: `mapfile < <(jq ...)` reports mapfile's exit status, not
+# jq's, so a BOM that emitted two images and then failed on a third left the
+# array non-empty and this script verified the prefix and passed. A command
+# substitution propagates the failure.
+if ! image_refs="$(jq -r '.images[] | (.reference | sub(":[^/]+$"; "")) + "@" + .digest' "${BOM}")"; then
+  echo "::error::could not read the image list from ${BOM}; refusing to treat it as verified"
+  exit 1
+fi
+
+if ! bom_image_count="$(jq -r '.images | length' "${BOM}")"; then
+  echo "::error::could not count the images in ${BOM}"
+  exit 1
+fi
+
+mapfile -t images <<<"$image_refs"
+
+# Drop the single empty element `<<<` produces for empty input.
+if (( ${#images[@]} == 1 )) && [[ -z "${images[0]}" ]]; then
+  images=()
+fi
 
 if (( ${#images[@]} == 0 )); then
   echo "::error::release BOM lists no images; refusing to treat it as verified"
+  exit 1
+fi
+
+# Cross-check against the BOM's own count, so an emission that stops early
+# without failing cannot pass either.
+if (( ${#images[@]} != bom_image_count )); then
+  echo "::error::release BOM lists ${bom_image_count} images but only ${#images[@]} resolved; refusing to treat it as verified"
   exit 1
 fi
 

--- a/hack/release/verify-release-artifacts.sh
+++ b/hack/release/verify-release-artifacts.sh
@@ -26,6 +26,10 @@
 #                       USE, which must be covered by the signed checksums.txt.
 #                       GoReleaser signs that file, not the individual binaries,
 #                       so this is how a binary gets verified before it runs.
+#   RELEASE_ASSETS_FILE a file listing the release's asset names, one per line
+#                       (`gh release view --json assets`). Required whenever the
+#                       BOM declares artifacts, because that is the only way to
+#                       tell whether the release still carries them.
 #
 # What is checked:
 #   1. Each signed blob (manifest tarball, operator manifest, release BOM)
@@ -36,6 +40,9 @@
 #   3. Every image the BOM pins is itself signed by the same identity.
 #   4. Every CHECKSUM_FILES entry is listed in checksums.txt, that file carries
 #      the same signed identity, and the bytes on disk match it.
+#   5. The release still carries every artifact the BOM declares, and each
+#      declared signature bundle. A deploy consumes three of the six; the rest
+#      are what users download, and nothing else would notice their absence.
 #
 # The expected commit is a parameter, not a 'git rev-parse HEAD': the check is
 # about the release, not about wherever this runs from, and an implicit HEAD
@@ -137,6 +144,55 @@ fi
 if (( ${#images[@]} != bom_image_count )); then
   echo "::error::release BOM lists ${bom_image_count} images but only ${#images[@]} resolved; refusing to treat it as verified"
   exit 1
+fi
+
+# The BOM is the release's own account of what it shipped, so it is what
+# "complete" is measured against. Checked by NAME against the release's asset
+# list rather than by downloading: the storage tarballs are large, a deploy
+# never consumes them, and the failure being caught here is a draft that lost
+# assets - to a partial upload, or to a hand-run `gh release delete-asset` -
+# rather than one whose bytes were altered.
+declared="$(jq -r '.artifacts // [] | .[] | .name, (.signatureBundle // empty)' "${BOM}")" || {
+  echo "::error::could not read the artifact list from ${BOM}"
+  exit 1
+}
+
+if [[ -z "$declared" ]]; then
+  if jq -e 'has("artifacts")' "${BOM}" >/dev/null 2>&1; then
+    echo "::error::release BOM declares an empty artifact list; refusing to treat it as complete"
+    exit 1
+  fi
+
+  # Older releases predate the field. Backfilling one is a documented path, so
+  # this reports rather than fails.
+  echo "::notice::release BOM has no artifact list; skipping the completeness check"
+else
+  if [[ -z "${RELEASE_ASSETS_FILE:-}" ]]; then
+    echo "::error::the BOM declares artifacts but RELEASE_ASSETS_FILE was not provided; completeness cannot be checked"
+    exit 2
+  fi
+
+  if [[ ! -f "$RELEASE_ASSETS_FILE" ]]; then
+    echo "::error::no asset list at ${RELEASE_ASSETS_FILE}"
+    exit 2
+  fi
+
+  # Collected and reported together: a half-uploaded draft is usually missing
+  # several things, and one name per run is a poor way to find that out.
+  missing=()
+
+  while read -r name; do
+    [[ -n "$name" ]] || continue
+
+    grep -qxF -- "$name" "$RELEASE_ASSETS_FILE" || missing+=("$name")
+  done <<<"$declared"
+
+  if (( ${#missing[@]} > 0 )); then
+    echo "::error::the release is missing $(printf '%s ' "${missing[@]}")- its BOM declares them, so it is incomplete"
+    exit 1
+  fi
+
+  echo "Release carries all $(wc -l <<<"$declared") declared artifact(s)"
 fi
 
 for image in "${images[@]}"; do

--- a/hack/release/verify-release-artifacts.sh
+++ b/hack/release/verify-release-artifacts.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# verify-release-artifacts: prove that a downloaded release was built by this
+# repository's release workflow, at this tag, from this commit.
+#
+# Shared by the deploy job and the forced-publish job in
+# .github/workflows/release-upgrade.yaml. Those are the only two paths that can
+# publish a release, and they previously would have carried separate copies of
+# this logic. The rollout gate next door already demonstrated where that leads:
+# two copies of one check drifted until the weaker one let a broken release
+# through.
+#
+# This needs no cluster access, which is the point. A forced publish exists
+# precisely for the case where the soak cluster is unreachable, and the soak is
+# the only thing it is allowed to skip. Provenance is not negotiable: forcing
+# means "we accept an unsoaked release", never "we accept an unverified one".
+#
+# Usage:
+#   hack/release/verify-release-artifacts.sh <tag> <expected-commit> [dist-dir]
+#
+# Contract (provided by the calling workflow):
+#   GITHUB_REPOSITORY   owner/repo, used to build the certificate identity.
+#
+# What is checked:
+#   1. Each signed blob (manifest tarball, operator manifest, release BOM)
+#      carries a Sigstore bundle whose certificate identity is this repo's
+#      release.yaml AT THIS TAG. That binding is what makes the signature mean
+#      anything: a signature from release.yaml@refs/heads/main, or from a fork,
+#      is rejected.
+#   2. The BOM's recorded tag and commit match what the caller expected.
+#   3. Every image the BOM pins is itself signed by the same identity.
+#
+# The expected commit is passed in rather than read from the working tree. The
+# check is about the release, not about wherever this script happens to be run
+# from, and an implicit 'git rev-parse HEAD' silently becomes a tautology if the
+# caller's checkout ever changes.
+
+set -euo pipefail
+
+TAG="${1:?usage: verify-release-artifacts.sh <tag> <expected-commit> [dist-dir]}"
+EXPECTED_COMMIT="${2:?expected commit is required}"
+DIST="${3:-dist}"
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+
+for tool in cosign jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "::error::verify-release-artifacts.sh requires ${tool} on PATH"
+    exit 2
+  fi
+done
+
+IDENTITY="^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yaml@refs/tags/${TAG}$"
+OIDC_ISSUER="https://token.actions.githubusercontent.com"
+
+ARCHIVE="${DIST}/unbounded-manifests-${TAG}.tar.gz"
+OPERATOR_MANIFEST="${DIST}/unbounded-operator-${TAG}.yaml"
+BOM="${DIST}/unbounded-release-bom-${TAG}.json"
+
+echo "Verifying release artifacts for ${TAG} (expected commit ${EXPECTED_COMMIT})"
+
+for artifact in "${ARCHIVE}" "${OPERATOR_MANIFEST}" "${BOM}"; do
+  if [[ ! -f "$artifact" ]]; then
+    echo "::error::missing release artifact ${artifact}; the release is incomplete"
+    exit 1
+  fi
+
+  if [[ ! -f "${artifact}.bundle.json" ]]; then
+    echo "::error::missing signature bundle for ${artifact}"
+    exit 1
+  fi
+
+  cosign verify-blob \
+    --bundle "${artifact}.bundle.json" \
+    --certificate-identity-regexp "${IDENTITY}" \
+    --certificate-oidc-issuer "${OIDC_ISSUER}" \
+    "${artifact}"
+done
+
+bom_tag="$(jq -r '.release.tag' "${BOM}")"
+if [[ "$bom_tag" != "$TAG" ]]; then
+  echo "::error::release BOM records tag ${bom_tag}, expected ${TAG}"
+  exit 1
+fi
+
+bom_commit="$(jq -r '.release.gitCommit' "${BOM}")"
+if [[ "$bom_commit" != "$EXPECTED_COMMIT" ]]; then
+  echo "::error::release BOM records commit ${bom_commit}, expected ${EXPECTED_COMMIT}"
+  exit 1
+fi
+
+# Piping into a while loop would run the body in a subshell, so a cosign failure
+# there could not fail this script. The digests are read into an array first so
+# the verification runs in this shell and 'set -e' still applies.
+mapfile -t images < <(jq -r '.images[] | (.reference | sub(":[^/]+$"; "")) + "@" + .digest' "${BOM}")
+
+if (( ${#images[@]} == 0 )); then
+  echo "::error::release BOM lists no images; refusing to treat it as verified"
+  exit 1
+fi
+
+for image in "${images[@]}"; do
+  cosign verify \
+    --certificate-identity-regexp "${IDENTITY}" \
+    --certificate-oidc-issuer "${OIDC_ISSUER}" \
+    "${image}" >/dev/null
+done
+
+echo "OK: ${#images[@]} image(s) and 3 blob(s) verified against ${TAG}@${EXPECTED_COMMIT}"

--- a/hack/release/verify-release-artifacts.sh
+++ b/hack/release/verify-release-artifacts.sh
@@ -52,7 +52,15 @@ for tool in cosign jq; do
   fi
 done
 
-IDENTITY="^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yaml@refs/tags/${TAG}$"
+# The tag is escaped before it goes into the certificate identity pattern.
+# Unescaped, the dots in v0.2.5 are regex wildcards, so the identity would also
+# match a signature made at a tag like v0X2Y5. The tag shape is validated
+# upstream so this is not reachable today, but this is the check that decides
+# whether a release was built by this repository, and it should not depend on
+# something two workflows away for its correctness.
+TAG_PATTERN="${TAG//./\\.}"
+
+IDENTITY="^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yaml@refs/tags/${TAG_PATTERN}$"
 OIDC_ISSUER="https://token.actions.githubusercontent.com"
 
 ARCHIVE="${DIST}/unbounded-manifests-${TAG}.tar.gz"

--- a/hack/release/verify-release-artifacts.sh
+++ b/hack/release/verify-release-artifacts.sh
@@ -5,17 +5,15 @@
 # verify-release-artifacts: prove that a downloaded release was built by this
 # repository's release workflow, at this tag, from this commit.
 #
-# Shared by the deploy job and the forced-publish job in
-# .github/workflows/release-upgrade.yaml. Those are the only two paths that can
-# publish a release, and they previously would have carried separate copies of
-# this logic. The rollout gate next door already demonstrated where that leads:
-# two copies of one check drifted until the weaker one let a broken release
-# through.
+# Shared by the deploy and forced-publish jobs in release-upgrade.yaml, the only
+# two paths that can publish a release. The rollout gate next door already
+# showed where two copies of one check leads: they drift, and the weaker one
+# lets a broken release through.
 #
-# This needs no cluster access, which is the point. A forced publish exists
-# precisely for the case where the soak cluster is unreachable, and the soak is
-# the only thing it is allowed to skip. Provenance is not negotiable: forcing
-# means "we accept an unsoaked release", never "we accept an unverified one".
+# It needs no cluster access, which is the point. Forcing a publish exists for
+# when the soak cluster is unreachable, and the soak is the only thing it may
+# skip: forcing means "we accept an unsoaked release", never "an unverified
+# one".
 #
 # Usage:
 #   hack/release/verify-release-artifacts.sh <tag> <expected-commit> [dist-dir]
@@ -27,15 +25,13 @@
 #   1. Each signed blob (manifest tarball, operator manifest, release BOM)
 #      carries a Sigstore bundle whose certificate identity is this repo's
 #      release.yaml AT THIS TAG. That binding is what makes the signature mean
-#      anything: a signature from release.yaml@refs/heads/main, or from a fork,
-#      is rejected.
+#      anything: one from @refs/heads/main, or from a fork, is rejected.
 #   2. The BOM's recorded tag and commit match what the caller expected.
 #   3. Every image the BOM pins is itself signed by the same identity.
 #
-# The expected commit is passed in rather than read from the working tree. The
-# check is about the release, not about wherever this script happens to be run
-# from, and an implicit 'git rev-parse HEAD' silently becomes a tautology if the
-# caller's checkout ever changes.
+# The expected commit is a parameter, not a 'git rev-parse HEAD': the check is
+# about the release, not about wherever this runs from, and an implicit HEAD
+# quietly becomes a tautology if a caller's checkout changes.
 
 set -euo pipefail
 
@@ -52,12 +48,10 @@ for tool in cosign jq; do
   fi
 done
 
-# The tag is escaped before it goes into the certificate identity pattern.
-# Unescaped, the dots in v0.2.5 are regex wildcards, so the identity would also
-# match a signature made at a tag like v0X2Y5. The tag shape is validated
-# upstream so this is not reachable today, but this is the check that decides
-# whether a release was built by this repository, and it should not depend on
-# something two workflows away for its correctness.
+# Escaped: unescaped, the dots in v0.2.5 are wildcards, so the identity would
+# also match a signature made at v0X2Y5. Not reachable while the tag shape is
+# validated upstream, but this check should not depend on something two
+# workflows away for its correctness.
 TAG_PATTERN="${TAG//./\\.}"
 
 IDENTITY="^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yaml@refs/tags/${TAG_PATTERN}$"
@@ -99,9 +93,8 @@ if [[ "$bom_commit" != "$EXPECTED_COMMIT" ]]; then
   exit 1
 fi
 
-# Piping into a while loop would run the body in a subshell, so a cosign failure
-# there could not fail this script. The digests are read into an array first so
-# the verification runs in this shell and 'set -e' still applies.
+# Read into an array first: piping into a while loop runs the body in a
+# subshell, where a cosign failure could not fail this script.
 mapfile -t images < <(jq -r '.images[] | (.reference | sub(":[^/]+$"; "")) + "@" + .digest' "${BOM}")
 
 if (( ${#images[@]} == 0 )); then

--- a/hack/release/verify-release-artifacts.sh
+++ b/hack/release/verify-release-artifacts.sh
@@ -21,6 +21,12 @@
 # Contract (provided by the calling workflow):
 #   GITHUB_REPOSITORY   owner/repo, used to build the certificate identity.
 #
+# Optional:
+#   CHECKSUM_FILES      space-separated artifact names the caller is about to
+#                       USE, which must be covered by the signed checksums.txt.
+#                       GoReleaser signs that file, not the individual binaries,
+#                       so this is how a binary gets verified before it runs.
+#
 # What is checked:
 #   1. Each signed blob (manifest tarball, operator manifest, release BOM)
 #      carries a Sigstore bundle whose certificate identity is this repo's
@@ -28,6 +34,8 @@
 #      anything: one from @refs/heads/main, or from a fork, is rejected.
 #   2. The BOM's recorded tag and commit match what the caller expected.
 #   3. Every image the BOM pins is itself signed by the same identity.
+#   4. Every CHECKSUM_FILES entry is listed in checksums.txt, that file carries
+#      the same signed identity, and the bytes on disk match it.
 #
 # The expected commit is a parameter, not a 'git rev-parse HEAD': the check is
 # about the release, not about wherever this runs from, and an implicit HEAD
@@ -60,6 +68,11 @@ OIDC_ISSUER="https://token.actions.githubusercontent.com"
 ARCHIVE="${DIST}/unbounded-manifests-${TAG}.tar.gz"
 OPERATOR_MANIFEST="${DIST}/unbounded-operator-${TAG}.yaml"
 BOM="${DIST}/unbounded-release-bom-${TAG}.json"
+CHECKSUMS="${DIST}/checksums.txt"
+
+# Word-split on purpose: one entry per artifact name.
+# shellcheck disable=SC2206
+CHECKSUM_TARGETS=( ${CHECKSUM_FILES:-} )
 
 echo "Verifying release artifacts for ${TAG} (expected commit ${EXPECTED_COMMIT})"
 
@@ -109,4 +122,41 @@ for image in "${images[@]}"; do
     "${image}" >/dev/null
 done
 
-echo "OK: ${#images[@]} image(s) and 3 blob(s) verified against ${TAG}@${EXPECTED_COMMIT}"
+# Binaries are covered by checksums.txt rather than individually: GoReleaser
+# signs that one file (.goreleaser.yml), which is what makes verifying it
+# equivalent to verifying everything it lists.
+if (( ${#CHECKSUM_TARGETS[@]} > 0 )); then
+  for artifact in "$CHECKSUMS" "${CHECKSUMS}.bundle.json"; do
+    if [[ ! -f "$artifact" ]]; then
+      echo "::error::missing ${artifact}; cannot verify $(printf '%s ' "${CHECKSUM_TARGETS[@]}")"
+      exit 1
+    fi
+  done
+
+  cosign verify-blob \
+    --bundle "${CHECKSUMS}.bundle.json" \
+    --certificate-identity-regexp "${IDENTITY}" \
+    --certificate-oidc-issuer "${OIDC_ISSUER}" \
+    "${CHECKSUMS}"
+
+  for name in "${CHECKSUM_TARGETS[@]}"; do
+    if [[ ! -f "${DIST}/${name}" ]]; then
+      echo "::error::${name} was not downloaded, so it cannot be verified"
+      exit 1
+    fi
+
+    # An artifact absent from the signed list is unverifiable, and
+    # --ignore-missing would pass it over in silence.
+    if ! grep -qF -- "  ${name}" "$CHECKSUMS"; then
+      echo "::error::${name} is not listed in checksums.txt; refusing to treat it as verified"
+      exit 1
+    fi
+  done
+
+  # --ignore-missing because the release lists every platform's artifacts and a
+  # caller downloads only what it needs; each target's presence is asserted
+  # above, and this fails outright when nothing at all was verified.
+  ( cd "$DIST" && sha256sum --ignore-missing -c checksums.txt )
+fi
+
+echo "OK: ${#images[@]} image(s), 3 blob(s) and ${#CHECKSUM_TARGETS[@]} checksummed artifact(s) verified against ${TAG}@${EXPECTED_COMMIT}"

--- a/hack/release/verify_release_artifacts_test.go
+++ b/hack/release/verify_release_artifacts_test.go
@@ -85,12 +85,68 @@ func newRelease(t *testing.T) *release {
 	r.write("unbounded-operator-"+verifyTag+".yaml", "kind: Deployment")
 	r.write("unbounded-operator-"+verifyTag+".yaml.bundle.json", "{}")
 	r.writeBOM(map[string]any{
-		"release": map[string]any{"tag": verifyTag, "gitCommit": verifyCommit},
+		"release":   map[string]any{"tag": verifyTag, "gitCommit": verifyCommit},
+		"artifacts": declaredArtifacts(),
 		"images": []any{
 			map[string]any{"reference": "ghcr.io/azure/gantry:" + verifyTag, "digest": "sha256:aa"},
 			map[string]any{"reference": "ghcr.io/azure/machina:" + verifyTag, "digest": "sha256:bb"},
 		},
 	})
+	r.publishAssets(declaredAssetNames()...)
+
+	return r
+}
+
+// declaredArtifacts mirrors hack/cmd/release-bom's list: what a release says it
+// shipped, only three of which a deploy ever consumes.
+func declaredArtifacts() []any {
+	return []any{
+		map[string]any{"name": "checksums.txt", "signatureBundle": "checksums.txt.bundle.json"},
+		map[string]any{
+			"name":            "unbounded-manifests-" + verifyTag + ".tar.gz",
+			"signatureBundle": "unbounded-manifests-" + verifyTag + ".tar.gz.bundle.json",
+		},
+		map[string]any{
+			"name":            "unbounded-storage-linux-amd64.tar.gz",
+			"signatureBundle": "unbounded-storage-linux-amd64.tar.gz.bundle.json",
+		},
+		map[string]any{"name": "unbounded.yaml"},
+	}
+}
+
+func declaredAssetNames() []string {
+	return []string{
+		"checksums.txt", "checksums.txt.bundle.json",
+		"unbounded-manifests-" + verifyTag + ".tar.gz",
+		"unbounded-manifests-" + verifyTag + ".tar.gz.bundle.json",
+		"unbounded-storage-linux-amd64.tar.gz",
+		"unbounded-storage-linux-amd64.tar.gz.bundle.json",
+		"unbounded.yaml",
+	}
+}
+
+// publishAssets writes the list of names the release carries, as
+// `gh release view --json assets` would.
+func (r *release) publishAssets(names ...string) {
+	r.t.Helper()
+
+	r.write("release-assets.txt", strings.Join(names, "\n")+"\n")
+}
+
+// withoutAsset republishes the asset list with one name removed, which is what
+// a partially uploaded or hand-pruned draft looks like.
+func (r *release) withoutAsset(drop string) *release {
+	r.t.Helper()
+
+	kept := make([]string, 0, len(declaredAssetNames()))
+
+	for _, name := range declaredAssetNames() {
+		if name != drop {
+			kept = append(kept, name)
+		}
+	}
+
+	r.publishAssets(kept...)
 
 	return r
 }
@@ -186,9 +242,10 @@ func (r *release) run(env map[string]string) (string, int) {
 	}
 
 	base := map[string]string{
-		"PATH":              filepath.Join(r.dir, "bin") + string(os.PathListSeparator) + os.Getenv("PATH"),
-		"FIXTURE_DIR":       r.dir,
-		"GITHUB_REPOSITORY": "Azure/unbounded",
+		"PATH":                filepath.Join(r.dir, "bin") + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"FIXTURE_DIR":         r.dir,
+		"GITHUB_REPOSITORY":   "Azure/unbounded",
+		"RELEASE_ASSETS_FILE": filepath.Join(r.dir, "dist", "release-assets.txt"),
 	}
 	for key, value := range env {
 		base[key] = value
@@ -290,8 +347,9 @@ func TestVerifierRejectsATagMismatch(t *testing.T) {
 
 	r := newRelease(t)
 	r.writeBOM(map[string]any{
-		"release": map[string]any{"tag": "v0.0.1", "gitCommit": verifyCommit},
-		"images":  []any{map[string]any{"reference": "ghcr.io/azure/gantry:v0.0.1", "digest": "sha256:aa"}},
+		"release":   map[string]any{"tag": "v0.0.1", "gitCommit": verifyCommit},
+		"artifacts": declaredArtifacts(),
+		"images":    []any{map[string]any{"reference": "ghcr.io/azure/gantry:v0.0.1", "digest": "sha256:aa"}},
 	})
 
 	output, code := r.run(nil)
@@ -306,8 +364,9 @@ func TestVerifierRejectsACommitMismatch(t *testing.T) {
 
 	r := newRelease(t)
 	r.writeBOM(map[string]any{
-		"release": map[string]any{"tag": verifyTag, "gitCommit": "deadbeef"},
-		"images":  []any{map[string]any{"reference": "ghcr.io/azure/gantry:" + verifyTag, "digest": "sha256:aa"}},
+		"release":   map[string]any{"tag": verifyTag, "gitCommit": "deadbeef"},
+		"artifacts": declaredArtifacts(),
+		"images":    []any{map[string]any{"reference": "ghcr.io/azure/gantry:" + verifyTag, "digest": "sha256:aa"}},
 	})
 
 	output, code := r.run(nil)
@@ -322,8 +381,9 @@ func TestVerifierRejectsAnEmptyImageList(t *testing.T) {
 
 	r := newRelease(t)
 	r.writeBOM(map[string]any{
-		"release": map[string]any{"tag": verifyTag, "gitCommit": verifyCommit},
-		"images":  []any{},
+		"release":   map[string]any{"tag": verifyTag, "gitCommit": verifyCommit},
+		"artifacts": declaredArtifacts(),
+		"images":    []any{},
 	})
 
 	output, code := r.run(nil)
@@ -341,7 +401,8 @@ func TestVerifierRejectsAPartialImageList(t *testing.T) {
 
 	r := newRelease(t)
 	r.writeRawBOM(`{"release":{"tag":"` + verifyTag + `","gitCommit":"` + verifyCommit +
-		`"},"images":[{"reference":"ghcr.io/azure/gantry:v9.9.9","digest":"sha256:aa"},"garbage"]}`)
+		`"},"artifacts":[{"name":"unbounded.yaml"}],` +
+		`"images":[{"reference":"ghcr.io/azure/gantry:v9.9.9","digest":"sha256:aa"},"garbage"]}`)
 
 	output, code := r.run(nil)
 
@@ -451,4 +512,109 @@ func TestVerifierSkipsChecksumsWhenNoBinaryIsUsed(t *testing.T) {
 	if strings.Contains(r.cosignCalls(), "checksums.txt") {
 		t.Errorf("did not expect checksums.txt to be verified when no binary was requested\n%s", r.cosignCalls())
 	}
+}
+
+// TestVerifierRejectsAReleaseMissingADeclaredArtifact is the regression guard
+// for a draft that lost assets. The deploy consumes three of the six artifacts
+// a release declares; nothing looked at the rest, so a release could publish
+// without its storage tarballs, its checksums or unbounded.yaml.
+func TestVerifierRejectsAReleaseMissingADeclaredArtifact(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	for _, missing := range []string{
+		"unbounded-storage-linux-amd64.tar.gz",
+		"unbounded.yaml",
+		"checksums.txt",
+	} {
+		r := newRelease(t).withoutAsset(missing)
+
+		output, code := r.run(nil)
+
+		requireCode(t, code, 1, output)
+		requireContains(t, output, missing)
+		requireContains(t, output, "it is incomplete")
+	}
+}
+
+// TestVerifierRejectsAMissingSignatureBundleAsset covers the bundles named
+// alongside each artifact: a signature nobody can fetch verifies nothing.
+func TestVerifierRejectsAMissingSignatureBundleAsset(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t).withoutAsset("unbounded-storage-linux-amd64.tar.gz.bundle.json")
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "unbounded-storage-linux-amd64.tar.gz.bundle.json")
+}
+
+// TestVerifierReportsEveryMissingArtifactAtOnce keeps a half-uploaded draft
+// from taking one run per missing file to diagnose.
+func TestVerifierReportsEveryMissingArtifactAtOnce(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.publishAssets("checksums.txt", "checksums.txt.bundle.json")
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "unbounded-manifests-"+verifyTag+".tar.gz")
+	requireContains(t, output, "unbounded-storage-linux-amd64.tar.gz")
+	requireContains(t, output, "unbounded.yaml")
+}
+
+// TestVerifierSkipsCompletenessForAnOlderBOM keeps backfilling a tag that
+// predates the artifact list working, which is a documented recovery path.
+func TestVerifierSkipsCompletenessForAnOlderBOM(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.writeBOM(map[string]any{
+		"release": map[string]any{"tag": verifyTag, "gitCommit": verifyCommit},
+		"images":  []any{map[string]any{"reference": "ghcr.io/azure/gantry:" + verifyTag, "digest": "sha256:aa"}},
+	})
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "no artifact list")
+}
+
+// TestVerifierRejectsAnEmptyArtifactList separates "this BOM predates the
+// field" from "this BOM claims the release shipped nothing".
+func TestVerifierRejectsAnEmptyArtifactList(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.writeBOM(map[string]any{
+		"release":   map[string]any{"tag": verifyTag, "gitCommit": verifyCommit},
+		"artifacts": []any{},
+		"images":    []any{map[string]any{"reference": "ghcr.io/azure/gantry:" + verifyTag, "digest": "sha256:aa"}},
+	})
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "empty artifact list")
+}
+
+// TestVerifierRequiresAnAssetListWhenArtifactsAreDeclared refuses to skip the
+// check quietly, which is how the gap existed in the first place.
+func TestVerifierRequiresAnAssetListWhenArtifactsAreDeclared(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+
+	output, code := r.run(map[string]string{"RELEASE_ASSETS_FILE": ""})
+
+	requireCode(t, code, 2, output)
+	requireContains(t, output, "completeness cannot be checked")
 }

--- a/hack/release/verify_release_artifacts_test.go
+++ b/hack/release/verify_release_artifacts_test.go
@@ -1,0 +1,454 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package release
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for verify-release-artifacts.sh.
+//
+// This script is the only thing standing between a GitHub Release and a deploy
+// that trusts it, and it runs on both paths that can publish. It was previously
+// covered by a matrix that lived in a pull request description rather than in
+// the repository, which is how two defects reached review: a truncated BOM
+// image list passed, and the plugin binary the deploy then executed was not
+// checked at all.
+//
+// cosign is stubbed; jq and sha256sum are real, so the payload handling is
+// exercised for real.
+
+const (
+	verifyTag    = "v9.9.9"
+	verifyCommit = "1234567890abcdef1234567890abcdef12345678"
+)
+
+// cosignStub records every invocation and fails the ones named in a file, so a
+// case can make exactly one verification fail.
+const cosignStub = `#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${FIXTURE_DIR}/cosign.log"
+
+# Fail if any argument appears in the fail list, one pattern per line.
+if [[ -f "${FIXTURE_DIR}/cosign.fail" ]]; then
+  while read -r pattern; do
+    [[ -n "$pattern" ]] || continue
+    if [[ "$*" == *"$pattern"* ]]; then
+      echo "cosign: verification failed for ${pattern}" >&2
+      exit 1
+    fi
+  done < "${FIXTURE_DIR}/cosign.fail"
+fi
+
+exit 0
+`
+
+// release builds a dist/ directory in the shape `gh release download` leaves.
+type release struct {
+	t   *testing.T
+	dir string
+}
+
+func newRelease(t *testing.T) *release {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(filepath.Join(dir, "dist"), 0o750); err != nil {
+		t.Fatalf("mkdir dist: %v", err)
+	}
+
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(binDir, "cosign"), []byte(cosignStub), 0o700); err != nil {
+		t.Fatalf("write cosign stub: %v", err)
+	}
+
+	r := &release{t: t, dir: dir}
+
+	// The three signed blobs, each with its bundle.
+	r.write("unbounded-manifests-"+verifyTag+".tar.gz", "tarball")
+	r.write("unbounded-manifests-"+verifyTag+".tar.gz.bundle.json", "{}")
+	r.write("unbounded-operator-"+verifyTag+".yaml", "kind: Deployment")
+	r.write("unbounded-operator-"+verifyTag+".yaml.bundle.json", "{}")
+	r.writeBOM(map[string]any{
+		"release": map[string]any{"tag": verifyTag, "gitCommit": verifyCommit},
+		"images": []any{
+			map[string]any{"reference": "ghcr.io/azure/gantry:" + verifyTag, "digest": "sha256:aa"},
+			map[string]any{"reference": "ghcr.io/azure/machina:" + verifyTag, "digest": "sha256:bb"},
+		},
+	})
+
+	return r
+}
+
+func (r *release) path(name string) string { return filepath.Join(r.dir, "dist", name) }
+
+func (r *release) write(name, content string) {
+	r.t.Helper()
+
+	if err := os.WriteFile(r.path(name), []byte(content), 0o600); err != nil {
+		r.t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func (r *release) writeBOM(bom any) {
+	r.t.Helper()
+
+	data, err := json.Marshal(bom)
+	if err != nil {
+		r.t.Fatalf("marshal bom: %v", err)
+	}
+
+	r.write("unbounded-release-bom-"+verifyTag+".json", string(data))
+	r.write("unbounded-release-bom-"+verifyTag+".json.bundle.json", "{}")
+}
+
+// writeRawBOM installs a BOM that is not necessarily valid JSON.
+func (r *release) writeRawBOM(content string) {
+	r.t.Helper()
+
+	r.write("unbounded-release-bom-"+verifyTag+".json", content)
+	r.write("unbounded-release-bom-"+verifyTag+".json.bundle.json", "{}")
+}
+
+// withPlugin adds the plugin tarball and a signed checksums.txt covering it,
+// which is how a binary is verified: GoReleaser signs the list, not each file.
+func (r *release) withPlugin(content string, corrupt bool) *release {
+	r.t.Helper()
+
+	name := "kubectl-unbounded-linux-amd64.tar.gz"
+	r.write(name, content)
+
+	listed := content
+	if corrupt {
+		listed = content + " tampered"
+	}
+
+	sum := sha256.Sum256([]byte(listed))
+	r.write("checksums.txt", fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), name))
+	r.write("checksums.txt.bundle.json", "{}")
+
+	return r
+}
+
+func (r *release) remove(name string) {
+	r.t.Helper()
+
+	if err := os.Remove(r.path(name)); err != nil {
+		r.t.Fatalf("remove %s: %v", name, err)
+	}
+}
+
+// failCosignFor makes any cosign call whose arguments contain pattern fail.
+func (r *release) failCosignFor(pattern string) {
+	r.t.Helper()
+
+	if err := os.WriteFile(filepath.Join(r.dir, "cosign.fail"), []byte(pattern+"\n"), 0o600); err != nil {
+		r.t.Fatalf("write fail list: %v", err)
+	}
+}
+
+func (r *release) cosignCalls() string {
+	r.t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(r.dir, "cosign.log"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ""
+		}
+
+		r.t.Fatalf("read cosign log: %v", err)
+	}
+
+	return string(data)
+}
+
+func (r *release) run(env map[string]string) (string, int) {
+	r.t.Helper()
+
+	script, err := filepath.Abs("verify-release-artifacts.sh")
+	if err != nil {
+		r.t.Fatalf("resolve script: %v", err)
+	}
+
+	base := map[string]string{
+		"PATH":              filepath.Join(r.dir, "bin") + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"FIXTURE_DIR":       r.dir,
+		"GITHUB_REPOSITORY": "Azure/unbounded",
+	}
+	for key, value := range env {
+		base[key] = value
+	}
+
+	environ := make([]string, 0, len(base))
+	for key, value := range base {
+		environ = append(environ, key+"="+value)
+	}
+
+	command := exec.Command("bash", script, verifyTag, verifyCommit, "dist")
+	command.Dir = r.dir
+	command.Env = environ
+
+	out, err := command.CombinedOutput()
+
+	code := 0
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		r.t.Fatalf("run script: %v", err)
+	}
+
+	return string(out), code
+}
+
+func requireVerifier(t *testing.T) {
+	t.Helper()
+
+	requireBash4(t)
+
+	for _, tool := range []string{"jq", "sha256sum"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not on PATH; skipping verify-release-artifacts.sh tests", tool)
+		}
+	}
+}
+
+func TestVerifierAcceptsACompleteRelease(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "2 image(s)")
+	// The identity binding is what makes any of this mean anything.
+	requireContains(t, r.cosignCalls(), "release\\.yaml@refs/tags/v9\\.9\\.9$")
+	requireContains(t, r.cosignCalls(), "ghcr.io/azure/gantry@sha256:aa")
+}
+
+func TestVerifierRejectsAMissingArtifact(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.remove("unbounded-manifests-" + verifyTag + ".tar.gz")
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "missing release artifact")
+}
+
+func TestVerifierRejectsAMissingBundle(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.remove("unbounded-operator-" + verifyTag + ".yaml.bundle.json")
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "missing signature bundle")
+}
+
+func TestVerifierRejectsAnUnverifiableBlob(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.failCosignFor("unbounded-manifests")
+
+	output, code := r.run(nil)
+
+	if code == 0 {
+		t.Errorf("expected a failure when a blob signature does not verify\n%s", output)
+	}
+}
+
+func TestVerifierRejectsATagMismatch(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.writeBOM(map[string]any{
+		"release": map[string]any{"tag": "v0.0.1", "gitCommit": verifyCommit},
+		"images":  []any{map[string]any{"reference": "ghcr.io/azure/gantry:v0.0.1", "digest": "sha256:aa"}},
+	})
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "records tag v0.0.1")
+}
+
+func TestVerifierRejectsACommitMismatch(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.writeBOM(map[string]any{
+		"release": map[string]any{"tag": verifyTag, "gitCommit": "deadbeef"},
+		"images":  []any{map[string]any{"reference": "ghcr.io/azure/gantry:" + verifyTag, "digest": "sha256:aa"}},
+	})
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "records commit deadbeef")
+}
+
+func TestVerifierRejectsAnEmptyImageList(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.writeBOM(map[string]any{
+		"release": map[string]any{"tag": verifyTag, "gitCommit": verifyCommit},
+		"images":  []any{},
+	})
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "lists no images")
+}
+
+// TestVerifierRejectsAPartialImageList is the regression guard for a BOM that
+// emits some images and then fails. `mapfile < <(jq ...)` reported mapfile's
+// exit status, so the prefix was verified and the release passed.
+func TestVerifierRejectsAPartialImageList(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.writeRawBOM(`{"release":{"tag":"` + verifyTag + `","gitCommit":"` + verifyCommit +
+		`"},"images":[{"reference":"ghcr.io/azure/gantry:v9.9.9","digest":"sha256:aa"},"garbage"]}`)
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "refusing to treat it as verified")
+	// Nothing may have been accepted on the strength of the prefix.
+	requireNotContains(t, output, "OK:")
+}
+
+func TestVerifierRejectsAnUnverifiableImage(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+	r.failCosignFor("ghcr.io/azure/machina")
+
+	output, code := r.run(nil)
+
+	if code == 0 {
+		t.Errorf("expected a failure when an image signature does not verify\n%s", output)
+	}
+}
+
+// TestVerifierChecksARequestedBinary covers the artifact the deploy job then
+// executes against the cluster. It is covered by the signed checksums.txt
+// rather than by a bundle of its own.
+func TestVerifierChecksARequestedBinary(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t).withPlugin("plugin bytes", false)
+
+	output, code := r.run(map[string]string{"CHECKSUM_FILES": "kubectl-unbounded-linux-amd64.tar.gz"})
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "1 checksummed artifact(s)")
+	requireContains(t, r.cosignCalls(), "checksums.txt")
+}
+
+func TestVerifierRejectsATamperedBinary(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t).withPlugin("plugin bytes", true)
+
+	output, code := r.run(map[string]string{"CHECKSUM_FILES": "kubectl-unbounded-linux-amd64.tar.gz"})
+
+	if code == 0 {
+		t.Errorf("expected a failure when the binary does not match checksums.txt\n%s", output)
+	}
+}
+
+func TestVerifierRejectsAnUnsignedChecksumList(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t).withPlugin("plugin bytes", false)
+	r.failCosignFor("checksums.txt")
+
+	output, code := r.run(map[string]string{"CHECKSUM_FILES": "kubectl-unbounded-linux-amd64.tar.gz"})
+
+	if code == 0 {
+		t.Errorf("expected a failure when checksums.txt does not verify\n%s", output)
+	}
+}
+
+// TestVerifierRejectsABinaryMissingFromTheList closes the gap --ignore-missing
+// would otherwise leave: an artifact absent from the signed list is
+// unverifiable, and sha256sum would simply pass over it.
+func TestVerifierRejectsABinaryMissingFromTheList(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t).withPlugin("plugin bytes", false)
+	r.write("checksums.txt", "0000  some-other-file.tar.gz\n")
+
+	output, code := r.run(map[string]string{"CHECKSUM_FILES": "kubectl-unbounded-linux-amd64.tar.gz"})
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "not listed in checksums.txt")
+}
+
+func TestVerifierRejectsAMissingChecksumList(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+
+	output, code := r.run(map[string]string{"CHECKSUM_FILES": "kubectl-unbounded-linux-amd64.tar.gz"})
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "checksums.txt")
+}
+
+// TestVerifierSkipsChecksumsWhenNoBinaryIsUsed keeps publish-forced, which
+// downloads no binaries, from being made to fetch artifacts it never runs.
+func TestVerifierSkipsChecksumsWhenNoBinaryIsUsed(t *testing.T) {
+	requireVerifier(t)
+	t.Parallel()
+
+	r := newRelease(t)
+
+	output, code := r.run(nil)
+
+	requireCode(t, code, 0, output)
+
+	if strings.Contains(r.cosignCalls(), "checksums.txt") {
+		t.Errorf("did not expect checksums.txt to be verified when no binary was requested\n%s", r.cosignCalls())
+	}
+}

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -72,8 +72,8 @@
 #   - its CURRENT pod template references EXPECTED_IMAGE_TAG;
 #   - between 1 and MAX_NOTREADY_NODES nodes are NotReady;
 #   - the DaemonSet controller has observed the current generation;
-#   - updated + stranded and ready + stranded both cover desiredNumberScheduled;
-#   - no pod on a READY node is unhealthy.
+#   - no pod on a READY node is unhealthy or still on the previous release;
+#   - healthy pods on Ready nodes plus stranded ones cover the desired count.
 #
 # Tolerance repeats the EXPECTED_IMAGE_TAG condition rather than trusting the
 # earlier phase: the template can arrive while a pod on a reachable node is
@@ -387,34 +387,51 @@ NOTREADY_NODE_FILTER='
 '
 
 # DAEMONSET_SHORTFALL_FILTER classifies a DaemonSet's pods against the NotReady
-# node names, emitting "<stranded>\t<unhealthy_on_ready>".
+# node names, emitting
+# "<stranded>\t<unhealthy_on_ready>\t<outdated_on_ready>\t<healthy_on_ready>".
 #
 #   stranded            pods on a NotReady node, which the controller can
 #                       neither update nor reap; they are why the rollout stalls.
 #   unhealthy_on_ready  pods elsewhere that are not Running+Ready. A pod with no
 #                       nodeName counts here: DaemonSet pods are assigned at
 #                       creation, so an unassigned one is a scheduling failure.
+#   outdated_on_ready   pods elsewhere still running something other than $tag.
+#   healthy_on_ready    pods elsewhere that are Running+Ready.
+#
+# Every number is derived from the pod list, never from .status counters. An
+# earlier revision compared updatedNumberScheduled + stranded against desired,
+# which double-counts: a stranded pod the controller had already updated is in
+# BOTH terms, so the sum reached desired while a reachable node was still
+# running the previous release. That is not a corner case - with maxUnavailable
+# 1 a stranded pod counts as unavailable, so the controller stops updating the
+# remaining nodes, making it the steady state of a stalled rollout.
 DAEMONSET_SHORTFALL_FILTER='
   [ .items[]
     | (.spec.nodeName // "") as $node
     | { stranded: ($notready | any(. == $node)),
         ready: ((.status.phase == "Running")
                  and ((((.status.conditions // [])
-                         | map(select(.type == "Ready")) | .[0].status) // "False") == "True"))
+                         | map(select(.type == "Ready")) | .[0].status) // "False") == "True")),
+        current: ([ (.spec.containers // [])[], (.spec.initContainers // [])[] ]
+                   | map(.image) | any(endswith($tag)))
       }
   ]
   | [ (map(select(.stranded)) | length),
-      (map(select((.stranded | not) and (.ready | not))) | length)
+      (map(select((.stranded | not) and (.ready | not))) | length),
+      (map(select((.stranded | not) and (.current | not))) | length),
+      (map(select((.stranded | not) and .ready)) | length)
     ]
   | @tsv
 '
 
-# DAEMONSET_STATUS_FILTER emits the five numbers tolerance is decided on:
-# "<desired>\t<ready>\t<updated>\t<generation>\t<observedGeneration>".
+# DAEMONSET_STATUS_FILTER emits what only the controller can tell us:
+# "<desired>\t<ready>\t<generation>\t<observedGeneration>". desired is the node
+# count no pod list can supply, ready detects the shortfall, and the generations
+# say whether the controller has caught up. Whether the fleet is UPDATED is
+# decided from the pods; see DAEMONSET_SHORTFALL_FILTER.
 DAEMONSET_STATUS_FILTER='
   [ (.status.desiredNumberScheduled // 0),
     (.status.numberReady // 0),
-    (.status.updatedNumberScheduled // 0),
     (.metadata.generation // 0),
     (.status.observedGeneration // -1)
   ]
@@ -498,7 +515,8 @@ running_expected_release() {
 node_tolerance() {
   local target="$1" kind="$2" selector="$3"
   local obj_json pods_json nodes_tsv notready_json counts status_tsv
-  local desired ready updated generation observed stranded unhealthy
+  local desired ready generation observed
+  local stranded unhealthy outdated healthy
   local notready_count
 
   # No selector means pods cannot be scoped to this workload. Also the state
@@ -524,7 +542,7 @@ node_tolerance() {
 
   status_tsv="$(printf '%s' "$obj_json" | jq -r "$DAEMONSET_STATUS_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
-  IFS=$'\t' read -r desired ready updated generation observed <<<"$status_tsv" || return 1
+  IFS=$'\t' read -r desired ready generation observed <<<"$status_tsv" || return 1
 
   # Stale or partial data. Any of these failing means "not yet", never "close
   # enough".
@@ -564,14 +582,19 @@ node_tolerance() {
   }
 
   counts="$(printf '%s' "$pods_json" | jq -r --argjson notready "$notready_json" \
-    "$DAEMONSET_SHORTFALL_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+    --arg tag ":${EXPECTED_IMAGE_TAG}" "$DAEMONSET_SHORTFALL_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
-  IFS=$'\t' read -r stranded unhealthy <<<"$counts" || return 1
+  IFS=$'\t' read -r stranded unhealthy outdated healthy <<<"$counts" || return 1
 
+  # The shortfall must be the unreachable nodes and nothing else: something is
+  # stranded, and everything reachable is both healthy and on this release.
   (( stranded > 0 )) || return 1
   (( unhealthy == 0 )) || return 1
-  (( updated + stranded >= desired )) || return 1
-  (( ready + stranded >= desired )) || return 1
+  (( outdated == 0 )) || return 1
+
+  # Coverage, counted from pods rather than from status counters so a stranded
+  # pod the controller already updated cannot be counted twice.
+  (( healthy + stranded >= desired )) || return 1
 
   echo "::warning::${target} is short ${stranded} of ${desired} pods, entirely on NotReady nodes: $(describe_nodes "$nodes_tsv")"
   echo "::warning::tolerating the ${target} shortfall (MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}); this release was NOT validated on those nodes"
@@ -580,7 +603,7 @@ node_tolerance() {
     {
       echo "### Degraded rollout tolerated: ${target}"
       echo
-      echo "- Ready pods: ${ready}/${desired} (${stranded} stranded on NotReady nodes)"
+      echo "- Ready pods: ${healthy}/${desired} (${stranded} stranded on NotReady nodes)"
       echo "- NotReady nodes: $(describe_nodes "$nodes_tsv")"
       echo "- Deployed image tag: \`${EXPECTED_IMAGE_TAG}\`"
       echo "- Tolerated because \`MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}\`"

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -43,9 +43,12 @@
 #                                a DaemonSet shortfall stops being excusable
 #                                (default 2). 0 disables tolerance entirely.
 #   EXPECTED_IMAGE_TAG           The release being deployed, e.g. v0.2.5 or
-#                                nightly-abc1234. No workload is judged until it
-#                                references this. Unset skips that wait and
-#                                disables tolerance.
+#                                nightly-abc1234. No workload is judged until
+#                                every image we publish carries it. Unset skips
+#                                that wait and disables tolerance.
+#   EXPECTED_IMAGE_REGISTRY      Where we publish, e.g. ghcr.io/azure. Required
+#                                with EXPECTED_IMAGE_TAG, and the only way to
+#                                tell our images from third-party pins.
 #
 # Design notes
 # ------------
@@ -107,6 +110,11 @@ POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
 IMAGE_FAILURE_GRACE_SECONDS="${IMAGE_FAILURE_GRACE_SECONDS:-90}"
 MAX_NOTREADY_NODES="${MAX_NOTREADY_NODES:-2}"
 EXPECTED_IMAGE_TAG="${EXPECTED_IMAGE_TAG:-}"
+# Lowercased because image references are, while the GitHub owner that usually
+# supplies this is not: ghcr.io/Azure never appears in a pod spec.
+EXPECTED_IMAGE_REGISTRY="${EXPECTED_IMAGE_REGISTRY:-}"
+EXPECTED_IMAGE_REGISTRY="${EXPECTED_IMAGE_REGISTRY,,}"
+EXPECTED_IMAGE_REGISTRY="${EXPECTED_IMAGE_REGISTRY%/}"
 
 if [[ ! "$MAX_NOTREADY_NODES" =~ ^[0-9]+$ ]]; then
   echo "::error::MAX_NOTREADY_NODES must be a non-negative integer (got '${MAX_NOTREADY_NODES}')"
@@ -119,6 +127,15 @@ fi
 # Both callers set it; this fires when a third one forgets to.
 if (( MAX_NOTREADY_NODES > 0 )) && [[ -z "$EXPECTED_IMAGE_TAG" ]]; then
   echo "::notice::EXPECTED_IMAGE_TAG is not set; degraded-node tolerance is unavailable for this run"
+fi
+
+# The two travel together. Deciding whether a workload is on this release means
+# telling the images we publish from the third-party ones pinned beside them,
+# and that is what the registry supplies. Falling back to a weaker rule when
+# only one is set would be a silent downgrade of the check.
+if [[ -n "$EXPECTED_IMAGE_TAG" && -z "$EXPECTED_IMAGE_REGISTRY" ]]; then
+  echo "::error::EXPECTED_IMAGE_TAG is set without EXPECTED_IMAGE_REGISTRY; both are needed to tell our images from pinned third-party ones"
+  exit 2
 fi
 
 # jq is preinstalled on GitHub-hosted runners and is already used by the
@@ -434,7 +451,9 @@ DAEMONSET_SHORTFALL_FILTER='
                  and ((((.status.conditions // [])
                          | map(select(.type == "Ready")) | .[0].status) // "False") == "True")),
         current: ([ (.spec.containers // [])[], (.spec.initContainers // [])[] ]
-                   | map(.image) | any(endswith($tag)))
+                    | map(.image)
+                    | map(select(startswith($registry + "/"))) as $ours
+                    | ($ours | length) > 0 and ($ours | all(endswith($tag))))
       }
   ] as $pods
   | [ ($pods | map(select(.stranded)) | map(.node) | unique | length),
@@ -460,14 +479,21 @@ DAEMONSET_STATUS_FILTER='
   | @tsv
 '
 
-# TEMPLATE_IMAGE_FILTER reports whether any image in the pod template carries
-# $tag. ANY, not all: gantry's pinned third-party init image legitimately does
-# not, and a component pinned elsewhere by an unbounded-component-overrides
-# entry is then never tolerated, which is reported rather than ignored.
+# TEMPLATE_IMAGE_FILTER reports whether a pod template is on this release:
+# every image we publish carries $tag, and there is at least one of them.
+#
+# Scoped to $registry because a component's images sit beside pinned
+# third-party ones - gantry's busybox init never carries a release tag - and
+# those must not be judged. An earlier revision asked whether ANY image carried
+# the tag, which meant a current sidecar excused a stale primary.
+#
+# `all` is true for an empty list, hence the length check: a workload with none
+# of our images is not on this release, it is something else entirely.
 TEMPLATE_IMAGE_FILTER='
   [ (.spec.template.spec.containers // [])[], (.spec.template.spec.initContainers // [])[] ]
   | map(.image)
-  | any(endswith($tag))
+  | map(select(startswith($registry + "/"))) as $ours
+  | ($ours | length) > 0 and ($ours | all(endswith($tag)))
 '
 
 # notready_nodes prints one TSV record per NotReady node. Empty output means
@@ -511,6 +537,7 @@ template_has_release() {
   [[ -n "$EXPECTED_IMAGE_TAG" ]] || return 1
 
   matched="$(printf '%s' "$obj_json" | jq -r --arg tag ":${EXPECTED_IMAGE_TAG}" \
+    --arg registry "$EXPECTED_IMAGE_REGISTRY" \
     "$TEMPLATE_IMAGE_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
   [[ "$matched" == "true" ]]
@@ -648,6 +675,7 @@ node_tolerance() {
 
   counts="$(printf '%s' "$pods_json" | jq -r --argjson notready "$notready_json" \
     --arg tag ":${EXPECTED_IMAGE_TAG}" --arg owner "$owner_uid" \
+    --arg registry "$EXPECTED_IMAGE_REGISTRY" \
     "$DAEMONSET_SHORTFALL_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
   IFS=$'\t' read -r stranded unhealthy outdated healthy <<<"$counts" || return 1

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -2,9 +2,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# wait-rollouts: wait for operator-managed workloads to become available, fail
-# fast with a named image when a pod cannot pull the image it needs, and
-# tolerate a DaemonSet shortfall that is caused only by unreachable nodes.
+# wait-rollouts: wait for operator-managed workloads to become the release under
+# test and then become available, fail fast with a named image when a pod cannot
+# pull the image it needs, and tolerate a DaemonSet shortfall that is caused
+# only by unreachable nodes.
+#
+# Each workload is waited on in three phases: it must exist, it must reference
+# EXPECTED_IMAGE_TAG, and only then is its rollout judged. The middle phase
+# matters because 'kubectl rollout status' answers "is this workload settled" -
+# and a workload the operator has not updated yet is perfectly settled, so
+# asking first would certify the PREVIOUS release.
 #
 # Shared by .github/workflows/nightly.yaml and release-upgrade.yaml. Both gates
 # previously carried a copy of this logic and had already drifted (gantry was
@@ -33,9 +40,9 @@
 #                                a DaemonSet shortfall stops being excusable
 #                                (default 2). 0 disables tolerance entirely.
 #   EXPECTED_IMAGE_TAG           The release being deployed, e.g. v0.2.5 or
-#                                nightly-abc1234. A shortfall is only excusable
-#                                on a workload that already references it.
-#                                Unset disables tolerance entirely.
+#                                nightly-abc1234. No workload is judged until it
+#                                references this. Unset skips that wait and
+#                                disables tolerance.
 #
 # Design notes
 # ------------
@@ -68,12 +75,9 @@
 #   - updated + stranded and ready + stranded both cover desiredNumberScheduled;
 #   - no pod on a READY node is unhealthy.
 #
-# The EXPECTED_IMAGE_TAG condition is what keeps tolerance from excusing the
-# PREVIOUS release. Component workloads are updated asynchronously, so early in
-# a wait a DaemonSet still carries the old template while every other condition
-# already holds: without it, a gate on a cluster with one permanently
-# unreachable node would pass a second after it started, having validated
-# nothing. Redeploying an already-deployed tag still tolerates immediately.
+# Tolerance repeats the EXPECTED_IMAGE_TAG condition rather than trusting the
+# earlier phase: the template can arrive while a pod on a reachable node is
+# still running the old one.
 #
 # Exceeding MAX_NOTREADY_NODES is reported immediately, grouped by site, so the
 # log explains the timeout while it is still counting down. It does NOT abort
@@ -623,6 +627,52 @@ wait_exists() {
   done
 }
 
+# wait_for_release blocks until the workload's pod template references
+# EXPECTED_IMAGE_TAG, i.e. until it IS the release under test.
+#
+# Without this the gate can pass against the PREVIOUS release. Component
+# workloads are updated asynchronously: the operator reconciles the Site some
+# time after its own Deployment reports available, so for the first seconds of a
+# wait every component still carries the template it had before - fully healthy,
+# fully rolled out. 'kubectl rollout status' answers "is this workload settled",
+# and a workload nobody has touched yet is settled, so it returns success
+# immediately and the deploy is declared good having validated nothing.
+#
+# This is the same condition node_tolerance applies, hoisted to cover every
+# path rather than only the degraded one.
+#
+# A workload whose image has been pinned elsewhere by an
+# unbounded-component-overrides entry never satisfies this and will time out.
+# That is deliberate: the gate cannot certify a release against a workload that
+# is not running it, and going quiet instead would be the failure this check
+# exists to prevent.
+wait_for_release() {
+  local target="$1" deadline=$(( SECONDS + CREATE_TIMEOUT_SECONDS )) obj_json
+
+  # Reported once at startup; tolerance is off too, so there is nothing to wait
+  # for and rollout status remains the only verdict.
+  [[ -n "$EXPECTED_IMAGE_TAG" ]] || return 0
+
+  while true; do
+    if obj_json="$(kubectl_json get "$target" -o json)"; then
+      if running_expected_release "$target" "$obj_json"; then
+        return 0
+      fi
+    else
+      warn_once "could not read ${target} while waiting for :${EXPECTED_IMAGE_TAG}: $(flatten "${WORKDIR}/kubectl.err")"
+    fi
+
+    if (( SECONDS >= deadline )); then
+      echo "::error::${target} never referenced :${EXPECTED_IMAGE_TAG} within ${CREATE_TIMEOUT_SECONDS}s; the operator has not rolled this release out to it"
+      echo "::error::if its image is pinned by an unbounded-component-overrides entry, that override has to go before this release can be gated"
+
+      return 1
+    fi
+
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
 # wait_rollout runs 'kubectl rollout status' in the background and polls
 # alongside it. Delegating to kubectl keeps the real rollout semantics
 # (observedGeneration, updated/available replicas) rather than reimplementing
@@ -676,6 +726,11 @@ wait_target() {
   LAST_WARNING=""
 
   wait_exists "$target" || return 1
+
+  # Before rollout status, not after: a workload the operator has not updated
+  # yet is already "rolled out", so asking kubectl first would accept the
+  # previous release.
+  wait_for_release "$target" || return 1
 
   if (( GUARD_DISABLED == 0 )); then
     meta="$(resolve_target "$target")" || rc=$?

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -2,8 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# wait-rollouts: wait for operator-managed workloads to become available, and
-# fail fast with a named image when a pod cannot pull the image it needs.
+# wait-rollouts: wait for operator-managed workloads to become available, fail
+# fast with a named image when a pod cannot pull the image it needs, and
+# tolerate a DaemonSet shortfall that is caused only by unreachable nodes.
 #
 # Shared by .github/workflows/nightly.yaml and .github/workflows/release-upgrade.yaml.
 # Both deploy gates previously carried a copy of this logic and had already
@@ -18,6 +19,12 @@
 # blocks for its full timeout, and the run reports a bare "pod not ready". That
 # failure mode kept the nightly red for 15 consecutive nights. Detecting the
 # pull error names the missing image in seconds instead.
+#
+# Why the node check exists: a DaemonSet counts every node toward
+# desiredNumberScheduled, including nodes the kubelet has stopped reporting for.
+# A single unreachable node therefore blocks 'rollout status' until its timeout,
+# every time, forever. For a project whose premise is nodes in flaky remote
+# sites that turns the release gate into a coin toss on hardware liveness.
 #
 # Usage:
 #   hack/release/wait-rollouts.sh deploy/unbounded-operator ds/gantry ...
@@ -35,6 +42,9 @@
 #   POLL_INTERVAL_SECONDS        Poll cadence for the image check (default 5).
 #   IMAGE_FAILURE_GRACE_SECONDS  How long a retryable image failure must persist
 #                                before it is treated as fatal (default 90).
+#   MAX_NOTREADY_NODES           How many NotReady nodes may be tolerated before
+#                                a DaemonSet shortfall stops being excusable
+#                                (default 2). 0 disables tolerance entirely.
 #
 # Design notes
 # ------------
@@ -44,10 +54,28 @@
 # is reported loudly and then ignored, never converted into a failed deploy. It
 # is an accelerator for diagnosis, not a second opinion on health.
 #
-# It is also strictly SCOPED to the workload currently being waited on. An
-# earlier revision scanned the whole namespace, which meant an unrelated tenant
-# (Orca, deployed by a later job) or a leftover pod from a previous broken run
-# could abort the very deploy that would have repaired the cluster.
+# The node check runs the opposite discipline and is deliberately FAIL-CLOSED.
+# It is the only thing here that can turn a failing wait into a passing one, so
+# anything it cannot positively verify means "keep waiting" and let rollout
+# status deliver the verdict. A broken diagnostic must never manufacture a green
+# release. Concretely it tolerates a shortfall only when ALL of these hold:
+#
+#   - the workload is a DaemonSet (a Deployment reschedules off a dead node, so
+#     a shortfall there is a real scheduling problem, not a stranded pod);
+#   - between 1 and MAX_NOTREADY_NODES nodes are NotReady;
+#   - the DaemonSet controller has observed the current generation;
+#   - updated + stranded and ready + stranded both cover desiredNumberScheduled;
+#   - no pod on a READY node is unhealthy.
+#
+# Exceeding MAX_NOTREADY_NODES is reported immediately, grouped by site, so the
+# log explains the timeout while it is still counting down. It deliberately does
+# NOT abort early: a node may recover inside the window, and inventing a new
+# abort path would break the fail-closed rule above.
+#
+# The image check is also strictly SCOPED to the workload currently being waited
+# on. An earlier revision scanned the whole namespace, which meant an unrelated
+# tenant (Orca, deployed by a later job) or a leftover pod from a previous
+# broken run could abort the very deploy that would have repaired the cluster.
 
 set -euo pipefail
 
@@ -66,6 +94,12 @@ ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-5m}"
 CREATE_TIMEOUT_SECONDS="${CREATE_TIMEOUT_SECONDS:-300}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
 IMAGE_FAILURE_GRACE_SECONDS="${IMAGE_FAILURE_GRACE_SECONDS:-90}"
+MAX_NOTREADY_NODES="${MAX_NOTREADY_NODES:-2}"
+
+if [[ ! "$MAX_NOTREADY_NODES" =~ ^[0-9]+$ ]]; then
+  echo "::error::MAX_NOTREADY_NODES must be a non-negative integer (got '${MAX_NOTREADY_NODES}')"
+  exit 2
+fi
 
 # jq is preinstalled on GitHub-hosted runners and is already used by the
 # smoke-discover jobs, but assert it rather than letting a missing binary
@@ -332,6 +366,158 @@ check_images() {
   return 1
 }
 
+# NOTREADY_NODE_FILTER emits "<name>\t<site>" per node whose Ready condition is
+# not True. A missing Ready condition counts as NotReady. The site label is only
+# used for the human-facing message; both the canonical and the deprecated key
+# are consulted because the net controllers still dual-write them.
+NOTREADY_NODE_FILTER='
+  .items[]
+  | select((((.status.conditions // []) | map(select(.type == "Ready")) | .[0].status) // "Unknown") != "True")
+  | [ .metadata.name,
+      (.metadata.labels["unbounded-cloud.io/site"]
+        // .metadata.labels["net.unbounded-cloud.io/site"]
+        // "no-site")
+    ]
+  | @tsv
+'
+
+# DAEMONSET_SHORTFALL_FILTER classifies a DaemonSet's pods against the NotReady
+# node names, emitting "<stranded>\t<unhealthy_on_ready>".
+#
+#   stranded            pods on a NotReady node. The controller can neither
+#                       update nor reap these; they are why the rollout stalls.
+#   unhealthy_on_ready  pods NOT on a NotReady node that are not Running+Ready.
+#                       A pod with no nodeName counts here: a DaemonSet pod is
+#                       assigned at creation, so an unassigned one is a real
+#                       scheduling failure rather than a stranded pod.
+DAEMONSET_SHORTFALL_FILTER='
+  [ .items[]
+    | (.spec.nodeName // "") as $node
+    | { stranded: ($notready | any(. == $node)),
+        ready: ((.status.phase == "Running")
+                 and ((((.status.conditions // [])
+                         | map(select(.type == "Ready")) | .[0].status) // "False") == "True"))
+      }
+  ]
+  | [ (map(select(.stranded)) | length),
+      (map(select((.stranded | not) and (.ready | not))) | length)
+    ]
+  | @tsv
+'
+
+# notready_nodes prints one TSV record per NotReady node. Empty output means
+# every node is Ready.
+#
+# Exit codes: 0 succeeded, 1 query or evaluation failed.
+notready_nodes() {
+  local nodes_json
+
+  nodes_json="$(kubectl_json get nodes -o json)" || return 1
+
+  printf '%s' "$nodes_json" | jq -r "$NOTREADY_NODE_FILTER" 2>"${WORKDIR}/jq.err" || return 1
+}
+
+# describe_nodes collapses the TSV into one annotation-safe line grouped by
+# site, for example "boulderlab[spark-3d37] edge[node-9, node-10]".
+describe_nodes() {
+  awk -F'\t' '
+    { order[$2] = ($2 in order) ? order[$2] : ++n; group[$2] = group[$2] (group[$2] ? ", " : "") $1 }
+    END { for (s in group) printf "%s[%s] ", s, group[s] }
+  ' <<<"$1" | sed 's/ $//'
+}
+
+# node_tolerance decides whether a stalled DaemonSet rollout is explained
+# entirely by nodes the cluster has lost contact with.
+#
+# Returns 0 to tolerate (the caller stops waiting and succeeds), 1 to keep
+# waiting. EVERY uncertain path returns 1: this is the one check that can turn a
+# failing wait into a passing one, so it must never guess. See the FAIL-CLOSED
+# note at the top of this file.
+node_tolerance() {
+  local target="$1" selector="$2"
+  local obj_json pods_json nodes_tsv notready_json counts status_tsv
+  local kind desired ready updated generation observed stranded unhealthy
+  local notready_count
+
+  # No selector means pods cannot be scoped to this workload.
+  [[ -n "$selector" ]] || return 1
+
+  obj_json="$(kubectl_json get "$target" -o json)" || {
+    warn_once "could not read ${target} while evaluating node tolerance: $(flatten "${WORKDIR}/kubectl.err")"
+
+    return 1
+  }
+
+  # A Deployment reschedules off a dead node, so a shortfall there is a real
+  # scheduling problem and must not be excused.
+  kind="$(printf '%s' "$obj_json" | jq -r '.kind // ""' 2>"${WORKDIR}/jq.err")" || return 1
+  [[ "$kind" == "DaemonSet" ]] || return 1
+
+  nodes_tsv="$(notready_nodes)" || {
+    warn_once "could not evaluate node readiness for ${target}: $(flatten "${WORKDIR}/kubectl.err")"
+
+    return 1
+  }
+
+  # Every node is Ready, so whatever is stalling this rollout is a real problem.
+  [[ -n "$nodes_tsv" ]] || return 1
+
+  notready_count="$(wc -l <<<"$nodes_tsv" | tr -d ' ')"
+
+  if (( notready_count > MAX_NOTREADY_NODES )); then
+    warn_once "too many NotReady nodes for the ${target} shortfall to be excused (${notready_count} > MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}): $(describe_nodes "$nodes_tsv")"
+
+    return 1
+  fi
+
+  notready_json="$(cut -f1 <<<"$nodes_tsv" | jq -R -s -c 'split("\n") | map(select(length > 0))' 2>"${WORKDIR}/jq.err")" || return 1
+
+  pods_json="$(kubectl_json get pods --selector "$selector" -o json)" || {
+    warn_once "could not list pods for ${target} while evaluating node tolerance: $(flatten "${WORKDIR}/kubectl.err")"
+
+    return 1
+  }
+
+  counts="$(printf '%s' "$pods_json" | jq -r --argjson notready "$notready_json" \
+    "$DAEMONSET_SHORTFALL_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+
+  IFS=$'\t' read -r stranded unhealthy <<<"$counts" || return 1
+
+  status_tsv="$(printf '%s' "$obj_json" | jq -r '
+    [ (.status.desiredNumberScheduled // 0),
+      (.status.numberReady // 0),
+      (.status.updatedNumberScheduled // 0),
+      (.metadata.generation // 0),
+      (.status.observedGeneration // -1)
+    ] | @tsv' 2>"${WORKDIR}/jq.err")" || return 1
+
+  IFS=$'\t' read -r desired ready updated generation observed <<<"$status_tsv" || return 1
+
+  # Guard against every way this could be evaluated against stale or partial
+  # data. Any of these failing simply means "not yet", never "close enough".
+  (( desired > 0 )) || return 1
+  (( observed >= generation )) || return 1
+  (( stranded > 0 )) || return 1
+  (( unhealthy == 0 )) || return 1
+  (( updated + stranded >= desired )) || return 1
+  (( ready + stranded >= desired )) || return 1
+
+  echo "::warning::${target} is short ${stranded} of ${desired} pods, entirely on NotReady nodes: $(describe_nodes "$nodes_tsv")"
+  echo "::warning::tolerating the ${target} shortfall (MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}); this release was NOT validated on those nodes"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### Degraded rollout tolerated: ${target}"
+      echo
+      echo "- Ready pods: ${ready}/${desired} (${stranded} stranded on NotReady nodes)"
+      echo "- NotReady nodes: $(describe_nodes "$nodes_tsv")"
+      echo "- Tolerated because \`MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  return 0
+}
+
 # wait_exists blocks until the operator materializes the workload. Component
 # workloads are created asynchronously after the operator reconciles the Site,
 # so they do not exist the moment the deploy step finishes.
@@ -370,10 +556,10 @@ wait_exists() {
   done
 }
 
-# wait_rollout runs 'kubectl rollout status' in the background and polls for
-# image failures alongside it. Delegating to kubectl keeps the real rollout
-# semantics (observedGeneration, updated/available replicas) rather than
-# reimplementing them; the poll only adds an early exit.
+# wait_rollout runs 'kubectl rollout status' in the background and polls
+# alongside it. Delegating to kubectl keeps the real rollout semantics
+# (observedGeneration, updated/available replicas) rather than reimplementing
+# them; the polls only add early exits, one in each direction.
 wait_rollout() {
   local target="$1" selector="$2" desired="$3" rc=0
 
@@ -393,6 +579,17 @@ wait_rollout() {
 
         return 1
       fi
+    fi
+
+    # Checked after the image guard so a missing image is still reported as
+    # such: an unreachable node cannot mask a pipeline that forgot to build
+    # something, because a stranded pod's image never gets pulled at all.
+    if node_tolerance "$target" "$selector"; then
+      kill "$ROLLOUT_PID" 2>/dev/null || true
+      wait "$ROLLOUT_PID" 2>/dev/null || true
+      ROLLOUT_PID=""
+
+      return 0
     fi
 
     sleep "$POLL_INTERVAL_SECONDS"

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -823,6 +823,11 @@ wait_rollout() {
       wait "$ROLLOUT_PID" 2>/dev/null || true
       ROLLOUT_PID=""
 
+      # Same confirmation the rollout path gets. node_tolerance checked the tag
+      # on the object it read, but then went on to query nodes and pods, and
+      # this is the one place a tolerated shortfall becomes a passing gate.
+      confirm_expected_release "$target" || return 1
+
       return 0
     fi
 

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -39,7 +39,8 @@
 #   ROLLOUT_TIMEOUT              Per-workload rollout timeout (default 5m).
 #   CREATE_TIMEOUT_SECONDS       How long to wait for a workload to be created
 #                                by the operator before giving up (default 300).
-#   POLL_INTERVAL_SECONDS        Poll cadence for the image check (default 5).
+#   POLL_INTERVAL_SECONDS        Cadence of both polls, image and node
+#                                (default 5).
 #   IMAGE_FAILURE_GRACE_SECONDS  How long a retryable image failure must persist
 #                                before it is treated as fatal (default 90).
 #   MAX_NOTREADY_NODES           How many NotReady nodes may be tolerated before

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -45,6 +45,10 @@
 #   MAX_NOTREADY_NODES           How many NotReady nodes may be tolerated before
 #                                a DaemonSet shortfall stops being excusable
 #                                (default 2). 0 disables tolerance entirely.
+#   EXPECTED_IMAGE_TAG           The release being deployed, e.g. v0.2.5 or
+#                                nightly-abc1234. A shortfall is only excusable
+#                                on a workload that already references it.
+#                                Unset disables tolerance entirely.
 #
 # Design notes
 # ------------
@@ -62,10 +66,34 @@
 #
 #   - the workload is a DaemonSet (a Deployment reschedules off a dead node, so
 #     a shortfall there is a real scheduling problem, not a stranded pod);
+#   - the workload's CURRENT pod template references EXPECTED_IMAGE_TAG;
 #   - between 1 and MAX_NOTREADY_NODES nodes are NotReady;
 #   - the DaemonSet controller has observed the current generation;
 #   - updated + stranded and ready + stranded both cover desiredNumberScheduled;
 #   - no pod on a READY node is unhealthy.
+#
+# The EXPECTED_IMAGE_TAG condition is what keeps tolerance from excusing the
+# PREVIOUS release. Component workloads are updated asynchronously: the operator
+# reconciles the Site some time after its own Deployment reports available, so
+# for the first seconds of a wait a DaemonSet still carries the old template.
+# Every other condition holds in that window - the controller has observed its
+# generation, every reachable pod is updated and Ready against the OLD spec, and
+# the only shortfall is the stranded pod - so without this check a deploy gate
+# on a cluster with one permanently unreachable node would return success
+# roughly a second after it started, having validated nothing. Requiring the tag
+# to be present makes tolerance wait for the operator, and the redeploy of an
+# already-deployed tag still tolerates immediately because the tag is already
+# there.
+#
+# The tag is matched against the CURRENT object on every poll, never against the
+# spec read once before the wait began, because observing the operator rewrite
+# that template mid-wait is the entire mechanism.
+#
+# It matches if ANY container image carries the tag, not all of them: gantry's
+# pinned third-party init image legitimately does not. A component whose image
+# has been pinned elsewhere by an unbounded-component-overrides entry will
+# therefore never be tolerated; that is reported rather than silently ignored,
+# and the operator already flags such a workload as version drift.
 #
 # Exceeding MAX_NOTREADY_NODES is reported immediately, grouped by site, so the
 # log explains the timeout while it is still counting down. It deliberately does
@@ -95,10 +123,19 @@ CREATE_TIMEOUT_SECONDS="${CREATE_TIMEOUT_SECONDS:-300}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
 IMAGE_FAILURE_GRACE_SECONDS="${IMAGE_FAILURE_GRACE_SECONDS:-90}"
 MAX_NOTREADY_NODES="${MAX_NOTREADY_NODES:-2}"
+EXPECTED_IMAGE_TAG="${EXPECTED_IMAGE_TAG:-}"
 
 if [[ ! "$MAX_NOTREADY_NODES" =~ ^[0-9]+$ ]]; then
   echo "::error::MAX_NOTREADY_NODES must be a non-negative integer (got '${MAX_NOTREADY_NODES}')"
   exit 2
+fi
+
+# Reported once, up front, rather than per poll: with no tag to check against
+# there is no way to tell the release being deployed from the one it replaces,
+# so tolerance is unavailable and a shortfall will run the rollout timeout down.
+# Both callers set it; this fires when a third one forgets to.
+if (( MAX_NOTREADY_NODES > 0 )) && [[ -z "$EXPECTED_IMAGE_TAG" ]]; then
+  echo "::notice::EXPECTED_IMAGE_TAG is not set; degraded-node tolerance is unavailable for this run"
 fi
 
 # jq is preinstalled on GitHub-hosted runners and is already used by the
@@ -216,8 +253,12 @@ kubectl_json() {
   return 1
 }
 
-# resolve_target prints the workload's pod selector on the first line and its
-# desired container images as a JSON array on the second.
+# resolve_target prints three lines: the workload's kind, its pod selector, and
+# its desired container images as a JSON array.
+#
+# The kind is read here, once, rather than per poll inside node_tolerance: it
+# cannot change for the life of the wait, and taking it from this read means a
+# Deployment costs no extra API calls at all during the poll loop.
 #
 # Exit codes: 0 resolved, 2 query failed, 3 evaluation failed.
 resolve_target() {
@@ -226,6 +267,7 @@ resolve_target() {
   json="$(kubectl_json get "$target" -o json)" || return 2
 
   printf '%s' "$json" | jq -r '
+    (.kind // ""),
     ((.spec.selector.matchLabels // {}) | to_entries | map("\(.key)=\(.value)") | join(",")),
     ([ (.spec.template.spec.containers // [])[], (.spec.template.spec.initContainers // [])[] ]
       | map(.image) | unique | tojson)
@@ -405,6 +447,27 @@ DAEMONSET_SHORTFALL_FILTER='
   | @tsv
 '
 
+# DAEMONSET_STATUS_FILTER emits the five numbers tolerance is decided on:
+# "<desired>\t<ready>\t<updated>\t<generation>\t<observedGeneration>".
+DAEMONSET_STATUS_FILTER='
+  [ (.status.desiredNumberScheduled // 0),
+    (.status.numberReady // 0),
+    (.status.updatedNumberScheduled // 0),
+    (.metadata.generation // 0),
+    (.status.observedGeneration // -1)
+  ]
+  | @tsv
+'
+
+# TEMPLATE_IMAGE_FILTER reports whether any image in the pod template carries
+# $tag. See the EXPECTED_IMAGE_TAG note at the top of this file for why "any"
+# and not "all".
+TEMPLATE_IMAGE_FILTER='
+  [ (.spec.template.spec.containers // [])[], (.spec.template.spec.initContainers // [])[] ]
+  | map(.image)
+  | any(endswith($tag))
+'
+
 # notready_nodes prints one TSV record per NotReady node. Empty output means
 # every node is Ready.
 #
@@ -419,11 +482,48 @@ notready_nodes() {
 
 # describe_nodes collapses the TSV into one annotation-safe line grouped by
 # site, for example "boulderlab[spark-3d37] edge[node-9, node-10]".
+#
+# Sites are emitted in the order they were first seen. awk iterates an
+# associative array in an unspecified order, so grouping without this would
+# reshuffle the message between polls of the same unchanged cluster.
 describe_nodes() {
   awk -F'\t' '
-    { order[$2] = ($2 in order) ? order[$2] : ++n; group[$2] = group[$2] (group[$2] ? ", " : "") $1 }
-    END { for (s in group) printf "%s[%s] ", s, group[s] }
-  ' <<<"$1" | sed 's/ $//'
+    !($2 in group) { order[++n] = $2 }
+    { group[$2] = group[$2] (group[$2] ? ", " : "") $1 }
+    END {
+      for (i = 1; i <= n; i++) {
+        printf "%s%s[%s]", (i > 1 ? " " : ""), order[i], group[order[i]]
+      }
+    }
+  ' <<<"$1"
+}
+
+# running_expected_release reports whether a workload's CURRENT pod template
+# references EXPECTED_IMAGE_TAG.
+#
+# This is the condition that stops tolerance excusing the PREVIOUS release: for
+# the first seconds of a wait the operator has not yet rewritten the template,
+# and every other condition already holds. See the top of this file.
+#
+# Returns 0 when it matches, 1 otherwise, including when the tag is unset or jq
+# fails: this is a fail-closed check like everything else node_tolerance does.
+running_expected_release() {
+  local target="$1" obj_json="$2" matched
+
+  [[ -n "$EXPECTED_IMAGE_TAG" ]] || return 1
+
+  matched="$(printf '%s' "$obj_json" | jq -r --arg tag ":${EXPECTED_IMAGE_TAG}" \
+    "$TEMPLATE_IMAGE_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+
+  [[ "$matched" == "true" ]] && return 0
+
+  # Normal for the first seconds of a deploy, and the reason the shortfall is
+  # not being excused yet, so it is worth saying out loud. It is also what an
+  # image pinned by an unbounded-component-overrides entry looks like, in which
+  # case it will not clear and the rollout runs its timeout down.
+  warn_once "${target} does not reference :${EXPECTED_IMAGE_TAG} yet, so its shortfall cannot be excused; waiting for the operator to update it"
+
+  return 1
 }
 
 # node_tolerance decides whether a stalled DaemonSet rollout is explained
@@ -433,25 +533,59 @@ describe_nodes() {
 # waiting. EVERY uncertain path returns 1: this is the one check that can turn a
 # failing wait into a passing one, so it must never guess. See the FAIL-CLOSED
 # note at the top of this file.
+#
+# The conditions are ordered cheapest-first, and each one that can be decided
+# without the apiserver is decided before anything is queried. This runs on
+# every poll of every workload, so an ordering that read the full node list
+# before noticing the workload was a Deployment, or that tolerance was switched
+# off, would cost tens of megabytes of node JSON per wait to reach the same
+# answer.
 node_tolerance() {
-  local target="$1" selector="$2"
+  local target="$1" kind="$2" selector="$3"
   local obj_json pods_json nodes_tsv notready_json counts status_tsv
-  local kind desired ready updated generation observed stranded unhealthy
+  local desired ready updated generation observed stranded unhealthy
   local notready_count
 
-  # No selector means pods cannot be scoped to this workload.
+  # No selector means pods cannot be scoped to this workload. This is also the
+  # state when the image guard has been disabled, which deliberately takes
+  # tolerance down with it: a script that could not read a workload's spec has
+  # no business excusing that workload's shortfall.
   [[ -n "$selector" ]] || return 1
 
+  # A Deployment reschedules off a dead node, so a shortfall there is a real
+  # scheduling problem and must not be excused. Free: read once, before the
+  # wait, by resolve_target.
+  [[ "$kind" == "DaemonSet" ]] || return 1
+
+  # Tolerance switched off, or nothing to compare a template against.
+  (( MAX_NOTREADY_NODES > 0 )) || return 1
+  [[ -n "$EXPECTED_IMAGE_TAG" ]] || return 1
+
+  # One read serves both the live status numbers and the image check, and both
+  # have to be evaluated against the CURRENT object.
   obj_json="$(kubectl_json get "$target" -o json)" || {
     warn_once "could not read ${target} while evaluating node tolerance: $(flatten "${WORKDIR}/kubectl.err")"
 
     return 1
   }
 
-  # A Deployment reschedules off a dead node, so a shortfall there is a real
-  # scheduling problem and must not be excused.
-  kind="$(printf '%s' "$obj_json" | jq -r '.kind // ""' 2>"${WORKDIR}/jq.err")" || return 1
-  [[ "$kind" == "DaemonSet" ]] || return 1
+  status_tsv="$(printf '%s' "$obj_json" | jq -r "$DAEMONSET_STATUS_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+
+  IFS=$'\t' read -r desired ready updated generation observed <<<"$status_tsv" || return 1
+
+  # Guard against every way this could be evaluated against stale or partial
+  # data. Any of these failing simply means "not yet", never "close enough".
+  (( desired > 0 )) || return 1
+  (( observed >= generation )) || return 1
+
+  # No shortfall to excuse. rollout status will return on its own, and there is
+  # no reason to list nodes or pods to find that out.
+  (( ready < desired )) || return 1
+
+  # The workload must already be the release under test. Checked before the
+  # node and pod queries because it is the condition most likely to be false
+  # early in a deploy, and it needs no further API calls.
+  running_expected_release "$target" "$obj_json" || return 1
 
   nodes_tsv="$(notready_nodes)" || {
     warn_once "could not evaluate node readiness for ${target}: $(flatten "${WORKDIR}/kubectl.err")"
@@ -483,20 +617,6 @@ node_tolerance() {
 
   IFS=$'\t' read -r stranded unhealthy <<<"$counts" || return 1
 
-  status_tsv="$(printf '%s' "$obj_json" | jq -r '
-    [ (.status.desiredNumberScheduled // 0),
-      (.status.numberReady // 0),
-      (.status.updatedNumberScheduled // 0),
-      (.metadata.generation // 0),
-      (.status.observedGeneration // -1)
-    ] | @tsv' 2>"${WORKDIR}/jq.err")" || return 1
-
-  IFS=$'\t' read -r desired ready updated generation observed <<<"$status_tsv" || return 1
-
-  # Guard against every way this could be evaluated against stale or partial
-  # data. Any of these failing simply means "not yet", never "close enough".
-  (( desired > 0 )) || return 1
-  (( observed >= generation )) || return 1
   (( stranded > 0 )) || return 1
   (( unhealthy == 0 )) || return 1
   (( updated + stranded >= desired )) || return 1
@@ -511,6 +631,7 @@ node_tolerance() {
       echo
       echo "- Ready pods: ${ready}/${desired} (${stranded} stranded on NotReady nodes)"
       echo "- NotReady nodes: $(describe_nodes "$nodes_tsv")"
+      echo "- Deployed image tag: \`${EXPECTED_IMAGE_TAG}\`"
       echo "- Tolerated because \`MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}\`"
     } >> "$GITHUB_STEP_SUMMARY"
   fi
@@ -561,7 +682,7 @@ wait_exists() {
 # (observedGeneration, updated/available replicas) rather than reimplementing
 # them; the polls only add early exits, one in each direction.
 wait_rollout() {
-  local target="$1" selector="$2" desired="$3" rc=0
+  local target="$1" kind="$2" selector="$3" desired="$4" rc=0
 
   IMAGE_FIRST_SEEN=()
 
@@ -584,7 +705,7 @@ wait_rollout() {
     # Checked after the image guard so a missing image is still reported as
     # such: an unreachable node cannot mask a pipeline that forgot to build
     # something, because a stranded pod's image never gets pulled at all.
-    if node_tolerance "$target" "$selector"; then
+    if node_tolerance "$target" "$kind" "$selector"; then
       kill "$ROLLOUT_PID" 2>/dev/null || true
       wait "$ROLLOUT_PID" 2>/dev/null || true
       ROLLOUT_PID=""
@@ -603,7 +724,7 @@ wait_rollout() {
 
 # wait_target waits for one workload to exist and then to roll out.
 wait_target() {
-  local target="$1" selector="" desired="[]" meta rc=0
+  local target="$1" kind="" selector="" desired="[]" meta rc=0
   local -a lines=()
 
   LAST_WARNING=""
@@ -616,8 +737,9 @@ wait_target() {
     case "$rc" in
       0)
         mapfile -t lines <<<"$meta"
-        selector="${lines[0]:-}"
-        desired="${lines[1]:-[]}"
+        kind="${lines[0]:-}"
+        selector="${lines[1]:-}"
+        desired="${lines[2]:-[]}"
 
         if [[ -z "$selector" ]]; then
           # Only matchExpressions, which this guard does not translate. Fail
@@ -634,7 +756,7 @@ wait_target() {
     esac
   fi
 
-  wait_rollout "$target" "$selector" "$desired"
+  wait_rollout "$target" "$kind" "$selector" "$desired"
 }
 
 echo "Waiting for rollouts in ${NS}: $*"

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -8,10 +8,13 @@
 # only by unreachable nodes.
 #
 # Each workload is waited on in three phases: it must exist, it must reference
-# EXPECTED_IMAGE_TAG, and only then is its rollout judged. The middle phase
-# matters because 'kubectl rollout status' answers "is this workload settled" -
-# and a workload the operator has not updated yet is perfectly settled, so
-# asking first would certify the PREVIOUS release.
+# EXPECTED_IMAGE_TAG, and only then is its rollout judged - and the tag is
+# confirmed again once kubectl reports success. The middle phase matters because
+# 'kubectl rollout status' answers "is this workload settled", and a workload
+# the operator has not updated yet is perfectly settled, so asking first would
+# certify the PREVIOUS release. The confirmation matters because a rollout takes
+# minutes, and whatever rewrites the template in that window is what kubectl
+# ends up reporting success for.
 #
 # Shared by .github/workflows/nightly.yaml and release-upgrade.yaml. Both gates
 # previously carried a copy of this logic and had already drifted (gantry was
@@ -476,28 +479,65 @@ describe_nodes() {
   ' <<<"$1"
 }
 
-# running_expected_release reports whether a workload's CURRENT pod template
-# references EXPECTED_IMAGE_TAG. Read from the object re-fetched on each poll,
-# never the spec read before the wait began: observing the operator rewrite that
-# template mid-wait is the entire mechanism.
+# template_has_release reports, quietly, whether a workload's CURRENT pod
+# template references EXPECTED_IMAGE_TAG. Read from the object re-fetched on
+# each poll, never the spec read before the wait began: observing the operator
+# rewrite that template mid-wait is the entire mechanism.
 #
 # Returns 1 when the tag is unset or jq fails, like every other uncertain path
 # in node_tolerance.
-running_expected_release() {
-  local target="$1" obj_json="$2" matched
+template_has_release() {
+  local obj_json="$1" matched
 
   [[ -n "$EXPECTED_IMAGE_TAG" ]] || return 1
 
   matched="$(printf '%s' "$obj_json" | jq -r --arg tag ":${EXPECTED_IMAGE_TAG}" \
     "$TEMPLATE_IMAGE_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
-  if [[ "$matched" == "true" ]]; then
+  [[ "$matched" == "true" ]]
+}
+
+# running_expected_release is template_has_release plus the explanation the
+# waiting paths want when it is not yet true.
+running_expected_release() {
+  local target="$1" obj_json="$2"
+
+  if template_has_release "$obj_json"; then
     return 0
   fi
 
   # Normal early in a deploy, and the reason the shortfall is not excused yet.
   # An image pinned by an overrides entry looks the same but never clears.
   warn_once "${target} does not reference :${EXPECTED_IMAGE_TAG} yet, so its shortfall cannot be excused; waiting for the operator to update it"
+
+  return 1
+}
+
+# confirm_expected_release re-reads a workload after its rollout succeeded and
+# fails if it is no longer the release under test.
+#
+# The tag was checked before rollout status was asked, and a rollout takes
+# minutes. Anything that rewrites the template in between - another release
+# deploying to the same cluster, a hand-applied manifest - and kubectl reports
+# THAT rollout as this one's success. The concurrency group now serializes
+# deploys per cluster, which removes the pipeline's own version of this; the
+# check remains because a shared cluster has other writers.
+confirm_expected_release() {
+  local target="$1" obj_json
+
+  [[ -n "$EXPECTED_IMAGE_TAG" ]] || return 0
+
+  obj_json="$(kubectl_json get "$target" -o json)" || {
+    echo "::error::${target} rolled out but could not be re-read to confirm it is still :${EXPECTED_IMAGE_TAG}: $(flatten "${WORKDIR}/kubectl.err")"
+
+    return 1
+  }
+
+  if template_has_release "$obj_json"; then
+    return 0
+  fi
+
+  echo "::error::${target} rolled out, but no longer references :${EXPECTED_IMAGE_TAG}; something replaced it mid-wait and this rollout is not the one being gated"
 
   return 1
 }
@@ -738,7 +778,10 @@ wait_rollout() {
   wait "$ROLLOUT_PID" || rc=$?
   ROLLOUT_PID=""
 
-  return "$rc"
+  (( rc == 0 )) || return "$rc"
+
+  # kubectl reported success. Confirm it reported it about the right thing.
+  confirm_expected_release "$target"
 }
 
 # wait_target waits for one workload to exist and then to roll out.

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -77,7 +77,8 @@
 #   - it is short of pods at all;
 #   - its CURRENT pod template references EXPECTED_IMAGE_TAG;
 #   - between 1 and MAX_NOTREADY_NODES nodes are NotReady;
-#   - the DaemonSet controller has observed the current generation;
+#   - the DaemonSet controller has observed the current generation, and nothing
+#     is misscheduled onto a node it no longer selects;
 #   - no pod on a READY node is unhealthy or still on the previous release;
 #   - Ready nodes carrying a healthy current pod, plus the unreachable ones,
 #     cover the desired count. Counted in NODES: the invariant is one pod per
@@ -466,13 +467,15 @@ DAEMONSET_SHORTFALL_FILTER='
 '
 
 # DAEMONSET_STATUS_FILTER emits what only the controller can tell us:
-# "<desired>\t<ready>\t<generation>\t<observedGeneration>". desired is the node
-# count no pod list can supply, ready detects the shortfall, and the generations
-# say whether the controller has caught up. Whether the fleet is UPDATED is
-# decided from the pods; see DAEMONSET_SHORTFALL_FILTER.
+# "<desired>\t<ready>\t<misscheduled>\t<generation>\t<observedGeneration>".
+# desired is the node count no pod list can supply, ready detects the shortfall,
+# misscheduled says whether any pod is running where it should not be, and the
+# generations say whether the controller has caught up. Whether the fleet is
+# UPDATED is decided from the pods; see DAEMONSET_SHORTFALL_FILTER.
 DAEMONSET_STATUS_FILTER='
   [ (.status.desiredNumberScheduled // 0),
     (.status.numberReady // 0),
+    (.status.numberMisscheduled // 0),
     (.metadata.generation // 0),
     (.status.observedGeneration // -1)
   ]
@@ -601,7 +604,7 @@ confirm_expected_release() {
 node_tolerance() {
   local target="$1" kind="$2" selector="$3"
   local obj_json pods_json nodes_tsv notready_json counts status_tsv
-  local desired ready generation observed owner_uid
+  local desired ready misscheduled generation observed owner_uid
   local stranded unhealthy outdated healthy
   local notready_count
 
@@ -628,12 +631,22 @@ node_tolerance() {
 
   status_tsv="$(printf '%s' "$obj_json" | jq -r "$DAEMONSET_STATUS_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
-  IFS=$'\t' read -r desired ready generation observed <<<"$status_tsv" || return 1
+  IFS=$'\t' read -r desired ready misscheduled generation observed <<<"$status_tsv" || return 1
 
   # Stale or partial data. Any of these failing means "not yet", never "close
   # enough".
   (( desired > 0 )) || return 1
   (( observed >= generation )) || return 1
+
+  # A pod running on a node the DaemonSet no longer selects. Coverage is counted
+  # in nodes, and this one is not a node the fleet is supposed to cover, so it
+  # could stand in for a desired node that has nothing. The controller reaps
+  # these, so it clears on its own.
+  if (( misscheduled != 0 )); then
+    warn_once "${target} has ${misscheduled} misscheduled pod(s); a shortfall cannot be excused while any pod is running where it should not be"
+
+    return 1
+  fi
 
   # No shortfall to excuse; rollout status will return on its own.
   (( ready < desired )) || return 1

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -76,7 +76,9 @@
 #   - between 1 and MAX_NOTREADY_NODES nodes are NotReady;
 #   - the DaemonSet controller has observed the current generation;
 #   - no pod on a READY node is unhealthy or still on the previous release;
-#   - healthy pods on Ready nodes plus stranded ones cover the desired count.
+#   - Ready nodes carrying a healthy current pod, plus the unreachable ones,
+#     cover the desired count. Counted in NODES: the invariant is one pod per
+#     node, and counting pods let a node with two cover for a node with none.
 #
 # Tolerance repeats the EXPECTED_IMAGE_TAG condition rather than trusting the
 # earlier phase: the template can arrive while a pod on a reachable node is
@@ -393,13 +395,26 @@ NOTREADY_NODE_FILTER='
 # node names, emitting
 # "<stranded>\t<unhealthy_on_ready>\t<outdated_on_ready>\t<healthy_on_ready>".
 #
-#   stranded            pods on a NotReady node, which the controller can
-#                       neither update nor reap; they are why the rollout stalls.
+#   stranded            NODES the cluster cannot reach that hold a pod, which
+#                       the controller can neither update nor reap; they are why
+#                       the rollout stalls.
 #   unhealthy_on_ready  pods elsewhere that are not Running+Ready. A pod with no
 #                       nodeName counts here: DaemonSet pods are assigned at
 #                       creation, so an unassigned one is a scheduling failure.
 #   outdated_on_ready   pods elsewhere still running something other than $tag.
-#   healthy_on_ready    pods elsewhere that are Running+Ready.
+#   healthy_on_ready    NODES elsewhere carrying a Running+Ready pod on $tag.
+#
+# The two coverage numbers count NODES, not pods, because the invariant being
+# checked is one pod per node. Counting pods let a node with two of them - a
+# terminating pod and its replacement - cover for a node with none, so the
+# fleet looked complete while a reachable node had nothing running on it.
+# Terminating pods are excluded from the reachable counts for the same reason:
+# a pod on its way out is not coverage. They still count toward stranded, which
+# is exactly what a pod on an unreachable node usually is.
+#
+# $owner scopes the list to pods this workload actually owns. The selector is
+# only a label match, and anything else wearing those labels is not evidence
+# about this rollout either way.
 #
 # Every number is derived from the pod list, never from .status counters. An
 # earlier revision compared updatedNumberScheduled + stranded against desired,
@@ -410,19 +425,23 @@ NOTREADY_NODE_FILTER='
 # remaining nodes, making it the steady state of a stalled rollout.
 DAEMONSET_SHORTFALL_FILTER='
   [ .items[]
+    | select((.metadata.ownerReferences // []) | any(.uid == $owner))
     | (.spec.nodeName // "") as $node
-    | { stranded: ($notready | any(. == $node)),
+    | { node: $node,
+        terminating: (.metadata.deletionTimestamp != null),
+        stranded: ($notready | any(. == $node)),
         ready: ((.status.phase == "Running")
                  and ((((.status.conditions // [])
                          | map(select(.type == "Ready")) | .[0].status) // "False") == "True")),
         current: ([ (.spec.containers // [])[], (.spec.initContainers // [])[] ]
                    | map(.image) | any(endswith($tag)))
       }
-  ]
-  | [ (map(select(.stranded)) | length),
-      (map(select((.stranded | not) and (.ready | not))) | length),
-      (map(select((.stranded | not) and (.current | not))) | length),
-      (map(select((.stranded | not) and .ready)) | length)
+  ] as $pods
+  | [ ($pods | map(select(.stranded)) | map(.node) | unique | length),
+      ($pods | map(select((.stranded | not) and (.terminating | not) and (.ready | not))) | length),
+      ($pods | map(select((.stranded | not) and (.terminating | not) and (.current | not))) | length),
+      ($pods | map(select((.stranded | not) and (.terminating | not) and .ready and .current and (.node != "")))
+             | map(.node) | unique | length)
     ]
   | @tsv
 '
@@ -555,7 +574,7 @@ confirm_expected_release() {
 node_tolerance() {
   local target="$1" kind="$2" selector="$3"
   local obj_json pods_json nodes_tsv notready_json counts status_tsv
-  local desired ready generation observed
+  local desired ready generation observed owner_uid
   local stranded unhealthy outdated healthy
   local notready_count
 
@@ -621,8 +640,15 @@ node_tolerance() {
     return 1
   }
 
+  # Scopes the pod list to what this workload owns. Without a uid there is no
+  # way to tell its pods from anything else wearing the same labels, which is
+  # not a judgement this check may make on a guess.
+  owner_uid="$(printf '%s' "$obj_json" | jq -r '.metadata.uid // ""' 2>"${WORKDIR}/jq.err")" || return 1
+  [[ -n "$owner_uid" ]] || return 1
+
   counts="$(printf '%s' "$pods_json" | jq -r --argjson notready "$notready_json" \
-    --arg tag ":${EXPECTED_IMAGE_TAG}" "$DAEMONSET_SHORTFALL_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+    --arg tag ":${EXPECTED_IMAGE_TAG}" --arg owner "$owner_uid" \
+    "$DAEMONSET_SHORTFALL_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
   IFS=$'\t' read -r stranded unhealthy outdated healthy <<<"$counts" || return 1
 
@@ -632,8 +658,8 @@ node_tolerance() {
   (( unhealthy == 0 )) || return 1
   (( outdated == 0 )) || return 1
 
-  # Coverage, counted from pods rather than from status counters so a stranded
-  # pod the controller already updated cannot be counted twice.
+  # Coverage counted in NODES, so a node carrying two pods cannot cover for a
+  # node carrying none.
   (( healthy + stranded >= desired )) || return 1
 
   echo "::warning::${target} is short ${stranded} of ${desired} pods, entirely on NotReady nodes: $(describe_nodes "$nodes_tsv")"

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -6,25 +6,11 @@
 # fast with a named image when a pod cannot pull the image it needs, and
 # tolerate a DaemonSet shortfall that is caused only by unreachable nodes.
 #
-# Shared by .github/workflows/nightly.yaml and .github/workflows/release-upgrade.yaml.
-# Both deploy gates previously carried a copy of this logic and had already
-# drifted (the gantry DaemonSet was gated in one and not the other), so the
-# single copy lives here next to the smoke tests those workflows also share.
-# Both invoke it from a sparse checkout of the workflow's own commit, so a
-# rollback or backfill onto an older tag still runs the current gate.
-#
-# Why the image check exists: the operator resolves every component image as
-# <registry>/<repository>:<operator version>. When a pipeline forgets to build
-# one of them the pods sit in ImagePullBackOff, 'kubectl rollout status' simply
-# blocks for its full timeout, and the run reports a bare "pod not ready". That
-# failure mode kept the nightly red for 15 consecutive nights. Detecting the
-# pull error names the missing image in seconds instead.
-#
-# Why the node check exists: a DaemonSet counts every node toward
-# desiredNumberScheduled, including nodes the kubelet has stopped reporting for.
-# A single unreachable node therefore blocks 'rollout status' until its timeout,
-# every time, forever. For a project whose premise is nodes in flaky remote
-# sites that turns the release gate into a coin toss on hardware liveness.
+# Shared by .github/workflows/nightly.yaml and release-upgrade.yaml. Both gates
+# previously carried a copy of this logic and had already drifted (gantry was
+# gated in one and not the other). Both invoke it from a sparse checkout of the
+# workflow's own commit, so a rollback or backfill onto an older tag still runs
+# the current gate.
 #
 # Usage:
 #   hack/release/wait-rollouts.sh deploy/unbounded-operator ds/gantry ...
@@ -53,58 +39,45 @@
 #
 # Design notes
 # ------------
-# 'kubectl rollout status' remains the authority on readiness; it evaluates
-# observedGeneration and updated/available replicas. The image check only adds
-# an early exit, so it is deliberately FAIL-OPEN: anything it cannot determine
-# is reported loudly and then ignored, never converted into a failed deploy. It
-# is an accelerator for diagnosis, not a second opinion on health.
+# 'kubectl rollout status' remains the authority on readiness. The two polls
+# beside it only add early exits, and they run opposite disciplines.
 #
-# The node check runs the opposite discipline and is deliberately FAIL-CLOSED.
-# It is the only thing here that can turn a failing wait into a passing one, so
-# anything it cannot positively verify means "keep waiting" and let rollout
-# status deliver the verdict. A broken diagnostic must never manufacture a green
-# release. Concretely it tolerates a shortfall only when ALL of these hold:
+# The image check is FAIL-OPEN: anything it cannot determine is reported loudly
+# and then ignored, never converted into a failed deploy. It is an accelerator
+# for diagnosis, not a second opinion on health. It exists because a pipeline
+# that forgets to build one component leaves its pods in ImagePullBackOff and
+# 'rollout status' just blocks for its full timeout, reporting a bare "pod not
+# ready" - a failure mode that kept the nightly red for 15 consecutive nights.
+# It is also strictly SCOPED to the workload being waited on: an earlier
+# revision scanned the whole namespace, so an unrelated tenant or a leftover pod
+# could abort the very deploy that would have repaired the cluster.
 #
-#   - the workload is a DaemonSet (a Deployment reschedules off a dead node, so
-#     a shortfall there is a real scheduling problem, not a stranded pod);
-#   - the workload's CURRENT pod template references EXPECTED_IMAGE_TAG;
+# The node check is FAIL-CLOSED. It is the only thing here that can turn a
+# failing wait into a passing one, so anything it cannot positively verify means
+# "keep waiting" and let rollout status deliver the verdict. It exists because a
+# DaemonSet counts every node toward desiredNumberScheduled, including nodes the
+# kubelet has stopped reporting for, so one unreachable node blocks the gate
+# until its timeout, every time, forever. It tolerates only when ALL of:
+#
+#   - the workload is a DaemonSet, since a Deployment reschedules off a dead
+#     node and a shortfall there is a real scheduling problem;
+#   - it is short of pods at all;
+#   - its CURRENT pod template references EXPECTED_IMAGE_TAG;
 #   - between 1 and MAX_NOTREADY_NODES nodes are NotReady;
 #   - the DaemonSet controller has observed the current generation;
 #   - updated + stranded and ready + stranded both cover desiredNumberScheduled;
 #   - no pod on a READY node is unhealthy.
 #
 # The EXPECTED_IMAGE_TAG condition is what keeps tolerance from excusing the
-# PREVIOUS release. Component workloads are updated asynchronously: the operator
-# reconciles the Site some time after its own Deployment reports available, so
-# for the first seconds of a wait a DaemonSet still carries the old template.
-# Every other condition holds in that window - the controller has observed its
-# generation, every reachable pod is updated and Ready against the OLD spec, and
-# the only shortfall is the stranded pod - so without this check a deploy gate
-# on a cluster with one permanently unreachable node would return success
-# roughly a second after it started, having validated nothing. Requiring the tag
-# to be present makes tolerance wait for the operator, and the redeploy of an
-# already-deployed tag still tolerates immediately because the tag is already
-# there.
-#
-# The tag is matched against the CURRENT object on every poll, never against the
-# spec read once before the wait began, because observing the operator rewrite
-# that template mid-wait is the entire mechanism.
-#
-# It matches if ANY container image carries the tag, not all of them: gantry's
-# pinned third-party init image legitimately does not. A component whose image
-# has been pinned elsewhere by an unbounded-component-overrides entry will
-# therefore never be tolerated; that is reported rather than silently ignored,
-# and the operator already flags such a workload as version drift.
+# PREVIOUS release. Component workloads are updated asynchronously, so early in
+# a wait a DaemonSet still carries the old template while every other condition
+# already holds: without it, a gate on a cluster with one permanently
+# unreachable node would pass a second after it started, having validated
+# nothing. Redeploying an already-deployed tag still tolerates immediately.
 #
 # Exceeding MAX_NOTREADY_NODES is reported immediately, grouped by site, so the
-# log explains the timeout while it is still counting down. It deliberately does
-# NOT abort early: a node may recover inside the window, and inventing a new
-# abort path would break the fail-closed rule above.
-#
-# The image check is also strictly SCOPED to the workload currently being waited
-# on. An earlier revision scanned the whole namespace, which meant an unrelated
-# tenant (Orca, deployed by a later job) or a leftover pod from a previous
-# broken run could abort the very deploy that would have repaired the cluster.
+# log explains the timeout while it is still counting down. It does NOT abort
+# early: a node may recover inside the window.
 
 set -euo pipefail
 
@@ -160,12 +133,10 @@ KUBECTL=(kubectl --request-timeout=30s -n "$NS")
 # ever succeed and there is nothing to wait for.
 TERMINAL_WAITING_REASONS='^InvalidImageName$'
 
-# ImagePullBackOff is RETRYABLE. The kubelet has backed off, but registry
-# throttling, a brief outage, or delayed credentials all land here and then
-# recover, and the gantry DaemonSet additionally pulls a pinned third-party
-# init image. It therefore only becomes fatal once it has persisted for
-# IMAGE_FAILURE_GRACE_SECONDS. A bare ErrImagePull is the first attempt and is
-# never fatal.
+# ImagePullBackOff is RETRYABLE: registry throttling, a brief outage or delayed
+# credentials all land here and then recover, so it is only fatal once it has
+# persisted for IMAGE_FAILURE_GRACE_SECONDS. A bare ErrImagePull is the first
+# attempt and is never fatal.
 BACKOFF_WAITING_REASONS='^ImagePullBackOff$'
 
 WORKDIR="$(mktemp -d)"
@@ -225,11 +196,10 @@ flatten() {
   tr -d '\r' <"$1" | tr '\n' ' ' | sed 's/[[:space:]]\{1,\}/ /g; s/^ //; s/ $//'
 }
 
-# disable_guard turns the image check off for the rest of the run. Used when the
-# check cannot be evaluated at all, which is a bug in this script or an
-# unexpected kubectl payload. It is reported as an error annotation so it cannot
-# pass unnoticed, but it does not fail the deploy: rollout status still returns
-# the authoritative verdict, and a broken diagnostic must not become an outage.
+# disable_guard turns the image check off for the rest of the run, for when it
+# cannot be evaluated at all. Reported as an error so it cannot pass unnoticed,
+# but it does not fail the deploy: rollout status still returns the
+# authoritative verdict, and a broken diagnostic must not become an outage.
 disable_guard() {
   GUARD_DISABLED=1
 
@@ -237,10 +207,9 @@ disable_guard() {
   echo "::error::rollout status still gates this deploy, but a missing image will no longer be named; fix wait-rollouts.sh"
 }
 
-# kubectl_json runs a read-only query and prints stdout on success. stderr is
-# captured to a file instead of being folded into stdout with 2>&1, because
-# kubectl writes deprecation and warning lines there and merging them would
-# corrupt the JSON that jq has to parse. Returns 1 on failure, leaving the
+# kubectl_json runs a read-only query and prints stdout on success. stderr goes
+# to a file rather than 2>&1, because kubectl's deprecation and warning lines
+# would corrupt the JSON jq has to parse. Returns 1 on failure, leaving the
 # message in ${WORKDIR}/kubectl.err.
 kubectl_json() {
   local out
@@ -255,11 +224,8 @@ kubectl_json() {
 }
 
 # resolve_target prints three lines: the workload's kind, its pod selector, and
-# its desired container images as a JSON array.
-#
-# The kind is read here, once, rather than per poll inside node_tolerance: it
-# cannot change for the life of the wait, and taking it from this read means a
-# Deployment costs no extra API calls at all during the poll loop.
+# its desired container images as a JSON array. Kind is taken from this one read
+# rather than per poll, so a Deployment costs no API calls in the poll loop.
 #
 # Exit codes: 0 resolved, 2 query failed, 3 evaluation failed.
 resolve_target() {
@@ -276,22 +242,14 @@ resolve_target() {
 }
 
 # IMAGE_FAILURE_FILTER emits one TSV record per container wedged on an image
-# error that this rollout is actually responsible for.
+# error that this rollout is actually responsible for. Three filters keep it
+# scoped: the caller restricts the pod list to the workload's selector,
+# terminating pods are skipped as unrepairable, and the failing image must be
+# one the workload currently WANTS, which drops superseded revisions.
 #
-# Three filters keep it scoped:
-#   - the caller restricts the pod list to the workload's own selector;
-#   - pods with a deletionTimestamp are skipped, since a terminating pod is
-#     already on its way out and cannot be repaired;
-#   - the failing container's image is matched against the images the workload
-#     currently WANTS, which drops pods left over from a previous revision that
-#     referenced a different (already superseded) image.
-#
-# The image comes from the POD SPEC rather than from containerStatuses, because
-# the runtime normalizes status images (adding a registry or a docker.io/library
-# prefix) and that would defeat the comparison against the workload template.
-#
-# Init containers are included: a failed init image never lets the main
-# container start.
+# The image comes from the POD SPEC, not containerStatuses: the runtime
+# normalizes status images, which would defeat that last comparison. Init
+# containers count, since a failed init image never lets the main one start.
 IMAGE_FAILURE_FILTER='
   .items[]
   | select(.metadata.deletionTimestamp == null)
@@ -427,12 +385,11 @@ NOTREADY_NODE_FILTER='
 # DAEMONSET_SHORTFALL_FILTER classifies a DaemonSet's pods against the NotReady
 # node names, emitting "<stranded>\t<unhealthy_on_ready>".
 #
-#   stranded            pods on a NotReady node. The controller can neither
-#                       update nor reap these; they are why the rollout stalls.
-#   unhealthy_on_ready  pods NOT on a NotReady node that are not Running+Ready.
-#                       A pod with no nodeName counts here: a DaemonSet pod is
-#                       assigned at creation, so an unassigned one is a real
-#                       scheduling failure rather than a stranded pod.
+#   stranded            pods on a NotReady node, which the controller can
+#                       neither update nor reap; they are why the rollout stalls.
+#   unhealthy_on_ready  pods elsewhere that are not Running+Ready. A pod with no
+#                       nodeName counts here: DaemonSet pods are assigned at
+#                       creation, so an unassigned one is a scheduling failure.
 DAEMONSET_SHORTFALL_FILTER='
   [ .items[]
     | (.spec.nodeName // "") as $node
@@ -461,8 +418,9 @@ DAEMONSET_STATUS_FILTER='
 '
 
 # TEMPLATE_IMAGE_FILTER reports whether any image in the pod template carries
-# $tag. See the EXPECTED_IMAGE_TAG note at the top of this file for why "any"
-# and not "all".
+# $tag. ANY, not all: gantry's pinned third-party init image legitimately does
+# not, and a component pinned elsewhere by an unbounded-component-overrides
+# entry is then never tolerated, which is reported rather than ignored.
 TEMPLATE_IMAGE_FILTER='
   [ (.spec.template.spec.containers // [])[], (.spec.template.spec.initContainers // [])[] ]
   | map(.image)
@@ -482,11 +440,9 @@ notready_nodes() {
 }
 
 # describe_nodes collapses the TSV into one annotation-safe line grouped by
-# site, for example "boulderlab[spark-3d37] edge[node-9, node-10]".
-#
-# Sites are emitted in the order they were first seen. awk iterates an
-# associative array in an unspecified order, so grouping without this would
-# reshuffle the message between polls of the same unchanged cluster.
+# site, for example "boulderlab[spark-3d37] edge[node-9, node-10]". Sites are
+# emitted in first-seen order; awk iterates an associative array in an
+# unspecified one, which would reshuffle the message between identical polls.
 describe_nodes() {
   awk -F'\t' '
     !($2 in group) { order[++n] = $2 }
@@ -500,14 +456,12 @@ describe_nodes() {
 }
 
 # running_expected_release reports whether a workload's CURRENT pod template
-# references EXPECTED_IMAGE_TAG.
+# references EXPECTED_IMAGE_TAG. Read from the object re-fetched on each poll,
+# never the spec read before the wait began: observing the operator rewrite that
+# template mid-wait is the entire mechanism.
 #
-# This is the condition that stops tolerance excusing the PREVIOUS release: for
-# the first seconds of a wait the operator has not yet rewritten the template,
-# and every other condition already holds. See the top of this file.
-#
-# Returns 0 when it matches, 1 otherwise, including when the tag is unset or jq
-# fails: this is a fail-closed check like everything else node_tolerance does.
+# Returns 1 when the tag is unset or jq fails, like every other uncertain path
+# in node_tolerance.
 running_expected_release() {
   local target="$1" obj_json="$2" matched
 
@@ -520,10 +474,8 @@ running_expected_release() {
     return 0
   fi
 
-  # Normal for the first seconds of a deploy, and the reason the shortfall is
-  # not being excused yet, so it is worth saying out loud. It is also what an
-  # image pinned by an unbounded-component-overrides entry looks like, in which
-  # case it will not clear and the rollout runs its timeout down.
+  # Normal early in a deploy, and the reason the shortfall is not excused yet.
+  # An image pinned by an overrides entry looks the same but never clears.
   warn_once "${target} does not reference :${EXPECTED_IMAGE_TAG} yet, so its shortfall cannot be excused; waiting for the operator to update it"
 
   return 1
@@ -533,31 +485,25 @@ running_expected_release() {
 # entirely by nodes the cluster has lost contact with.
 #
 # Returns 0 to tolerate (the caller stops waiting and succeeds), 1 to keep
-# waiting. EVERY uncertain path returns 1: this is the one check that can turn a
-# failing wait into a passing one, so it must never guess. See the FAIL-CLOSED
-# note at the top of this file.
+# waiting. EVERY uncertain path returns 1; see the FAIL-CLOSED note at the top.
 #
-# The conditions are ordered cheapest-first, and each one that can be decided
-# without the apiserver is decided before anything is queried. This runs on
-# every poll of every workload, so an ordering that read the full node list
-# before noticing the workload was a Deployment, or that tolerance was switched
-# off, would cost tens of megabytes of node JSON per wait to reach the same
-# answer.
+# Conditions are ordered cheapest-first, and everything decidable without the
+# apiserver is decided before anything is queried: this runs on every poll of
+# every workload, so reading the node list before noticing the workload was a
+# Deployment would cost tens of megabytes per wait to reach the same answer.
 node_tolerance() {
   local target="$1" kind="$2" selector="$3"
   local obj_json pods_json nodes_tsv notready_json counts status_tsv
   local desired ready updated generation observed stranded unhealthy
   local notready_count
 
-  # No selector means pods cannot be scoped to this workload. This is also the
-  # state when the image guard has been disabled, which deliberately takes
-  # tolerance down with it: a script that could not read a workload's spec has
-  # no business excusing that workload's shortfall.
+  # No selector means pods cannot be scoped to this workload. Also the state
+  # when the image guard has been disabled, which takes tolerance down with it:
+  # a script that could not read a workload's spec has no business excusing that
+  # workload's shortfall.
   [[ -n "$selector" ]] || return 1
 
-  # A Deployment reschedules off a dead node, so a shortfall there is a real
-  # scheduling problem and must not be excused. Free: read once, before the
-  # wait, by resolve_target.
+  # Free: read once, before the wait, by resolve_target.
   [[ "$kind" == "DaemonSet" ]] || return 1
 
   # Tolerance switched off, or nothing to compare a template against.
@@ -576,18 +522,16 @@ node_tolerance() {
 
   IFS=$'\t' read -r desired ready updated generation observed <<<"$status_tsv" || return 1
 
-  # Guard against every way this could be evaluated against stale or partial
-  # data. Any of these failing simply means "not yet", never "close enough".
+  # Stale or partial data. Any of these failing means "not yet", never "close
+  # enough".
   (( desired > 0 )) || return 1
   (( observed >= generation )) || return 1
 
-  # No shortfall to excuse. rollout status will return on its own, and there is
-  # no reason to list nodes or pods to find that out.
+  # No shortfall to excuse; rollout status will return on its own.
   (( ready < desired )) || return 1
 
-  # The workload must already be the release under test. Checked before the
-  # node and pod queries because it is the condition most likely to be false
-  # early in a deploy, and it needs no further API calls.
+  # Checked before the node and pod queries: it is the condition most likely to
+  # be false early in a deploy, and it needs no further API calls.
   running_expected_release "$target" "$obj_json" || return 1
 
   nodes_tsv="$(notready_nodes)" || {
@@ -655,10 +599,9 @@ wait_exists() {
 
     last_error="$(flatten "${WORKDIR}/get.err")"
 
-    # NotFound is the expected state while the operator is still reconciling.
-    # Anything else (RBAC denial, expired credentials, an unreachable
-    # apiserver, an unknown resource type) is surfaced as it happens and
-    # carried into the timeout message, so it can no longer masquerade as a
+    # NotFound is expected while the operator reconciles. Anything else (RBAC,
+    # expired credentials, an unreachable apiserver) is surfaced as it happens
+    # and carried into the timeout message, so it cannot masquerade as a
     # workload the operator simply never created.
     if [[ "$last_error" != *NotFound* && "$last_error" != *"not found"* ]]; then
       warn_once "querying ${target} in ${NS} failed: ${last_error}"

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -515,7 +515,9 @@ running_expected_release() {
   matched="$(printf '%s' "$obj_json" | jq -r --arg tag ":${EXPECTED_IMAGE_TAG}" \
     "$TEMPLATE_IMAGE_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
-  [[ "$matched" == "true" ]] && return 0
+  if [[ "$matched" == "true" ]]; then
+    return 0
+  fi
 
   # Normal for the first seconds of a deploy, and the reason the shortfall is
   # not being excused yet, so it is worth saying out loud. It is also what an

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -511,13 +511,14 @@ func (f *fake) run(env map[string]string, args ...string) (string, int) {
 	return string(output), code
 }
 
-// requireBash skips when the host bash cannot run the script.
-func requireBash(t *testing.T) {
+// requireBash4 skips when the host bash is too old to run the scripts in this
+// directory. Both of them use bash 4 features (associative arrays, mapfile).
+func requireBash4(t *testing.T) {
 	t.Helper()
 
 	path, err := exec.LookPath("bash")
 	if err != nil {
-		t.Skip("bash not on PATH; skipping wait-rollouts.sh tests")
+		t.Skip("bash not on PATH; skipping shell script tests")
 	}
 
 	out, err := exec.Command(path, "-c", "echo ${BASH_VERSINFO[0]}").Output()
@@ -527,8 +528,25 @@ func requireBash(t *testing.T) {
 
 	major, err := strconv.Atoi(strings.TrimSpace(string(out)))
 	if err != nil || major < 4 {
-		t.Skipf("wait-rollouts.sh requires bash 4+; found %q", strings.TrimSpace(string(out)))
+		t.Skipf("these scripts require bash 4+; found %q", strings.TrimSpace(string(out)))
 	}
+}
+
+// requireGit skips when git is unavailable, which the resolver fixtures need.
+func requireGit(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping next-version.sh tests")
+	}
+}
+
+// requireBash skips when the host cannot run wait-rollouts.sh. jq is checked
+// here rather than in requireBash4 because only this script needs it.
+func requireBash(t *testing.T) {
+	t.Helper()
+
+	requireBash4(t)
 
 	if _, err := exec.LookPath("jq"); err != nil {
 		t.Skip("jq not on PATH; skipping wait-rollouts.sh tests")

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -1070,6 +1070,62 @@ func TestWaitsForTheOperatorToRollTheWorkloadOut(t *testing.T) {
 	requireContains(t, output, "OK: all workloads rolled out")
 }
 
+// TestRefusesAWorkloadReplacedDuringTheRollout guards the window between
+// checking the tag and kubectl reporting success. A rollout takes minutes;
+// anything that rewrites the template in between - another release deploying to
+// the same cluster, a hand-applied manifest - and kubectl reports THAT rollout
+// as this one's success.
+//
+// Call 1 is the spec resolve, 2 the release wait, 3 the confirmation after
+// rollout status returns.
+func TestRefusesAWorkloadReplacedDuringTheRollout(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	current := daemonSet(selectorLabel, dsStatus{desired: 1, ready: 1, updated: 1, generation: 4, observed: 4}, gantryImage)
+	// Calls 1 and 2 are the spec resolve and the release wait, which see this
+	// release. Everything after is someone else's, which is what the rollout
+	// then reports success for.
+	f.setNth("getjson-ds_gantry", 1, reply{stdout: current})
+	f.setNth("getjson-ds_gantry", 2, reply{stdout: current})
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 1, ready: 1, updated: 1, generation: 5, observed: 5}, staleImage),
+	})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+	)})
+	f.set("rollout", reply{})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "no longer references :"+releaseTag)
+	requireNotContains(t, output, "OK: all workloads rolled out")
+}
+
+// TestRefusesWhenTheWorkloadCannotBeReReadAfterRollout keeps the confirmation
+// fail-closed: an unreadable workload is not a confirmed one.
+func TestRefusesWhenTheWorkloadCannotBeReReadAfterRollout(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	current := daemonSet(selectorLabel, dsStatus{desired: 1, ready: 1, updated: 1, generation: 4, observed: 4}, gantryImage)
+	f.setNth("getjson-ds_gantry", 1, reply{stdout: current})
+	f.setNth("getjson-ds_gantry", 2, reply{stdout: current})
+	f.set("getjson-ds_gantry", reply{stderr: "error: connection refused", exit: 1})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+	)})
+	f.set("rollout", reply{})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "could not be re-read")
+}
+
 // TestAcceptsAWorkloadAlreadyOnTheRelease covers redeploying a tag that is
 // already deployed, which must not wait for a change that will never come.
 func TestAcceptsAWorkloadAlreadyOnTheRelease(t *testing.T) {

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -49,6 +49,12 @@ const (
 	selectorLabel = "app.kubernetes.io/name=gantry"
 
 	target = "ds/gantry"
+
+	// workloadUID owns the fixture pods. The tolerance filter scopes the pod
+	// list to what the workload actually owns, since a selector is only a label
+	// match and anything else wearing those labels is not evidence about this
+	// rollout.
+	workloadUID = "11111111-2222-3333-4444-555555555555"
 )
 
 // container describes one container in a fake pod.
@@ -73,6 +79,9 @@ type pod struct {
 	// notReady sets phase Running with Ready=False, the shape of a pod on a
 	// node the kubelet has stopped reporting for.
 	notReady bool
+	// foreign gives the pod a different owner, as a pod that merely matches the
+	// selector would have.
+	foreign bool
 }
 
 // node describes one fake cluster node.
@@ -329,8 +338,10 @@ func renderWorkload(kind, selector string, images, initImages []string, status *
 		spec["kind"] = kind
 	}
 
+	metadata := map[string]any{"uid": workloadUID}
+
 	if status != nil {
-		spec["metadata"] = map[string]any{"generation": status.generation}
+		metadata["generation"] = status.generation
 		spec["status"] = map[string]any{
 			"desiredNumberScheduled": status.desired,
 			"numberReady":            status.ready,
@@ -338,6 +349,8 @@ func renderWorkload(kind, selector string, images, initImages []string, status *
 			"observedGeneration":     status.observed,
 		}
 	}
+
+	spec["metadata"] = metadata
 
 	return marshal(spec)
 }
@@ -374,7 +387,15 @@ func podList(pods ...pod) string {
 	items := make([]map[string]any, 0, len(pods))
 
 	for _, p := range pods {
-		meta := map[string]any{"name": p.name}
+		owner := workloadUID
+		if p.foreign {
+			owner = "99999999-9999-9999-9999-999999999999"
+		}
+
+		meta := map[string]any{
+			"name":            p.name,
+			"ownerReferences": []map[string]any{{"kind": "DaemonSet", "uid": owner}},
+		}
 		if p.terminating {
 			meta["deletionTimestamp"] = "2026-08-13T00:00:00Z"
 		}
@@ -1218,6 +1239,77 @@ func TestRefusesToTolerateAnOutdatedPodOnAReachableNode(t *testing.T) {
 	f.set("pods", reply{stdout: podList(
 		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: staleImage}}},
 		pod{name: "gantry-b", node: "node-b", containers: []container{{name: "c0", image: gantryImage}}},
+		pod{
+			name: "gantry-c", node: "spark-3d37", notReady: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
+	)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+}
+
+// TestRefusesToTolerateWhenANodeIsCoveredTwice is the regression guard for
+// counting pods where the invariant is one pod per node. A node carrying a
+// terminating pod and its replacement produced two units of coverage, which
+// covered for a node carrying none:
+//
+//	desired 3
+//	node A: terminating pod + replacement, both Running+Ready on this release
+//	node B: nothing at all
+//	spark-3d37: stranded
+//
+// 2 + 1 >= 3, so it tolerated while node B ran nothing.
+func TestRefusesToTolerateWhenANodeIsCoveredTwice(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 3, ready: 2, updated: 2, generation: 4, observed: 4}, gantryImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: podList(
+		pod{
+			name: "gantry-a-old", node: "node-a", terminating: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
+		pod{name: "gantry-a-new", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+		pod{
+			name: "gantry-c", node: "spark-3d37", notReady: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
+	)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+}
+
+// TestIgnoresPodsThisWorkloadDoesNotOwn keeps a pod that merely matches the
+// selector from providing coverage. The gate is judging one rollout, and
+// anything else wearing those labels is not evidence about it.
+func TestIgnoresPodsThisWorkloadDoesNotOwn(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 3, ready: 2, updated: 2, generation: 4, observed: 4}, gantryImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+		// Same labels, another owner: node-b is not actually covered.
+		pod{
+			name: "impostor-b", node: "node-b", foreign: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
 		pod{
 			name: "gantry-c", node: "spark-3d37", notReady: true,
 			containers: []container{{name: "c0", image: gantryImage}},

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -35,12 +35,16 @@ const (
 	// carrying it has not been updated by the operator yet.
 	previousTag = "nightly-old"
 
+	// releaseRegistry is where this project publishes. Images from anywhere else
+	// in a pod spec are third-party pins and are not judged.
+	releaseRegistry = "ghcr.io/azure"
+
 	// gantryImage is the image the workload under test wants.
-	gantryImage = "ghcr.io/azure/gantry:" + releaseTag
+	gantryImage = releaseRegistry + "/gantry:" + releaseTag
 
 	// staleImage is an image a previous revision wanted. Pods still running it
 	// belong to a superseded revision and must not gate the current rollout.
-	staleImage = "ghcr.io/azure/gantry:" + previousTag
+	staleImage = releaseRegistry + "/gantry:" + previousTag
 
 	// initImage is the pinned third-party init image the gantry DaemonSet
 	// pulls. A blip on a public registry must not fail a deploy on its own.
@@ -994,8 +998,9 @@ var shortByOne = dsStatus{desired: 3, ready: 2, updated: 2, generation: 4, obser
 // tolerating is the env a deploy gate runs with: the release cap of two dead
 // nodes, and the tag the operator resolves component images at.
 var tolerating = map[string]string{
-	"MAX_NOTREADY_NODES": "2",
-	"EXPECTED_IMAGE_TAG": releaseTag,
+	"MAX_NOTREADY_NODES":      "2",
+	"EXPECTED_IMAGE_TAG":      releaseTag,
+	"EXPECTED_IMAGE_REGISTRY": releaseRegistry,
 }
 
 func withEnv(extra map[string]string) map[string]string {
@@ -1145,6 +1150,94 @@ func TestRefusesWhenTheWorkloadCannotBeReReadAfterRollout(t *testing.T) {
 
 	requireCode(t, code, 1, output)
 	requireContains(t, output, "could not be re-read")
+}
+
+// TestRefusesAStalePrimaryBesideACurrentSidecar is the regression guard for
+// asking whether ANY image carried the tag. gantry's pinned busybox init never
+// does, so "any" was chosen to accommodate it - and it meant one current image
+// excused every other. A container pinned to the previous release by an
+// overrides entry passed.
+func TestRefusesAStalePrimaryBesideACurrentSidecar(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: renderWorkload("DaemonSet", selectorLabel,
+			[]string{staleImage, releaseRegistry + "/sidecar:" + releaseTag}, nil,
+			&dsStatus{desired: 1, ready: 1, updated: 1, generation: 4, observed: 4}),
+	})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: staleImage}}},
+	)})
+	f.set("rollout", reply{})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "never referenced :"+releaseTag)
+}
+
+// TestAcceptsAPinnedThirdPartyImage is why the check is scoped to our registry
+// rather than applied to every image: gantry's init container is a fixed public
+// reference that will never carry a release tag.
+func TestAcceptsAPinnedThirdPartyImage(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: renderWorkload("DaemonSet", selectorLabel,
+			[]string{gantryImage}, []string{initImage},
+			&dsStatus{desired: 1, ready: 1, updated: 1, generation: 4, observed: 4}),
+	})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+	)})
+	f.set("rollout", reply{})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "OK: all workloads rolled out")
+}
+
+// TestRefusesAWorkloadWithNoneOfOurImages covers a component pinned wholesale
+// to somewhere else: nothing to judge is not the same as nothing wrong.
+func TestRefusesAWorkloadWithNoneOfOurImages(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: renderWorkload("DaemonSet", selectorLabel,
+			[]string{"docker.io/someone/gantry:" + releaseTag}, nil,
+			&dsStatus{desired: 1, ready: 1, updated: 1, generation: 4, observed: 4}),
+	})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: "docker.io/someone/gantry:" + releaseTag}}},
+	)})
+	f.set("rollout", reply{})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "never referenced :"+releaseTag)
+}
+
+// TestRequiresARegistryAlongsideTheTag keeps the two from drifting apart: with
+// only a tag there is no way to tell our images from third-party pins, and
+// quietly falling back to the weaker rule is how the sidecar hole appeared.
+func TestRequiresARegistryAlongsideTheTag(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+
+	output, code := f.run(map[string]string{"EXPECTED_IMAGE_TAG": releaseTag}, target)
+
+	requireCode(t, code, 2, output)
+	requireContains(t, output, "without EXPECTED_IMAGE_REGISTRY")
 }
 
 // TestAcceptsAWorkloadAlreadyOnTheRelease covers redeploying a tag that is

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -460,11 +460,19 @@ func marshal(v any) string {
 	return string(data)
 }
 
-// run executes the real script against the fake kubectl.
+// run executes wait-rollouts.sh against the fake kubectl.
 func (f *fake) run(env map[string]string, args ...string) (string, int) {
 	f.t.Helper()
 
-	script, err := filepath.Abs("wait-rollouts.sh")
+	return f.runScript("wait-rollouts.sh", env, args...)
+}
+
+// runScript executes any script in this directory against the fake kubectl, so
+// the stub and its fixtures serve every shell tool here rather than just one.
+func (f *fake) runScript(name string, env map[string]string, args ...string) (string, int) {
+	f.t.Helper()
+
+	script, err := filepath.Abs(name)
 	if err != nil {
 		f.t.Fatalf("resolve script: %v", err)
 	}

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -1012,33 +1012,110 @@ func TestToleratesAShortfallExplainedByUnreachableNodes(t *testing.T) {
 	requireGroupsBalanced(t, output)
 }
 
-// TestRefusesToTolerateThePreviousRelease is the regression guard for a
-// false green: component workloads are updated asynchronously, so early in a
-// deploy the DaemonSet still carries the tag it had before. Every other
-// condition holds in that window, so without the image check the gate would
-// pass in about a second having validated nothing.
-func TestRefusesToTolerateThePreviousRelease(t *testing.T) {
+// TestRefusesAHealthyWorkloadOnThePreviousRelease is the regression guard for
+// the widest false green available: `kubectl rollout status` answers "is this
+// workload settled", and a workload the operator has not touched yet is
+// perfectly settled. The rollout reply here SUCCEEDS immediately, exactly as it
+// would against the previous release, and the gate must still refuse.
+//
+// This needs no degraded node. It is the ordinary healthy case.
+func TestRefusesAHealthyWorkloadOnThePreviousRelease(t *testing.T) {
 	requireBash(t)
 	t.Parallel()
 
 	f := newFake(t)
-	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, staleImage)})
-	f.set("getjson-nodes", reply{stdout: degradedNodes()})
-	f.set("pods", reply{stdout: strandedFleet(staleImage)})
-	f.set("rollout", reply{sleep: "3", exit: 1})
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 3, ready: 3, updated: 3, generation: 4, observed: 4}, staleImage),
+	})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: staleImage}}},
+	)})
+	// Would report success the moment it is asked.
+	f.set("rollout", reply{})
 
 	output, code := f.run(tolerating, target)
 
 	requireCode(t, code, 1, output)
-	requireContains(t, output, "does not reference :"+releaseTag+" yet")
-	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+	requireContains(t, output, "never referenced :"+releaseTag)
+	requireContains(t, output, "unbounded-component-overrides")
+	// The wait must not even reach rollout status, whose answer would be a
+	// misleading success.
+	requireNotContains(t, f.calls(), "rollout status")
 	requireGroupsBalanced(t, output)
 }
 
-// TestToleratesOnceTheOperatorUpdatesTheWorkload is the other half: the wait
-// must not deadlock waiting for a tag that does arrive. Calls 1 and 2 are the
-// spec resolve and the first poll, both still on the old release; the operator
-// reconciles, and the poll after that tolerates.
+// TestWaitsForTheOperatorToRollTheWorkloadOut is the other half: the gate must
+// not deadlock waiting for a tag that does arrive. The first reads are the old
+// template, the operator reconciles, and the wait proceeds to rollout status.
+func TestWaitsForTheOperatorToRollTheWorkloadOut(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 1, ready: 1, updated: 1, generation: 4, observed: 4}, gantryImage),
+	})
+	f.setNth("getjson-ds_gantry", 1, reply{stdout: daemonSet(selectorLabel, shortByOne, staleImage)})
+	f.setNth("getjson-ds_gantry", 2, reply{stdout: daemonSet(selectorLabel, shortByOne, staleImage)})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+	)})
+	f.set("rollout", reply{})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "does not reference :"+releaseTag+" yet")
+	requireContains(t, f.calls(), "rollout status")
+	requireContains(t, output, "OK: all workloads rolled out")
+}
+
+// TestAcceptsAWorkloadAlreadyOnTheRelease covers redeploying a tag that is
+// already deployed, which must not wait for a change that will never come.
+func TestAcceptsAWorkloadAlreadyOnTheRelease(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 1, ready: 1, updated: 1, generation: 4, observed: 4}, gantryImage),
+	})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+	)})
+	f.set("rollout", reply{})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 0, output)
+	requireNotContains(t, output, "does not reference")
+	requireContains(t, output, "OK: all workloads rolled out")
+}
+
+// TestWithoutAnExpectedTagTheReleaseCheckIsSkipped keeps the unset case
+// backwards compatible: rollout status remains the only verdict, as before.
+func TestWithoutAnExpectedTagTheReleaseCheckIsSkipped(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 1, ready: 1, updated: 1, generation: 4, observed: 4}, staleImage),
+	})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: staleImage}}},
+	)})
+	f.set("rollout", reply{})
+
+	output, code := f.run(map[string]string{"MAX_NOTREADY_NODES": "2"}, target)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "EXPECTED_IMAGE_TAG is not set")
+}
+
+// TestToleratesOnceTheOperatorUpdatesTheWorkload is the tolerance path's
+// version of the same story: the template arrives, and the shortfall left on
+// the unreachable node is then excusable.
 func TestToleratesOnceTheOperatorUpdatesTheWorkload(t *testing.T) {
 	requireBash(t)
 	t.Parallel()

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -24,12 +24,23 @@ import (
 )
 
 const (
+	// releaseTag is the tag the deploy under test is rolling out. The operator
+	// resolves every component image as <registry>/<repository>:<its own
+	// compiled version>, so the release tag and the image tag are the same
+	// string, which is what lets wait-rollouts.sh tell the release being
+	// deployed from the one it replaces.
+	releaseTag = "nightly-abc"
+
+	// previousTag is the tag the cluster was on before. A workload still
+	// carrying it has not been updated by the operator yet.
+	previousTag = "nightly-old"
+
 	// gantryImage is the image the workload under test wants.
-	gantryImage = "ghcr.io/azure/gantry:nightly-abc"
+	gantryImage = "ghcr.io/azure/gantry:" + releaseTag
 
 	// staleImage is an image a previous revision wanted. Pods still running it
 	// belong to a superseded revision and must not gate the current rollout.
-	staleImage = "ghcr.io/azure/gantry:nightly-old"
+	staleImage = "ghcr.io/azure/gantry:" + previousTag
 
 	// initImage is the pinned third-party init image the gantry DaemonSet
 	// pulls. A blip on a public registry must not fail a deploy on its own.
@@ -55,6 +66,32 @@ type pod struct {
 	terminating bool
 	containers  []container
 	noStatus    bool
+
+	// node is .spec.nodeName. Empty means unscheduled, which the tolerance
+	// filter counts as a real scheduling failure rather than a stranded pod.
+	node string
+	// notReady sets phase Running with Ready=False, the shape of a pod on a
+	// node the kubelet has stopped reporting for.
+	notReady bool
+}
+
+// node describes one fake cluster node.
+type node struct {
+	name string
+	site string
+	// ready is the value of the Ready condition's status. Empty means the
+	// condition is absent entirely. An unreachable kubelet reports "Unknown",
+	// not "False", which is the case tolerance exists for.
+	ready string
+}
+
+// dsStatus is the DaemonSet status tolerance is decided on.
+type dsStatus struct {
+	desired    int
+	ready      int
+	updated    int
+	generation int
+	observed   int
 }
 
 // fake stubs kubectl for one script invocation. Responses are keyed by the
@@ -226,18 +263,37 @@ func (f *fake) calls() string {
 	return string(data)
 }
 
-// workload renders a DaemonSet with the given selector and container images.
+// workload renders a workload with the given selector and container images.
+//
+// It deliberately emits NO kind, so node_tolerance stops at its first
+// condition. The image-guard tests below are about the image guard; a fixture
+// that opted them all into the tolerance path as well would make an unrelated
+// change to tolerance able to break every one of them.
 func workload(selector string, images ...string) string {
-	return renderWorkload(selector, images, nil)
+	return renderWorkload("", selector, images, nil, nil)
 }
 
-// workloadWithInit renders a DaemonSet that also declares an init container,
+// workloadWithInit renders a workload that also declares an init container,
 // matching the shape of deploy/gantry/daemonset.yaml.tmpl.
 func workloadWithInit(selector, image, init string) string {
-	return renderWorkload(selector, []string{image}, []string{init})
+	return renderWorkload("", selector, []string{image}, []string{init}, nil)
 }
 
-func renderWorkload(selector string, images, initImages []string) string {
+// daemonSet renders a DaemonSet complete with the kind and status fields
+// node_tolerance reads, which is what a real `kubectl get ds/x -o json`
+// returns.
+func daemonSet(selector string, status dsStatus, images ...string) string {
+	return renderWorkload("DaemonSet", selector, images, nil, &status)
+}
+
+// deployment renders a Deployment carrying a DaemonSet-shaped status. A
+// Deployment reschedules off a dead node, so its shortfall must never be
+// excused however good the rest of the evidence looks.
+func deployment(selector string, status dsStatus, images ...string) string {
+	return renderWorkload("Deployment", selector, images, nil, &status)
+}
+
+func renderWorkload(kind, selector string, images, initImages []string, status *dsStatus) string {
 	labels := map[string]string{}
 
 	if selector != "" {
@@ -269,7 +325,48 @@ func renderWorkload(selector string, images, initImages []string) string {
 		},
 	}
 
+	if kind != "" {
+		spec["kind"] = kind
+	}
+
+	if status != nil {
+		spec["metadata"] = map[string]any{"generation": status.generation}
+		spec["status"] = map[string]any{
+			"desiredNumberScheduled": status.desired,
+			"numberReady":            status.ready,
+			"updatedNumberScheduled": status.updated,
+			"observedGeneration":     status.observed,
+		}
+	}
+
 	return marshal(spec)
+}
+
+// nodeList renders a node list in the shape kubectl returns.
+func nodeList(nodes ...node) string {
+	items := make([]map[string]any, 0, len(nodes))
+
+	for _, n := range nodes {
+		labels := map[string]any{}
+		if n.site != "" {
+			labels["unbounded-cloud.io/site"] = n.site
+		}
+
+		status := map[string]any{}
+		if n.ready != "" {
+			status["conditions"] = []map[string]any{
+				{"type": "MemoryPressure", "status": "False"},
+				{"type": "Ready", "status": n.ready},
+			}
+		}
+
+		items = append(items, map[string]any{
+			"metadata": map[string]any{"name": n.name, "labels": labels},
+			"status":   status,
+		})
+	}
+
+	return marshal(map[string]any{"items": items})
 }
 
 // podList renders a pod list in the shape kubectl returns.
@@ -312,15 +409,37 @@ func podList(pods ...pod) string {
 			}
 		}
 
+		podSpec := map[string]any{"containers": specContainers, "initContainers": specInit}
+		if p.node != "" {
+			podSpec["nodeName"] = p.node
+		}
+
 		item := map[string]any{
 			"metadata": meta,
-			"spec":     map[string]any{"containers": specContainers, "initContainers": specInit},
+			"spec":     podSpec,
+		}
+
+		// Running+Ready unless the fixture says otherwise. Both are read by the
+		// tolerance filter; the image guard ignores them.
+		readiness := map[string]any{
+			"phase": "Running",
+			"conditions": []map[string]any{
+				{"type": "Ready", "status": "True"},
+			},
+		}
+
+		if p.notReady {
+			readiness["conditions"] = []map[string]any{
+				{"type": "Ready", "status": "False"},
+			}
 		}
 
 		if p.noStatus {
 			item["status"] = map[string]any{"phase": "Pending"}
 		} else {
 			item["status"] = map[string]any{
+				"phase":                 readiness["phase"],
+				"conditions":            readiness["conditions"],
 				"containerStatuses":     statuses,
 				"initContainerStatuses": initStatuses,
 			}
@@ -781,4 +900,348 @@ func TestRequiresKubeconfig(t *testing.T) {
 	}
 
 	requireContains(t, output, "KUBECONFIG")
+}
+
+// ---------------------------------------------------------------------------
+// Degraded-node tolerance.
+//
+// A DaemonSet counts every node toward desiredNumberScheduled, including nodes
+// the kubelet has stopped reporting for, so one unreachable node blocks
+// `rollout status` until its timeout every single time. Tolerating that is the
+// only thing in this script that can turn a failing wait into a passing one,
+// which is why it is fail-closed and why the cases below spend most of their
+// effort on the ways it must REFUSE.
+// ---------------------------------------------------------------------------
+
+// degradedNodes is a three-node cluster with one node the cluster has lost
+// contact with.
+//
+// The condition is Unknown, not False: that is what an unreachable kubelet
+// reports, and a check written against False would silently never fire.
+func degradedNodes() string {
+	return nodeList(
+		node{name: "node-a", site: "hq", ready: "True"},
+		node{name: "node-b", site: "hq", ready: "True"},
+		node{name: "spark-3d37", site: "boulderlab", ready: "Unknown"},
+	)
+}
+
+// strandedFleet is the pod list that goes with degradedNodes: two healthy pods
+// on reachable nodes and one the controller can neither update nor reap.
+func strandedFleet(image string) string {
+	return podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: image}}},
+		pod{name: "gantry-b", node: "node-b", containers: []container{{name: "c0", image: image}}},
+		pod{
+			name: "gantry-c", node: "spark-3d37", notReady: true,
+			containers: []container{{name: "c0", image: image}},
+		},
+	)
+}
+
+// shortByOne is the status of a DaemonSet whose only missing pod is the
+// stranded one: the controller has caught up, and everything it can reach is
+// updated and Ready.
+var shortByOne = dsStatus{desired: 3, ready: 2, updated: 2, generation: 4, observed: 4}
+
+// tolerating is the env a deploy gate runs with: a cap that allows one dead
+// node, and the tag the operator resolves component images at.
+var tolerating = map[string]string{
+	"MAX_NOTREADY_NODES": "2",
+	"EXPECTED_IMAGE_TAG": releaseTag,
+}
+
+func withEnv(extra map[string]string) map[string]string {
+	merged := map[string]string{}
+	for key, value := range tolerating {
+		merged[key] = value
+	}
+
+	for key, value := range extra {
+		merged[key] = value
+	}
+
+	return merged
+}
+
+func TestToleratesAShortfallExplainedByUnreachableNodes(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, gantryImage)})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	// Held open: without tolerance this wait would run to its timeout, which is
+	// the behaviour being replaced.
+	f.set("rollout", reply{sleep: "20"})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "tolerating the ds/gantry shortfall")
+	requireContains(t, output, "short 1 of 3 pods")
+	requireContains(t, output, "boulderlab[spark-3d37]")
+	requireContains(t, output, "OK: all workloads rolled out")
+	requireGroupsBalanced(t, output)
+}
+
+// TestRefusesToTolerateThePreviousRelease is the regression guard for a
+// false green: component workloads are updated asynchronously, so early in a
+// deploy the DaemonSet still carries the tag it had before. Every other
+// condition holds in that window, so without the image check the gate would
+// pass in about a second having validated nothing.
+func TestRefusesToTolerateThePreviousRelease(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, staleImage)})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(staleImage)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "does not reference :"+releaseTag+" yet")
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+	requireGroupsBalanced(t, output)
+}
+
+// TestToleratesOnceTheOperatorUpdatesTheWorkload is the other half: the wait
+// must not deadlock waiting for a tag that does arrive. Calls 1 and 2 are the
+// spec resolve and the first poll, both still on the old release; the operator
+// reconciles, and the poll after that tolerates.
+func TestToleratesOnceTheOperatorUpdatesTheWorkload(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, gantryImage)})
+	f.setNth("getjson-ds_gantry", 1, reply{stdout: daemonSet(selectorLabel, shortByOne, staleImage)})
+	f.setNth("getjson-ds_gantry", 2, reply{stdout: daemonSet(selectorLabel, shortByOne, staleImage)})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "20"})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "does not reference :"+releaseTag+" yet")
+	requireContains(t, output, "tolerating the ds/gantry shortfall")
+	requireGroupsBalanced(t, output)
+}
+
+func TestRefusesToTolerateBeyondTheCap(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, gantryImage)})
+	f.set("getjson-nodes", reply{stdout: nodeList(
+		node{name: "node-a", site: "hq", ready: "True"},
+		node{name: "node-b", site: "edge", ready: "Unknown"},
+		node{name: "node-c", site: "edge", ready: "Unknown"},
+		node{name: "spark-3d37", site: "boulderlab", ready: "Unknown"},
+	)})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "too many NotReady nodes")
+	requireContains(t, output, "3 > MAX_NOTREADY_NODES=2")
+	// Grouped by site and in first-seen order, so the message is stable enough
+	// to be compared between polls of an unchanged cluster.
+	requireContains(t, output, "edge[node-b, node-c] boulderlab[spark-3d37]")
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+}
+
+// TestRefusesToTolerateWhenAReachablePodIsUnhealthy keeps the check honest
+// about what it is excusing. A pod that is broken on a node the cluster can
+// still talk to is a real failure, and the fact that some OTHER node is
+// unreachable says nothing about it.
+func TestRefusesToTolerateWhenAReachablePodIsUnhealthy(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 3, ready: 1, updated: 2, generation: 4, observed: 4}, gantryImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+		// On a READY node and not Ready: a real failure.
+		pod{
+			name: "gantry-b", node: "node-b", notReady: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
+		pod{
+			name: "gantry-c", node: "spark-3d37", notReady: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
+	)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+}
+
+// TestNeverToleratesADeploymentShortfall covers the kind check. A Deployment
+// reschedules off a dead node, so a shortfall there is a scheduling problem,
+// not a stranded pod. The kind comes from the spec read before the wait, so
+// this must also cost no node query at all.
+func TestNeverToleratesADeploymentShortfall(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_machina-controller", reply{
+		stdout: deployment("app=machina", shortByOne, gantryImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, "deploy/machina-controller")
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
+	requireNotContains(t, f.calls(), "get nodes")
+}
+
+func TestRefusesToTolerateWhenNodeReadinessCannotBeRead(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, gantryImage)})
+	f.set("getjson-nodes", reply{stderr: "error: the server could not find the requested resource", exit: 1})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "could not evaluate node readiness for ds/gantry")
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+}
+
+// TestCapOfZeroDisablesToleranceWithoutQueryingNodes covers the switch-off
+// path and the cost of it: a run that cannot tolerate anything must not pay
+// for a full node list on every poll to find that out.
+func TestCapOfZeroDisablesToleranceWithoutQueryingNodes(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, gantryImage)})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(withEnv(map[string]string{"MAX_NOTREADY_NODES": "0"}), target)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+	requireNotContains(t, f.calls(), "get nodes")
+}
+
+// TestWithoutAnExpectedTagToleranceIsUnavailable covers the other switch-off
+// path. With no tag there is no way to tell the release being deployed from
+// the one it replaces, so the only safe answer is to keep waiting, and to say
+// why rather than appearing to work.
+func TestWithoutAnExpectedTagToleranceIsUnavailable(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, gantryImage)})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(map[string]string{"MAX_NOTREADY_NODES": "2"}, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "EXPECTED_IMAGE_TAG is not set")
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+	requireNotContains(t, f.calls(), "get nodes")
+}
+
+func TestRejectsANonNumericCap(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+
+	output, code := f.run(withEnv(map[string]string{"MAX_NOTREADY_NODES": "two"}), target)
+
+	requireCode(t, code, 2, output)
+	requireContains(t, output, "MAX_NOTREADY_NODES must be a non-negative integer")
+}
+
+// TestAnUnreachableNodeCannotMaskAMissingImage locks in the order of the two
+// polls. A stranded pod never pulls anything, so a NotReady node can never be
+// the reason an image is missing, and the pipeline error must still win.
+func TestAnUnreachableNodeCannotMaskAMissingImage(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, gantryImage)})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: podList(
+		pod{
+			name: "gantry-a", node: "node-a",
+			containers: []container{{name: "c0", image: gantryImage, waiting: "InvalidImageName"}},
+		},
+		pod{
+			name: "gantry-c", node: "spark-3d37", notReady: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
+	)})
+	f.set("rollout", reply{sleep: "20"})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "cannot pull "+gantryImage)
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+	requireGroupsBalanced(t, output)
+}
+
+// TestRecordsATolerationInTheStepSummary covers the durable record. The run
+// log scrolls past; the job summary is what a reviewer sees when asking what
+// this release was actually validated against.
+func TestRecordsATolerationInTheStepSummary(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, gantryImage)})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "20"})
+
+	summary := filepath.Join(f.dir, "summary.md")
+
+	output, code := f.run(withEnv(map[string]string{"GITHUB_STEP_SUMMARY": summary}), target)
+
+	requireCode(t, code, 0, output)
+
+	written, err := os.ReadFile(summary)
+	if err != nil {
+		t.Fatalf("read step summary: %v", err)
+	}
+
+	requireContains(t, string(written), "Degraded rollout tolerated: ds/gantry")
+	requireContains(t, string(written), "Ready pods: 2/3")
+	requireContains(t, string(written), "boulderlab[spark-3d37]")
+	requireContains(t, string(written), "Deployed image tag: `"+releaseTag+"`")
 }

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -105,6 +105,9 @@ type dsStatus struct {
 	updated    int
 	generation int
 	observed   int
+	// misscheduled is .status.numberMisscheduled: pods running on nodes the
+	// DaemonSet no longer selects.
+	misscheduled int
 }
 
 // fake stubs kubectl for one script invocation. Responses are keyed by the
@@ -350,6 +353,7 @@ func renderWorkload(kind, selector string, images, initImages []string, status *
 			"desiredNumberScheduled": status.desired,
 			"numberReady":            status.ready,
 			"updatedNumberScheduled": status.updated,
+			"numberMisscheduled":     status.misscheduled,
 			"observedGeneration":     status.observed,
 		}
 	}
@@ -1469,6 +1473,32 @@ func TestRefusesAToleratedWorkloadReplacedMidEvaluation(t *testing.T) {
 	requireCode(t, code, 1, output)
 	requireContains(t, output, "no longer references :"+releaseTag)
 	requireNotContains(t, output, "OK: all workloads rolled out")
+}
+
+// TestRefusesToTolerateWithAMisscheduledPod covers a pod left running on a
+// node the DaemonSet no longer selects. Coverage is counted in nodes, and that
+// node is not one the fleet is meant to cover, so it could stand in for a
+// desired node with nothing on it. The controller reaps such pods, so this
+// clears on its own rather than needing an override.
+func TestRefusesToTolerateWithAMisscheduledPod(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{
+			desired: 3, ready: 2, updated: 2, generation: 4, observed: 4, misscheduled: 1,
+		}, gantryImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "misscheduled pod(s)")
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
 }
 
 func TestRefusesToTolerateBeyondTheCap(t *testing.T) {

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -265,10 +265,10 @@ func (f *fake) calls() string {
 
 // workload renders a workload with the given selector and container images.
 //
-// It deliberately emits NO kind, so node_tolerance stops at its first
-// condition. The image-guard tests below are about the image guard; a fixture
-// that opted them all into the tolerance path as well would make an unrelated
-// change to tolerance able to break every one of them.
+// It deliberately emits NO kind, so node_tolerance stops at its kind check.
+// The image-guard tests below are about the image guard; a fixture that opted
+// them all into the tolerance path as well would make an unrelated change to
+// tolerance able to break every one of them.
 func workload(selector string, images ...string) string {
 	return renderWorkload("", selector, images, nil, nil)
 }
@@ -962,8 +962,8 @@ func strandedFleet(image string) string {
 // updated and Ready.
 var shortByOne = dsStatus{desired: 3, ready: 2, updated: 2, generation: 4, observed: 4}
 
-// tolerating is the env a deploy gate runs with: a cap that allows one dead
-// node, and the tag the operator resolves component images at.
+// tolerating is the env a deploy gate runs with: the release cap of two dead
+// nodes, and the tag the operator resolves component images at.
 var tolerating = map[string]string{
 	"MAX_NOTREADY_NODES": "2",
 	"EXPECTED_IMAGE_TAG": releaseTag,

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -1136,6 +1136,72 @@ func TestToleratesOnceTheOperatorUpdatesTheWorkload(t *testing.T) {
 	requireGroupsBalanced(t, output)
 }
 
+// TestRefusesToTolerateAnOutdatedPodOnAReachableNode is the regression guard
+// for a double count. Tolerance used to compare updatedNumberScheduled +
+// stranded against desired, and a stranded pod the controller had already
+// updated appears in BOTH terms:
+//
+//	desired 3, updated 2 (node B and the stranded node C), numberReady 2
+//	node A: previous release, Running+Ready     <- the release is NOT on it
+//	node B: this release, Running+Ready
+//	node C: this release, stranded on a NotReady node
+//
+// 2 + 1 >= 3 and 2 + 1 >= 3, nothing unhealthy, so it tolerated while a
+// reachable node still ran the previous release. With maxUnavailable 1 the
+// stranded pod counts as unavailable and the controller stops updating the
+// rest, so this is the steady state of a stalled rollout, not a race.
+func TestRefusesToTolerateAnOutdatedPodOnAReachableNode(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 3, ready: 2, updated: 2, generation: 4, observed: 4}, gantryImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: staleImage}}},
+		pod{name: "gantry-b", node: "node-b", containers: []container{{name: "c0", image: gantryImage}}},
+		pod{
+			name: "gantry-c", node: "spark-3d37", notReady: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
+	)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+}
+
+// TestRefusesToTolerateWhenTheFleetIsShortOfCoverage keeps the count honest in
+// the other direction: a node with no pod at all is not a stranded pod.
+func TestRefusesToTolerateWhenTheFleetIsShortOfCoverage(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-ds_gantry", reply{
+		stdout: daemonSet(selectorLabel, dsStatus{desired: 3, ready: 1, updated: 1, generation: 4, observed: 4}, gantryImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	// One healthy pod and one stranded pod for three nodes: node-b has none.
+	f.set("pods", reply{stdout: podList(
+		pod{name: "gantry-a", node: "node-a", containers: []container{{name: "c0", image: gantryImage}}},
+		pod{
+			name: "gantry-c", node: "spark-3d37", notReady: true,
+			containers: []container{{name: "c0", image: gantryImage}},
+		},
+	)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
+}
+
 func TestRefusesToTolerateBeyondTheCap(t *testing.T) {
 	requireBash(t)
 	t.Parallel()

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -1443,6 +1443,34 @@ func TestRefusesToTolerateWhenTheFleetIsShortOfCoverage(t *testing.T) {
 	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
 }
 
+// TestRefusesAToleratedWorkloadReplacedMidEvaluation is the tolerance path's
+// version of the rollout confirmation. node_tolerance checks the tag on the
+// object it reads, then goes on to query nodes and pods, and this is the one
+// place a tolerated shortfall becomes a passing gate - so the tag is confirmed
+// again before it does.
+func TestRefusesAToleratedWorkloadReplacedMidEvaluation(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	current := daemonSet(selectorLabel, shortByOne, gantryImage)
+	// The spec resolve, the release wait and node_tolerance itself all see this
+	// release; anything after that sees somebody else's.
+	f.setNth("getjson-ds_gantry", 1, reply{stdout: current})
+	f.setNth("getjson-ds_gantry", 2, reply{stdout: current})
+	f.setNth("getjson-ds_gantry", 3, reply{stdout: current})
+	f.set("getjson-ds_gantry", reply{stdout: daemonSet(selectorLabel, shortByOne, staleImage)})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
+	f.set("rollout", reply{sleep: "20"})
+
+	output, code := f.run(tolerating, target)
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "no longer references :"+releaseTag)
+	requireNotContains(t, output, "OK: all workloads rolled out")
+}
+
 func TestRefusesToTolerateBeyondTheCap(t *testing.T) {
 	requireBash(t)
 	t.Parallel()

--- a/internal/operator/imagecoverage_test.go
+++ b/internal/operator/imagecoverage_test.go
@@ -52,8 +52,9 @@ import (
 // that is merely wrong.
 //
 // Both of those are only caught at deploy time, by the ImagePullBackOff guard
-// in hack/release/wait-rollouts.sh, and then only for the workloads named in
-// that script's argument list, which today omits metalman and storage.
+// in hack/release/wait-rollouts.sh, and then only for the workloads that gate
+// passes over. That list covers the three cluster components and, on the
+// release path, every Site that enables metalman; it still omits storage.
 //
 // Images pinned to a fixed public reference are not operator-managed and do not
 // belong here, such as the busybox init container in gantry's DaemonSet.


### PR DESCRIPTION
## Summary

The release pipeline had accumulated several independent ways to either block a good release indefinitely or publish a release that had not actually passed the checks attributed to it. This PR hardens the rollout gate, release preparation, artifact verification, and publication path, and documents the resulting process in `RELEASING.md`.

## Problems Fixed

### Unreachable nodes permanently blocked releases

A DaemonSet includes every eligible node in `desiredNumberScheduled`, even when the kubelet has stopped reporting. One unreachable edge node therefore left `gantry` and `unbounded-net-node` at 15/16 on `unbounded-stable`, causing every rollout gate to wait for its full timeout. Releases were consequently being published by hand, outside the automated gate and without an audit trail.

`hack/release/wait-rollouts.sh` now tolerates a DaemonSet shortfall only when it is fully explained by a bounded number of NotReady nodes. This path is strictly fail-closed because it can turn a failed rollout into a successful one. It requires all of the following:

- the workload is a DaemonSet;
- its current template contains the expected release tag on every project-published image;
- the number of NotReady nodes is within `MAX_NOTREADY_NODES`;
- the controller has observed the current generation and reports no misscheduled pods;
- every reachable owned pod is healthy and current;
- distinct healthy nodes plus distinct stranded nodes cover the desired fleet.

The gate counts nodes rather than pods, excludes terminating reachable pods, scopes evidence to pods controlled by the workload, and re-confirms the expected release before accepting either normal rollout success or a tolerated shortfall. Deployments remain outside tolerance because they can reschedule away from a failed node.

Both nightly and release-upgrade default to tolerating at most two NotReady nodes. Manual dispatch can tighten or override the limit, while the automatic release path always uses the workflow default. Diagnostics and smoke output now include node readiness and identify stranded pods by site.

### The gate could validate the wrong release

`kubectl rollout status` answers whether the current workload is settled. Before this PR, an old, healthy workload could report success before the operator had rewritten it for the release under test. Concurrent deployments could also replace workloads while another run was waiting, allowing one release to claim another release's rollout.

The gate now waits in three phases: the workload must exist, its template must reference the expected release, and that specific release must roll out. The expected tag is checked again after success. Deployments to each shared cluster are serialized with a cluster-scoped concurrency group so different tags cannot race on the same cluster.

The image check distinguishes project images by `EXPECTED_IMAGE_REGISTRY`. All project-published images must carry the expected tag, while intentionally pinned third-party images, such as gantry's busybox init container, are ignored. A stale primary container can no longer be hidden by a current sidecar.

### The soak did not cover everything it claimed to cover

Metalman runs on `unbounded-stable` but was absent from the rollout gate. It is a per-Site component, and its deployment names cannot be derived from the cluster's own `SITE_NAME`. `hack/release/metalman-targets.sh` now discovers every Site that enables Metalman and adds its Deployment to the release gate. Query failures and malformed cluster data fail closed rather than looking like an intentionally empty result.

Smoke discovery also had two false-green paths: an empty smoke directory skipped the matrix, and a failed discovery job also produced a skipped matrix. Publication accepted both. Discovery now fails when no smoke tasks are present, and normal publication requires both discovery and every smoke task to succeed. Nightly uses the same rule.

### Break-glass publication was unaudited and unsafe

When the soak cluster prevented a release from passing, maintainers published drafts manually with `gh release edit --draft=false`. That bypass left no durable explanation and made the release gate advisory in practice.

The release workflow now has a dedicated `publish-forced` path that:

- is reachable only through manual dispatch with `force_publish` and a written reason;
- uses the `unbounded-reviewers` environment so required reviewers can be configured independently;
- still runs artifact and provenance verification;
- records the actor, reason, and every gate result in the release body;
- composes the audit notice before publication and applies the notice and `draft=false` in one API call;
- does not publish after workflow cancellation.

Normal and forced publication are mutually exclusive for UI boolean inputs, REST/`gh` string inputs, and automatic `workflow_run` events.

### Release artifacts were incompletely verified

Artifact verification previously lived inline in one job and missed several failure modes. The shared `hack/release/verify-release-artifacts.sh` now protects both normal deployment and forced publication by checking:

- the manifest archive, operator manifest, and release BOM Sigstore bundles against this repository's tag-scoped release workflow identity;
- the BOM's release tag and commit;
- every image signature named by the BOM;
- a non-empty, completely parsed image list;
- every artifact and signature bundle declared by the BOM is still present in the GitHub Release;
- any binary about to be executed matches the signed `checksums.txt`.

This closes the path where the downloaded `kubectl-unbounded` plugin was executed against the cluster without verification, as well as partial-BOM parsing and incomplete-draft publication failures. The verification tooling is loaded from the workflow's own commit so backfills are not dependent on an older release tag containing current gate scripts.

### Version resolution could fork, guess, or tag the wrong tree

The old inline resolver reapplied `bump` to the latest final on every run, accepted unvalidated prerelease suffixes, guessed which train to promote, and tagged `main` HEAD rather than the candidate commit that had actually soaked.

Version resolution now lives in `hack/release/next-version.sh` and follows one consistent policy:

- an existing live train is continued instead of forked;
- blank `pre` selects the next canonical `rc.N` automatically;
- only bounded, non-zero-prefixed `vX.Y.Z-rc.N` tags count as release candidates;
- malformed, legacy, and off-branch tags do not create release trains or affect numbering;
- stale trains older than the latest final are reported but cannot be promoted;
- concurrent trains require an explicit opt-in, after which promotion requires an explicit version;
- version components and RC numbers are bounded to avoid Bash arithmetic overflow;
- promotion tags the highest canonical RC's commit, not current HEAD;
- the promoted commit must be an ancestor of the branch being released.

`dry_run` reports the tag and commit without pushing. Release preparation is serialized so two dispatches cannot race to mint the same version.

### Workflow errors and release knowledge were hard to detect

`release-prepare.yaml` contained a duplicate YAML key that made it undispatchable, but CI did not lint workflow syntax. `make lint` now runs pinned `actionlint`, with repository-specific runner labels configured.

`RELEASING.md` provides task-oriented guides for direct releases, candidate trains, promotion, recovery, break-glass operation, urgent fixes, and the current lack of maintenance branches. The large process comments previously duplicated across workflows were reduced in favor of this single runbook.

The nightly operator build also drops component build arguments that its Containerfile never consumed; component tags are selected from the operator's compiled version during reconciliation.

## Testing

The release shell tooling is exercised through committed tests that run the real scripts against controlled fake `kubectl`, Git repositories, `cosign`, `jq`, and checksum inputs. Coverage includes:

- healthy, degraded, stale, replaced, misscheduled, duplicated, foreign-owned, and malformed rollout states;
- Metalman discovery success, absence, query failure, and malformed payloads;
- forced-publication result reporting, required reasons, atomic notice composition, and idempotency;
- valid, missing, malformed, tampered, unsigned, and incomplete release artifacts;
- release, prerelease, concurrent-train, stale-train, off-branch, malformed-tag, numeric-boundary, and promotion-commit version cases.

The resolver suite currently passes 65 cases, and `go test ./hack/release` passes.

## Operational Note

Repository administrators should configure required reviewers on the `unbounded-reviewers` environment. GitHub creates the environment on first reference, so this does not block merging, but the forced path has no second-person approval until those protection rules are added.

Part of #610. Storage supervisor rollout coverage remains tracked in #625.
