### PR TITLE
fix(gantry): route stalled pulls to next-ranked node

### DIFF
--- a/internal/gantry/coldstart/coldstart.go
+++ b/internal/gantry/coldstart/coldstart.go
@@ -549,7 +549,8 @@ func (r *Resolver) probe(ctx context.Context, d digest.Digest, kind ifaces.Origi
 	}
 
 	// Rule 3: in-flight piggyback.
-	if v := findInFlight(reachable, r.opts.Inflight, kind, expectedSize, r.opts.Now(), r.opts.Metrics.OnDesignatedPullerTakeover); v != nil {
+	inFlight, stalledPullers := findInFlight(reachable, r.opts.Inflight, kind, expectedSize, r.opts.Now(), r.opts.Metrics.OnDesignatedPullerTakeover)
+	if inFlight != nil {
 		if r.opts.Metrics.OnTopKProbeHit != nil {
 			r.opts.Metrics.OnTopKProbeHit()
 		}
@@ -581,10 +582,10 @@ func (r *Resolver) probe(ctx context.Context, d digest.Digest, kind ifaces.Origi
 	}
 
 	// Rule 7: cold-start. Lowest hrw_rank reachable wins.
-	puller := lowestRankReachable(reachable)
+	puller := lowestRankReachable(withoutStalledPullers(reachable, stalledPullers))
 	if puller == nil {
 		// Defensive: should not be possible - reachable is non-empty
-		// but no entry had a valid rank. Treat as exhausted.
+		// but every entry may have a stalled in-flight pull. Treat as exhausted.
 		return nil, prefix(expandLabel, "rule7_no_puller"), ErrExhausted
 	}
 
@@ -779,7 +780,9 @@ func findCacheHit(rs []response) *response {
 	return nil
 }
 
-func findInFlight(rs []response, infl *inflight.Map, kind ifaces.OriginRefKind, expectedSize int64, now time.Time, onTakeover func(kindLabel string)) *response {
+func findInFlight(rs []response, infl *inflight.Map, kind ifaces.OriginRefKind, expectedSize int64, now time.Time, onTakeover func(kindLabel string)) (*response, map[ifaces.NodeID]struct{}) {
+	var stalledPullers map[ifaces.NodeID]struct{}
+
 	for i := range rs {
 		intent := rs[i].intent
 		if !intent.InFlight {
@@ -792,8 +795,14 @@ func findInFlight(rs []response, infl *inflight.Map, kind ifaces.OriginRefKind, 
 
 			threshold := infl.Stalls().ResolveStall(kind, expectedSize)
 			if elapsed > threshold {
-				// Stale puller - emit the takeover metric and
-				// keep searching. Rank-1 (next entry) may still serve.
+				// Stale puller - exclude it from both piggybacking and the
+				// subsequent please_pull candidate set.
+				if stalledPullers == nil {
+					stalledPullers = make(map[ifaces.NodeID]struct{})
+				}
+
+				stalledPullers[rs[i].node.ID] = struct{}{}
+
 				if onTakeover != nil {
 					onTakeover(kindLabel(kind))
 				}
@@ -802,10 +811,25 @@ func findInFlight(rs []response, infl *inflight.Map, kind ifaces.OriginRefKind, 
 			}
 		}
 
-		return &rs[i]
+		return &rs[i], stalledPullers
 	}
 
-	return nil
+	return nil, stalledPullers
+}
+
+func withoutStalledPullers(rs []response, stalled map[ifaces.NodeID]struct{}) []response {
+	if len(stalled) == 0 {
+		return rs
+	}
+
+	out := make([]response, 0, len(rs)-len(stalled))
+	for _, r := range rs {
+		if _, ok := stalled[r.node.ID]; !ok {
+			out = append(out, r)
+		}
+	}
+
+	return out
 }
 
 func findTransientCooldown(rs []response) (bool, time.Time) {

--- a/internal/gantry/coldstart/coldstart_test.go
+++ b/internal/gantry/coldstart/coldstart_test.go
@@ -426,6 +426,10 @@ func TestRule3_InFlightStaleExcluded(t *testing.T) {
 		t.Fatalf("please_pull dialed %d times; want 1", len(coord.pleasePullCalls))
 	}
 
+	if coord.pleasePullCalls[0] != top[1].Node.ID {
+		t.Errorf("please_pull target = %q; want next-ranked node %q", coord.pleasePullCalls[0], top[1].Node.ID)
+	}
+
 	if len(takeoverKinds) == 0 {
 		t.Fatalf("OnDesignatedPullerTakeover never fired; want at least one (manifest)")
 	}


### PR DESCRIPTION
## Summary

Fix designated-puller takeover when the highest-ranked Gantry node has a stalled in-flight pull.

## Design deviation

The previous implementation did not match the takeover behavior specified in `designs/gantry-detailed-design.md`.

The design requires a puller whose in-flight operation exceeds the per-digest stall threshold to be excluded from subsequent `please_pull` candidates. The next-ranked reachable node should then take over.

Previously, Gantry recognized stale rank 0 during the in-flight piggyback check and incremented `p2p_designated_puller_takeover_total`, but Rule 7 selected from the original, unfiltered reachable set. This could send `please_pull` back to stale rank 0 instead of rank 1. The metric could therefore report a takeover that never occurred.

## Changes

- Track pullers whose in-flight work has exceeded the per-digest stall threshold.
- Exclude those pullers when Rule 7 selects the lowest-ranked eligible node.
- Preserve stalled-node responses for earlier failure, cache, and cooldown evaluation.
- Strengthen `TestRule3_InFlightStaleExcluded` to verify that `please_pull` targets the next-ranked node.

This brings the implementation back into conformance with the documented stalled-puller takeover flow.

## Validation

- `go test ./internal/gantry/coldstart ./internal/gantry/mirror ./cmd/gantry -count=1`
- `golangci-lint run ./internal/gantry/coldstart`

The new recipient assertion failed against the previous implementation because it selected stale rank 0. It passes after the fix and confirms that rank 1 receives the takeover request.
