### PR TITLE
docs: treat code as the source of truth, docs and comments as leads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,25 @@ unbounded-kube is organized into several directories:
 
 - Add tests for new behavior. Cover success, failure, and edge cases.
 
+## Sources of Truth
+
+- Code is authoritative. Design docs (`designs/`), site docs (`docs/`), comments, commit messages, and PR or issue
+  text describe intent and drift from the code over time. Treat them as leads to verify, not as evidence.
+- Establish what the code does before reading what it is said to do: the implementation first, then its tests for the
+  contract as actually enforced, then the prose for intent. Read the prose too; do not skip it, and do not trust it.
+- Verify before asserting:
+    - Read a test's assertions before citing it as a constraint. A test named for a resource may assert a floor
+      ("must grant") rather than a ceiling ("must not grant").
+    - Read the enclosing block, not the matched line. A container in a pod spec may be an init container; a flag
+      default may be unreachable.
+    - Confirm a symbol is reachable before assuming it takes effect. An `-X` ldflag on a package the binary never
+      imports is silently ignored.
+- Cite `file:line` for any claim about behaviour that a decision rests on. If a claim cannot be cited, say it is an
+  inference.
+- When code and prose disagree, report both with citations rather than silently following either. The doc may be
+  stale, or the code may be the bug, and which it is changes the work. Ask when the answer would change what gets
+  built; offer to fix it when it is merely stale.
+
 ## Boundaries
 
 - **Ask first**
@@ -84,6 +103,7 @@ unbounded-kube is organized into several directories:
     - New dependencies with broad impact.
     - Destructive data or migration changes.
     - Removal of _test.go or Test* functions or subtests.
+    - Proceeding when a design doc or comment contradicts the code.
 - **Never**
     - Commit secrets, credentials, or tokens.
     - Edit generated files by hand when a generation workflow exists.


### PR DESCRIPTION
Adds a `## Sources of Truth` section to `AGENTS.md`, and one `Ask first` entry for acting on a divergence between the code and the prose describing it.

## Why

Agents working here have repeatedly asserted things about the code that came from prose rather than from the code, and been wrong. Four from a single session in the inventory subsystem, each of which reached a human as a confident statement:

| Claim | Reality |
|---|---|
| The read-only `batch` RBAC grant is "guarded by `internal/operator/rbac_test.go`" | `TestOperatorClusterRoleGrantsForeignWorkloadAudit` (`:183-207`) asserts a **floor**, that get/list/watch must be granted. Nothing forbids widening it. The test's semantics were inferred from its name rather than read. |
| "The inspector is not yet implemented" (`designs/inventory.md`) | `internal/inventory/inspector` is 641 lines with tests, running two conflict detectors. Acting on this would have deferred working functionality. |
| "The aggregator runs a `postgres:17` sidecar" | It is an **init container** creating the database on an external server. Different architecture, different consequences for what the operator must own. |
| Adding `STAMP_LDFLAGS` "so the binaries report a real version" | No inventory command imported `internal/version`, so the `-X` flags would have been silently ignored and every binary would have kept reporting `dev`. |

The prose here has measurably drifted. `designs/inventory.md` alone was wrong in four places, and a comment repeated across nine Containerfiles asserts a `make` fallback that cannot happen (#634): an `ARG` with an empty default still enters the `RUN` environment, and make's `?=` then leaves it empty.

## What it says

The ordering is code, then tests for the contract as actually enforced, then prose for intent. Prose is still to be **read** rather than skipped: in one of the four cases above the design doc was correct and had simply not been consulted. It is just not evidence.

The three sub-bullets are the specific traps hit, not general advice. A rule like "verify carefully" changes no behaviour, so none is included.

Two mechanisms do the real work. The `file:line` citation requirement is self-enforcing, because producing a citation means opening the file, and its absence is visible to a reviewer. The `Ask first` entry gates an action rather than describing an attitude: whether a doc is stale or the code is the bug changes what gets built, so it is not a call to make silently.

## Verification

Nothing in CI lints markdown, and `AGENTS.md` is referenced only once in the tree, as a citation in a comment (`internal/operator/override_examples_test.go:202`). No test reads its content, so I did not run the suite locally for a markdown-only change; CI covers it regardless.

Checked by hand: the file's only em-dash remains the one inside the rule naming the character (`AGENTS.md:73`), and the new lines stay within the file's ~120-column prose convention.

Independent of #633, which is where the four misreadings above are visible in the history.
