### PR TITLE
release: release branches, and the versioning rule that makes them possible

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -1,0 +1,152 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: create release branch
+
+# ---------------------------------------------------------------------------
+# Creates a release-X.Y maintenance branch, from which patches to an already
+# shipped series are cut.
+#
+# Branches are created lazily, on demand, the first time an older series needs a
+# fix. Creating one at every release would produce dozens a year at this
+# project's cadence and would destroy the branch list's usefulness as the answer
+# to which series are actually still maintained - which is the question
+# SECURITY.md raises when it says fixes reach branches that are still being
+# maintained.
+#
+# The branch point is derived, not supplied. Under the versioning rule in
+# RELEASING.md, main cuts only vX.Y.0, so a series normally holds exactly one
+# release when its branch is created; where a series has several, the newest is
+# the only one that can be patched forward from, because branching at an older
+# one computes a version that already exists.
+#
+# A workflow rather than a documented `git branch`, so the act is validated and
+# recorded. It is not gated on an environment: creating a branch is less
+# consequential than pushing a tag, which release-prepare.yaml already does
+# ungated.
+# ---------------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      series:
+        description: "Series to open a maintenance branch for, as X.Y (e.g. 0.3). The branch point is the newest release in that series."
+        required: true
+        type: string
+      dry_run:
+        description: "Resolve and report the branch point without creating anything"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+# Serialize, so two dispatches cannot race to create the same branch.
+concurrency:
+  group: create-release-branch
+  cancel-in-progress: false
+
+jobs:
+  create:
+    if: github.repository == 'Azure/unbounded'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Resolve the branch point
+        id: resolve
+        # The series arrives as an env var rather than being interpolated into
+        # the script: a `${{ }}` inlined in a run block is expanded before bash
+        # parses it, so a shell metacharacter in a free-form string input would
+        # become script syntax.
+        env:
+          SERIES: ${{ inputs.series }}
+        run: |
+          set -euo pipefail
+
+          # Anchored, and no leading zeros, matching next-version.sh's
+          # SEMVER_COMPONENT. A series like 01.2 could never match a tag, since
+          # v01.2.3 is not a version.
+          if [[ ! "$SERIES" =~ ^(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})$ ]]; then
+            echo "::error::series must be X.Y with no leading zeros, got: ${SERIES}"
+            exit 1
+          fi
+
+          BRANCH="release-${SERIES}"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::error::${BRANCH} already exists; nothing to do. To move it, delete it deliberately first."
+            exit 1
+          fi
+
+          # Finals only, and the highest of them. A candidate is not something a
+          # maintenance release can be patched forward from, and an older final
+          # would compute a version that has already shipped.
+          TAG="$(git tag --list "v${SERIES}.*" \
+            | grep -E "^v${SERIES}\.(0|[1-9][0-9]{0,8})\$" \
+            | sort -V \
+            | tail -n1 || true)"
+
+          if [[ -z "$TAG" ]]; then
+            echo "::error::series ${SERIES} has no released version; there is nothing to branch from"
+            exit 1
+          fi
+
+          COMMIT="$(git rev-parse "${TAG}^{commit}")"
+
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${BRANCH} at ${TAG} (${COMMIT})"
+
+      - name: Create the branch
+        # Compared explicitly, not by truthiness: `gh workflow run -f
+        # dry_run=false` submits a string, and a non-empty string is truthy, so
+        # `!inputs.dry_run` would skip creation on an ordinary run.
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
+        env:
+          BRANCH: ${{ steps.resolve.outputs.branch }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          COMMIT: ${{ steps.resolve.outputs.commit }}
+        run: |
+          set -euo pipefail
+
+          # GITHUB_TOKEN is sufficient here. release-prepare.yaml needs an SSH
+          # deploy key because GitHub suppresses workflow triggers for TAGS
+          # pushed with the default token; no trigger is wanted for this branch,
+          # and the commit it points at has already been through CI on main.
+          git push origin "${COMMIT}:refs/heads/${BRANCH}"
+
+          echo "Created ${BRANCH} at ${TAG} (${COMMIT})"
+          {
+            echo "### Created \`${BRANCH}\`"
+            echo ""
+            echo "- Branch point: \`${TAG}\` (\`${COMMIT}\`)"
+            echo ""
+            echo "Cherry-pick fixes onto it through a pull request, then cut a patch:"
+            echo ""
+            echo '```sh'
+            echo "gh workflow run release-prepare.yaml --repo ${GITHUB_REPOSITORY} \\"
+            echo "  -f mode=release -f branch=${BRANCH}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report dry run
+        if: ${{ inputs.dry_run == true || inputs.dry_run == 'true' }}
+        env:
+          BRANCH: ${{ steps.resolve.outputs.branch }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          COMMIT: ${{ steps.resolve.outputs.commit }}
+        run: |
+          set -euo pipefail
+
+          echo "Dry run: would have created ${BRANCH} at ${TAG} (${COMMIT}). Nothing was created."
+          {
+            echo "### Dry run: would create \`${BRANCH}\`"
+            echo ""
+            echo "- Branch point: \`${TAG}\` (\`${COMMIT}\`)"
+            echo ""
+            echo "No branch was created. Re-run with dry_run unchecked to create it."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -76,7 +76,17 @@ jobs:
 
           BRANCH="release-${SERIES}"
 
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+          # The dots are literal in the glob below but are any-char in the ERE,
+          # so escape them for the grep. Not reachable given the validation
+          # above, but the neighbouring patterns are exact and this one should
+          # be too.
+          SERIES_ESCAPED="${SERIES//./\\.}"
+
+          # Fully qualified. `git ls-remote --heads origin release-0.3` also
+          # matches refs/heads/anything/release-0.3, so a branch nested under a
+          # prefix would make this refuse to create a branch that does not
+          # exist, with an error the operator cannot act on.
+          if git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
             echo "::error::${BRANCH} already exists; nothing to do. To move it, delete it deliberately first."
             exit 1
           fi
@@ -85,7 +95,7 @@ jobs:
           # maintenance release can be patched forward from, and an older final
           # would compute a version that has already shipped.
           TAG="$(git tag --list "v${SERIES}.*" \
-            | grep -E "^v${SERIES}\.(0|[1-9][0-9]{0,8})\$" \
+            | grep -E "^v${SERIES_ESCAPED}\.(0|[1-9][0-9]{0,8})\$" \
             | sort -V \
             | tail -n1 || true)"
 
@@ -96,10 +106,26 @@ jobs:
 
           COMMIT="$(git rev-parse "${TAG}^{commit}")"
 
+          # Whether the branch point predates release-* CI coverage. Workflow
+          # trigger lists live in the branch's OWN copy of .github/workflows/,
+          # so a branch cut from a tag without them runs no CI at all: a pull
+          # request targeting it matches nothing and silently reports zero
+          # checks. The operator holding this workflow is exactly the person who
+          # needs to know, so say it here rather than only in RELEASING.md.
+          CI_OK=true
+          if ! git show "${TAG}:.github/workflows/ci.yaml" 2>/dev/null | grep -q 'release-\*'; then
+            CI_OK=false
+          fi
+
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "ci_ok=${CI_OK}" >> "$GITHUB_OUTPUT"
           echo "Resolved ${BRANCH} at ${TAG} (${COMMIT})"
+
+          if [[ "$CI_OK" != "true" ]]; then
+            echo "::warning::${TAG} predates release-* CI triggers; nothing will run on ${BRANCH} until ci.yaml is updated on it."
+          fi
 
       - name: Create the branch
         # Compared explicitly, not by truthiness: `gh workflow run -f
@@ -110,6 +136,7 @@ jobs:
           BRANCH: ${{ steps.resolve.outputs.branch }}
           TAG: ${{ steps.resolve.outputs.tag }}
           COMMIT: ${{ steps.resolve.outputs.commit }}
+          CI_OK: ${{ steps.resolve.outputs.ci_ok }}
         run: |
           set -euo pipefail
 
@@ -125,6 +152,15 @@ jobs:
             echo ""
             echo "- Branch point: \`${TAG}\` (\`${COMMIT}\`)"
             echo ""
+            if [[ "${CI_OK}" != "true" ]]; then
+              echo "> **This branch has no CI.** \`${TAG}\` predates the \`release-*\` triggers, and"
+              echo "> workflow trigger lists come from the branch's own copy of \`.github/workflows/\`."
+              echo "> A pull request targeting it will report **zero checks**."
+              echo ">"
+              echo "> Add \`release-*\` to \`ci.yaml\`'s \`push\` and \`pull_request\` branch filters as"
+              echo "> this branch's first commit."
+              echo ""
+            fi
             echo "Cherry-pick fixes onto it through a pull request, then cut a patch:"
             echo ""
             echo '```sh'

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -117,23 +117,6 @@ jobs:
           # tag push triggers release.yaml.
           ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}
 
-      - name: Take the release tooling from the default branch
-        # The branch supplies the history the version is computed against; main
-        # supplies the scripts that compute it. Without this, a release-0.3
-        # branch would resolve versions with whatever tooling existed when it
-        # was cut, and would execute scripts from a branch that is protected
-        # less strictly than main.
-        #
-        # Only hack/release/ is replaced. The tags, and therefore what
-        # `git tag --merged HEAD` sees, still come from the checked-out branch,
-        # which is what scopes resolution to that series.
-        run: |
-          set -euo pipefail
-
-          git fetch --no-tags origin main
-          git checkout FETCH_HEAD -- hack/release/
-          echo "Release tooling taken from origin/main at $(git rev-parse --short FETCH_HEAD)"
-
       - name: Preflight deploy key
         # Fail fast before any tag is created if the deploy key is missing or
         # cannot authenticate, so we never leave a pushed tag without a build.
@@ -153,6 +136,29 @@ jobs:
           fi
 
           echo "Deploy key authenticates to origin."
+
+      - name: Take the release tooling from the default branch
+        # The branch supplies the history the version is computed against; main
+        # supplies the scripts that compute it. Without this, a release-0.3
+        # branch would resolve versions with whatever tooling existed when it
+        # was cut, and would execute scripts from a branch that is protected
+        # less strictly than main.
+        #
+        # Only hack/release/ is touched, and it is overlaid rather than
+        # replaced: a file present on the branch but absent from main survives.
+        # That is harmless here, since the only scripts run are
+        # bump-for-branch.sh and next-version.sh and both come from main, but it
+        # is worth knowing before adding a third.
+        #
+        # The tags, and therefore what `git tag --merged HEAD` sees, still come
+        # from the checked-out branch, which is what scopes resolution to that
+        # series.
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin main
+          git checkout FETCH_HEAD -- hack/release/
+          echo "Release tooling taken from origin/main at $(git rev-parse --short FETCH_HEAD)"
 
       - name: Resolve bump and series from the branch
         # main cuts minors, release-X.Y cuts patches, and nothing else may

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -26,9 +26,16 @@ name: unbounded release prepare
 # that went backwards, and `promote` guessing at the highest prerelease in the
 # repository - which is what orphaned v0.1.24.
 #
-# NOTE: the script comes from the checkout below, pinned to the default branch,
-# so changes to it take effect only once merged. They cannot be rehearsed by
-# dispatching this workflow from a branch, `dry_run` included.
+# What a branch is allowed to release is decided by hack/release/bump-for-branch.sh:
+# main cuts minors (or a major when explicitly asked), a release-X.Y branch cuts
+# patches. There is no `bump` input, because the answer is fully determined by
+# where you are cutting from. See RELEASING.md.
+#
+# NOTE: the release tooling comes from the default branch, not from the branch
+# being released. That is deliberate for release branches: the branch supplies
+# the history the version is computed against, main supplies the scripts that
+# compute it. An old branch would otherwise cut releases with old tooling, and
+# would be running scripts from a branch with weaker protection.
 # ---------------------------------------------------------------------------
 
 on:
@@ -43,15 +50,15 @@ on:
           - prerelease
           - promote
         default: release
-      bump:
-        description: "Bump level. Only used to START a train or cut a final; ignored while continuing a live train."
+      branch:
+        description: "Branch to cut from: main, or a release-X.Y maintenance branch."
         required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-        default: patch
+        type: string
+        default: main
+      major:
+        description: "main only: cut a major (vX.0.0) instead of a minor. Majors are never derived."
+        type: boolean
+        default: false
       pre:
         description: "Prerelease suffix (e.g. rc.3). Blank takes the next rc automatically, which is almost always what you want."
         required: false
@@ -85,15 +92,47 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      # Always cut releases from the default branch, regardless of which ref
-      # the manual dispatch selected.
+      - name: Validate branch
+        # Checked before the checkout, so an unexpected ref never reaches it.
+        # Restricted to main and release-X.Y rather than accepting any ref:
+        # `ref: main` used to be a hard guarantee that a release came from
+        # reviewed code on a protected branch, and an unrestricted input would
+        # give that up. A tag cut from a feature branch still signs correctly
+        # and passes every downstream check, so nothing else would catch it.
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$BRANCH" =~ ^(main|release-(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8}))$ ]]; then
+            echo "::error::branch must be main or release-X.Y, got: ${BRANCH}"
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
           # Wires git to push over SSH with the deploy key so the resulting
           # tag push triggers release.yaml.
           ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}
+
+      - name: Take the release tooling from the default branch
+        # The branch supplies the history the version is computed against; main
+        # supplies the scripts that compute it. Without this, a release-0.3
+        # branch would resolve versions with whatever tooling existed when it
+        # was cut, and would execute scripts from a branch that is protected
+        # less strictly than main.
+        #
+        # Only hack/release/ is replaced. The tags, and therefore what
+        # `git tag --merged HEAD` sees, still come from the checked-out branch,
+        # which is what scopes resolution to that series.
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin main
+          git checkout FETCH_HEAD -- hack/release/
+          echo "Release tooling taken from origin/main at $(git rev-parse --short FETCH_HEAD)"
 
       - name: Preflight deploy key
         # Fail fast before any tag is created if the deploy key is missing or
@@ -115,6 +154,19 @@ jobs:
 
           echo "Deploy key authenticates to origin."
 
+      - name: Resolve bump and series from the branch
+        # main cuts minors, release-X.Y cuts patches, and nothing else may
+        # release at all. SERIES is empty on main and X.Y on a release branch,
+        # where it guards the computed tag against escaping the series.
+        id: bump
+        env:
+          MAJOR: ${{ inputs.major }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+
+          hack/release/bump-for-branch.sh "$BRANCH" >> "$GITHUB_OUTPUT"
+
       - name: Compute tag
         # Inputs arrive as env vars, not interpolated into the script: `pre`
         # and `version` are free-form, and a `${{ }}` inlined in a run block is
@@ -126,7 +178,8 @@ jobs:
         id: compute
         env:
           MODE: ${{ inputs.mode }}
-          BUMP: ${{ inputs.bump }}
+          BUMP: ${{ steps.bump.outputs.bump }}
+          SERIES: ${{ steps.bump.outputs.series }}
           PRE: ${{ inputs.pre }}
           VERSION: ${{ inputs.version }}
           ALLOW_CONCURRENT_TRAINS: ${{ inputs.allow_concurrent_trains }}
@@ -150,6 +203,8 @@ jobs:
           TAG: ${{ steps.compute.outputs.tag }}
           BASE: ${{ steps.compute.outputs.base }}
           MODE: ${{ inputs.mode }}
+          BRANCH: ${{ inputs.branch }}
+          BUMP: ${{ steps.bump.outputs.bump }}
         run: |
           set -euo pipefail
 
@@ -161,14 +216,22 @@ jobs:
           git tag "$TAG" "$BASE"
           git push origin "$TAG"
 
-          echo "Pushed ${TAG} at ${BASE} (mode=${MODE}); release.yaml will build and sign it in tag context."
-          echo "### Prepared release ${TAG}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pushed ${TAG} at ${BASE} (mode=${MODE}, branch=${BRANCH}, bump=${BUMP}); release.yaml will build and sign it in tag context."
+          {
+            echo "### Prepared release ${TAG}"
+            echo ""
+            echo "- Branch: \`${BRANCH}\`"
+            echo "- Bump: \`${BUMP}\`"
+            echo "- Commit: \`${BASE}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report dry run
         if: ${{ inputs.dry_run == true || inputs.dry_run == 'true' }}
         env:
           TAG: ${{ steps.compute.outputs.tag }}
           BASE: ${{ steps.compute.outputs.base }}
+          BRANCH: ${{ inputs.branch }}
+          BUMP: ${{ steps.bump.outputs.bump }}
         run: |
           set -euo pipefail
 
@@ -176,6 +239,8 @@ jobs:
           {
             echo "### Dry run: would prepare ${TAG}"
             echo
+            echo "- Branch: \`${BRANCH}\`"
+            echo "- Bump: \`${BUMP}\`"
             echo "- Commit: \`${BASE}\`"
             echo "- Commits on HEAD not included: $(git rev-list --count "${BASE}..HEAD")"
             echo

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -127,7 +127,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
-      maintenance: ${{ steps.maintenance.outputs.maintenance }}
+      from_main: ${{ steps.classify.outputs.from_main }}
+      latest: ${{ steps.classify.outputs.latest }}
     steps:
       - name: Resolve tag
         id: resolve
@@ -176,45 +177,51 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Classify the release
-        id: maintenance
-        # A maintenance release is one that is not the newest: a patch cut from
-        # a release-X.Y branch after a later series has shipped. Deploying it to
-        # unbounded-stable would DOWNGRADE that cluster, so the soak is skipped
-        # and the release stays a draft, publishable only through the recorded
-        # force_publish path.
+        id: classify
+        # Two answers, and they are not the same question.
         #
-        # The comparison is a Go program rather than `sort -V`, which does not
-        # implement semver precedence: it ranks v1.0.0 BELOW v1.0.0-rc.1, the
-        # opposite of clause 11.3. This job routinely sees candidate tags, and
-        # RELEASING.md documents dispatching it by hand for backfills, so
-        # v1.7.0-rc.1 arriving after v1.7.0 shipped is a real case. Under
-        # sort -V that candidate would outrank its own final and be redeployed.
+        #   from_main  whether this soaks. unbounded-stable soaks main and only
+        #              main; a release cut from a release-X.Y branch has its own
+        #              soak story and must not replace what main last deployed.
+        #              Deliberately provenance, not ordering: the cluster can be
+        #              running a candidate newer than the newest final, so an
+        #              ordering test says deploy when the honest answer is that
+        #              this release does not belong on that cluster at all.
+        #
+        #   latest     whether the GitHub release is marked Latest, which is
+        #              what releases/latest/download resolves to and therefore
+        #              the install command in README.md and every guide. GitHub
+        #              defaults make_latest to true on any newly published
+        #              release, so this is passed explicitly on both publish
+        #              paths below.
+        #
+        # The logic lives in a tested script rather than here, because it is the
+        # thing deciding whether a cluster is touched and YAML cannot be tested
+        # without cutting a release.
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
 
-          maintenance="$(git tag --list 'v*' | go run ./hack/cmd/semver is-maintenance "$TAG")"
+          hack/release/classify-release.sh "$TAG" >> "$GITHUB_OUTPUT"
 
-          echo "maintenance=${maintenance}" >> "$GITHUB_OUTPUT"
+      - name: Report a release-branch release
+        if: steps.classify.outputs.from_main != 'true'
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+          LATEST: ${{ steps.classify.outputs.latest }}
+        run: |
+          set -euo pipefail
 
-          if [[ "$maintenance" == "true" ]]; then
-            echo "::notice::${TAG} is a maintenance release; skipping deploy, Orca and smoke. It will stay a draft."
-            {
-              echo "### ${TAG} is a maintenance release"
-              echo ""
-              echo "It is not the newest release, so deploying it to \`unbounded-stable\` would downgrade that cluster."
-              echo "Deploy, Orca and smoke were skipped and the release remains a **draft**."
-              echo ""
-              echo "Publish it deliberately with the recorded override:"
-              echo ""
-              echo '```sh'
-              echo "gh workflow run release-upgrade.yaml --repo ${GITHUB_REPOSITORY} \\"
-              echo "  -f tag=${TAG} -f force_publish=true \\"
-              echo "  -f reason=\"maintenance release for an older series\""
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "::notice::${TAG} was cut from a release branch; skipping deploy, Orca and smoke. It will publish without a soak."
+          {
+            echo "### ${TAG} was cut from a release branch"
+            echo ""
+            echo "\`unbounded-stable\` soaks \`main\` only, so deploy, Orca and smoke were skipped."
+            echo "The release is published anyway; maintenance branches will get their own soak clusters."
+            echo ""
+            echo "- Marked Latest: \`${LATEST}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
   # Deploy the release to the target cluster.
@@ -229,9 +236,9 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy:
     needs: resolve
-    # Skipped for a maintenance release: it is not the newest, so deploying
-    # it here would downgrade unbounded-stable. See resolve's classify step.
-    if: github.repository == 'Azure/unbounded' && needs.resolve.outputs.maintenance != 'true'
+    # unbounded-stable soaks main only. A release cut from a release branch
+    # skips deploy, Orca and smoke entirely; see resolve's classify step.
+    if: github.repository == 'Azure/unbounded' && needs.resolve.outputs.from_main == 'true'
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -602,7 +609,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-orca:
     needs: [resolve, deploy]
-    if: github.repository == 'Azure/unbounded' && needs.resolve.outputs.maintenance != 'true'
+    if: github.repository == 'Azure/unbounded' && needs.resolve.outputs.from_main == 'true'
     runs-on: ubuntu-latest
     environment: unbounded-stable
     env:
@@ -712,7 +719,7 @@ jobs:
   # ---------------------------------------------------------------------------
   smoke-discover:
     needs: [resolve, deploy]
-    if: needs.resolve.outputs.maintenance != 'true'
+    if: needs.resolve.outputs.from_main == 'true'
     runs-on: ubuntu-latest
     outputs:
       tasks: ${{ steps.list.outputs.tasks }}
@@ -777,7 +784,7 @@ jobs:
   # ---------------------------------------------------------------------------
   smoke-tests:
     needs: [resolve, deploy, deploy-orca, smoke-discover]
-    if: needs.resolve.outputs.maintenance != 'true'
+    if: needs.resolve.outputs.from_main == 'true'
     runs-on: ubuntu-latest
     environment: unbounded-stable
     strategy:
@@ -861,27 +868,109 @@ jobs:
     # would fall through to here and publish without recording the bypass.
     # On workflow_run there are no inputs at all, so both comparisons are
     # against '' and the automatic path can never be forced.
+    # !cancelled() is REQUIRED, not stylistic: a job whose needs are skipped is
+    # itself skipped without its `if` ever being evaluated, unless the condition
+    # carries a status function. A release-branch release skips all four gates,
+    # so without this the release would never publish at all.
+    #
+    # Two ways in, and no third:
+    #
+    #   every gate succeeded   the ordinary soaked release
+    #   every gate skipped     cut from a release branch; unbounded-stable soaks
+    #                          main only, so there was nothing to run
+    #
+    # A FAILED gate matches neither and publishes nothing, which is the property
+    # worth protecting. `skipped` is compared explicitly rather than testing for
+    # "not success", which would let a failure through.
     if: >
+      !cancelled() &&
       github.repository == 'Azure/unbounded' &&
       inputs.force_publish != true &&
       inputs.force_publish != 'true' &&
-      needs.deploy.result == 'success' &&
-      needs.deploy-orca.result == 'success' &&
-      needs.smoke-discover.result == 'success' &&
-      needs.smoke-tests.result == 'success'
+      (
+        (needs.deploy.result == 'success' &&
+         needs.deploy-orca.result == 'success' &&
+         needs.smoke-discover.result == 'success' &&
+         needs.smoke-tests.result == 'success') ||
+        (needs.resolve.outputs.from_main != 'true' &&
+         needs.deploy.result == 'skipped' &&
+         needs.deploy-orca.result == 'skipped' &&
+         needs.smoke-discover.result == 'skipped' &&
+         needs.smoke-tests.result == 'skipped')
+      )
     permissions:
       contents: write
     runs-on: ubuntu-latest
     env:
       TAG: ${{ needs.resolve.outputs.tag }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LATEST: ${{ needs.resolve.outputs.latest }}
+      SOAKED: ${{ needs.deploy.result == 'success' }}
     steps:
+      # Verification normally happens in the deploy job. A release cut from a
+      # release branch skips that job, so it happens here instead. Skipping the
+      # SOAK is a deliberate decision; skipping VERIFICATION is not, and would
+      # publish artifacts whose signatures and BOM nobody ever checked. Same
+      # script as the other two paths, so none of them can drift apart.
+      #
+      # Mirrors deploy: the primary checkout is the deployed tag, and the
+      # tooling comes from the workflow's own commit, because older tags do not
+      # contain it.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.deploy.result != 'success' }}
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Fetch verification tooling from the workflow's own commit
+        if: ${{ needs.deploy.result != 'success' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: _verify-tools
+          sparse-checkout: hack/release
+          sparse-checkout-cone-mode: true
+
+      - name: Install cosign
+        if: ${{ needs.deploy.result != 'success' }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Download and verify artifacts
+        if: ${{ needs.deploy.result != 'success' }}
+        env:
+          RELEASE_ASSETS_FILE: dist/release-assets.txt
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir dist
+
+          # What the release actually carries, so the verifier can compare it
+          # against what the BOM says it should.
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets -q '.assets[].name' > "$RELEASE_ASSETS_FILE"
+
+          # HEAD is the tag's commit, which is what the BOM must record.
+          _verify-tools/hack/release/verify-release-artifacts.sh \
+            "$TAG" "$(git rev-parse HEAD)" dist
+
       - name: Publish release
         run: |
           set -euo pipefail
-          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false
-          echo "Published ${TAG}."
-          echo "### Published ${TAG}" >> "$GITHUB_STEP_SUMMARY"
+
+          # --latest is passed explicitly on every publish. GitHub defaults
+          # make_latest to true for a newly published release, so a patch from
+          # an older series would otherwise repoint releases/latest/download -
+          # the install command in README.md and every guide - at itself.
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --draft=false --latest="$LATEST"
+
+          echo "Published ${TAG} (latest=${LATEST}, soaked=${SOAKED})."
+          {
+            echo "### Published ${TAG}"
+            echo ""
+            echo "- Marked Latest: \`${LATEST}\`"
+            echo "- Soaked on unbounded-stable: \`${SOAKED}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
   # BREAK GLASS: publish without a green soak. Documented in RELEASING.md.
@@ -920,6 +1009,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REASON: ${{ inputs.reason }}
       ACTOR: ${{ github.actor }}
+      LATEST: ${{ needs.resolve.outputs.latest }}
       DEPLOY_RESULT: ${{ needs.deploy.result }}
       ORCA_RESULT: ${{ needs.deploy-orca.result }}
       # Both smoke jobs, because a failed discovery skips the matrix: without
@@ -1015,8 +1105,12 @@ jobs:
             *) exit "$rc" ;;
           esac
 
+          # --latest for the same reason as the ordinary path: GitHub defaults
+          # make_latest to true on a newly published release, so forcing out a
+          # patch from an older series would repoint releases/latest/download
+          # at it.
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
-            --notes-file "$updated" --draft=false
+            --notes-file "$updated" --draft=false --latest="$LATEST"
 
           echo "::warning::${TAG} was published through the break-glass path by ${ACTOR}: ${REASON}"
 

--- a/.github/workflows/release-upgrade.yaml
+++ b/.github/workflows/release-upgrade.yaml
@@ -127,6 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
+      maintenance: ${{ steps.maintenance.outputs.maintenance }}
     steps:
       - name: Resolve tag
         id: resolve
@@ -160,6 +161,61 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Resolved deploy tag: ${TAG}"
 
+      # The default branch, deliberately, and never the incoming tag: this job
+      # runs in the privileged workflow_run context, so checking out a ref
+      # derived from the upstream event would execute that ref's code with this
+      # workflow's token. Tags are needed to know what the newest release is.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Classify the release
+        id: maintenance
+        # A maintenance release is one that is not the newest: a patch cut from
+        # a release-X.Y branch after a later series has shipped. Deploying it to
+        # unbounded-stable would DOWNGRADE that cluster, so the soak is skipped
+        # and the release stays a draft, publishable only through the recorded
+        # force_publish path.
+        #
+        # The comparison is a Go program rather than `sort -V`, which does not
+        # implement semver precedence: it ranks v1.0.0 BELOW v1.0.0-rc.1, the
+        # opposite of clause 11.3. This job routinely sees candidate tags, and
+        # RELEASING.md documents dispatching it by hand for backfills, so
+        # v1.7.0-rc.1 arriving after v1.7.0 shipped is a real case. Under
+        # sort -V that candidate would outrank its own final and be redeployed.
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          maintenance="$(git tag --list 'v*' | go run ./hack/cmd/semver is-maintenance "$TAG")"
+
+          echo "maintenance=${maintenance}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$maintenance" == "true" ]]; then
+            echo "::notice::${TAG} is a maintenance release; skipping deploy, Orca and smoke. It will stay a draft."
+            {
+              echo "### ${TAG} is a maintenance release"
+              echo ""
+              echo "It is not the newest release, so deploying it to \`unbounded-stable\` would downgrade that cluster."
+              echo "Deploy, Orca and smoke were skipped and the release remains a **draft**."
+              echo ""
+              echo "Publish it deliberately with the recorded override:"
+              echo ""
+              echo '```sh'
+              echo "gh workflow run release-upgrade.yaml --repo ${GITHUB_REPOSITORY} \\"
+              echo "  -f tag=${TAG} -f force_publish=true \\"
+              echo "  -f reason=\"maintenance release for an older series\""
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   # ---------------------------------------------------------------------------
   # Deploy the release to the target cluster.
   #
@@ -173,7 +229,9 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy:
     needs: resolve
-    if: github.repository == 'Azure/unbounded'
+    # Skipped for a maintenance release: it is not the newest, so deploying
+    # it here would downgrade unbounded-stable. See resolve's classify step.
+    if: github.repository == 'Azure/unbounded' && needs.resolve.outputs.maintenance != 'true'
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -544,7 +602,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-orca:
     needs: [resolve, deploy]
-    if: github.repository == 'Azure/unbounded'
+    if: github.repository == 'Azure/unbounded' && needs.resolve.outputs.maintenance != 'true'
     runs-on: ubuntu-latest
     environment: unbounded-stable
     env:
@@ -654,6 +712,7 @@ jobs:
   # ---------------------------------------------------------------------------
   smoke-discover:
     needs: [resolve, deploy]
+    if: needs.resolve.outputs.maintenance != 'true'
     runs-on: ubuntu-latest
     outputs:
       tasks: ${{ steps.list.outputs.tasks }}
@@ -718,6 +777,7 @@ jobs:
   # ---------------------------------------------------------------------------
   smoke-tests:
     needs: [resolve, deploy, deploy-orca, smoke-discover]
+    if: needs.resolve.outputs.maintenance != 'true'
     runs-on: ubuntu-latest
     environment: unbounded-stable
     strategy:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,9 @@ How to cut, soak, and publish a release, and what to do when one of those goes
 wrong. Maintainer-facing; for using a release, see the
 [documentation site](https://unbounded-cloud.io/).
 
-Releases are cut from `main` only. There are no maintenance branches today (see
-[Maintenance lines](#maintenance-lines)).
+Releases come from two places. `main` cuts minors and majors (`vX.Y.0`); a
+`release-X.Y` branch cuts patches (`vX.Y.Z`) against a series that has already
+shipped. See [The tag and branch model](#the-tag-and-branch-model).
 
 ## At a glance
 
@@ -33,14 +34,12 @@ GitHub suppresses workflow triggers for tags pushed with the default token.
 One dispatch, then waiting. Nothing between the tag and the published release
 needs a human.
 
-### Patch release
+### From `main`
 
-The common case: fixes and incremental work with no behaviour change for
-existing users.
+The common case. Everything merged since the last release, cut as a minor.
 
 ```sh
-# 1. Is main releasable? The nightly deploys it to a real cluster, so this is
-#    the strongest signal available. It should be green, and green recently.
+# 1. Is main releasable? See "Is main releasable?" below for what to check.
 gh run list --repo Azure/unbounded --workflow nightly.yaml --limit 5
 
 # 2. What would ship? Everything on main since the last final tag.
@@ -51,11 +50,10 @@ git log --oneline \
 # 3. Confirm the version without cutting anything. The run log prints the tag
 #    it would create and the commit it would tag.
 gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=release -f bump=patch -f dry_run=true
+  -f mode=release -f dry_run=true
 
 # 4. Cut it. Same command, without dry_run.
-gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=release -f bump=patch
+gh workflow run release-prepare.yaml --repo Azure/unbounded -f mode=release
 
 # 5. Watch it through. The tag push starts the build, which drafts the release;
 #    finishing that starts the soak, which publishes it.
@@ -63,17 +61,38 @@ gh run list --repo Azure/unbounded --workflow release.yaml --limit 3
 gh run list --repo Azure/unbounded --workflow release-upgrade.yaml --limit 3
 
 # 6. Confirm. isDraft false means it shipped.
-gh release view v0.2.5 --repo Azure/unbounded --json tagName,isDraft,url
+gh release view v0.4.0 --repo Azure/unbounded --json tagName,isDraft,url
 ```
+
+There is no `bump` input: `main` always cuts a minor. For the rare major, add
+`-f major=true`; see [Choosing a version](#2-choosing-a-version).
 
 If a step fails, see [Recovery](#recovery). If the soak cluster is the problem
 rather than the release, see [Break glass](#break-glass).
 
-### Minor release
+### From a release branch
 
-The same, with `-f bump=minor`. Use it for new capabilities, breaking changes,
-removed flags or CRD field changes; see [Choosing a version](#2-choosing-a-version).
-Consider cutting a candidate first.
+To patch a series that has already shipped, without taking everything merged to
+`main` since. Open the branch if it does not exist, cherry-pick the fix, then
+cut a patch.
+
+```sh
+# 1. Open the branch. The branch point is derived: the newest release in the
+#    series. Add -f dry_run=true first if you want to see it without creating.
+gh workflow run create-release-branch.yaml --repo Azure/unbounded -f series=0.3
+
+# 2. Cherry-pick the fix onto it through a pull request. Fixes land on main
+#    first and are cherry-picked down; never the other way round.
+
+# 3. Cut the patch.
+gh workflow run release-prepare.yaml --repo Azure/unbounded \
+  -f mode=release -f branch=release-0.3
+```
+
+The branch cuts `v0.3.1`, then `v0.3.2`, and can never mint a number `main`
+owns. Once a newer series has shipped, these are
+[maintenance releases](#maintenance-releases-skip-the-soak) and do not deploy to
+the soak cluster.
 
 ### With a release candidate first
 
@@ -82,31 +101,29 @@ built, signed and soaked on `unbounded-stable` exactly like a final release, and
 published as a prerelease, so it never becomes "Latest".
 
 ```sh
-# 1. Start the train. bump is relative to the latest final tag.
-gh workflow run release-prepare.yaml --repo Azure/unbounded \
-  -f mode=prerelease -f bump=minor
+# 1. Start the train. Add -f branch=release-X.Y to run one on a release branch.
+gh workflow run release-prepare.yaml --repo Azure/unbounded -f mode=prerelease
 
-# 2. Iterate. Same command with NO input changes: the train in flight is
-#    detected and the next rc taken automatically.
+# 2. Iterate. Same command: the train in flight is detected and the next rc
+#    taken automatically.
 gh workflow run release-prepare.yaml --repo Azure/unbounded -f mode=prerelease
 
 # 3. Promote when it is good.
 gh workflow run release-prepare.yaml --repo Azure/unbounded -f mode=promote
 ```
 
-`promote` tags the **last candidate's commit**, so anything merged to `main`
-after that candidate is not in the release. That is a feature as much as a
-constraint: cut a candidate as soon as your change lands and you hold that exact
-tree, whatever merges afterwards.
+`promote` tags the **last candidate's commit**, not `main` HEAD, so anything
+merged after that candidate is not in the release. That is a feature as much as
+a constraint: cut a candidate as soon as your change lands and you hold that
+exact tree, whatever merges afterwards. See
+[How trains work](#how-trains-work) for the detail.
 
 ## Shipping an urgent fix
 
-There are no maintenance branches yet, so an urgent fix rolls forward: land it
-on `main` and cut a patch release. What that costs depends on what else is
-sitting on `main`.
+Land it on `main` first, always. Which release it then ships in depends on who
+needs it and what else is sitting on `main`.
 
-**`main` is clean.** Land the fix, cut a patch release as above. Nothing
-special.
+**`main` is clean.** Cut from `main` as above. Nothing special.
 
 **`main` carries work you are not ready to ship.** A release from `main` takes
 all of it, and there is no way to exclude it. Read the list first (step 2
@@ -114,12 +131,14 @@ above), then pick:
 
 - cut a candidate the moment your fix lands and promote that. `promote` ships
   the candidate's tree, so anything merged afterwards is excluded;
-- revert the unready work on `main`, cut the patch, re-land it after;
+- revert the unready work on `main`, cut it, re-land it after;
 - ship it anyway, having read the list.
 
-**The fix is for an older line**, e.g. a `v0.2.x` user after `v0.3.0` shipped.
-Not supported today: `release-prepare` cuts from `main` only. See
-[Maintenance lines](#maintenance-lines).
+**The user is on an older series**, e.g. someone on `v0.3.x` after `v0.4.0`
+shipped. Cherry-pick the fix from `main` onto `release-0.3` and cut a patch; see
+[From a release branch](#from-a-release-branch). This is the case release
+branches exist for, and it is the only way to ship the fix without also shipping
+everything else merged since.
 
 ## Reference
 
@@ -148,14 +167,44 @@ unreachable nodes, which the rollout gate tolerates. See
 
 ## 2. Choosing a version
 
-The project is pre-1.0, so semver's compatibility guarantees are not yet in
-force and breaking changes can land in a minor bump. In practice:
+You do not choose. The version is determined by where you are cutting from:
 
-- **patch** (`v0.2.4` to `v0.2.5`) for fixes and incremental work with no
-  behaviour change for existing users.
-- **minor** (`v0.2.4` to `v0.3.0`) for new capabilities, breaking changes,
-  removed flags, or CRD field changes.
-- **major** is reserved for 1.0.
+| Number | Cut from | Means |
+|---|---|---|
+| **major** (`v0.4.0` to `v1.0.0`) | `main`, with `-f major=true` | incompatible changes |
+| **minor** (`v0.3.0` to `v0.4.0`) | `main` | every other release from `main` |
+| **patch** (`v0.3.0` to `v0.3.1`) | `release-0.3` | cherry-picked fixes to a shipped series |
+
+`main` never cuts a patch, and a release branch never cuts anything else. That
+is what lets the two coexist: every series' patch space belongs to exactly one
+branch, so `main` and `release-0.3` can never compute the same number. Without
+it they would compete, and pre-1.0 they would compete for months, because a
+series here runs twenty-odd releases before the minor turns over.
+
+A major is the one deliberate choice, and it is never derived.
+
+### On semantic versioning
+
+This follows [semver 2.0.0](https://semver.org/) with one declared deviation.
+
+While the project is pre-1.0 it is not even a deviation: clause 4 gives `0.y.z`
+total latitude, and the specification's own FAQ recommends exactly this scheme,
+to *"start your initial development release at 0.1.0 and then increment the
+minor version for each subsequent release"*.
+
+After 1.0, clause 6 says a release containing only backward compatible bug fixes
+MUST increment the patch. A fixes-only release cut from `main` takes a minor
+here instead. Every other case is covered by clause 7, which permits a minor for
+new functionality and says it may include patch level changes, so an ordinary
+mixed release from `main` is correctly a minor. Where it matters, the compliant
+route is also the better one: cherry-pick the fixes to a release branch and cut
+a patch, which is what the branch is for.
+
+What `main`'s numbering no longer expresses is "this release contains no
+behaviour change", because minor absorbs patch. That signal was never reliable:
+a release from `main` takes everything merged since, with no way to exclude it.
+Patches now come only from a release branch carrying a deliberate set of
+cherry-picks, so the patch signal means more than it used to, not less.
 
 ### Prereleases use `rc` only
 
@@ -185,10 +234,20 @@ tag; it builds nothing, so a mistake here is cheap to undo. The commands are in
 `-f dry_run=true` works with any mode and prints the version and commit it would
 cut without pushing anything.
 
-Note that `release-prepare` runs the resolver from `main`, so a change to it
-takes effect only once merged. It cannot be rehearsed by dispatching the
-workflow from a branch, `dry_run` included; `hack/release/next-version-test.sh`
-is how you test it before that.
+`-f branch=` selects what to cut from: `main`, or a `release-X.Y` branch.
+Anything else is refused, so a tag can never come from a feature branch. The
+bump follows from that choice and is not an input.
+
+The release tooling itself always comes from `main`, even when cutting from a
+release branch. The two supply different things: the branch supplies the history
+the version is computed against, which is what scopes resolution to its series,
+while `main` supplies the scripts that do the computing. An old branch would
+otherwise cut releases with whatever tooling existed when it was created.
+
+A consequence is that a change to the resolver takes effect only once merged to
+`main`. It cannot be rehearsed by dispatching this workflow from a branch,
+`dry_run` included; `hack/release/next-version-test.sh` is how you test it
+before that.
 
 ### How trains work
 
@@ -237,7 +296,9 @@ in the tag.
 
 ## 5. Soaking and publishing
 
-`release-upgrade.yaml` starts automatically when the build finishes. It:
+`release-upgrade.yaml` starts automatically when the build finishes. A
+[maintenance release](#maintenance-releases-skip-the-soak) skips straight past
+all of this and stays a draft. Otherwise it:
 
 1. downloads the draft release's artifacts,
 2. verifies their signatures and the BOM against the tag's cosign identity,
@@ -270,9 +331,9 @@ on the default branch, and publishing requires both discovery and every task to
 succeed, so a release that ran no smoke tests stays a draft. Shipping one anyway
 is the [break-glass path](#break-glass), where it is recorded.
 
-This is also why `promote` tags the last candidate's commit: the soak is
-evidence about one specific tree, and it is only worth anything if that is the
-tree that ships.
+This is also why [`promote` tags the last candidate's commit](#how-trains-work):
+the soak is evidence about one specific tree, and it is only worth anything if
+that is the tree that ships.
 
 Prereleases are published too, but stay flagged as prereleases and never become
 "Latest".
@@ -303,7 +364,7 @@ When a known outage takes out more nodes than the cap allows:
 
 ```sh
 gh workflow run release-upgrade.yaml --repo Azure/unbounded \
-  -f tag=v0.2.5 -f max_notready_nodes=7
+  -f tag=v0.4.0 -f max_notready_nodes=7
 ```
 
 This raises the ceiling only. A shortfall must still be entirely explained by
@@ -316,7 +377,7 @@ For when the soak cluster itself is the problem and the release must ship:
 
 ```sh
 gh workflow run release-upgrade.yaml --repo Azure/unbounded \
-  -f tag=v0.2.5 -f force_publish=true \
+  -f tag=v0.4.0 -f force_publish=true \
   -f reason="unbounded-stable unreachable during DC maintenance"
 ```
 
@@ -338,7 +399,7 @@ design: a dispatched build would sign with the wrong identity and fail
 verification downstream.
 
 ```sh
-git push origin :refs/tags/v0.2.5
+git push origin :refs/tags/v0.4.0
 ```
 
 **The build failed partway.** Fix the cause, delete the tag, and cut it again.
@@ -356,37 +417,76 @@ explicitly; so is a rollout blocked by unreachable nodes.
 **A release was published by mistake.** Re-draft it:
 
 ```sh
-gh release edit v0.2.5 --repo Azure/unbounded --draft=true
+gh release edit v0.4.0 --repo Azure/unbounded --draft=true
 ```
 
 **Stale drafts.** Abandoned candidates linger as drafts and should be deleted
 once their train is promoted, otherwise the release list becomes misleading.
 
-## Maintenance lines
+## The tag and branch model
 
-**Not yet implemented**, tracked in
-[#627](https://github.com/Azure/unbounded/issues/627). `release-prepare.yaml`
-cuts from `main` only, so an older release cannot be patched without shipping
-everything merged since.
+`main` owns `.0`; a release branch owns `.1` upward. Nothing else releases at
+all. Because those spaces are disjoint, two branches can never compute the same
+number, and the collision is impossible rather than merely detected.
 
-The agreed model is a **lazy** `release-X.Y` branch, created on demand from a
-tag or commit the first time an older line needs a fix, with every subsequent
-release on that line cut from it:
+A **release branch** is `release-X.Y`, created on demand. A **maintenance
+release** is a patch cut from one. `main` is never a release branch, even though
+releases are cut from it.
 
-- version resolution scoped to the line, so `release-0.2` cuts `v0.2.5` while
-  `main` is on `v0.3.x` and neither can mint the other's numbers;
-- fixes cherry-picked onto the branch through a PR, with CI and code scanning
-  extended to `release-*` - today both run on `main` only, so a cherry-pick
-  would be tested by nothing;
-- a maintenance release **skips the soak**, because deploying an older line to
-  `unbounded-stable` would downgrade it, and stays a draft until someone
-  publishes it deliberately through the recorded
-  [break-glass path](#publish-without-a-soak).
+A worked sequence:
 
-Until that lands, the remedy is rolling forward, which matches the support
-policy in [SECURITY.md](SECURITY.md): fixes land on the latest release and
-`main`, and older releases are not routinely supported. See
-[Shipping an urgent fix](#shipping-an-urgent-fix).
+| Event | Branch | Tag | Soaked? |
+|---|---|---|---|
+| Normal release | `main` | `v0.4.0` | yes |
+| Start a candidate train | `main` | `v0.5.0-rc.1` | yes, as a prerelease |
+| Promote | `main` | `v0.5.0` | yes |
+| A `v0.4.0` user needs a fix | `release-0.4` created from `v0.4.0` | - | - |
+| Cherry-pick, then cut | `release-0.4` | `v0.4.1` | no; stays a draft |
+| Work continues | `main` | `v0.6.0` | yes |
+| Second fix on the branch | `release-0.4` | `v0.4.2` | no |
+| The big one | `main` | `v1.0.0` | yes |
+
+### Common situations
+
+**A fix, and `main` is clean.** Cut from `main`. It is a minor.
+
+**A fix, and `main` carries unready work.** Cut a candidate and promote it,
+which holds that exact tree; or revert, cut, re-land.
+
+**A fix for someone on an older series.** Open the release branch if it does not
+exist, cherry-pick, cut a patch.
+
+**A fix needed on both.** Land on `main` first, then cherry-pick down. Never the
+reverse: the flow is one-way, so nothing needs forward-porting.
+
+**A patch on the newest series.** Allowed immediately. `release-0.5` can be
+opened the moment `v0.5.0` ships, without waiting for `main` to move, because
+`main` will never take `v0.5.1`. This is the property the whole rule buys.
+
+**Two branches at once.** Independent. Their numbers cannot collide.
+
+### Maintenance releases skip the soak
+
+Once a newer series has shipped, a patch from an older branch is a maintenance
+release. Deploying it to `unbounded-stable` would downgrade that cluster, so
+deploy, Orca and smoke are skipped and the release stays a **draft**. Publish it
+deliberately through the recorded
+[break-glass path](#publish-without-a-soak).
+
+The first patch on a branch may still soak: while its series is the newest
+thing released, it is an upgrade for the soak cluster, not a downgrade. The
+classification is automatic and needs no input.
+
+### Which branches are maintained
+
+Not published anywhere: the branch list is the answer, which is why branches are
+created on demand rather than at every release. Security fixes land on `main`
+and reach a maintained branch as cherry-picks; see [SECURITY.md](SECURITY.md).
+
+Note that a branch cut from a release predating `release-*` CI coverage will not
+run any workflow, because the trigger lists live in the branch's own copy of
+`.github/workflows/`. Add `release-*` to `ci.yaml`'s `push` and `pull_request`
+branch filters as the branch's first commit if so.
 
 ## Rehearsing locally
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,9 +90,8 @@ gh workflow run release-prepare.yaml --repo Azure/unbounded \
 ```
 
 The branch cuts `v0.3.1`, then `v0.3.2`, and can never mint a number `main`
-owns. Once a newer series has shipped, these are
-[maintenance releases](#maintenance-releases-skip-the-soak) and do not deploy to
-the soak cluster.
+owns. These [do not soak](#release-branches-do-not-soak): `unbounded-stable`
+soaks `main` only. They publish anyway, verified but unsoaked.
 
 ### With a release candidate first
 
@@ -194,11 +193,16 @@ minor version for each subsequent release"*.
 
 After 1.0, clause 6 says a release containing only backward compatible bug fixes
 MUST increment the patch. A fixes-only release cut from `main` takes a minor
-here instead. Every other case is covered by clause 7, which permits a minor for
-new functionality and says it may include patch level changes, so an ordinary
-mixed release from `main` is correctly a minor. Where it matters, the compliant
-route is also the better one: cherry-pick the fixes to a release branch and cut
-a patch, which is what the branch is for.
+here instead.
+
+The clearest way to hold this is that **`main`'s minor is a release counter, and
+the compatibility signal lives entirely in the major**. That is structural rather
+than an oversight: patch cannot also be a counter on `main` without colliding
+with the branch that owns it. Every other case is covered by clause 7, which
+permits a minor for new functionality and says it may include patch level
+changes, so an ordinary mixed release from `main` is correctly a minor. Where it
+matters, the compliant route is also the better one: cherry-pick the fixes to a
+release branch and cut a patch, which is what the branch is for.
 
 What `main`'s numbering no longer expresses is "this release contains no
 behaviour change", because minor absorbs patch. That signal was never reliable:
@@ -296,9 +300,9 @@ in the tag.
 
 ## 5. Soaking and publishing
 
-`release-upgrade.yaml` starts automatically when the build finishes. A
-[maintenance release](#maintenance-releases-skip-the-soak) skips straight past
-all of this and stays a draft. Otherwise it:
+`release-upgrade.yaml` starts automatically when the build finishes. A release
+cut from a [release branch](#release-branches-do-not-soak) skips straight past
+the cluster work and publishes. Otherwise it:
 
 1. downloads the draft release's artifacts,
 2. verifies their signatures and the BOM against the tag's cosign identity,
@@ -441,9 +445,9 @@ A worked sequence:
 | Start a candidate train | `main` | `v0.5.0-rc.1` | yes, as a prerelease |
 | Promote | `main` | `v0.5.0` | yes |
 | A `v0.4.0` user needs a fix | `release-0.4` created from `v0.4.0` | - | - |
-| Cherry-pick, then cut | `release-0.4` | `v0.4.1` | no; stays a draft |
+| Cherry-pick, then cut | `release-0.4` | `v0.4.1` | no; publishes unsoaked |
 | Work continues | `main` | `v0.6.0` | yes |
-| Second fix on the branch | `release-0.4` | `v0.4.2` | no |
+| Second fix on the branch | `release-0.4` | `v0.4.2` | no; publishes unsoaked |
 | The big one | `main` | `v1.0.0` | yes |
 
 ### Common situations
@@ -465,17 +469,41 @@ opened the moment `v0.5.0` ships, without waiting for `main` to move, because
 
 **Two branches at once.** Independent. Their numbers cannot collide.
 
-### Maintenance releases skip the soak
+### Release branches do not soak
 
-Once a newer series has shipped, a patch from an older branch is a maintenance
-release. Deploying it to `unbounded-stable` would downgrade that cluster, so
-deploy, Orca and smoke are skipped and the release stays a **draft**. Publish it
-deliberately through the recorded
-[break-glass path](#publish-without-a-soak).
+`unbounded-stable` soaks `main`, and only `main`. A release cut from a release
+branch skips deploy, Orca and smoke entirely, and then **publishes** - it does
+not sit as a draft waiting for someone.
 
-The first patch on a branch may still soak: while its series is the newest
-thing released, it is an upgrade for the soak cluster, not a downgrade. The
-classification is automatic and needs no input.
+That is a decision about provenance, not about version numbers. The soak cluster
+runs whatever `main` last put there, including a candidate, so "is this version
+newer" is the wrong question: a release from a branch has no business on that
+cluster whatever its number. Maintenance branches will get their own soak
+clusters; until they do, these releases ship unsoaked and that is deliberate.
+
+**Verification is not skipped.** Signatures and the release BOM are checked
+before publishing, by the same script the soaked path uses. Skipping a soak is a
+decision someone made; shipping something unverified is not.
+
+Candidates on a release branch are a special case worth knowing. A candidate
+exists to soak, so one cut from a branch cannot do its job: it will skip the
+soak like everything else from that branch. Cut candidates on `main`.
+
+### What gets marked "Latest"
+
+"Latest" is what `releases/latest/download` resolves to, which is the install
+command in the README and every guide, so it is set explicitly on every publish
+rather than left to GitHub's default of "whatever was published most recently".
+
+A release is marked Latest when no higher release exists on `main`'s trunk or in
+its own series, and it is not a prerelease. So:
+
+- a release from `main` is Latest, as you would expect;
+- the first patch on a branch **is** Latest while `main` has not moved on, because
+  it genuinely is the newest release;
+- a patch from an older series is not, so shipping `v0.3.1` after `v0.5.0` leaves
+  the install command pointing at `v0.5.0`;
+- republishing an older patch does not steal the marker back from a newer one.
 
 ### Which branches are maintained
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,12 @@
 
 ## Supported Versions
 
-Unbounded Kubernetes is in early development. Security fixes are applied to the
-latest release and the `main` branch. Older releases are not routinely supported.
-Users should upgrade to the latest available release before reporting a problem
-that may already have been corrected.
+Unbounded Kubernetes is in early development. Security fixes land on `main` and
+ship in the next release cut from it. A `release-X.Y` line that is still being
+maintained receives them as cherry-picks; older lines are not routinely
+maintained, and no support window is committed. Users should upgrade to the
+latest available release before reporting a problem that may already have been
+corrected.
 
 ## Reporting a Vulnerability
 

--- a/hack/cmd/semver/main.go
+++ b/hack/cmd/semver/main.go
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Command semver answers semantic version questions that shell cannot answer
+// correctly.
+//
+// The release tooling is otherwise shell, and deliberately so, but `sort -V`
+// does not implement semantic version precedence. It orders a final release
+// BELOW its own release candidates:
+//
+//	$ printf 'v1.0.0\nv1.0.0-rc.1\n' | sort -V
+//	v1.0.0
+//	v1.0.0-rc.1
+//
+// Semver 2.0.0 clause 11.3 requires the opposite: a pre-release has lower
+// precedence than the associated normal version. Nothing in next-version.sh is
+// affected, because it filters to finals before sorting and strips `-rc.N`
+// before comparing cores, but the release soak has to compare an arbitrary
+// incoming tag against the highest release, and that tag is routinely a
+// candidate. Getting it backwards there deploys a superseded candidate to the
+// soak cluster.
+//
+// Tags arrive on stdin rather than being read from git, so the tests need no
+// repository fixture and the caller decides what set of tags the question is
+// being asked about.
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// errUsage is returned for anything the caller got wrong about invocation, as
+// opposed to a legitimate false answer.
+var errUsage = errors.New("usage")
+
+const usage = `semver answers semantic version questions for the release tooling.
+
+Usage:
+  semver compare <a> <b>            print -1, 0 or 1 for a against b
+  semver is-maintenance <tag>       read tags on stdin, print true or false
+
+is-maintenance reports whether <tag> is a maintenance release: a release that
+is not the newest, and so must not be deployed to the soak cluster because
+doing so would downgrade it.
+
+  git tag --list 'v*' | semver is-maintenance v1.4.1
+`
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
+		if errors.Is(err, errUsage) {
+			fmt.Fprint(os.Stderr, usage)
+		}
+
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("%w: no subcommand", errUsage)
+	}
+
+	switch args[0] {
+	case "compare":
+		if len(args) != 3 {
+			return fmt.Errorf("%w: compare takes two versions, got %d", errUsage, len(args)-1)
+		}
+
+		return compare(args[1], args[2], stdout)
+
+	case "is-maintenance":
+		if len(args) != 2 {
+			return fmt.Errorf("%w: is-maintenance takes one tag, got %d", errUsage, len(args)-1)
+		}
+
+		return isMaintenance(args[1], stdin, stdout, stderr)
+
+	default:
+		return fmt.Errorf("%w: unknown subcommand %q", errUsage, args[0])
+	}
+}
+
+// compare prints the precedence of a against b as -1, 0 or 1.
+func compare(a, b string, stdout io.Writer) error {
+	if err := validate(a); err != nil {
+		return err
+	}
+
+	if err := validate(b); err != nil {
+		return err
+	}
+
+	_, err := fmt.Fprintln(stdout, semver.Compare(a, b))
+
+	return err
+}
+
+// isMaintenance prints whether tag is a maintenance release, given the tags on
+// stdin.
+//
+// A tag is a maintenance release when it ranks strictly below the highest
+// release in the set. Equality is deliberately not maintenance: re-running the
+// soak for the release that is already current is a supported operation
+// (RELEASING.md documents dispatching it by hand for backfills), and treating
+// it as maintenance would silently skip the deploy it was asked for.
+func isMaintenance(tag string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if err := validate(tag); err != nil {
+		return err
+	}
+
+	tags, err := readTags(stdin)
+	if err != nil {
+		return err
+	}
+
+	if len(tags) == 0 {
+		// Distinguished from "no finals among the tags" below. An entirely
+		// empty stream means the caller's `git tag` produced nothing, which is
+		// a broken invocation rather than an answer, and answering "false"
+		// would let a release deploy on the strength of a failed command.
+		return errors.New("no tags on stdin; expected the output of `git tag --list`")
+	}
+
+	highest := highestFinal(tags)
+	if highest == "" {
+		// Tags exist but none is a final release. Nothing has shipped yet, so
+		// nothing can be older than it.
+		//
+		// Diagnostics are deliberately unchecked throughout: failing to write
+		// an explanation is not worth failing a release over, whereas failing
+		// to write the answer is, so only that write is checked.
+		fmt.Fprintln(stderr, "no final release tags found; treating as not a maintenance release") //nolint:errcheck // diagnostic
+
+		return answer(false, stdout)
+	}
+
+	result := semver.Compare(tag, highest) < 0
+
+	fmt.Fprintf(stderr, "highest release: %s; %s is %sa maintenance release\n", //nolint:errcheck // diagnostic
+		highest, tag, map[bool]string{true: "", false: "not "}[result])
+
+	return answer(result, stdout)
+}
+
+// answer writes the decision, which is the command's entire contract with its
+// caller and so is the one write whose failure matters.
+func answer(result bool, stdout io.Writer) error {
+	if _, err := fmt.Fprintln(stdout, result); err != nil {
+		return fmt.Errorf("writing result: %w", err)
+	}
+
+	return nil
+}
+
+// readTags reads one tag per line, ignoring blanks and surrounding whitespace.
+func readTags(stdin io.Reader) ([]string, error) {
+	var tags []string
+
+	scanner := bufio.NewScanner(stdin)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		tags = append(tags, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading tags: %w", err)
+	}
+
+	return tags, nil
+}
+
+// highestFinal returns the highest final release among tags, or "" when there
+// is none.
+//
+// Only finals count. A candidate for a version that has not shipped is not
+// something a maintenance release can be older than, and including it would
+// make an unreleased train suppress the soak for everything below it.
+//
+// Anything that is not a strictly canonical vX.Y.Z is skipped rather than
+// rejected: this repository's tag namespace contains genuine debris, such as
+// v0.1.23-alpha.0 and a v0.1.24 train abandoned at rc.18, and a stray malformed
+// tag must not be able to break every subsequent release.
+func highestFinal(tags []string) string {
+	highest := ""
+
+	for _, tag := range tags {
+		if validate(tag) != nil {
+			continue
+		}
+
+		if semver.Prerelease(tag) != "" {
+			continue
+		}
+
+		if highest == "" || semver.Compare(tag, highest) > 0 {
+			highest = tag
+		}
+	}
+
+	return highest
+}
+
+// validate accepts only a strictly canonical version.
+//
+// semver.IsValid alone is too permissive here. golang.org/x/mod/semver
+// documents two deviations from the spec: it requires the leading "v", which
+// suits us because our tags carry it, and it accepts vMAJOR and vMAJOR.MINOR as
+// shorthands for vMAJOR.0.0 and vMAJOR.MINOR.0. A tag named "v1" would
+// therefore be read as v1.0.0 and could outrank a real release.
+//
+// Comparing against Canonical rejects those shorthands, and rejects build
+// metadata too, which we do not use and which the spec requires be ignored in
+// precedence, so a tag carrying it could never be ordered reliably.
+func validate(v string) error {
+	if !semver.IsValid(v) {
+		return fmt.Errorf("not a semantic version: %q", v)
+	}
+
+	if semver.Canonical(v) != v {
+		return fmt.Errorf("not a canonical vX.Y.Z version: %q (canonical form is %q)", v, semver.Canonical(v))
+	}
+
+	return nil
+}

--- a/hack/cmd/semver/main_test.go
+++ b/hack/cmd/semver/main_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestIsMaintenance covers the decision the release soak depends on.
+func TestIsMaintenance(t *testing.T) {
+	cases := []struct {
+		name    string
+		tag     string
+		tags    []string
+		want    string
+		wantErr bool
+	}{
+		{
+			// The case sort -V gets backwards, and the reason this command
+			// exists. Dispatching an old candidate by hand after its final has
+			// shipped must not redeploy it to the soak cluster.
+			name: "candidate below its own final",
+			tag:  "v1.0.0-rc.1",
+			tags: []string{"v1.0.0-rc.1", "v1.0.0"},
+			want: "true",
+		},
+		{
+			// Re-running the soak for the current release is supported, so
+			// equality must not be treated as maintenance.
+			name: "the current release itself",
+			tag:  "v1.7.0",
+			tags: []string{"v1.6.0", "v1.7.0"},
+			want: "false",
+		},
+		{
+			name: "patch on an older series",
+			tag:  "v1.4.1",
+			tags: []string{"v1.4.0", "v1.7.0"},
+			want: "true",
+		},
+		{
+			name: "candidate for a newer series",
+			tag:  "v1.8.0-rc.1",
+			tags: []string{"v1.7.0"},
+			want: "false",
+		},
+		{
+			name: "patch on the newest series",
+			tag:  "v1.7.1",
+			tags: []string{"v1.6.0", "v1.7.0"},
+			want: "false",
+		},
+		{
+			// A train in flight must not suppress the soak for everything
+			// below it, so only finals set the bar.
+			name: "unreleased candidate does not raise the bar",
+			tag:  "v1.7.0",
+			tags: []string{"v1.7.0", "v1.8.0-rc.1"},
+			want: "false",
+		},
+		{
+			// This repository's tag namespace contains real debris.
+			name: "malformed tags are skipped",
+			tag:  "v0.2.5",
+			tags: []string{"v0.1.23-alpha.0", "not-a-tag", "v9", "v0.3.0", ""},
+			want: "true",
+		},
+		{
+			// "v9" is valid to x/mod/semver as shorthand for v9.0.0. If it were
+			// accepted it would outrank every real release and mark everything
+			// as maintenance, silently disabling the soak.
+			name: "shorthand versions do not outrank real releases",
+			tag:  "v0.3.0",
+			tags: []string{"v9", "v0.2.0"},
+			want: "false",
+		},
+		{
+			name: "no finals yet",
+			tag:  "v0.1.0-rc.1",
+			tags: []string{"v0.1.0-rc.1"},
+			want: "false",
+		},
+		{
+			// An empty stream means the caller's git command produced nothing.
+			// Answering "false" would deploy on the strength of a failed
+			// command.
+			name:    "empty input is an error, not an answer",
+			tag:     "v1.0.0",
+			tags:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid tag argument",
+			tag:     "1.0.0",
+			tags:    []string{"v1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "shorthand tag argument is rejected",
+			tag:     "v1.0",
+			tags:    []string{"v1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "build metadata is rejected",
+			tag:     "v1.0.0+build.1",
+			tags:    []string{"v1.0.0"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			stdin := strings.NewReader(strings.Join(tc.tags, "\n"))
+			err := run([]string{"is-maintenance", tc.tag}, stdin, &stdout, &stderr)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got output %q", stdout.String())
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v (stderr: %s)", err, stderr.String())
+			}
+
+			if got := strings.TrimSpace(stdout.String()); got != tc.want {
+				t.Errorf("got %q, want %q (stderr: %s)", got, tc.want, stderr.String())
+			}
+		})
+	}
+}
+
+// TestCompare checks the general primitive, including the precedence rule that
+// sort -V violates.
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		name    string
+		a, b    string
+		want    string
+		wantErr bool
+	}{
+		{name: "prerelease is lower than its final", a: "v1.0.0-rc.1", b: "v1.0.0", want: "-1"},
+		{name: "final is higher than its prerelease", a: "v1.0.0", b: "v1.0.0-rc.1", want: "1"},
+		{name: "equal", a: "v1.2.3", b: "v1.2.3", want: "0"},
+		{name: "minor ordering is numeric not lexical", a: "v1.10.0", b: "v1.9.0", want: "1"},
+		{name: "rc ordering is numeric not lexical", a: "v1.0.0-rc.10", b: "v1.0.0-rc.9", want: "1"},
+		{name: "invalid left", a: "nope", b: "v1.0.0", wantErr: true},
+		{name: "invalid right", a: "v1.0.0", b: "nope", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			err := run([]string{"compare", tc.a, tc.b}, strings.NewReader(""), &stdout, &stderr)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got %q", stdout.String())
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := strings.TrimSpace(stdout.String()); got != tc.want {
+				t.Errorf("compare(%s, %s) = %s, want %s", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUsageErrors covers invocation mistakes, which must be distinguishable
+// from a legitimate "false".
+func TestUsageErrors(t *testing.T) {
+	cases := [][]string{
+		{},
+		{"unknown"},
+		{"compare"},
+		{"compare", "v1.0.0"},
+		{"compare", "v1.0.0", "v1.0.1", "v1.0.2"},
+		{"is-maintenance"},
+		{"is-maintenance", "v1.0.0", "extra"},
+	}
+
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			if err := run(args, strings.NewReader("v1.0.0"), &stdout, &stderr); err == nil {
+				t.Fatalf("expected an error for args %q", args)
+			}
+		})
+	}
+}

--- a/hack/release/bump-for-branch.sh
+++ b/hack/release/bump-for-branch.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# bump-for-branch: decide what a branch is allowed to release.
+#
+# Called by .github/workflows/release-prepare.yaml, which feeds the result to
+# next-version.sh.
+#
+# The versioning rule (RELEASING.md, and #627):
+#
+#   main          cuts vX.Y.0  - a minor, or a major when explicitly asked
+#   release-X.Y   cuts vX.Y.Z  - a patch, and nothing else
+#
+# Every minor's patch space therefore belongs to exactly one branch, and main
+# never enters it. That is what makes a release branch possible at all: without
+# it, main and release-0.2 would both compute v0.2.5 and compete for the same
+# tag, which pre-1.0 they would do for months, since a minor series here runs
+# twenty-odd releases.
+#
+# This lives outside next-version.sh on purpose. The resolver is a general
+# version calculator with sixty cases, most of which exercise train mechanics
+# through patch bumps that stay perfectly legal on a release branch. Enforcing
+# the regime inside it would invalidate them to express a policy that is really
+# about where you are cutting from, not about how versions are computed.
+#
+# Contract:
+#   $1        branch name, `main` or `release-X.Y`
+#   MAJOR     "true" to cut a major instead of a minor. Only valid on main, and
+#             never derived: a major is always a deliberate human decision.
+#
+# Output contract:
+#   stdout    `bump=` and `series=` lines, in next-version.sh's own key=value
+#             style. series is empty for main.
+#   stderr    errors
+#   exit      0 resolved, 1 refused
+
+set -euo pipefail
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+BRANCH="${1:-}"
+MAJOR="${MAJOR:-false}"
+
+[[ -n "$BRANCH" ]] || fail "no branch given; expected main or release-X.Y"
+
+case "$MAJOR" in
+  true | false) ;;
+  *) fail "MAJOR must be true or false, got: ${MAJOR}" ;;
+esac
+
+# Anchored, and no leading zeros, matching next-version.sh's SEMVER_COMPONENT.
+# A branch named release-01.2 would otherwise imply a series that can never
+# match a tag, since v01.2.3 is not a version.
+RELEASE_BRANCH='^release-(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})$'
+
+if [[ "$BRANCH" == "main" ]]; then
+  if [[ "$MAJOR" == "true" ]]; then
+    BUMP="major"
+  else
+    BUMP="minor"
+  fi
+
+  SERIES=""
+elif [[ "$BRANCH" =~ $RELEASE_BRANCH ]]; then
+  # A release branch exists to patch a series that has already shipped. Letting
+  # it cut a minor would escape the series it is named for and collide with
+  # main, which is the exact failure this rule prevents.
+  [[ "$MAJOR" != "true" ]] || fail "major is only valid on main; ${BRANCH} cuts patches"
+
+  BUMP="patch"
+  SERIES="${BRANCH#release-}"
+else
+  fail "refusing to release from ${BRANCH}; expected main or release-X.Y"
+fi
+
+echo "bump=${BUMP}"
+echo "series=${SERIES}"

--- a/hack/release/bump_for_branch_test.go
+++ b/hack/release/bump_for_branch_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package release
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for bump-for-branch.sh.
+//
+// The script encodes the versioning rule: main cuts minors and majors, a
+// release branch cuts patches, and nothing else may release at all. Every case
+// below is a way of getting that wrong, because getting it wrong produces a tag
+// that collides with another branch's number space rather than an error anyone
+// would notice at the time.
+
+// runBumpForBranch executes the script with the given branch and environment.
+// It deliberately does not use the fake-kubectl harness the other scripts need:
+// this one talks to nothing.
+func runBumpForBranch(t *testing.T, branch string, env map[string]string) (string, int) {
+	t.Helper()
+
+	script, err := filepath.Abs("bump-for-branch.sh")
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+
+	args := []string{script}
+	if branch != "" {
+		args = append(args, branch)
+	}
+
+	command := exec.Command("bash", args...) //nolint:gosec // fixed script path
+
+	command.Env = append(os.Environ(), envSlice(env)...)
+
+	output, err := command.CombinedOutput()
+
+	code := 0
+	if exitErr, ok := err.(*exec.ExitError); ok { //nolint:errorlint // exec only returns this
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run script: %v", err)
+	}
+
+	return string(output), code
+}
+
+func envSlice(env map[string]string) []string {
+	out := make([]string, 0, len(env))
+	for key, value := range env {
+		out = append(out, key+"="+value)
+	}
+
+	return out
+}
+
+// field extracts one key=value line from the script's stdout.
+func field(t *testing.T, output, key string) string {
+	t.Helper()
+
+	for _, line := range strings.Split(output, "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), key+"="); ok {
+			return rest
+		}
+	}
+
+	return ""
+}
+
+func TestBumpForBranchResolves(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		branch     string
+		major      string
+		wantBump   string
+		wantSeries string
+	}{
+		{name: "main cuts a minor", branch: "main", wantBump: "minor"},
+		{name: "main cuts a major when asked", branch: "main", major: "true", wantBump: "major"},
+		{name: "main with major false is still a minor", branch: "main", major: "false", wantBump: "minor"},
+		{name: "release branch cuts a patch", branch: "release-0.2", wantBump: "patch", wantSeries: "0.2"},
+		{name: "multi-digit series", branch: "release-12.34", wantBump: "patch", wantSeries: "12.34"},
+		{name: "zero series", branch: "release-0.0", wantBump: "patch", wantSeries: "0.0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := map[string]string{}
+			if tc.major != "" {
+				env["MAJOR"] = tc.major
+			}
+
+			output, code := runBumpForBranch(t, tc.branch, env)
+
+			requireCode(t, code, 0, output)
+
+			if got := field(t, output, "bump"); got != tc.wantBump {
+				t.Errorf("bump = %q, want %q\n--- output ---\n%s", got, tc.wantBump, output)
+			}
+
+			if got := field(t, output, "series"); got != tc.wantSeries {
+				t.Errorf("series = %q, want %q\n--- output ---\n%s", got, tc.wantSeries, output)
+			}
+		})
+	}
+}
+
+// TestBumpForBranchRefuses covers every way of asking for a release that would
+// escape its branch's number space.
+func TestBumpForBranchRefuses(t *testing.T) {
+	requireBash4(t)
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		branch string
+		major  string
+		want   string
+	}{
+		{
+			// The rule's whole point. A release branch cutting a minor would
+			// mint a number main owns.
+			name:   "major on a release branch",
+			branch: "release-0.2",
+			major:  "true",
+			want:   "only valid on main",
+		},
+		{
+			name:   "a feature branch",
+			branch: "feat/something",
+			want:   "expected main or release-X.Y",
+		},
+		{
+			name:   "a tag-like ref",
+			branch: "v0.2.4",
+			want:   "expected main or release-X.Y",
+		},
+		{
+			// release-1 has no minor, so it names no series.
+			name:   "release branch without a minor",
+			branch: "release-1",
+			want:   "expected main or release-X.Y",
+		},
+		{
+			// v01.2.3 is not a version, so release-01.2 names a series that no
+			// tag could ever match.
+			name:   "leading zeros in the series",
+			branch: "release-01.2",
+			want:   "expected main or release-X.Y",
+		},
+		{
+			name:   "a patch-level branch name",
+			branch: "release-0.2.4",
+			want:   "expected main or release-X.Y",
+		},
+		{
+			name:   "no branch at all",
+			branch: "",
+			want:   "no branch given",
+		},
+		{
+			name:   "a non-boolean MAJOR",
+			branch: "main",
+			major:  "yes",
+			want:   "MAJOR must be true or false",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := map[string]string{}
+			if tc.major != "" {
+				env["MAJOR"] = tc.major
+			}
+
+			output, code := runBumpForBranch(t, tc.branch, env)
+
+			requireCode(t, code, 1, output)
+			requireContains(t, output, tc.want)
+			requireNotContains(t, output, "bump=")
+		})
+	}
+}

--- a/hack/release/classify-release.sh
+++ b/hack/release/classify-release.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# classify-release: decide what happens to a release once it has been built.
+#
+# Called by .github/workflows/release-upgrade.yaml, which turns the answers into
+# job conditions.
+#
+# There are two questions here and they are NOT the same question. An earlier
+# design answered both with one version comparison and got the first one wrong.
+#
+#   from_main  Should this soak on unbounded-stable?
+#
+#              That cluster soaks main, and only main. A release cut from a
+#              release-X.Y branch has its own soak story - eventually its own
+#              cluster - and deploying it to stable would replace whatever main
+#              last put there.
+#
+#              This is deliberately a question about PROVENANCE, not about
+#              version ordering. Ordering cannot answer it: stable can be
+#              running a candidate that is newer than the newest final, so
+#              "is this version the highest" says deploy when the honest answer
+#              is that this release has no business on that cluster at all.
+#
+#              Assumes release branches are never merged back into main. The
+#              flow is one-way: fixes land on main and are cherry-picked down,
+#              so a branch's commits stay off main and its tags stay
+#              unreachable.
+#
+#   latest     Should this be marked "Latest" on the GitHub release?
+#
+#              This one IS about version ordering, because "Latest" is what
+#              releases/latest/download resolves to, which is the install
+#              command in README.md and every guide. Publishing v0.3.1 after
+#              v0.5.0 must not repoint those at v0.3.1.
+#
+#              GitHub defaults make_latest to true on any newly published
+#              release, so this must be passed explicitly on every publish.
+#
+# Contract:
+#   $1      the tag being released, vX.Y.Z[-suffix]
+#   SEMVER  optional override for the comparison command; defaults to running
+#           hack/cmd/semver from the repository root. Word-split on purpose so
+#           it can hold a command with arguments.
+#
+# Expects to run inside a checkout of the DEFAULT BRANCH with full history and
+# tags, so HEAD is main. HEAD is used rather than origin/main because the
+# checkout already puts us there and a remote-tracking ref may not exist.
+#
+# Output contract:
+#   stdout  `from_main=` and `latest=` lines, in next-version.sh's key=value style
+#   stderr  the reasoning, and errors
+#   exit    0 classified, non-zero on a malformed or unknown tag
+
+set -euo pipefail
+
+note() { echo "$*" >&2; }
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+TAG="${1:-}"
+SEMVER="${SEMVER:-go run ./hack/cmd/semver}"
+
+[[ -n "$TAG" ]] || fail "no tag given; usage: classify-release.sh vX.Y.Z[-suffix]"
+
+# Same shape the resolver mints and release-upgrade already validates. Checked
+# again here because this script is the thing deciding whether a cluster gets
+# touched, and it should not depend on a caller two workflows away.
+SEMVER_COMPONENT='(0|[1-9][0-9]{0,8})'
+if [[ ! "$TAG" =~ ^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}(-[0-9A-Za-z.-]+)?$ ]]; then
+  fail "not a release tag: ${TAG}"
+fi
+
+git rev-parse -q --verify "${TAG}^{commit}" >/dev/null 2>&1 ||
+  fail "tag ${TAG} does not exist here; the checkout needs full history and tags"
+
+# --- from_main -------------------------------------------------------------
+
+if git merge-base --is-ancestor "${TAG}^{commit}" HEAD 2>/dev/null; then
+  FROM_MAIN=true
+  note "${TAG} is reachable from HEAD: cut from the default branch, so it soaks."
+else
+  FROM_MAIN=false
+  note "${TAG} is NOT reachable from HEAD: cut from a release branch, so it does not soak."
+fi
+
+# --- latest ----------------------------------------------------------------
+
+if [[ "$TAG" == *-* ]]; then
+  # GitHub refuses to mark a prerelease as Latest, so asking for it is at best
+  # ignored. Answer honestly rather than sending a flag that cannot apply.
+  LATEST=false
+  note "${TAG} is a prerelease; a prerelease can never be Latest."
+else
+  SERIES="$(sed -E 's/^v([0-9]+\.[0-9]+)\..*/\1/' <<<"$TAG")"
+
+  # Everything on the trunk, plus everything in this tag's own line. That is
+  # exactly the set of releases that could legitimately outrank it:
+  #
+  #   - Tags reachable from HEAD are main's releases. Scoping to them keeps a
+  #     stray final cut on someone's feature branch from suppressing Latest
+  #     forever, the same reason next-version.sh scopes discovery by
+  #     reachability.
+  #   - Tags in the same series are the branch's own, which reachability cannot
+  #     see from main. Without them, republishing v0.3.1 while v0.3.2 exists
+  #     would mark the older one Latest - flipping the marker backwards, which
+  #     is the bug this whole check exists to prevent.
+  #
+  # shellcheck disable=SC2086 # SEMVER may carry arguments and must word-split
+  SUPERSEDED="$(
+    {
+      git tag --merged HEAD --list 'v*'
+      git tag --list "v${SERIES}.*"
+    } | sort -u | $SEMVER is-maintenance "$TAG"
+  )"
+
+  case "$SUPERSEDED" in
+    true) LATEST=false ;;
+    false) LATEST=true ;;
+    *) fail "unexpected verdict from semver: ${SUPERSEDED}" ;;
+  esac
+fi
+
+echo "from_main=${FROM_MAIN}"
+echo "latest=${LATEST}"

--- a/hack/release/classify_release_test.go
+++ b/hack/release/classify_release_test.go
@@ -1,0 +1,311 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package release
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Tests for classify-release.sh.
+//
+// The script answers two questions that look similar and are not: whether a
+// release soaks (provenance) and whether it is marked Latest (ordering). An
+// earlier design answered both with one comparison and got the first one wrong,
+// so the cases below deliberately include the shapes where the two answers
+// diverge.
+//
+// Both answers depend on repository topology, so these build throwaway git
+// repositories with a trunk and a divergent release branch. That is the only
+// way to exercise the reachability half at all.
+
+// semverBinary builds hack/cmd/semver once and returns its path. The script
+// shells out to it, and `go run` on every invocation would dominate the runtime
+// of this file.
+var semverBinary = sync.OnceValues(func() (string, error) {
+	dir, err := os.MkdirTemp("", "classify-semver-")
+	if err != nil {
+		return "", err
+	}
+
+	bin := filepath.Join(dir, "semver")
+
+	out, err := exec.Command("go", "build", "-o", bin,
+		"github.com/Azure/unbounded/hack/cmd/semver").CombinedOutput()
+	if err != nil {
+		return "", &buildError{output: string(out), err: err}
+	}
+
+	return bin, nil
+})
+
+type buildError struct {
+	output string
+	err    error
+}
+
+func (e *buildError) Error() string { return e.err.Error() + ": " + e.output }
+
+// gitRepo is a throwaway repository under test.
+type gitRepo struct {
+	t   *testing.T
+	dir string
+}
+
+func newGitRepo(t *testing.T) *gitRepo {
+	t.Helper()
+
+	r := &gitRepo{t: t, dir: t.TempDir()}
+
+	r.run("init", "-q", "-b", "main")
+	r.run("config", "user.email", "test@example.com")
+	r.run("config", "user.name", "test")
+	r.commit("base")
+
+	return r
+}
+
+func (r *gitRepo) run(args ...string) string {
+	r.t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = r.dir
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		r.t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+func (r *gitRepo) commit(msg string)   { r.run("commit", "-q", "--allow-empty", "-m", msg) }
+func (r *gitRepo) tag(name string)     { r.run("tag", name) }
+func (r *gitRepo) checkout(ref string) { r.run("checkout", "-q", ref) }
+
+// branchFrom creates a release branch at a ref and leaves HEAD on it.
+func (r *gitRepo) branchFrom(name, ref string) { r.run("checkout", "-q", "-b", name, ref) }
+
+// classify runs the script with HEAD wherever the caller left it, which models
+// the workflow checking out the default branch before classifying.
+func (r *gitRepo) classify(tag string) (fields map[string]string, output string, code int) {
+	r.t.Helper()
+
+	script, err := filepath.Abs("classify-release.sh")
+	if err != nil {
+		r.t.Fatalf("resolve script: %v", err)
+	}
+
+	bin, err := semverBinary()
+	if err != nil {
+		r.t.Fatalf("build semver: %v", err)
+	}
+
+	cmd := exec.Command("bash", script, tag) //nolint:gosec // fixed script path
+	cmd.Dir = r.dir
+
+	cmd.Env = append(os.Environ(), "SEMVER="+bin)
+
+	raw, err := cmd.CombinedOutput()
+	output = string(raw)
+
+	var exitErr *exec.ExitError
+	if ok := asExitError(err, &exitErr); ok {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		r.t.Fatalf("run script: %v\n%s", err, output)
+	}
+
+	fields = map[string]string{}
+
+	for _, line := range strings.Split(output, "\n") {
+		key, value, found := strings.Cut(strings.TrimSpace(line), "=")
+		if found && (key == "from_main" || key == "latest") {
+			fields[key] = value
+		}
+	}
+
+	return fields, output, code
+}
+
+func asExitError(err error, target **exec.ExitError) bool {
+	if err == nil {
+		return false
+	}
+
+	e, ok := err.(*exec.ExitError) //nolint:errorlint // exec returns only this
+	if ok {
+		*target = e
+	}
+
+	return ok
+}
+
+func TestClassifyRelease(t *testing.T) {
+	requireBash4(t)
+	requireGit(t)
+
+	cases := []struct {
+		name         string
+		build        func(r *gitRepo)
+		tag          string
+		wantFromMain string
+		wantLatest   string
+	}{
+		{
+			// The ordinary release. Soaks, and is Latest.
+			name: "release cut from main",
+			build: func(r *gitRepo) {
+				r.commit("work")
+				r.tag("v0.4.0")
+			},
+			tag:          "v0.4.0",
+			wantFromMain: "true",
+			wantLatest:   "true",
+		},
+		{
+			// The case that proves the two questions differ. A patch cut from a
+			// release branch while main has not moved is the newest release, so
+			// it IS Latest, but it must not soak: it did not come from main.
+			name: "patch on a release branch, main not moved",
+			build: func(r *gitRepo) {
+				r.commit("work")
+				r.tag("v0.4.0")
+				r.branchFrom("release-0.4", "v0.4.0")
+				r.commit("cherry-pick")
+				r.tag("v0.4.1")
+				r.checkout("main")
+			},
+			tag:          "v0.4.1",
+			wantFromMain: "false",
+			wantLatest:   "true",
+		},
+		{
+			name: "patch on a release branch after main moved on",
+			build: func(r *gitRepo) {
+				r.commit("work")
+				r.tag("v0.4.0")
+				r.branchFrom("release-0.4", "v0.4.0")
+				r.commit("cherry-pick")
+				r.tag("v0.4.1")
+				r.checkout("main")
+				r.commit("more work")
+				r.tag("v0.5.0")
+			},
+			tag:          "v0.4.1",
+			wantFromMain: "false",
+			wantLatest:   "false",
+		},
+		{
+			// Backfill. v0.4.2 exists on the branch and is invisible from main,
+			// so scoping to main alone would mark the older v0.4.1 Latest and
+			// flip the marker backwards.
+			name: "republishing a superseded patch on the same branch",
+			build: func(r *gitRepo) {
+				r.commit("work")
+				r.tag("v0.4.0")
+				r.branchFrom("release-0.4", "v0.4.0")
+				r.commit("first fix")
+				r.tag("v0.4.1")
+				r.commit("second fix")
+				r.tag("v0.4.2")
+				r.checkout("main")
+			},
+			tag:          "v0.4.1",
+			wantFromMain: "false",
+			wantLatest:   "false",
+		},
+		{
+			name: "candidate from main",
+			build: func(r *gitRepo) {
+				r.commit("work")
+				r.tag("v0.4.0")
+				r.commit("more")
+				r.tag("v0.5.0-rc.1")
+			},
+			tag:          "v0.5.0-rc.1",
+			wantFromMain: "true",
+			wantLatest:   "false",
+		},
+		{
+			// A stray final on an unmerged branch must not suppress Latest
+			// forever, which is why the trunk half is reachability-scoped.
+			name: "stray final on an unrelated branch is ignored",
+			build: func(r *gitRepo) {
+				r.commit("work")
+				r.tag("v0.4.0")
+				r.branchFrom("someones-experiment", "main")
+				r.commit("experiment")
+				r.tag("v9.0.0")
+				r.checkout("main")
+			},
+			tag:          "v0.4.0",
+			wantFromMain: "true",
+			wantLatest:   "true",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newGitRepo(t)
+			tc.build(r)
+
+			fields, output, code := r.classify(tc.tag)
+
+			requireCode(t, code, 0, output)
+
+			if got := fields["from_main"]; got != tc.wantFromMain {
+				t.Errorf("from_main = %q, want %q\n--- output ---\n%s", got, tc.wantFromMain, output)
+			}
+
+			if got := fields["latest"]; got != tc.wantLatest {
+				t.Errorf("latest = %q, want %q\n--- output ---\n%s", got, tc.wantLatest, output)
+			}
+		})
+	}
+}
+
+// TestClassifyReleaseRefuses covers input the script must not answer for. A
+// wrong answer here decides whether a cluster is touched, so an unknown tag has
+// to be an error rather than a default.
+func TestClassifyReleaseRefuses(t *testing.T) {
+	requireBash4(t)
+	requireGit(t)
+
+	cases := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{name: "no tag", tag: "", want: "no tag given"},
+		{name: "not a version", tag: "nonsense", want: "not a release tag"},
+		{name: "no v prefix", tag: "0.4.0", want: "not a release tag"},
+		{name: "leading zeros", tag: "v01.2.3", want: "not a release tag"},
+		{name: "unknown tag", tag: "v9.9.9", want: "does not exist here"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newGitRepo(t)
+			r.commit("work")
+			r.tag("v0.4.0")
+
+			fields, output, code := r.classify(tc.tag)
+
+			if code == 0 {
+				t.Fatalf("expected a non-zero exit, got 0\n--- output ---\n%s", output)
+			}
+
+			requireContains(t, output, tc.want)
+
+			if len(fields) != 0 {
+				t.Errorf("expected no verdict on refusal, got %v", fields)
+			}
+		})
+	}
+}

--- a/hack/release/next-version-test.sh
+++ b/hack/release/next-version-test.sh
@@ -328,5 +328,101 @@ expect "unknown mode" nonsense "ERROR" v0.2.4 --
 expect "unknown bump" release "ERROR" v0.2.4 -- BUMP=sideways
 
 echo
+echo "=== release branches (SERIES) ==="
+# A release-0.3 branch after main has moved on. v0.4.0 is off-branch because
+# that is exactly what it is: cut from main, never merged back, so unreachable
+# from the release branch. Reachability alone already gives the right answer
+# here; SERIES is the guard that catches the cases where it stops being true.
+expect "patch on a release branch while main has moved on" release "v0.3.1" \
+  v0.3.0 v0.4.0@off -- BUMP=patch SERIES=0.3
+expect "second patch on the same release branch" release "v0.3.2" \
+  v0.3.0 v0.3.1 v0.5.0@off -- BUMP=patch SERIES=0.3
+# main never enters a series' patch space, so the branch's next number is free
+# even when main is several minors ahead.
+expect "release branch unaffected by newer minors" release "v0.3.1" \
+  v0.3.0 v0.4.0@off v0.5.0@off v0.6.0@off -- BUMP=patch SERIES=0.3
+
+# A candidate train on a release branch, then promoting it.
+expect "candidate on a release branch" prerelease "v0.3.1-rc.1" \
+  v0.3.0 v0.4.0@off -- BUMP=patch SERIES=0.3
+expect "promote on a release branch" promote "v0.3.1" \
+  v0.3.0 v0.3.1-rc.1 v0.4.0@off -- SERIES=0.3
+
+# The guard proper: anything that would escape the series is refused, even
+# though the resolver would happily compute it.
+expect "minor refused on a release branch" release "ERROR" \
+  v0.3.0 -- BUMP=minor SERIES=0.3
+expect "major refused on a release branch" release "ERROR" \
+  v0.3.0 -- BUMP=major SERIES=0.3
+expect "malformed series refused" release "ERROR" \
+  v0.3.0 -- BUMP=patch SERIES=03.1
+expect "series without a minor refused" release "ERROR" \
+  v0.3.0 -- BUMP=patch SERIES=3
+
+# A branch cut from a tag that is not in its own series would compute a tag
+# outside it. Reachability cannot catch this; the guard does.
+expect "tag outside the series refused" release "ERROR" \
+  v0.4.0 -- BUMP=patch SERIES=0.3
+
+# An empty release branch: the series has shipped nothing, so there is no
+# vX.Y.0 to patch and the resolver would fall back to the repository's floor.
+expect "release branch with no tags in its series refused" release "ERROR" \
+  v0.9.0@off -- BUMP=patch SERIES=0.3
+
+echo
+echo "=== version_gt ==="
+# version_gt is internal and, by construction, never receives a prerelease: its
+# callers compare bare cores only, because latest_final filters to finals and
+# train_cores strips -rc.N first. The refusal inside it therefore cannot be
+# reached through any input to the resolver, and these cases exist so that it is
+# not deleted as unreachable. It guards a real trap: sort -V ranks v1.0.0 BELOW
+# v1.0.0-rc.1, the opposite of semver clause 11.3, so a future caller passing a
+# prerelease would get a silently inverted answer rather than an error.
+#
+# The function is extracted rather than driven through the resolver, since no
+# input reaches it.
+expect_version_gt() {
+  local name="$1" a="$2" b="$3" expected="$4"
+
+  local out rc=0
+  out="$(
+    {
+      echo 'fail() { echo "::error::$*" >&2; exit 1; }'
+      sed -n '/^version_gt()/,/^}/p' "$RESOLVER"
+      printf 'version_gt %q %q\n' "$a" "$b"
+    } | bash 2>&1
+  )" || rc=$?
+
+  local got
+  # Classify by the refusal message, not the exit code. `fail` exits 1 and so
+  # does a plain "not greater", so the codes are identical here. In the resolver
+  # they are not confusable: `exit` terminates the script even from inside an
+  # `if` condition, so a refusal stops the run rather than being read as false.
+  if [[ "$out" == *"finals only"* ]]; then
+    got=ERROR
+  else
+    case "$rc" in
+      0) got=true ;;
+      1) got=false ;;
+      *) got=ERROR ;;
+    esac
+  fi
+
+  if [[ "$got" == "$expected" ]]; then
+    printf 'PASS  %-46s %s\n' "$name" "$got"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL  %-46s got=%q want=%q out=%q\n' "$name" "$got" "$expected" "$out"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+expect_version_gt "finals compare normally"        v0.3.0      v0.2.9      true
+expect_version_gt "finals order numerically"       v0.10.0     v0.9.0      true
+expect_version_gt "equal finals are not greater"   v0.3.0      v0.3.0      false
+expect_version_gt "prerelease on the left refused" v1.0.0-rc.1 v1.0.0      ERROR
+expect_version_gt "prerelease on the right refused" v1.0.0     v1.0.0-rc.1 ERROR
+
+echo
 echo "passed=${PASS} failed=${FAIL}"
 exit $(( FAIL > 0 ))

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -30,6 +30,9 @@
 # Inputs (environment, matching how the workflow binds its dispatch inputs):
 #   MODE                     release | prerelease | promote
 #   BUMP                     patch | minor | major (only used to START a train)
+#   SERIES                   optional X.Y this run must stay within, e.g. 0.2.
+#                            Set by release-prepare.yaml when cutting from a
+#                            release-X.Y branch; empty on main.
 #   PRE                      optional explicit prerelease suffix, e.g. rc.3
 #   VERSION                  optional explicit final version for promote
 #   ALLOW_CONCURRENT_TRAINS  "true" to permit a second live train
@@ -48,6 +51,7 @@ set -euo pipefail
 
 MODE="${MODE:?MODE must be set}"
 BUMP="${BUMP:-patch}"
+SERIES="${SERIES:-}"
 PRE="${PRE:-}"
 VERSION="${VERSION:-}"
 ALLOW_CONCURRENT_TRAINS="${ALLOW_CONCURRENT_TRAINS:-false}"
@@ -58,7 +62,18 @@ fail() { echo "::error::$*" >&2; exit 1; }
 
 # version_gt compares two vX.Y.Z strings. sort -V understands the leading v and
 # orders 1.10 above 1.9, which a lexical comparison does not.
+#
+# Finals only, and that is enforced rather than assumed: sort -V does NOT
+# implement semver precedence for prereleases. It ranks v1.0.0 BELOW v1.0.0-rc.1,
+# where clause 11.3 requires the opposite. Every caller here compares bare cores
+# already - latest_final filters to finals, train_cores strips -rc.N - so the
+# refusal below never fires today. It exists so that a future caller passing a
+# prerelease fails loudly instead of silently inverting the comparison. Where a
+# prerelease genuinely has to be compared, use hack/cmd/semver.
 version_gt() {
+  [[ "$1" != *-* && "$2" != *-* ]] ||
+    fail "version_gt compares finals only, got: $1 $2 (sort -V misorders prereleases; use hack/cmd/semver)"
+
   [[ "$1" != "$2" ]] || return 1
 
   [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" == "$1" ]]
@@ -350,6 +365,21 @@ case "$MODE" in
 esac
 
 [[ "$TAG" =~ $SEMVER_ANY_TAG ]] || fail "computed tag is not vX.Y.Z[-suffix]: ${TAG}"
+
+# When cutting from a release-X.Y branch, the computed tag must stay inside that
+# series. Discovery is already scoped by reachability - v0.4.0 cut on main is
+# simply not an ancestor of release-0.3 - so this should be unreachable, and
+# that is the point: it catches the cases where reachability stops being true,
+# such as a force-pushed release branch or main merged into one. Getting this
+# wrong mints a number the other branch owns, which the tag-exists check below
+# would only catch once that number had already been taken.
+if [[ -n "$SERIES" ]]; then
+  [[ "$SERIES" =~ ^(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})$ ]] ||
+    fail "SERIES must be X.Y with no leading zeros, got: ${SERIES}"
+
+  [[ "$TAG" == "v${SERIES}."* ]] ||
+    fail "computed tag ${TAG} is outside series ${SERIES}; a release-${SERIES} branch may only cut v${SERIES}.Z"
+fi
 
 if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
   fail "tag ${TAG} already exists"

--- a/hack/release/next-version.sh
+++ b/hack/release/next-version.sh
@@ -101,8 +101,12 @@ SEMVER_ANY_TAG="^v${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}(
 #
 # Tags anywhere else in the repository must not influence the numbering: a
 # `v9.0.0` cut on someone's feature branch would otherwise become the latest
-# final and make the next release from main v9.0.1. The workflow checks out the
-# default branch, so "reachable from HEAD" is "released from this line".
+# final and make the next release from main v9.0.1.
+#
+# The workflow checks out the branch being released - main, or a release-X.Y
+# maintenance branch - so "reachable from HEAD" is "released from this line".
+# That is what scopes a release branch to its own series without any explicit
+# filtering: v0.4.0 cut on main is simply not an ancestor of release-0.3.
 #
 # The cost is that a tag whose commit later leaves the branch's history stops
 # being seen. That fails safe - the resolver would recompute a version whose tag
@@ -242,8 +246,8 @@ FINAL="$(latest_final)"
 mapfile -t LIVE < <(live_trains "$FINAL")
 mapfile -t STALE < <(stale_trains "$FINAL")
 
-# Every mode but promote cuts from wherever the workflow checked out, which it
-# pins to the default branch.
+# Every mode but promote cuts from wherever the workflow checked out, which is
+# the branch being released: main, or a release-X.Y maintenance branch.
 BASE="$(git rev-parse HEAD)"
 
 note "Latest final: ${FINAL}"


### PR DESCRIPTION
Closes the last unimplemented essential from #610 and implements #627: a `release-X.Y` branch can now be opened on demand and cut patches against a series that has already shipped, without taking everything merged to `main` since.

Read the first commit before the rest. The versioning rule is the whole design; the other five commits implement it.

## The rule

| Branch | Cuts | Never cuts |
|---|---|---|
| `main` | `vX.Y.0` — minor, or major when explicitly asked | any patch |
| `release-X.Y` | `vX.Y.Z` for `Z >= 1` — patch only | any minor or major |

Every series' patch space belongs to exactly one branch, and `main` never enters it. That is what makes the two able to coexist: they can never compute the same number, so a collision is impossible by construction rather than caught after the fact.

Without it they compete, and pre-1.0 they compete for months — a series here runs 20-24 releases over two to three months, and semver leaves no room between `v0.3.0` and `v0.3.1` to escape into.

`bump` is therefore gone as an input: the answer is fully determined by where you cut from. Majors stay explicit via a `major` boolean, since a major is a decision rather than a derivation.

## Semver

Checked against [2.0.0](https://semver.org/). Pre-1.0 this is not a deviation at all — clause 4 gives `0.y.z` total latitude, and the specification's own FAQ recommends exactly this scheme. After 1.0 there is **one declared deviation**: a fixes-only release from `main` takes a minor where clause 6 asks for a patch. Clause 7 covers every other case, and the compliant route stays available and preferred — cherry-pick to a release branch and cut a patch, which is what it exists for.

Documented rather than glossed, in `RELEASING.md` §2.

## What is in each commit

| Commit | Contents |
|---|---|
| `docs:` | `RELEASING.md` §2 as the rule, a new tag-and-branch-model section, `SECURITY.md` |
| `semver command` | `hack/cmd/semver`, 27 tests |
| `bump from the branch` | `bump-for-branch.sh`, 14 tests |
| `guard the resolver` | `SERIES` and `version_gt` guards, 16 new cases |
| `cut from a release branch` | `release-prepare.yaml` |
| `create release branches` | `create-release-branch.yaml` |
| `skip the soak` | `release-upgrade.yaml` |

## Three things worth a reviewer's attention

**`sort -V` does not implement semver precedence.** It ranks `v1.0.0` *below* `v1.0.0-rc.1`, the opposite of clause 11.3. Nothing was affected before, because `latest_final` filters to finals and `train_cores` strips `-rc.N`, but the soak has to compare an arbitrary incoming tag against the newest release and that tag is routinely a candidate. `RELEASING.md:12-13` documents dispatching `release-upgrade` by hand for backfills, so `v1.7.0-rc.1` arriving after `v1.7.0` shipped is real — and under `sort -V` it would outrank its own final and redeploy a superseded tree to the soak cluster. Hence a Go command rather than more shell. With the `version_gt` guard removed, the test suite reports `version_gt v1.0.0-rc.1 v1.0.0` returning **true**.

**The tooling comes from `main`, the history from the branch.** `release-prepare.yaml` checks out the branch and then restores `hack/release/` from `origin/main`. The two pull in opposite directions and both matter: the branch supplies the history the version is computed against, which is what scopes resolution to its series; `main` supplies the scripts that compute it. Otherwise an old branch cuts releases with old tooling, and executes scripts from a branch protected less strictly than `main`.

**Nothing was needed to stop a maintenance release publishing.** `publish` already requires `result == 'success'` on all four gates, and a skipped job is not a successful one, so the draft simply stays a draft. `publish-forced` uses `!cancelled()` and remains reachable. The explicit result checks added earlier to stop a skipped smoke matrix from publishing turn out to handle this case too.

## Verification

Against the repository as it stands, with this branch's tooling:

```
main         -> bump=minor series=''    tag=v0.4.0
release-0.3  -> bump=patch series=0.3   tag=v0.3.1
release-0.3 forced to minor -> refused: v0.4.0 is outside series 0.3
```

Branch-point resolution against the real tag set: `0.3` → `v0.3.0` (not the `-rc.1`), `0.2` → `v0.2.4` (not `v0.2.0`), `9.9` → refused.

`make test` passes: 81 resolver cases, 27 for `hack/cmd/semver`, 14 for `bump-for-branch.sh`. The three load-bearing decisions in `hack/cmd/semver`, both resolver guards, and the `bump-for-branch` refusal are each mutation-verified — removed, confirmed failing, restored.

## Nothing changes until a release branch exists

`main` is always the newest release, so nothing it cuts is ever classified as maintenance; the `SERIES` guard is inert when empty; `create-release-branch.yaml` runs only when dispatched. The single live change is that `main` now cuts minors, and `-f dry_run=true` rehearses that in full without pushing.

## Merge order

**#643 must merge before this.** It adds `release-*` CI triggers, and every required status check comes from `ci.yaml`; a release branch without them could never merge a cherry-pick. Nothing enforces the order.

The `release-*` ruleset is an admin action that must follow #643 and should land before the first branch is created. Details are in #627.
