### PR TITLE
ci: run main's checks on release-* branches

### DIFF
--- a/.github/workflows/agent-e2e-kind.yaml
+++ b/.github/workflows/agent-e2e-kind.yaml
@@ -26,7 +26,10 @@ on:
       - go.sum
       - .github/workflows/agent-e2e-kind.yaml
   push:
-    branches: [main]
+    # release-* included so a cherry-pick onto a release branch gets the same
+    # post-merge validation as main. The pull_request trigger above is
+    # path-filtered with no branch filter, so it already covers release branches.
+    branches: [main, release-*]
     paths:
       - cmd/agent/**
       - cmd/kubectl-unbounded/**

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,14 @@ on:
   push:
     branches:
       - main
+      # Release branches cut supported releases, so they get the same checks as
+      # main. Every check this repository requires to merge comes from this
+      # workflow, so a release branch without it could not merge a cherry-pick.
+      - release-*
   pull_request:
     branches:
       - main
+      - release-*
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -7,9 +7,13 @@ on:
   push:
     branches:
       - main
+      # Release branches receive cherry-picked fixes, including security fixes,
+      # so they need code scanning as much as main does.
+      - release-*
   pull_request:
     branches:
       - main
+      - release-*
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/operator-e2e-kind.yaml
+++ b/.github/workflows/operator-e2e-kind.yaml
@@ -17,7 +17,10 @@ on:
       - go.sum
       - .github/workflows/operator-e2e-kind.yaml
   push:
-    branches: [main]
+    # release-* included so a cherry-pick onto a release branch gets the same
+    # post-merge validation as main. The pull_request trigger above is
+    # path-filtered with no branch filter, so it already covers release branches.
+    branches: [main, release-*]
     paths:
       - internal/operator/**
       - internal/net/controller/**

--- a/.github/workflows/playpen-e2e.yaml
+++ b/.github/workflows/playpen-e2e.yaml
@@ -17,8 +17,12 @@ on:
       - Makefile
       - .github/workflows/playpen-e2e.yaml
   push:
+    # release-* included so a cherry-pick onto a release branch gets the same
+    # post-merge validation as main. The pull_request trigger above is
+    # path-filtered with no branch filter, so it already covers release branches.
     branches:
       - main
+      - release-*
   schedule:
     - cron: "23 8 * * *"
   workflow_dispatch:

--- a/.github/workflows/smoke-metalman.yaml
+++ b/.github/workflows/smoke-metalman.yaml
@@ -19,7 +19,10 @@ on:
       - hack/smoke-metalman.py
       - .github/workflows/smoke-metalman.yaml
   push:
-    branches: [main]
+    # release-* included so a cherry-pick onto a release branch gets the same
+    # post-merge validation as main. The pull_request trigger above is
+    # path-filtered with no branch filter, so it already covers release branches.
+    branches: [main, release-*]
     paths:
       - cmd/agent/**
       - cmd/metalman/**

--- a/.github/workflows/smoke-storage.yaml
+++ b/.github/workflows/smoke-storage.yaml
@@ -12,7 +12,10 @@ on:
       - Makefile
       - .github/workflows/smoke-storage.yaml
   push:
-    branches: [main]
+    # release-* included so a cherry-pick onto a release branch gets the same
+    # post-merge validation as main. The pull_request trigger above is
+    # path-filtered with no branch filter, so it already covers release branches.
+    branches: [main, release-*]
     paths:
       - cmd/unbounded-storage/**
       - hack/smoke-storage.py

--- a/.github/workflows/unbounded-storage.yaml
+++ b/.github/workflows/unbounded-storage.yaml
@@ -10,7 +10,10 @@ on:
       - Makefile
       - .github/workflows/unbounded-storage.yaml
   push:
-    branches: [main]
+    # release-* included so a cherry-pick onto a release branch gets the same
+    # post-merge validation as main. The pull_request trigger above is
+    # path-filtered with no branch filter, so it already covers release branches.
+    branches: [main, release-*]
     paths:
       - cmd/unbounded-storage/**
       - Makefile


### PR DESCRIPTION
First piece of #627. Release branches do not exist yet; this makes them safe to create.

## Why this has to come first

When `release-X.Y` branches arrive they will carry cherry-picked fixes to shipped versions, including security fixes. Today nothing would test them: `ci.yaml` and `codeql.yaml` trigger on `push` and `pull_request` to `main` only.

That is worse than it first looks. Every status check this repository requires to merge comes from `ci.yaml` — Build, Build Frontend, Build Images (amd64), Build Images (arm64), Lint, Test, Verify Generated Files, Vulnerability Check, per ruleset `14882559`. A release branch protected by a ruleset requiring those checks, on a branch where `ci.yaml` never runs, could never merge anything at all. So the triggers must land before the branch protection does.

## What changed

| Workflow | Change |
|---|---|
| `ci.yaml`, `codeql.yaml` | `release-*` added to both `push` and `pull_request` |
| `agent-e2e-kind`, `operator-e2e-kind`, `smoke-metalman`, `smoke-storage`, `unbounded-storage`, `playpen-e2e` | `release-*` added to `push` only |

The six are a different shape and worth understanding before reviewing: their `pull_request` trigger carries `paths` but **no** `branches` filter, so it already fires on a pull request targeting any branch, release branches included. Only the `push` side, which is post-merge validation, was pinned to `main`. Verified by parsing each file:

```
agent-e2e-kind       push=['main', 'release-*'] pull_request=None
operator-e2e-kind    push=['main', 'release-*'] pull_request=None
...
```

## Excluded deliberately

- **`docs.yaml`** deploys the `github-pages` environment, and its concurrency group is `pages` rather than ref-scoped, so a release branch could republish the public site from an older tree.
- **`nightly.yaml`** and **`storage-nightly.yaml`** are scheduled; **`release-upgrade.yaml`** deploys `unbounded-stable`. Deployment workflows stay on `main`, per the agreed rule of "everything `main` runs except nightly and stable deployment".
- **`release.yaml`** and **`images.yaml`** trigger on tag pushes, so a tag cut from a release branch already reaches them with no change.

## Verification

- All eight files parse, and `release-*` is read as a string rather than a YAML alias — worth checking, since a leading `*` would have been one.
- Concurrency groups are ref-scoped wherever they exist (`ci-${{ github.ref }}`, `codeql-${{ github.ref }}`, and three others), so a release-branch run cannot cancel `main`'s. Three of the six have no concurrency group at all, so there is no cross-branch cancellation risk either way.
- `internal/operator/imagecoverage_test.go` is the only test that parses workflow files; it reads image matrices, which are untouched. Its three cases still pass.

## Note for the reviewer

This has no effect until a `release-*` branch exists. The follow-up admin action is a `release-*` ruleset mirroring `14882559` — `deletion`, `non_fast_forward`, `pull_request`, `required_status_checks`, `code_scanning` — which must land **after** this and must **not** include a `creation` rule, or the branch-creation workflow could not create a branch without a bypass.
