### PR TITLE
Update to Go 1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/unbounded
 
-go 1.26.6
+go 1.27.0
 
 tool (
 	golang.org/x/vuln/cmd/govulncheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/unbounded
 
-go 1.27.0
+go 1.26.6
 
 tool (
 	golang.org/x/vuln/cmd/govulncheck

--- a/images/acr-origin-proxy/Containerfile
+++ b/images/acr-origin-proxy/Containerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 WORKDIR /src
 

--- a/images/gantry/Containerfile
+++ b/images/gantry/Containerfile
@@ -4,7 +4,7 @@
 # Build stage
 # Pin the builder to BUILDPLATFORM so the Go toolchain runs natively on the
 # host even when targeting a foreign TARGETPLATFORM.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/images/inventory/aggregator/Containerfile
+++ b/images/inventory/aggregator/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/inventory/inspector/Containerfile
+++ b/images/inventory/inspector/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/inventory/viewer/Containerfile
+++ b/images/inventory/viewer/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/machina/Containerfile
+++ b/images/machina/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/machine-ops-controller/Containerfile
+++ b/images/machine-ops-controller/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/metalman/Containerfile
+++ b/images/metalman/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.

--- a/images/net/Containerfile
+++ b/images/net/Containerfile
@@ -15,7 +15,7 @@
 # when targeting a foreign TARGETPLATFORM. ntttcp is the only piece of C code
 # we still build; for cross-arch we use a Debian cross gcc.
 # =============================================================================
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 # Platform args. TARGETOS / TARGETARCH are populated automatically by
 # buildkit/buildah from --platform. BUILDARCH should be too, but podman

--- a/images/orca/Containerfile
+++ b/images/orca/Containerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Build stage
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/images/playpen/Containerfile
+++ b/images/playpen/Containerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/images/unbounded-storage-supervisor/Containerfile
+++ b/images/unbounded-storage-supervisor/Containerfile
@@ -6,7 +6,7 @@
 # host even when targeting a foreign TARGETPLATFORM. Without this, buildkit
 # would emulate the entire builder under QEMU when producing arm64 images on
 # an amd64 runner, which makes "go build" painfully slow.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-trixie AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.27.0-trixie AS builder
 
 # Install build dependencies. The base image already provides the Go
 # toolchain at /usr/local/go/bin, so we don't install the apt golang package.


### PR DESCRIPTION
Bump our builds and go.mod limit to require the new version of Go.