### PR TITLE
build: fail vulncheck only on vulnerabilities that have a fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ unbounded-kube is organized into several directories:
 - Net-specific build tasks (container images, frontend, eBPF, render) are exposed via `net-` prefixed targets in the main `Makefile` (e.g., `make net-frontend`, `make net-ebpf-build`, `make net-ebpf-generate`, `make net-manifests`). Cluster deploy/undeploy targets live separately under `hack/net/` and are invoked via `make -C hack/net <target>` (e.g., `make -C hack/net deploy`). Run `make help` and `make -C hack/net help` for the full lists.
 - `make generate` runs `go generate ./...` to regenerate deepcopy, CRDs, and protobuf for all packages.
 - `make build` compiles all Go packages (`go build ./...`).
-- `make vulncheck` runs `govulncheck` for known vulnerabilities.
+- `make vulncheck` runs `govulncheck` and fails only on vulnerabilities that are both reachable from our code and have a published fix, since those are the ones a module bump resolves. Reachable ones with no fix available are reported and allowed through; acting on those means dropping or replacing the dependency, which is a judgement call rather than a build failure.
 - `make fmt` formats Go source (gofumpt + wsl_v5 blank-line rules); `make lint` runs golangci-lint; `make test` runs all tests.
 - `make lint` runs the same checks locally and in CI and does NOT auto-fix. Always run `make fmt` before committing to satisfy the linter (gofumpt and wsl_v5 are enforced by `make lint`/CI); do not hand-format.
 - Locally `test` implies `lint`. In CI (`CI=1`), each runs independently.

--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ help: ## Show this help
 	@echo "  test                             Run all tests"
 	@echo "  build                            Compile all Go packages"
 	@echo "  generate                         Run go generate (deepcopy, CRDs, protobuf)"
-	@echo "  vulncheck                        Run govulncheck"
+	@echo "  vulncheck                        Run govulncheck; fails only on fixable vulnerabilities"
 	@echo "  gomod                            go mod tidy"
 	@echo "  notice                           Regenerate NOTICE from Go, npm, Cargo, and native dependencies"
 	@echo "  notice-check                     Verify NOTICE is in sync with dependencies"
@@ -514,20 +514,15 @@ build: machina-manifests machine-ops-manifests playpen-manifests net-manifests u
 generate: install-protoc ## Run go generate for API types (deepcopy, CRDs) and protobuf
 	PATH="$(PROTOC_DIR)/bin:$$PATH" $(GOCMD) generate $(GO_PACKAGES)
 
-vulncheck: machina-manifests machine-ops-manifests playpen-manifests net-manifests unbounded-storage-supervisor-manifests unbounded-operator-manifests gantry-manifests ## Run govulncheck for known vulnerabilities
-	@# GO-2024-3218 (libp2p/go-libp2p-kad-dht): all versions affected, no fix
-	@# available. Theoretical DHT content-censorship attack, not exploitable in
-	@# gantry's private-cluster deployment model. Tracked upstream at
-	@# https://github.com/advisories/GHSA-mqr9-hjr8-2m9w
-	@tmpf=$$(mktemp); \
-	$(GOCMD) tool govulncheck $(GO_PACKAGE_PATTERNS) > "$$tmpf" 2>&1; rc=$$?; \
-	cat "$$tmpf"; \
-	if [ $$rc -eq 0 ]; then rm -f "$$tmpf"; exit 0; fi; \
-	if grep -q 'affected by 1 vulnerability' "$$tmpf" && grep -q 'GO-2024-3218' "$$tmpf"; then \
-	  echo "vulncheck: only known-unfixable GO-2024-3218 found (accepted)"; \
-	  rm -f "$$tmpf"; exit 0; \
-	fi; \
-	rm -f "$$tmpf"; exit $$rc
+vulncheck: machina-manifests machine-ops-manifests playpen-manifests net-manifests unbounded-storage-supervisor-manifests unbounded-operator-manifests gantry-manifests ## Run govulncheck; fails only on vulnerabilities that have an available fix
+	@# The JSON stream is the documented programmatic interface. The gate owns
+	@# the verdict, so govulncheck is not asked for one: in JSON mode it exits 0
+	@# whether or not it found anything, and a non-zero exit here means the scan
+	@# itself failed, which must still fail the target. Progress goes to stderr
+	@# and stays visible.
+	@mkdir -p tmp
+	$(GOCMD) tool govulncheck -format json $(GO_PACKAGE_PATTERNS) > tmp/govulncheck.json
+	$(GOCMD) run ./hack/cmd/vulncheck-gate tmp/govulncheck.json
 
 gomod: ## Tidy go.mod and go.sum
 	$(GOMOD) tidy

--- a/hack/cmd/vulncheck-gate/main.go
+++ b/hack/cmd/vulncheck-gate/main.go
@@ -1,0 +1,315 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// vulncheck-gate decides whether a govulncheck run should fail the build.
+//
+// It fails only on vulnerabilities that are both reachable from our code and
+// have a published fix, because those are the only ones anyone can act on: the
+// fix is a module bump. A reachable vulnerability with no fix available is
+// reported prominently and allowed through. Blocking on it would wedge every
+// branch in the repository for as long as upstream takes to publish a fix,
+// which can be indefinitely, while changing nothing about our exposure.
+//
+// That trade is deliberate and it has a cost: a serious vulnerability with no
+// upstream fix will pass this gate every day without anyone being forced to
+// look at it. The report exists so that "nobody was forced to" does not become
+// "nobody knew". Acting on those means dropping or replacing the dependency,
+// which is a judgement call this tool cannot make.
+//
+// Input is the JSON stream from `govulncheck -format json`. That format is the
+// documented programmatic interface; the human-readable output is not, and the
+// previous incarnation of this gate parsed it and broke the first time the
+// finding count changed.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// govulncheckMessage is one object in the `govulncheck -format json` stream.
+// Exactly one field is populated per message. Only the three that bear on the
+// verdict are decoded; config is decoded because its absence means the scan
+// did not run (see errNoConfig).
+type govulncheckMessage struct {
+	Config  *configMessage `json:"config"`
+	OSV     *osvRecord     `json:"osv"`
+	Finding *finding       `json:"finding"`
+}
+
+type configMessage struct {
+	ScannerName    string `json:"scanner_name"`
+	ScannerVersion string `json:"scanner_version"`
+	ScanLevel      string `json:"scan_level"`
+}
+
+type osvRecord struct {
+	ID      string `json:"id"`
+	Summary string `json:"summary"`
+}
+
+type finding struct {
+	OSV string `json:"osv"`
+
+	// FixedVersion is absent, not empty, when no fix has been published. That
+	// distinction is the whole basis of the verdict, so it is read through a
+	// plain string: absent and empty both decode to "" and both mean "nothing
+	// to bump to".
+	FixedVersion string `json:"fixed_version"`
+
+	// Trace runs from the vulnerable symbol outward. A frame carries a
+	// function only at symbol scan level, and only for a vulnerability
+	// govulncheck could actually trace into our code, so trace[0].function is
+	// what distinguishes "we call this" from "this is somewhere in the module
+	// graph". It reproduces govulncheck's own "your code is affected by N
+	// vulnerabilities" set.
+	Trace []traceFrame `json:"trace"`
+}
+
+type traceFrame struct {
+	Module   string `json:"module"`
+	Version  string `json:"version"`
+	Package  string `json:"package"`
+	Function string `json:"function"`
+	Receiver string `json:"receiver"`
+}
+
+// vulnerability is what the gate knows about one OSV entry after folding
+// together every finding that mentions it.
+type vulnerability struct {
+	id      string
+	summary string
+	module  string
+	version string
+
+	// reachable is true when any finding traced into our code.
+	reachable bool
+
+	// fixedVersion is set when any reachable finding has one. Taking it from
+	// any rather than all is deliberate: an OSV can span modules, and one of
+	// them being fixable is enough to make the finding actionable.
+	fixedVersion string
+}
+
+func (v vulnerability) blocking() bool {
+	return v.reachable && v.fixedVersion != ""
+}
+
+// errNoConfig guards the one failure mode that would silently disarm the gate.
+//
+// An empty or truncated input decodes cleanly into zero findings, which is
+// indistinguishable from a clean scan. govulncheck always emits a config
+// message first, so requiring one turns "the scan did not run" into a loud
+// failure rather than a pass.
+var errNoConfig = errors.New("no govulncheck config message found: the scan did not run, or its output was truncated")
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "vulncheck-gate: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdin io.Reader, stdout io.Writer) error {
+	var input io.Reader
+
+	switch len(args) {
+	case 0:
+		input = stdin
+	case 1:
+		file, err := os.Open(args[0])
+		if err != nil {
+			return fmt.Errorf("open findings: %w", err)
+		}
+
+		defer file.Close() //nolint:errcheck // read-only
+
+		input = file
+	default:
+		return errors.New("usage: vulncheck-gate [govulncheck-json-file]")
+	}
+
+	vulns, err := parse(input)
+	if err != nil {
+		return err
+	}
+
+	return report(stdout, vulns, os.Getenv("GITHUB_ACTIONS") == "true")
+}
+
+// parse folds the govulncheck message stream into one entry per OSV.
+func parse(r io.Reader) ([]vulnerability, error) {
+	decoder := json.NewDecoder(r)
+
+	var (
+		sawConfig bool
+		vulns     = map[string]*vulnerability{}
+	)
+
+	for {
+		var message govulncheckMessage
+
+		switch err := decoder.Decode(&message); {
+		case errors.Is(err, io.EOF):
+			if !sawConfig {
+				return nil, errNoConfig
+			}
+
+			return sorted(vulns), nil
+		case err != nil:
+			return nil, fmt.Errorf("decode govulncheck output: %w", err)
+		}
+
+		switch {
+		case message.Config != nil:
+			sawConfig = true
+		case message.OSV != nil:
+			entry := entryFor(vulns, message.OSV.ID)
+			entry.summary = message.OSV.Summary
+		case message.Finding != nil:
+			absorb(entryFor(vulns, message.Finding.OSV), message.Finding)
+		}
+	}
+}
+
+func entryFor(vulns map[string]*vulnerability, id string) *vulnerability {
+	if entry, ok := vulns[id]; ok {
+		return entry
+	}
+
+	entry := &vulnerability{id: id}
+	vulns[id] = entry
+
+	return entry
+}
+
+// absorb merges one finding into the entry for its OSV.
+//
+// Findings arrive at several levels for the same vulnerability - module,
+// package, symbol - so this accumulates rather than overwrites. Only the
+// symbol-level ones carry a function, and only those establish reachability or
+// contribute a fixed version.
+func absorb(entry *vulnerability, f *finding) {
+	if len(f.Trace) == 0 {
+		return
+	}
+
+	top := f.Trace[0]
+
+	// The module-level finding is the one that names the module and the
+	// version we are actually on; deeper frames repeat it.
+	if entry.module == "" {
+		entry.module = top.Module
+		entry.version = top.Version
+	}
+
+	if top.Function == "" {
+		return
+	}
+
+	entry.reachable = true
+
+	if entry.fixedVersion == "" {
+		entry.fixedVersion = f.FixedVersion
+	}
+}
+
+func sorted(vulns map[string]*vulnerability) []vulnerability {
+	out := make([]vulnerability, 0, len(vulns))
+	for _, entry := range vulns {
+		out = append(out, *entry)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].id < out[j].id })
+
+	return out
+}
+
+// report prints the verdict and returns an error when anything blocks.
+//
+// The whole report is rendered into a builder and written once, so there is a
+// single write to check rather than one per line.
+func report(w io.Writer, vulns []vulnerability, annotate bool) error {
+	var blocking, unfixed []vulnerability
+
+	for _, v := range vulns {
+		switch {
+		case v.blocking():
+			blocking = append(blocking, v)
+		case v.reachable:
+			unfixed = append(unfixed, v)
+		}
+	}
+
+	var b strings.Builder
+
+	if len(unfixed) > 0 {
+		fmt.Fprintf(&b, "Reachable, no fix available (%d, not blocking):\n\n", len(unfixed))
+
+		for _, v := range unfixed {
+			b.WriteString(describe(v))
+
+			if annotate {
+				// Annotations surface these on the workflow summary, which is
+				// the only reason anyone reads a passing job.
+				fmt.Fprintf(&b, "::warning title=%s::%s (%s): no fix available\n", v.id, v.summaryOrID(), v.module)
+			}
+		}
+	}
+
+	if len(blocking) > 0 {
+		fmt.Fprintf(&b, "Reachable with a fix available (%d, blocking):\n\n", len(blocking))
+
+		for _, v := range blocking {
+			b.WriteString(describe(v))
+		}
+	} else {
+		b.WriteString("vulncheck: no reachable vulnerability has an available fix\n")
+	}
+
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+
+	if len(blocking) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%s reachable and fixable: upgrade the affected module(s)", plural(len(blocking)))
+}
+
+func describe(v vulnerability) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "  %s  %s\n", v.id, v.summaryOrID())
+	fmt.Fprintf(&b, "    module:    %s@%s\n", v.module, v.version)
+
+	if v.fixedVersion != "" {
+		fmt.Fprintf(&b, "    fixed in:  %s\n", v.fixedVersion)
+	}
+
+	fmt.Fprintf(&b, "    more info: https://pkg.go.dev/vuln/%s\n\n", v.id)
+
+	return b.String()
+}
+
+func (v vulnerability) summaryOrID() string {
+	if v.summary != "" {
+		return v.summary
+	}
+
+	return v.id
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "1 vulnerability is"
+	}
+
+	return fmt.Sprintf("%d vulnerabilities are", n)
+}

--- a/hack/cmd/vulncheck-gate/main_test.go
+++ b/hack/cmd/vulncheck-gate/main_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stream builds a govulncheck JSON stream from message literals. The real tool
+// output is a sequence of pretty-printed objects rather than an array or
+// NDJSON, but json.Decoder treats all three the same, so joining with newlines
+// is a faithful stand-in.
+func stream(messages ...string) string {
+	return strings.Join(messages, "\n") + "\n"
+}
+
+const configMsg = `{"config":{"scanner_name":"govulncheck","scanner_version":"v1.2.0","scan_level":"symbol"}}`
+
+// osvMsg is the advisory record govulncheck emits for every vulnerability it
+// knows about, whether or not our code reaches it.
+func osvMsg(id, summary string) string {
+	return `{"osv":{"id":"` + id + `","summary":"` + summary + `"}}`
+}
+
+// moduleFinding is the shallowest level govulncheck reports: the module is in
+// the graph, but nothing has been traced into our code. It carries no function.
+func moduleFinding(id, module, version, fixed string) string {
+	return `{"finding":{"osv":"` + id + `"` + fixedField(fixed) +
+		`,"trace":[{"module":"` + module + `","version":"` + version + `"}]}}`
+}
+
+// symbolFinding is the level that establishes reachability: trace[0] names the
+// vulnerable function our code calls.
+func symbolFinding(id, module, version, fixed, function string) string {
+	return `{"finding":{"osv":"` + id + `"` + fixedField(fixed) +
+		`,"trace":[{"module":"` + module + `","version":"` + version +
+		`","package":"` + module + `","function":"` + function + `"}]}}`
+}
+
+// fixedField omits the key entirely when there is no fix, which is what
+// govulncheck does. The gate must read an absent key and an empty string
+// identically, so the fixtures exercise the absent form.
+func fixedField(fixed string) string {
+	if fixed == "" {
+		return ""
+	}
+
+	return `,"fixed_version":"` + fixed + `"`
+}
+
+// TestGateBlocksOnlyOnFixableReachableVulnerabilities is the policy.
+//
+// The failing case cannot be observed against the repository's own scan: every
+// vulnerability that currently reaches our code is unfixable upstream, so
+// without a fixture the blocking path would ship untested and a regression
+// would look exactly like a clean run.
+func TestGateBlocksOnlyOnFixableReachableVulnerabilities(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		wantBlocked bool
+		wantMention []string
+	}{
+		{
+			name: "reachable with no fix is reported and allowed",
+			input: stream(
+				configMsg,
+				osvMsg("GO-2026-6170", "Malformed backend frame length causes panic"),
+				moduleFinding("GO-2026-6170", "github.com/lib/pq", "v1.12.3", ""),
+				symbolFinding("GO-2026-6170", "github.com/lib/pq", "v1.12.3", "", "Open"),
+			),
+			wantBlocked: false,
+			wantMention: []string{"GO-2026-6170", "no fix available", "not blocking"},
+		},
+		{
+			name: "reachable with a fix blocks",
+			input: stream(
+				configMsg,
+				osvMsg("GO-2026-9999", "Something fixable"),
+				moduleFinding("GO-2026-9999", "example.com/mod", "v1.0.0", "v1.2.0"),
+				symbolFinding("GO-2026-9999", "example.com/mod", "v1.0.0", "v1.2.0", "Vulnerable"),
+			),
+			wantBlocked: true,
+			wantMention: []string{"GO-2026-9999", "fixed in:  v1.2.0", "blocking"},
+		},
+		{
+			// govulncheck reports these; they are somebody else's problem
+			// (dependabot's), and blocking on code we never call would be the
+			// same false urgency the old count-based guard produced.
+			name: "unreachable with a fix does not block",
+			input: stream(
+				configMsg,
+				osvMsg("GO-2026-8888", "Fixable but never called"),
+				moduleFinding("GO-2026-8888", "example.com/unused", "v0.1.0", "v0.2.0"),
+			),
+			wantBlocked: false,
+			wantMention: []string{"no reachable vulnerability has an available fix"},
+		},
+		{
+			// One OSV can span modules. If any reachable finding names a fix,
+			// there is something to bump, so the whole entry blocks.
+			name: "mixed findings for one OSV block on the fixable one",
+			input: stream(
+				configMsg,
+				osvMsg("GO-2026-7777", "Two modules, one fixed"),
+				symbolFinding("GO-2026-7777", "example.com/nofix", "v1.0.0", "", "A"),
+				symbolFinding("GO-2026-7777", "example.com/fixed", "v1.0.0", "v1.1.0", "B"),
+			),
+			wantBlocked: true,
+			wantMention: []string{"GO-2026-7777", "fixed in:  v1.1.0"},
+		},
+		{
+			name:        "a clean scan passes",
+			input:       stream(configMsg),
+			wantBlocked: false,
+			wantMention: []string{"no reachable vulnerability has an available fix"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vulns, err := parse(strings.NewReader(tc.input))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+
+			var out bytes.Buffer
+
+			err = report(&out, vulns, false)
+
+			if blocked := err != nil; blocked != tc.wantBlocked {
+				t.Fatalf("blocked = %v (err %v), want %v\noutput:\n%s", blocked, err, tc.wantBlocked, out.String())
+			}
+
+			for _, want := range tc.wantMention {
+				if !strings.Contains(out.String(), want) {
+					t.Fatalf("output does not mention %q:\n%s", want, out.String())
+				}
+			}
+		})
+	}
+}
+
+// TestGateRejectsOutputThatProvesNothing guards the one failure mode that would
+// silently disarm the gate.
+//
+// An empty or truncated stream decodes into zero findings, which is
+// indistinguishable from a clean scan. govulncheck always emits config first,
+// so its absence means the scan did not run and the result means nothing.
+func TestGateRejectsOutputThatProvesNothing(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty output", input: ""},
+		{
+			name: "findings with no config",
+			input: stream(
+				osvMsg("GO-2026-6170", "Reachable and unfixable"),
+				symbolFinding("GO-2026-6170", "github.com/lib/pq", "v1.12.3", "", "Open"),
+			),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parse(strings.NewReader(tc.input)); !errors.Is(err, errNoConfig) {
+				t.Fatalf("parse err = %v, want errNoConfig", err)
+			}
+		})
+	}
+}
+
+func TestGateRejectsMalformedOutput(t *testing.T) {
+	_, err := parse(strings.NewReader(configMsg + "\n{\"finding\": {\"osv\":\n"))
+	if err == nil || errors.Is(err, errNoConfig) {
+		t.Fatalf("parse err = %v, want a decode failure", err)
+	}
+}
+
+// TestAnnotationsAreEmittedOnlyUnderActions pins the reporting side channel.
+//
+// A passing job's log is not read, so the unfixable set is surfaced as a
+// workflow annotation instead. Emitting the same syntax locally would be noise.
+func TestAnnotationsAreEmittedOnlyUnderActions(t *testing.T) {
+	vulns, err := parse(strings.NewReader(stream(
+		configMsg,
+		osvMsg("GO-2026-6170", "Malformed backend frame length causes panic"),
+		symbolFinding("GO-2026-6170", "github.com/lib/pq", "v1.12.3", "", "Open"),
+	)))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var annotated, plain bytes.Buffer
+
+	if err := report(&annotated, vulns, true); err != nil {
+		t.Fatalf("report: %v", err)
+	}
+
+	if err := report(&plain, vulns, false); err != nil {
+		t.Fatalf("report: %v", err)
+	}
+
+	if !strings.Contains(annotated.String(), "::warning title=GO-2026-6170::") {
+		t.Fatalf("no workflow annotation emitted:\n%s", annotated.String())
+	}
+
+	if strings.Contains(plain.String(), "::warning") {
+		t.Fatalf("workflow annotation emitted outside Actions:\n%s", plain.String())
+	}
+}


### PR DESCRIPTION
## What

`make vulncheck` now fails only when a vulnerability is **both** reachable from our code **and** has a published fix. Reachable vulnerabilities with no fix available are reported prominently and allowed through.

This unblocks every branch in the repository. CI is currently red everywhere, including `main`.

## Why now

Seven advisories against `github.com/lib/pq` were published on 18 August 2026, all reachable from the inventory binaries, all *all versions affected, no known fix*:

| ID | Summary |
|---|---|
| GO-2026-6166 | GSS authentication completes without mutual proof |
| GO-2026-6168 | Unbounded iteration count causes CPU denial of service (scram) |
| GO-2026-6169 | Disclosure of wrong `.pgpass` credential via `hostaddr` |
| GO-2026-6170 | Malformed backend frame length causes panic |
| GO-2026-6171 | Malformed RowDescription and DataRow messages cause panics |
| GO-2026-6172 | Backend frame lengths cause pre-validation memory exhaustion |
| GO-2026-6173 | Pre-protocol error reader permits unbounded memory consumption |

`v1.12.3` is already the latest release, so there is nothing to bump to. Main last passed on `acb37bcc` at 2026-08-14, four days before these existed.

## The guard could not do anything else

```make
if grep -q 'affected by 1 vulnerability' "$tmpf" && grep -q 'GO-2024-3218' "$tmpf"
```

It allowed exactly one known-unfixable finding through, and only while it was the only finding. So it fails on the *arrival of any new advisory* rather than on the arrival of an actionable one. It also parsed the human-readable output, which upstream does not treat as a stable interface.

## The new rule

| Reachable from our code | Fix published | Gate |
|---|---|---|
| yes | yes | **fail** — bump the module |
| yes | no | pass, reported loudly |
| no | any | pass (dependabot already sends these) |

`govulncheck` reports fix availability per finding, so this needs **no allowlist**. The existing `GO-2024-3218` acceptance in the Makefile goes away with it: that vulnerability has no fix, so the new rule reaches the same verdict without anyone writing it down, and there is no longer a list to go stale or a count to break.

## The trade, stated plainly

A serious vulnerability with no upstream fix now passes every day without forcing anyone to look at it. The gate prints those in their own section and, under Actions, emits them as workflow annotations, since nobody reads the log of a job that passed. Acting on them means dropping or replacing the dependency, which is a judgement call rather than something a build can make.

## Implementation

`hack/cmd/vulncheck-gate` consumes `govulncheck -format json`, the documented programmatic interface. Two details worth review:

- govulncheck exits 0 in JSON mode regardless of findings, so the gate owns the verdict. A non-zero exit means the scan itself failed and still fails the target.
- An empty or truncated stream decodes into zero findings and looks exactly like a clean run, which is the one failure mode that would silently disarm the gate. It refuses any input that does not carry govulncheck's `config` message.

Reachability is `finding.trace[0].function != ""`, which I verified reproduces govulncheck's own "your code is affected by N vulnerabilities" set exactly. An OSV blocks if *any* reachable finding for it carries a `fixed_version`, which is defensive against a vulnerability spanning two modules where only one is fixed.

## Testing

The failing path cannot be exercised by this repository's own scan, since nothing reachable currently has a fix, so it is covered by fixtures: reachable-unfixable, reachable-fixable, unreachable-fixable, the mixed two-module case, a clean scan, missing `config`, and malformed JSON.

Verified end to end:
- `make vulncheck` passes and reports the 8 reachable-unfixable findings
- injecting a `fixed_version` into a reachable finding makes the gate exit 1 and `make` fail with `Error 1`
- `make fmt`, `make lint`, `go test -race ./hack/cmd/vulncheck-gate/...` clean
- both `ci.yaml` and `inventory.yaml` call `make vulncheck`, so both are fixed

## Not in scope

`deploy/inventory/common/02-config.yaml.tmpl:12` defaults `POSTGRES_SSL_MODE` to `disable`, which is the on-path precondition five of those `lib/pq` advisories need. Filed separately; it is a security decision, not a CI one.