### PR TITLE
release: tolerate workloads stranded by an unreachable site

### DIFF
--- a/deploy/gantry/daemonset.yaml.tmpl
+++ b/deploy/gantry/daemonset.yaml.tmpl
@@ -82,22 +82,12 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      # 100%, matching unbounded-net-node and unbounded-storage-supervisor.
-      #
-      # A percentage here is a budget for the WHOLE fleet, not just the nodes
-      # being updated, and pods on unreachable nodes count against it. At 10%
-      # of a 16-node fleet the budget was 1, so seven nodes that had lost their
-      # kubelet consumed it before the rollout started and the controller never
-      # updated any of the nine reachable nodes. The release gate then sat
-      # through its full timeout every time, because a fleet where most healthy
-      # nodes still run the previous release is not one it can certify.
-      #
-      # Restarting every agent at once is cheap here for the reason the old
-      # comment gave for keeping the number small: the mirror endpoint is
-      # per-node and containerd falls back to origin on connection failure, so
-      # an agent that is briefly gone only affects pulls happening in that
-      # window, and it costs latency rather than correctness.
-      maxUnavailable: 100%
+      # Limit blast radius: at most 10% of nodes lose their agent at
+      # any one time during an update. The mirror endpoint is per-node
+      # and containerd falls back to origin on connection failure, so
+      # a node losing its agent only affects pulls happening during
+      # the window.
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/deploy/gantry/daemonset.yaml.tmpl
+++ b/deploy/gantry/daemonset.yaml.tmpl
@@ -82,12 +82,22 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      # Limit blast radius: at most 10% of nodes lose their agent at
-      # any one time during an update. The mirror endpoint is per-node
-      # and containerd falls back to origin on connection failure, so
-      # a node losing its agent only affects pulls happening during
-      # the window.
-      maxUnavailable: 10%
+      # 100%, matching unbounded-net-node and unbounded-storage-supervisor.
+      #
+      # A percentage here is a budget for the WHOLE fleet, not just the nodes
+      # being updated, and pods on unreachable nodes count against it. At 10%
+      # of a 16-node fleet the budget was 1, so seven nodes that had lost their
+      # kubelet consumed it before the rollout started and the controller never
+      # updated any of the nine reachable nodes. The release gate then sat
+      # through its full timeout every time, because a fleet where most healthy
+      # nodes still run the previous release is not one it can certify.
+      #
+      # Restarting every agent at once is cheap here for the reason the old
+      # comment gave for keeping the number small: the mirror endpoint is
+      # per-node and containerd falls back to origin on connection failure, so
+      # an agent that is briefly gone only affects pulls happening in that
+      # window, and it costs latency rather than correctness.
+      maxUnavailable: 100%
   template:
     metadata:
       labels:

--- a/hack/release/smoke/core-namespaces-ready.sh
+++ b/hack/release/smoke/core-namespaces-ready.sh
@@ -112,11 +112,25 @@ is_notready_node() {
 
 # site_entirely_unreachable answers whether a site exists and has no Ready node.
 # A site no node claims returns 1: that is a label matching nothing, which is
-# indistinguishable from a typo and must not excuse anything.
+# indistinguishable from a typo and must not excuse anything. It says so out
+# loud, because a typo is the case this refusal exists to catch.
 #
 # This mirrors the site check in hack/release/wait-rollouts.sh. The two are
 # deliberately separate copies, because a smoke test is meant to stand alone -
 # but they answer the same question, so change them together.
+#
+# Two of the gate's conditions are deliberately NOT re-applied here:
+#
+#   MAX_NOTREADY_NODES   how much of the cluster may be down is decided once,
+#                        by the gate.
+#   the image tag        whether the workload is on this release is likewise
+#                        the gate's judgement.
+#
+# Both rest on the gate having passed minutes earlier, which is an assumption
+# rather than an invariant: nodes can go down in between, and a site that was
+# partly reachable then may be entirely unreachable now. That widens what smoke
+# excuses, never what it fails, so the direction is safe - but it is an
+# assumption, and this is where to look when it stops holding.
 site_entirely_unreachable() {
   local want="$1" site total ready
 
@@ -131,7 +145,8 @@ site_entirely_unreachable() {
     return 0
   done <<<"${site_readiness}"
 
-  # No node claims this site at all.
+  echo "::warning::pinned to site ${want}, which has no nodes; a label matching nothing is not a dead site"
+
   return 1
 }
 
@@ -188,31 +203,47 @@ for ns in "${NAMESPACES[@]}"; do
 
   # "<name>|<phase>|<ready_status>|<node>|<site_pins>" per pod, joined on the
   # ASCII unit separator rather than a tab. Tab is IFS whitespace, so bash
-  # collapses runs of it and an EMPTY field silently disappears: an unscheduled
-  # pod has neither a Ready condition nor a nodeName, so two fields in a row are
-  # empty and every later field shifts left. The separator below cannot appear
-  # in a Kubernetes name or label value.
+  # collapses runs of it and an EMPTY field silently disappears. That bites in
+  # two places: an unscheduled pod has neither a Ready condition nor a nodeName,
+  # and a pod on a NotReady node whose kubelet never reported has no Ready
+  # condition either, which used to lose its nodeName and get counted as a
+  # failure. The separator below cannot appear in a Kubernetes name or label.
   #
   # ready_status is the status of the Ready condition (True/False/empty if
   # missing). site_pins is comma-separated, and empty for a pod that is not
   # site-scoped.
+  #
+  # EVERY nodeSelectorTerm must name a site, for the reason set out against
+  # SITE_PIN_FILTER in hack/release/wait-rollouts.sh: the terms are OR-ed, so a
+  # term without one lets the pod run somewhere this cannot see, and claiming a
+  # pin it does not have would excuse a real scheduling failure. Kept
+  # structurally identical to that filter, differing only in .spec versus
+  # .spec.template.spec, so the two can be diffed for drift.
   if ! pods="$(jq -r '
     .items[]
-    | [ .metadata.name,
-        (.status.phase // ""),
-        ((((.status.conditions // []) | map(select(.type == "Ready")) | .[0].status) // "")),
-        (.spec.nodeName // ""),
-        ([ (.spec.affinity.nodeAffinity
-              .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [])[]
-            | (.matchExpressions // [])[]
-            | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
-            | select(.operator == "In")
-            | (.values // [])[]
-          ] + [ ((.spec.nodeSelector // {}) | to_entries)[]
-                | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
-                | .value
-              ]
-          | unique | join(","))
+    | . as $pod
+    | ((.spec.affinity.nodeAffinity
+          .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [])) as $terms
+    | ([ $terms[]
+         | [ (.matchExpressions // [])[]
+             | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
+             | select(.operator == "In")
+             | (.values // [])[]
+           ]
+       ]) as $per_term
+    | ((if ($terms | length) > 0 and ($per_term | all(length > 0))
+        then ($per_term | add)
+        else [] end)
+       + [ (($pod.spec.nodeSelector // {}) | to_entries)[]
+           | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
+           | .value
+         ]
+       | unique) as $pins
+    | [ $pod.metadata.name,
+        ($pod.status.phase // ""),
+        (((($pod.status.conditions // []) | map(select(.type == "Ready")) | .[0].status) // "")),
+        ($pod.spec.nodeName // ""),
+        ($pins | join(","))
       ]
     | join("\u001f")
   ' <<<"${pods_json}")"; then

--- a/hack/release/smoke/core-namespaces-ready.sh
+++ b/hack/release/smoke/core-namespaces-ready.sh
@@ -5,9 +5,10 @@
 # release-smoke: core-namespaces-ready
 #
 # Verifies that the core Unbounded namespaces exist on the deployed cluster
-# and that every pod on a REACHABLE node in those namespaces is Running and
-# Ready. Pods stranded on a node the kubelet has stopped reporting for are
-# reported and not counted; see the convention on that below.
+# and that every pod the release can be judged on is Running and Ready. Pods
+# stranded by a node the kubelet has stopped reporting for, whether they are on
+# it or merely pinned to it, are reported and not counted; see the convention on
+# that below.
 #
 # This script is the canonical TEMPLATE for release smoke tests. Copy it
 # as the starting point for new smoke checks under hack/release/smoke/.
@@ -39,6 +40,11 @@ set -euo pipefail
 : "${TAG:?TAG must be set}"
 : "${KUBECONFIG:?KUBECONFIG must be set}"
 
+command -v jq >/dev/null 2>&1 || {
+  echo "::error::core-namespaces-ready requires jq on PATH"
+  exit 1
+}
+
 NAMESPACES=(unbounded-system)
 KUBECTL=(kubectl --request-timeout=30s)
 
@@ -56,17 +62,39 @@ for ns in "${NAMESPACES[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
-# 2. Collect nodes that are not Ready. Their pods are reported, never counted:
-#    with the kubelet gone they can sit Terminating indefinitely through no
-#    fault of the release.
+# 2. Collect node readiness. Pods on a node that is not Ready are reported,
+#    never counted: with the kubelet gone they can sit Terminating indefinitely
+#    through no fault of the release.
+#
+#    Per-SITE readiness is collected from the same payload, for the unscheduled
+#    case in section 3. Read once because two queries could disagree.
 # ---------------------------------------------------------------------------
 notready_nodes=""
-# Filtered here rather than with a jsonpath predicate on .items: kubectl cannot
-# evaluate a nested filter inside an item selector, and silently returns nothing
-# when asked to.
-if node_readiness="$("${KUBECTL[@]}" get nodes \
-  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null)"; then
-  notready_nodes="$(awk -F'\t' '$2 != "True" { print $1 }' <<<"${node_readiness}")"
+site_readiness=""
+
+if nodes_json="$("${KUBECTL[@]}" get nodes -o json 2>/dev/null)"; then
+  notready_nodes="$(jq -r '
+    .items[]
+    | select(((((.status.conditions // []) | map(select(.type == "Ready")) | .[0].status) // "Unknown")) != "True")
+    | .metadata.name
+  ' <<<"${nodes_json}")"
+
+  # "<site>\t<total>\t<ready>" per site any node claims. Both label keys are
+  # consulted because the net controllers still dual-write them.
+  site_readiness="$(jq -r '
+    [ .items[]
+      | { site: (.metadata.labels["unbounded-cloud.io/site"]
+                  // .metadata.labels["net.unbounded-cloud.io/site"]
+                  // ""),
+          ready: (((((.status.conditions // [])
+                      | map(select(.type == "Ready")) | .[0].status) // "Unknown")) == "True")
+        }
+      | select(.site != "")
+    ]
+    | group_by(.site)[]
+    | [ .[0].site, (. | length), ([ .[] | select(.ready) ] | length) ]
+    | @tsv
+  ' <<<"${nodes_json}")"
 else
   # Fail closed: if node readiness cannot be established, judge every pod.
   echo "::warning::could not list node readiness; every unready pod will be treated as a failure"
@@ -82,10 +110,65 @@ is_notready_node() {
   grep -qxF "$1" <<<"${notready_nodes}"
 }
 
+# site_entirely_unreachable answers whether a site exists and has no Ready node.
+# A site no node claims returns 1: that is a label matching nothing, which is
+# indistinguishable from a typo and must not excuse anything.
+#
+# This mirrors the site check in hack/release/wait-rollouts.sh. The two are
+# deliberately separate copies, because a smoke test is meant to stand alone -
+# but they answer the same question, so change them together.
+site_entirely_unreachable() {
+  local want="$1" site total ready
+
+  [[ -n "${want}" && -n "${site_readiness}" ]] || return 1
+
+  while IFS=$'\t' read -r site total ready; do
+    [[ "${site}" == "${want}" ]] || continue
+
+    (( total > 0 )) || return 1
+    (( ready == 0 )) || return 1
+
+    return 0
+  done <<<"${site_readiness}"
+
+  # No node claims this site at all.
+  return 1
+}
+
+# pod_is_stranded_unscheduled answers whether an unscheduled pod is explained by
+# every site it is pinned to being unreachable. Only REQUIRED affinity counts: a
+# preferred term is a hint the scheduler may ignore, so a pod carrying one could
+# have run elsewhere and its being unscheduled is a real failure.
+#
+# $1 is the comma-separated pin list extracted by the pod query below. Empty
+# means the pod is not site-scoped, so nothing here excuses it.
+pod_is_stranded_unscheduled() {
+  local pins="$1" site
+
+  [[ -n "${pins}" ]] || return 1
+
+  while IFS= read -r site; do
+    [[ -n "${site}" ]] || continue
+
+    site_entirely_unreachable "${site}" || return 1
+  done <<<"$(tr ',' '\n' <<<"${pins}")"
+
+  return 0
+}
+
 # ---------------------------------------------------------------------------
-# 3. Every pod on a Ready node is Running and Ready.
-#    Completed pods (Job-style workloads in phase Succeeded) are ignored;
-#    they are not a failure even though they are not Running.
+# 3. Every pod the release can be judged on is Running and Ready.
+#
+#    Three kinds are reported rather than counted, because none of them is
+#    something a release can fix:
+#      - Completed pods (Job-style workloads in phase Succeeded);
+#      - pods on a node that is not Ready;
+#      - UNSCHEDULED pods pinned to a site with no reachable node. These have no
+#        nodeName, so they cannot be matched against the NotReady list at all,
+#        and used to be counted as failures. The operator creates one Deployment
+#        per Site for some components, and when that site is entirely
+#        unreachable its pod has nowhere to go. The deploy gate has already
+#        tolerated exactly this before smoke runs; see wait-rollouts.sh.
 # ---------------------------------------------------------------------------
 failures=0
 stranded=0
@@ -95,15 +178,49 @@ for ns in "${NAMESPACES[@]}"; do
   # Captured before the loop, not piped into it: a failing process substitution
   # is invisible to `set -e`, so an errored query would feed the loop nothing
   # and this check would pass having examined no pods at all.
-  if ! pods="$("${KUBECTL[@]}" -n "${ns}" get pods \
-      -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.spec.nodeName}{"\n"}{end}')"; then
+  #
+  # -o json rather than jsonpath because the site pins need a nested filter,
+  # and kubectl silently returns nothing when asked for one.
+  if ! pods_json="$("${KUBECTL[@]}" -n "${ns}" get pods -o json)"; then
     echo "::error::could not list pods in ${ns}"
     exit 1
   fi
 
-  # Emit "<name>\t<phase>\t<ready_status>\t<node>" per pod. ready_status is the
-  # status of the Ready condition (True/False/<empty> if missing).
-  while IFS=$'\t' read -r name phase ready node; do
+  # "<name>|<phase>|<ready_status>|<node>|<site_pins>" per pod, joined on the
+  # ASCII unit separator rather than a tab. Tab is IFS whitespace, so bash
+  # collapses runs of it and an EMPTY field silently disappears: an unscheduled
+  # pod has neither a Ready condition nor a nodeName, so two fields in a row are
+  # empty and every later field shifts left. The separator below cannot appear
+  # in a Kubernetes name or label value.
+  #
+  # ready_status is the status of the Ready condition (True/False/empty if
+  # missing). site_pins is comma-separated, and empty for a pod that is not
+  # site-scoped.
+  if ! pods="$(jq -r '
+    .items[]
+    | [ .metadata.name,
+        (.status.phase // ""),
+        ((((.status.conditions // []) | map(select(.type == "Ready")) | .[0].status) // "")),
+        (.spec.nodeName // ""),
+        ([ (.spec.affinity.nodeAffinity
+              .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [])[]
+            | (.matchExpressions // [])[]
+            | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
+            | select(.operator == "In")
+            | (.values // [])[]
+          ] + [ ((.spec.nodeSelector // {}) | to_entries)[]
+                | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
+                | .value
+              ]
+          | unique | join(","))
+      ]
+    | join("\u001f")
+  ' <<<"${pods_json}")"; then
+    echo "::error::could not evaluate pods in ${ns}"
+    exit 1
+  fi
+
+  while IFS=$'\037' read -r name phase ready node pins; do
     [[ -z "${name}" ]] && continue
     if [[ "${phase}" == "Succeeded" ]]; then
       continue
@@ -113,6 +230,11 @@ for ns in "${NAMESPACES[@]}"; do
     fi
     if is_notready_node "${node}"; then
       echo "  stranded: ${ns}/${name} on NotReady node ${node} (phase=${phase})"
+      stranded=$((stranded + 1))
+      continue
+    fi
+    if [[ -z "${node}" ]] && pod_is_stranded_unscheduled "${pins}"; then
+      echo "  stranded: ${ns}/${name} unscheduled; pinned to unreachable site(s) ${pins} (phase=${phase})"
       stranded=$((stranded + 1))
       continue
     fi
@@ -127,7 +249,7 @@ if (( failures > 0 )); then
 fi
 
 if (( stranded > 0 )); then
-  echo "::warning::${stranded} pod(s) stranded on NotReady nodes were not validated by this release"
+  echo "::warning::${stranded} pod(s) stranded by unreachable nodes were not validated by this release"
 fi
 
-echo "OK: namespaces present and every pod on a Ready node is Running+Ready"
+echo "OK: namespaces present and every pod the release can be judged on is Running+Ready"

--- a/hack/release/smoke_core_namespaces_test.go
+++ b/hack/release/smoke_core_namespaces_test.go
@@ -1,0 +1,380 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package release
+
+import (
+	"sort"
+	"testing"
+)
+
+// Tests for smoke/core-namespaces-ready.sh.
+//
+// The script decides which unready pods a release may be judged on. Everything
+// it excuses is a pod that would otherwise fail the soak, so every case below
+// is a way of excusing one that should have failed, or of failing one that a
+// site outage explains.
+//
+// It shares the fake kubectl in wait_rollouts_test.go rather than standing up
+// its own: the stub dispatches on the shape of the call, and this script makes
+// the same three kinds (get namespace, get nodes -o json, get pods).
+//
+// The site logic here is a deliberate second copy of the one in
+// wait-rollouts.sh, so these cases deliberately overlap that file's. If one set
+// changes, check the other.
+
+// smokePod describes one pod in a core-namespaces-ready fixture.
+type smokePod struct {
+	name  string
+	phase string
+	// ready is the status of the Ready condition. Empty means the condition is
+	// absent entirely, which is what a pod the kubelet never reported on looks
+	// like, and what used to lose its nodeName to tab collapsing.
+	ready string
+	// node is .spec.nodeName. Empty means unscheduled.
+	node string
+	// terms become required nodeSelectorTerms, one per entry, each key/value an
+	// In matchExpression. Terms are OR-ed by Kubernetes.
+	terms []map[string]string
+	// nodeSelector is the older spelling, AND-ed with the above.
+	nodeSelector map[string]string
+	// preferredSite adds a PREFERRED site affinity, which must never excuse
+	// anything: the scheduler may ignore it, so the pod could have run
+	// elsewhere.
+	preferredSite string
+}
+
+// smokePodList renders a pod list in the shape kubectl returns.
+func smokePodList(pods ...smokePod) string {
+	items := make([]map[string]any, 0, len(pods))
+
+	for _, p := range pods {
+		spec := map[string]any{}
+		if p.node != "" {
+			spec["nodeName"] = p.node
+		}
+
+		if len(p.nodeSelector) > 0 {
+			spec["nodeSelector"] = p.nodeSelector
+		}
+
+		affinity := map[string]any{}
+
+		if len(p.terms) > 0 {
+			built := make([]map[string]any, 0, len(p.terms))
+
+			for _, term := range p.terms {
+				keys := make([]string, 0, len(term))
+				for key := range term {
+					keys = append(keys, key)
+				}
+
+				sort.Strings(keys)
+
+				expressions := make([]map[string]any, 0, len(term))
+				for _, key := range keys {
+					expressions = append(expressions, map[string]any{
+						"key":      key,
+						"operator": "In",
+						"values":   []string{term[key]},
+					})
+				}
+
+				built = append(built, map[string]any{"matchExpressions": expressions})
+			}
+
+			affinity["requiredDuringSchedulingIgnoredDuringExecution"] = map[string]any{
+				"nodeSelectorTerms": built,
+			}
+		}
+
+		if p.preferredSite != "" {
+			affinity["preferredDuringSchedulingIgnoredDuringExecution"] = []map[string]any{{
+				"weight": 100,
+				"preference": map[string]any{
+					"matchExpressions": []map[string]any{{
+						"key":      "unbounded-cloud.io/site",
+						"operator": "In",
+						"values":   []string{p.preferredSite},
+					}},
+				},
+			}}
+		}
+
+		if len(affinity) > 0 {
+			spec["affinity"] = map[string]any{"nodeAffinity": affinity}
+		}
+
+		status := map[string]any{"phase": p.phase}
+		if p.ready != "" {
+			status["conditions"] = []map[string]any{
+				{"type": "PodScheduled", "status": "True"},
+				{"type": "Ready", "status": p.ready},
+			}
+		} else {
+			status["conditions"] = []map[string]any{
+				{"type": "PodScheduled", "status": "False"},
+			}
+		}
+
+		items = append(items, map[string]any{
+			"metadata": map[string]any{"name": p.name},
+			"spec":     spec,
+			"status":   status,
+		})
+	}
+
+	return marshal(map[string]any{"items": items})
+}
+
+// smokeNodes is the cluster every case below runs against unless it needs
+// another shape: one healthy site, one entirely unreachable.
+func smokeNodes() string {
+	return nodeList(
+		node{name: "node-a", site: "hq", ready: "True"},
+		node{name: "spark-3d37", site: "boulderlab", ready: "Unknown"},
+	)
+}
+
+// runSmoke drives the real script against the fake kubectl.
+func runSmoke(t *testing.T, nodes, pods string) (string, int) {
+	t.Helper()
+
+	f := newFake(t)
+	f.set("get-namespace", reply{stdout: "namespace/unbounded-system"})
+	f.set("getjson-nodes", reply{stdout: nodes})
+	f.set("pods", reply{stdout: pods})
+
+	return f.runScript("smoke/core-namespaces-ready.sh", map[string]string{
+		"TAG":       releaseTag,
+		"SITE_NAME": "stable",
+	})
+}
+
+// pinnedToDeadSite is the pod the whole feature exists for: the operator's
+// per-Site Deployment could not schedule, because its site is gone.
+var pinnedToDeadSite = smokePod{
+	name:  "metalman-controller-boulderlab-abc",
+	phase: "Pending",
+	terms: []map[string]string{{"unbounded-cloud.io/site": "boulderlab"}},
+}
+
+func TestSmokeToleratesAnUnscheduledPodPinnedToADeadSite(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(pinnedToDeadSite))
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "unscheduled; pinned to unreachable site(s) boulderlab")
+	requireNotContains(t, output, "::error::")
+}
+
+func TestSmokeToleratesAPodPinnedToTwoDeadSites(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	nodes := nodeList(
+		node{name: "node-a", site: "hq", ready: "True"},
+		node{name: "spark-3d37", site: "boulderlab", ready: "Unknown"},
+		node{name: "edge-1", site: "edge", ready: "Unknown"},
+	)
+
+	pod := pinnedToDeadSite
+	pod.terms = []map[string]string{
+		{"unbounded-cloud.io/site": "boulderlab"},
+		{"unbounded-cloud.io/site": "edge"},
+	}
+
+	output, code := runSmoke(t, nodes, smokePodList(pod))
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "unreachable site(s) boulderlab,edge")
+}
+
+// TestSmokeRefusesAPodWhenOneOfItsSitesIsReachable is the OR condition: the
+// terms are alternatives, so one reachable site means the pod could have run.
+func TestSmokeRefusesAPodWhenOneOfItsSitesIsReachable(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	nodes := nodeList(
+		node{name: "node-a", site: "hq", ready: "True"},
+		node{name: "spark-3d37", site: "boulderlab", ready: "Unknown"},
+		node{name: "edge-1", site: "edge", ready: "True"},
+	)
+
+	pod := pinnedToDeadSite
+	pod.terms = []map[string]string{
+		{"unbounded-cloud.io/site": "boulderlab"},
+		{"unbounded-cloud.io/site": "edge"},
+	}
+
+	output, code := runSmoke(t, nodes, smokePodList(pod))
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "::error::pod")
+}
+
+// TestSmokeRefusesAPodWhoseTermCarriesNoSite is the regression guard for the OR
+// under-approximation. Smoke has no equivalent of the gate's "no pod on a
+// reachable node" contradiction check, because it judges each pod alone and an
+// unscheduled pod is on no node by definition. Nothing else would catch this.
+func TestSmokeRefusesAPodWhoseTermCarriesNoSite(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	pod := pinnedToDeadSite
+	pod.terms = []map[string]string{
+		{"unbounded-cloud.io/site": "boulderlab"},
+		{"kubernetes.io/arch": "amd64"},
+	}
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(pod))
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "::error::pod")
+	requireNotContains(t, output, "unscheduled; pinned to unreachable")
+}
+
+func TestSmokeToleratesAPodPinnedByTheDeprecatedSiteKey(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	pod := pinnedToDeadSite
+	pod.terms = []map[string]string{{"net.unbounded-cloud.io/site": "boulderlab"}}
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(pod))
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "unreachable site(s) boulderlab")
+}
+
+func TestSmokeToleratesAPodPinnedByNodeSelector(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	pod := smokePod{
+		name:         "metalman-controller-boulderlab-abc",
+		phase:        "Pending",
+		nodeSelector: map[string]string{"unbounded-cloud.io/site": "boulderlab"},
+	}
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(pod))
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "unreachable site(s) boulderlab")
+}
+
+// TestSmokeRefusesAnUnscheduledPodWithNoSitePin covers the ordinary
+// unschedulable pod: no resources, a taint, a typo'd selector. Nothing about a
+// dead site explains it.
+func TestSmokeRefusesAnUnscheduledPodWithNoSitePin(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(smokePod{
+		name:  "orphan",
+		phase: "Pending",
+	}))
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "::error::pod unbounded-system/orphan not ready")
+}
+
+func TestSmokeRefusesAPodPinnedToASiteWithAReadyNode(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	pod := pinnedToDeadSite
+	pod.terms = []map[string]string{{"unbounded-cloud.io/site": "hq"}}
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(pod))
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "::error::pod")
+}
+
+// TestSmokeRefusesAPodPinnedToASiteWithNoNodes covers the typo case, and that
+// it says so: a label matching nothing is not a dead site, and an operator
+// staring at a plain "not ready" would have no way to tell the difference.
+func TestSmokeRefusesAPodPinnedToASiteWithNoNodes(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	pod := pinnedToDeadSite
+	pod.terms = []map[string]string{{"unbounded-cloud.io/site": "atlantis"}}
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(pod))
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "pinned to site atlantis, which has no nodes")
+}
+
+// TestSmokeRefusesAPodWithOnlyPreferredAffinity keeps preferred out. The
+// scheduler may ignore it, so the pod could have run on a reachable node.
+func TestSmokeRefusesAPodWithOnlyPreferredAffinity(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(smokePod{
+		name:          "soft",
+		phase:         "Pending",
+		preferredSite: "boulderlab",
+	}))
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "::error::pod unbounded-system/soft not ready")
+}
+
+// TestSmokeRefusesAnUnreadyPodOnAReadyNode is the behaviour that existed before
+// any of this and must survive it: a pod failing on a healthy node is the
+// regression a release smoke test exists to catch.
+func TestSmokeRefusesAnUnreadyPodOnAReadyNode(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(smokePod{
+		name: "broken", phase: "Running", ready: "False", node: "node-a",
+	}))
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "::error::pod unbounded-system/broken not ready")
+}
+
+// TestSmokeToleratesAnUnreadyPodOnANotReadyNode is the other pre-existing
+// behaviour. It also covers the pod shape that used to lose its nodeName to tab
+// collapsing: no Ready condition at all, with a nodeName after it.
+func TestSmokeToleratesAnUnreadyPodOnANotReadyNode(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	output, code := runSmoke(t, smokeNodes(), smokePodList(smokePod{
+		name: "stranded", phase: "Running", node: "spark-3d37",
+	}))
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "stranded: unbounded-system/stranded on NotReady node spark-3d37")
+}
+
+// TestSmokeFailsClosedWhenNodeReadinessCannotBeRead covers the contract stated
+// at the top of the script: if node readiness cannot be established, every
+// unready pod is judged. Excusing pods against an unknown cluster would be the
+// worst of both.
+func TestSmokeFailsClosedWhenNodeReadinessCannotBeRead(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("get-namespace", reply{stdout: "namespace/unbounded-system"})
+	f.set("getjson-nodes", reply{stderr: "error: the server could not find the requested resource", exit: 1})
+	f.set("pods", reply{stdout: smokePodList(pinnedToDeadSite)})
+
+	output, code := f.runScript("smoke/core-namespaces-ready.sh", map[string]string{
+		"TAG":       releaseTag,
+		"SITE_NAME": "stable",
+	})
+
+	requireCode(t, code, 1, output)
+	requireContains(t, output, "could not list node readiness")
+}

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -834,6 +834,11 @@ daemonset_tolerance() {
 # The nodes are read ONCE here and both questions answered from that one
 # payload: which nodes are NotReady, and how many nodes each pinned site has.
 # Asking twice would cost a second full node list on every poll.
+#
+# hack/release/smoke/core-namespaces-ready.sh makes the same judgement about the
+# pod this Deployment could not schedule, from a separate copy of this logic: a
+# smoke test is meant to stand alone. They answer the same question, so change
+# them together.
 site_deployment_tolerance() {
   local target="$1" selector="$2"
   local obj_json nodes_json nodes_tsv notready_json sites_json site_tsv status_tsv

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -70,10 +70,12 @@
 # "keep waiting" and let rollout status deliver the verdict. It exists because a
 # DaemonSet counts every node toward desiredNumberScheduled, including nodes the
 # kubelet has stopped reporting for, so one unreachable node blocks the gate
-# until its timeout, every time, forever. It tolerates only when ALL of:
+# until its timeout, every time, forever.
 #
-#   - the workload is a DaemonSet, since a Deployment reschedules off a dead
-#     node and a shortfall there is a real scheduling problem;
+# There are two shapes of that problem, and each has its own set of conditions.
+#
+# A DAEMONSET is tolerated only when ALL of:
+#
 #   - it is short of pods at all;
 #   - its CURRENT pod template references EXPECTED_IMAGE_TAG;
 #   - between 1 and MAX_NOTREADY_NODES nodes are NotReady;
@@ -83,6 +85,23 @@
 #   - Ready nodes carrying a healthy current pod, plus the unreachable ones,
 #     cover the desired count. Counted in NODES: the invariant is one pod per
 #     node, and counting pods let a node with two cover for a node with none.
+#
+# A DEPLOYMENT is ordinarily NOT tolerated: it reschedules off a dead node, so a
+# shortfall is a real scheduling problem. The exception is a SITE-SCOPED one,
+# whose required node affinity pins it to a site whose nodes are ALL
+# unreachable. It has nowhere to reschedule to, so it stalls exactly the way a
+# DaemonSet does, and the operator creates one per Site that enables a component
+# (metalman is the current example). Tolerated only when ALL of:
+#
+#   - it is short of available replicas;
+#   - its CURRENT pod template references EXPECTED_IMAGE_TAG;
+#   - the Deployment controller has observed the current generation;
+#   - it is pinned, by required affinity or nodeSelector, to at least one site;
+#   - EVERY site it is pinned to has at least one node and NO Ready node. One
+#     Ready node anywhere in the set means it could run there, so the shortfall
+#     is a real problem;
+#   - between 1 and MAX_NOTREADY_NODES nodes are NotReady;
+#   - none of its pods is on a Ready node, which would contradict the above.
 #
 # Tolerance repeats the EXPECTED_IMAGE_TAG condition rather than trusting the
 # earlier phase: the template can arrive while a pod on a reachable node is
@@ -499,6 +518,84 @@ TEMPLATE_IMAGE_FILTER='
   | ($ours | length) > 0 and ($ours | all(endswith($tag)))
 '
 
+# SITE_PIN_FILTER emits, as a JSON array, the sites a workload is pinned to.
+#
+# Only REQUIRED affinity counts: a preferred term is a hint the scheduler may
+# ignore, so a workload carrying one can still run elsewhere and its shortfall
+# is not explained by a dead site. nodeSelector is included because it is the
+# older spelling of the same constraint, and both keys are consulted because the
+# net controllers still dual-write them.
+#
+# nodeSelectorTerms are OR-ed, nodeSelector entries AND-ed. Collapsing both into
+# one set and later demanding that EVERY site in it be unreachable is exact for
+# the OR and conservative for the AND, which is the right direction: the worst
+# it does is decline to tolerate.
+SITE_PIN_FILTER='
+  [ (.spec.template.spec.affinity.nodeAffinity
+       .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [])[]
+    | (.matchExpressions // [])[]
+    | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
+    | select(.operator == "In")
+    | (.values // [])[]
+  ]
+  + [ ((.spec.template.spec.nodeSelector // {}) | to_entries)[]
+      | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
+      | .value
+    ]
+  | unique
+'
+
+# SITE_NODE_FILTER emits "<site>\t<total>\t<ready>" for each site in $sites.
+# A site with no nodes at all reports total 0, which the caller treats as
+# unverifiable rather than as "entirely unreachable".
+SITE_NODE_FILTER='
+  [ .items[]
+    | { site: (.metadata.labels["unbounded-cloud.io/site"]
+                // .metadata.labels["net.unbounded-cloud.io/site"]
+                // ""),
+        ready: (((((.status.conditions // [])
+                    | map(select(.type == "Ready")) | .[0].status) // "Unknown")) == "True")
+      }
+  ] as $nodes
+  | $sites[]
+  | . as $site
+  | [ $site,
+      ([ $nodes[] | select(.site == $site) ] | length),
+      ([ $nodes[] | select(.site == $site and .ready) ] | length)
+    ]
+  | @tsv
+'
+
+# DEPLOYMENT_STATUS_FILTER emits
+# "<desired>\t<available>\t<generation>\t<observedGeneration>".
+DEPLOYMENT_STATUS_FILTER='
+  [ (.spec.replicas // 0),
+    (.status.availableReplicas // 0),
+    (.metadata.generation // 0),
+    (.status.observedGeneration // -1)
+  ]
+  | @tsv
+'
+
+# DEPLOYMENT_PLACEMENT_FILTER counts this Deployment's pods that sit on a node
+# which is NOT NotReady. The answer must be zero: a pod on a reachable node
+# means the workload can run somewhere after all, so its shortfall is not
+# explained by the dead site.
+#
+# $owners holds the uids of the ReplicaSets this Deployment owns, because a
+# Deployment does not own its pods directly. Terminating pods are excluded for
+# the same reason the DaemonSet filter excludes them: a pod on its way out is
+# not evidence either way.
+DEPLOYMENT_PLACEMENT_FILTER='
+  [ .items[]
+    | select(.metadata.deletionTimestamp == null)
+    | select(any((.metadata.ownerReferences // [])[]; .uid as $uid | ($owners | index($uid)) != null))
+    | (.spec.nodeName // "") as $node
+    | select($node != "" and (($notready | index($node)) == null))
+  ]
+  | length
+'
+
 # notready_nodes prints one TSV record per NotReady node. Empty output means
 # every node is Ready.
 #
@@ -591,22 +688,19 @@ confirm_expected_release() {
   return 1
 }
 
-# node_tolerance decides whether a stalled DaemonSet rollout is explained
-# entirely by nodes the cluster has lost contact with.
+# node_tolerance decides whether a stalled rollout is explained entirely by
+# nodes the cluster has lost contact with, and dispatches to the check for the
+# workload's kind.
 #
 # Returns 0 to tolerate (the caller stops waiting and succeeds), 1 to keep
 # waiting. EVERY uncertain path returns 1; see the FAIL-CLOSED note at the top.
 #
 # Conditions are ordered cheapest-first, and everything decidable without the
 # apiserver is decided before anything is queried: this runs on every poll of
-# every workload, so reading the node list before noticing the workload was a
-# Deployment would cost tens of megabytes per wait to reach the same answer.
+# every workload, so reading the node list before noticing the workload was
+# neither kind would cost tens of megabytes per wait to reach the same answer.
 node_tolerance() {
   local target="$1" kind="$2" selector="$3"
-  local obj_json pods_json nodes_tsv notready_json counts status_tsv
-  local desired ready misscheduled generation observed owner_uid
-  local stranded unhealthy outdated healthy
-  local notready_count
 
   # No selector means pods cannot be scoped to this workload. Also the state
   # when the image guard has been disabled, which takes tolerance down with it:
@@ -614,12 +708,26 @@ node_tolerance() {
   # workload's shortfall.
   [[ -n "$selector" ]] || return 1
 
-  # Free: read once, before the wait, by resolve_target.
-  [[ "$kind" == "DaemonSet" ]] || return 1
-
   # Tolerance switched off, or nothing to compare a template against.
   (( MAX_NOTREADY_NODES > 0 )) || return 1
   [[ -n "$EXPECTED_IMAGE_TAG" ]] || return 1
+
+  # Free: read once, before the wait, by resolve_target.
+  case "$kind" in
+    DaemonSet)  daemonset_tolerance "$target" "$selector" ;;
+    Deployment) site_deployment_tolerance "$target" "$selector" ;;
+    *)          return 1 ;;
+  esac
+}
+
+# daemonset_tolerance decides whether a stalled DaemonSet rollout is explained
+# entirely by nodes the cluster has lost contact with.
+daemonset_tolerance() {
+  local target="$1" selector="$2"
+  local obj_json pods_json nodes_tsv notready_json counts status_tsv
+  local desired ready misscheduled generation observed owner_uid
+  local stranded unhealthy outdated healthy
+  local notready_count
 
   # One read serves both the live status numbers and the image check, and both
   # have to be evaluated against the CURRENT object.
@@ -711,6 +819,138 @@ node_tolerance() {
       echo "### Degraded rollout tolerated: ${target}"
       echo
       echo "- Ready pods: ${healthy}/${desired} (${stranded} stranded on NotReady nodes)"
+      echo "- NotReady nodes: $(describe_nodes "$nodes_tsv")"
+      echo "- Deployed image tag: \`${EXPECTED_IMAGE_TAG}\`"
+      echo "- Tolerated because \`MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  return 0
+}
+
+# site_deployment_tolerance decides whether a stalled Deployment rollout is
+# explained entirely by its target site being unreachable.
+#
+# The nodes are read ONCE here and both questions answered from that one
+# payload: which nodes are NotReady, and how many nodes each pinned site has.
+# Asking twice would cost a second full node list on every poll.
+site_deployment_tolerance() {
+  local target="$1" selector="$2"
+  local obj_json nodes_json nodes_tsv notready_json sites_json site_tsv status_tsv
+  local rs_json owners_json pods_json
+  local desired available generation observed owner_uid
+  local notready_count on_ready site total ready_count
+
+  obj_json="$(kubectl_json get "$target" -o json)" || {
+    warn_once "could not read ${target} while evaluating node tolerance: $(flatten "${WORKDIR}/kubectl.err")"
+
+    return 1
+  }
+
+  # The sites this Deployment is pinned to. Checked before anything is queried:
+  # a Deployment that is not site-scoped can reschedule, so the ordinary rule
+  # applies and its shortfall is a real scheduling problem.
+  sites_json="$(printf '%s' "$obj_json" | jq -c "$SITE_PIN_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+  [[ -n "$sites_json" && "$sites_json" != "[]" ]] || return 1
+
+  status_tsv="$(printf '%s' "$obj_json" | jq -r "$DEPLOYMENT_STATUS_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+
+  IFS=$'\t' read -r desired available generation observed <<<"$status_tsv" || return 1
+
+  # Stale or partial data. Any of these failing means "not yet", never "close
+  # enough".
+  (( desired > 0 )) || return 1
+  (( observed >= generation )) || return 1
+
+  # No shortfall to excuse; rollout status will return on its own.
+  (( available < desired )) || return 1
+
+  # Checked before the node and pod queries: it is the condition most likely to
+  # be false early in a deploy, and it needs no further API calls.
+  running_expected_release "$target" "$obj_json" || return 1
+
+  nodes_json="$(kubectl_json get nodes -o json)" || {
+    warn_once "could not evaluate node readiness for ${target}: $(flatten "${WORKDIR}/kubectl.err")"
+
+    return 1
+  }
+
+  nodes_tsv="$(printf '%s' "$nodes_json" | jq -r "$NOTREADY_NODE_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+
+  # Every node is Ready, so whatever is stalling this rollout is a real problem.
+  [[ -n "$nodes_tsv" ]] || return 1
+
+  notready_count="$(wc -l <<<"$nodes_tsv" | tr -d ' ')"
+
+  if (( notready_count > MAX_NOTREADY_NODES )); then
+    warn_once "too many NotReady nodes for the ${target} shortfall to be excused (${notready_count} > MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}): $(describe_nodes "$nodes_tsv")"
+
+    return 1
+  fi
+
+  site_tsv="$(printf '%s' "$nodes_json" | jq -r --argjson sites "$sites_json" \
+    "$SITE_NODE_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+
+  [[ -n "$site_tsv" ]] || return 1
+
+  # Every pinned site must be populated and entirely unreachable. A site with no
+  # nodes proves nothing, and one Ready node anywhere in the set means the
+  # workload could be running there.
+  while IFS=$'\t' read -r site total ready_count; do
+    [[ -n "$site" ]] || continue
+
+    if (( total == 0 )); then
+      warn_once "${target} is pinned to site ${site}, which has no nodes; its shortfall cannot be excused"
+
+      return 1
+    fi
+
+    (( ready_count == 0 )) || return 1
+  done <<<"$site_tsv"
+
+  notready_json="$(cut -f1 <<<"$nodes_tsv" | jq -R -s -c 'split("\n") | map(select(length > 0))' 2>"${WORKDIR}/jq.err")" || return 1
+
+  # A Deployment does not own its pods directly, so the ReplicaSets it owns are
+  # resolved first. Without them there is no way to tell its pods from anything
+  # else wearing the same labels, which is not a judgement this check may make
+  # on a guess.
+  owner_uid="$(printf '%s' "$obj_json" | jq -r '.metadata.uid // ""' 2>"${WORKDIR}/jq.err")" || return 1
+  [[ -n "$owner_uid" ]] || return 1
+
+  rs_json="$(kubectl_json get replicasets --selector "$selector" -o json)" || {
+    warn_once "could not list replicasets for ${target} while evaluating node tolerance: $(flatten "${WORKDIR}/kubectl.err")"
+
+    return 1
+  }
+
+  owners_json="$(printf '%s' "$rs_json" | jq -c --arg owner "$owner_uid" \
+    '[ .items[] | select((.metadata.ownerReferences // []) | any(.uid == $owner)) | .metadata.uid ]' \
+    2>"${WORKDIR}/jq.err")" || return 1
+
+  [[ -n "$owners_json" && "$owners_json" != "[]" ]] || return 1
+
+  pods_json="$(kubectl_json get pods --selector "$selector" -o json)" || {
+    warn_once "could not list pods for ${target} while evaluating node tolerance: $(flatten "${WORKDIR}/kubectl.err")"
+
+    return 1
+  }
+
+  on_ready="$(printf '%s' "$pods_json" | jq -r --argjson notready "$notready_json" \
+    --argjson owners "$owners_json" "$DEPLOYMENT_PLACEMENT_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+
+  # Contradicts the site check above: something of this workload is running on a
+  # reachable node, so the shortfall is not the dead site.
+  (( on_ready == 0 )) || return 1
+
+  echo "::warning::${target} is short $(( desired - available )) of ${desired} replicas; every site it is pinned to is unreachable: $(describe_nodes "$nodes_tsv")"
+  echo "::warning::tolerating the ${target} shortfall (MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}); this release was NOT validated on those nodes"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### Degraded rollout tolerated: ${target}"
+      echo
+      echo "- Available replicas: ${available}/${desired}"
+      echo "- Pinned to site(s) with no reachable node: $(cut -f1 <<<"$site_tsv" | paste -sd', ' -)"
       echo "- NotReady nodes: $(describe_nodes "$nodes_tsv")"
       echo "- Deployed image tag: \`${EXPECTED_IMAGE_TAG}\`"
       echo "- Tolerated because \`MAX_NOTREADY_NODES=${MAX_NOTREADY_NODES}\`"

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -526,18 +526,35 @@ TEMPLATE_IMAGE_FILTER='
 # older spelling of the same constraint, and both keys are consulted because the
 # net controllers still dual-write them.
 #
-# nodeSelectorTerms are OR-ed, nodeSelector entries AND-ed. Collapsing both into
-# one set and later demanding that EVERY site in it be unreachable is exact for
-# the OR and conservative for the AND, which is the right direction: the worst
-# it does is decline to tolerate.
+# nodeSelectorTerms are OR-ed, so a pod may run wherever ANY term is satisfied.
+# EVERY term therefore has to name a site, or the collapse below would ignore
+# the terms that do not and claim a pin the workload does not have:
+#
+#   term1: unbounded-cloud.io/site In [boulderlab]   <- dead site
+#   term2: kubernetes.io/arch      In [amd64]        <- any amd64 node, anywhere
+#
+# That workload can run on any amd64 node, so nothing about it is explained by
+# boulderlab being unreachable. A term carrying no site value yields [] here,
+# and the caller declines to tolerate. Terms using matchFields, or NotIn on the
+# site key, contribute nothing and so land in the same place.
+#
+# nodeSelector entries are AND-ed with all of that, so a site named there is
+# required on its own and is merged in directly. Demanding that EVERY site in
+# the resulting set be unreachable is then exact for the OR and conservative for
+# the AND, which is the right direction: the worst it does is decline.
 SITE_PIN_FILTER='
-  [ (.spec.template.spec.affinity.nodeAffinity
-       .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [])[]
-    | (.matchExpressions // [])[]
-    | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
-    | select(.operator == "In")
-    | (.values // [])[]
-  ]
+  ((.spec.template.spec.affinity.nodeAffinity
+      .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [])) as $terms
+  | ([ $terms[]
+       | [ (.matchExpressions // [])[]
+           | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
+           | select(.operator == "In")
+           | (.values // [])[]
+         ]
+     ]) as $per_term
+  | (if ($terms | length) > 0 and ($per_term | all(length > 0))
+     then ($per_term | add)
+     else [] end)
   + [ ((.spec.template.spec.nodeSelector // {}) | to_entries)[]
       | select(.key == "unbounded-cloud.io/site" or .key == "net.unbounded-cloud.io/site")
       | .value
@@ -545,9 +562,13 @@ SITE_PIN_FILTER='
   | unique
 '
 
-# SITE_NODE_FILTER emits "<site>\t<total>\t<ready>" for each site in $sites.
-# A site with no nodes at all reports total 0, which the caller treats as
-# unverifiable rather than as "entirely unreachable".
+# SITE_NODE_FILTER emits "<site>\t<total>\t<ready>" for every site any node
+# claims. A site absent from the output is one no node claims at all, which the
+# caller treats as unverifiable rather than as "entirely unreachable".
+#
+# Kept structurally identical to the same filter in
+# hack/release/smoke/core-namespaces-ready.sh, so the two can be diffed for
+# drift rather than compared by reading.
 SITE_NODE_FILTER='
   [ .items[]
     | { site: (.metadata.labels["unbounded-cloud.io/site"]
@@ -556,13 +577,10 @@ SITE_NODE_FILTER='
         ready: (((((.status.conditions // [])
                     | map(select(.type == "Ready")) | .[0].status) // "Unknown")) == "True")
       }
-  ] as $nodes
-  | $sites[]
-  | . as $site
-  | [ $site,
-      ([ $nodes[] | select(.site == $site) ] | length),
-      ([ $nodes[] | select(.site == $site and .ready) ] | length)
-    ]
+    | select(.site != "")
+  ]
+  | group_by(.site)[]
+  | [ .[0].site, (. | length), ([ .[] | select(.ready) ] | length) ]
   | @tsv
 '
 
@@ -828,6 +846,33 @@ daemonset_tolerance() {
   return 0
 }
 
+# site_entirely_unreachable answers whether a site exists and has no Ready node.
+# A site no node claims returns 1: that is a label matching nothing, which is
+# indistinguishable from a typo and must not excuse anything. It says so out
+# loud, because a typo is the case this refusal exists to catch.
+#
+# $1 is the target, for the message. $2 is the site. $3 is SITE_NODE_FILTER's
+# output. Kept structurally identical to the same function in
+# hack/release/smoke/core-namespaces-ready.sh; change them together.
+site_entirely_unreachable() {
+  local target="$1" want="$2" table="$3" site total ready
+
+  [[ -n "$want" && -n "$table" ]] || return 1
+
+  while IFS=$'\t' read -r site total ready; do
+    [[ "$site" == "$want" ]] || continue
+
+    (( total > 0 )) || return 1
+    (( ready == 0 )) || return 1
+
+    return 0
+  done <<<"$table"
+
+  warn_once "${target} is pinned to site ${want}, which has no nodes; its shortfall cannot be excused"
+
+  return 1
+}
+
 # site_deployment_tolerance decides whether a stalled Deployment rollout is
 # explained entirely by its target site being unreachable.
 #
@@ -852,9 +897,10 @@ site_deployment_tolerance() {
     return 1
   }
 
-  # The sites this Deployment is pinned to. Checked before anything is queried:
-  # a Deployment that is not site-scoped can reschedule, so the ordinary rule
-  # applies and its shortfall is a real scheduling problem.
+  # The sites this Deployment is pinned to. Checked before the node and pod
+  # queries, which are the expensive ones: a Deployment that is not site-scoped
+  # can reschedule, so the ordinary rule applies and its shortfall is a real
+  # scheduling problem.
   sites_json="$(printf '%s' "$obj_json" | jq -c "$SITE_PIN_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
   [[ -n "$sites_json" && "$sites_json" != "[]" ]] || return 1
 
@@ -893,25 +939,18 @@ site_deployment_tolerance() {
     return 1
   fi
 
-  site_tsv="$(printf '%s' "$nodes_json" | jq -r --argjson sites "$sites_json" \
-    "$SITE_NODE_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
+  site_tsv="$(printf '%s' "$nodes_json" | jq -r "$SITE_NODE_FILTER" 2>"${WORKDIR}/jq.err")" || return 1
 
   [[ -n "$site_tsv" ]] || return 1
 
   # Every pinned site must be populated and entirely unreachable. A site with no
   # nodes proves nothing, and one Ready node anywhere in the set means the
   # workload could be running there.
-  while IFS=$'\t' read -r site total ready_count; do
+  while IFS= read -r site; do
     [[ -n "$site" ]] || continue
 
-    if (( total == 0 )); then
-      warn_once "${target} is pinned to site ${site}, which has no nodes; its shortfall cannot be excused"
-
-      return 1
-    fi
-
-    (( ready_count == 0 )) || return 1
-  done <<<"$site_tsv"
+    site_entirely_unreachable "$target" "$site" "$site_tsv" || return 1
+  done <<<"$(printf '%s' "$sites_json" | jq -r '.[]' 2>"${WORKDIR}/jq.err")"
 
   notready_json="$(cut -f1 <<<"$nodes_tsv" | jq -R -s -c 'split("\n") | map(select(length > 0))' 2>"${WORKDIR}/jq.err")" || return 1
 

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -339,6 +340,31 @@ func deployment(selector string, status dsStatus, images ...string) string {
 // sites empty produces an unpinned Deployment with a Deployment status, which
 // separates "not site-scoped" from "wrong status shape" in the refusal tests.
 func siteDeployment(selector string, status deployStatus, sites []string, images ...string) string {
+	// One nodeSelectorTerm per site, which is how the operator writes it: the
+	// terms are OR-ed, so the pod may run in any of them.
+	terms := make([]map[string]string, 0, len(sites))
+	for _, site := range sites {
+		terms = append(terms, map[string]string{"unbounded-cloud.io/site": site})
+	}
+
+	return pinnedDeployment(selector, status, terms, nil, images...)
+}
+
+// pinnedDeployment renders a Deployment with arbitrary required affinity terms
+// and an optional nodeSelector, for the pin shapes siteDeployment cannot
+// express: a term carrying no site key, the deprecated label key, and the older
+// nodeSelector spelling.
+//
+// Each entry in terms becomes one nodeSelectorTerm, and each key/value in it
+// one In matchExpression within that term. Terms are OR-ed by Kubernetes;
+// expressions inside a term are AND-ed.
+func pinnedDeployment(
+	selector string,
+	status deployStatus,
+	terms []map[string]string,
+	nodeSelector map[string]string,
+	images ...string,
+) string {
 	labels := map[string]string{}
 
 	if selector != "" {
@@ -356,27 +382,43 @@ func siteDeployment(selector string, status deployStatus, sites []string, images
 
 	podSpec := map[string]any{"containers": containers}
 
-	// One nodeSelectorTerm per site, which is how the operator writes it: the
-	// terms are OR-ed, so the pod may run in any of them.
-	if len(sites) > 0 {
-		terms := make([]map[string]any, 0, len(sites))
-		for _, site := range sites {
-			terms = append(terms, map[string]any{
-				"matchExpressions": []map[string]any{{
-					"key":      "unbounded-cloud.io/site",
+	if len(terms) > 0 {
+		built := make([]map[string]any, 0, len(terms))
+
+		for _, term := range terms {
+			// Sorted so the rendered object is stable: a map iterates in an
+			// unspecified order, and a fixture that reshuffles between runs
+			// makes a failure impossible to read.
+			keys := make([]string, 0, len(term))
+			for key := range term {
+				keys = append(keys, key)
+			}
+
+			sort.Strings(keys)
+
+			expressions := make([]map[string]any, 0, len(term))
+			for _, key := range keys {
+				expressions = append(expressions, map[string]any{
+					"key":      key,
 					"operator": "In",
-					"values":   []string{site},
-				}},
-			})
+					"values":   []string{term[key]},
+				})
+			}
+
+			built = append(built, map[string]any{"matchExpressions": expressions})
 		}
 
 		podSpec["affinity"] = map[string]any{
 			"nodeAffinity": map[string]any{
 				"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
-					"nodeSelectorTerms": terms,
+					"nodeSelectorTerms": built,
 				},
 			},
 		}
+	}
+
+	if len(nodeSelector) > 0 {
+		podSpec["nodeSelector"] = nodeSelector
 	}
 
 	return marshal(map[string]any{
@@ -1700,9 +1742,10 @@ func TestRefusesToTolerateWhenAReachablePodIsUnhealthy(t *testing.T) {
 // scheduling problem, not a stranded pod. Site-scoped Deployments are the one
 // exception and are covered separately below.
 //
-// The kind comes from the spec read before the wait, and whether the workload
-// is pinned to a site comes from that same read, so this must still cost no
-// node query at all.
+// The kind comes from the spec read before the wait. Whether the workload is
+// pinned to a site comes from the per-poll read of the object itself, which is
+// cheap; the assertion that matters is that no NODE LIST is fetched, since that
+// is the query worth avoiding on every poll of every workload.
 func TestNeverToleratesADeploymentShortfall(t *testing.T) {
 	requireBash(t)
 	t.Parallel()
@@ -1729,8 +1772,8 @@ func TestNeverToleratesADeploymentShortfall(t *testing.T) {
 // to refuse it is that nothing pins it to a site.
 //
 // The node query assertion is the point: whether a workload is site-scoped is
-// decided from the spec already in hand, so an ordinary Deployment must cost no
-// node list on any poll.
+// decided from the object itself, so an ordinary Deployment must never cost a
+// node list, however many times it is polled.
 func TestNeverToleratesAnUnpinnedDeploymentShortfall(t *testing.T) {
 	requireBash(t)
 	t.Parallel()
@@ -1963,6 +2006,142 @@ func TestRefusesASiteScopedDeploymentThatIsNotShort(t *testing.T) {
 
 	requireCode(t, code, 1, output)
 	requireNotContains(t, output, "tolerating")
+}
+
+// twoSiteNodes is degradedNodes with a second site that is also entirely
+// unreachable, for the workloads pinned to more than one.
+func twoSiteNodes(secondSiteReady string) string {
+	return nodeList(
+		node{name: "node-a", site: "hq", ready: "True"},
+		node{name: "spark-3d37", site: "boulderlab", ready: "Unknown"},
+		node{name: "edge-1", site: "edge", ready: secondSiteReady},
+	)
+}
+
+// TestToleratesADeploymentPinnedToTwoUnreachableSites covers the "EVERY site it
+// is pinned to" condition, which the header leans on hardest and which every
+// other test leaves at one site.
+func TestToleratesADeploymentPinnedToTwoUnreachableSites(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall,
+			[]string{"boulderlab", "edge"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: twoSiteNodes("Unknown")})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "20"})
+
+	output, code := f.run(withEnv(map[string]string{"MAX_NOTREADY_NODES": "3"}), metalmanTarget)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "tolerating the deploy/metalman-controller-boulderlab shortfall")
+}
+
+// TestRefusesADeploymentWhenOnlyOneOfTwoSitesIsUnreachable is the other half of
+// the same condition. The terms are OR-ed, so one reachable site means the
+// workload could be running there and the shortfall is a real problem.
+func TestRefusesADeploymentWhenOnlyOneOfTwoSitesIsUnreachable(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall,
+			[]string{"boulderlab", "edge"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: twoSiteNodes("True")})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(withEnv(map[string]string{"MAX_NOTREADY_NODES": "3"}), metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
+}
+
+// TestRefusesADeploymentWhoseTermCarriesNoSite is the regression guard for the
+// OR under-approximation.
+//
+// nodeSelectorTerms are OR-ed. A term naming no site is satisfiable by nodes
+// this check never looks at, so the workload can run somewhere reachable and
+// nothing about its shortfall is explained by the dead site the OTHER term
+// names. Collecting site values across terms and ignoring the terms without one
+// claimed a pin the workload does not have, and excused a real scheduling
+// failure whenever the pod was also unschedulable for an unrelated reason.
+func TestRefusesADeploymentWhoseTermCarriesNoSite(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: pinnedDeployment(metalmanSelector, pinnedShortfall,
+			[]map[string]string{
+				{"unbounded-cloud.io/site": "boulderlab"},
+				{"kubernetes.io/arch": "amd64"},
+			}, nil, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
+	// Refused from the spec alone, so it must not have cost a node list.
+	requireNotContains(t, f.calls(), "get nodes")
+}
+
+// TestToleratesADeploymentPinnedByTheDeprecatedSiteKey covers the second label
+// key. The net controllers still dual-write it, so a workload can be pinned by
+// either and the check has to read both.
+func TestToleratesADeploymentPinnedByTheDeprecatedSiteKey(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: pinnedDeployment(metalmanSelector, pinnedShortfall,
+			[]map[string]string{{"net.unbounded-cloud.io/site": "boulderlab"}}, nil, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "20"})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "tolerating the deploy/metalman-controller-boulderlab shortfall")
+}
+
+// TestToleratesADeploymentPinnedByNodeSelector covers the older spelling of the
+// same constraint. nodeSelector is AND-ed rather than OR-ed, so a site named
+// there is required on its own.
+func TestToleratesADeploymentPinnedByNodeSelector(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: pinnedDeployment(metalmanSelector, pinnedShortfall, nil,
+			map[string]string{"unbounded-cloud.io/site": "boulderlab"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "20"})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "tolerating the deploy/metalman-controller-boulderlab shortfall")
 }
 
 func TestRefusesToTolerateWhenNodeReadinessCannotBeRead(t *testing.T) {

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -59,7 +59,30 @@ const (
 	// match and anything else wearing those labels is not evidence about this
 	// rollout.
 	workloadUID = "11111111-2222-3333-4444-555555555555"
+
+	// replicaSetUID owns a site-scoped Deployment's fixture pods. A Deployment
+	// does not own its pods directly, so tolerance resolves its ReplicaSets
+	// first and matches pods against those.
+	replicaSetUID = "66666666-7777-8888-9999-000000000000"
+
+	// metalmanTarget is the site-scoped Deployment the operator creates per
+	// Site that enables the component. It is the workload the Deployment half
+	// of tolerance exists for.
+	metalmanTarget = "deploy/metalman-controller-boulderlab"
+
+	metalmanSelector = "app.kubernetes.io/name=metalman-controller"
+
+	metalmanImage = releaseRegistry + "/metalman:" + releaseTag
 )
+
+// deployStatus is the Deployment status tolerance is decided on. A Deployment
+// counts replicas, not nodes, so it shares nothing with dsStatus.
+type deployStatus struct {
+	replicas   int
+	available  int
+	generation int
+	observed   int
+}
 
 // container describes one container in a fake pod.
 type container struct {
@@ -302,11 +325,123 @@ func daemonSet(selector string, status dsStatus, images ...string) string {
 	return renderWorkload("DaemonSet", selector, images, nil, &status)
 }
 
-// deployment renders a Deployment carrying a DaemonSet-shaped status. A
-// Deployment reschedules off a dead node, so its shortfall must never be
-// excused however good the rest of the evidence looks.
+// deployment renders a Deployment carrying a DaemonSet-shaped status. An
+// ordinary Deployment reschedules off a dead node, so its shortfall must never
+// be excused however good the rest of the evidence looks. The site-scoped
+// exception is built by siteDeployment.
 func deployment(selector string, status dsStatus, images ...string) string {
 	return renderWorkload("Deployment", selector, images, nil, &status)
+}
+
+// siteDeployment renders the shape the operator creates per Site: a Deployment
+// pinned by REQUIRED node affinity to one site, with a real Deployment status.
+//
+// sites empty produces an unpinned Deployment with a Deployment status, which
+// separates "not site-scoped" from "wrong status shape" in the refusal tests.
+func siteDeployment(selector string, status deployStatus, sites []string, images ...string) string {
+	labels := map[string]string{}
+
+	if selector != "" {
+		key, value, _ := strings.Cut(selector, "=")
+		labels[key] = value
+	}
+
+	containers := make([]map[string]string, 0, len(images))
+	for i, image := range images {
+		containers = append(containers, map[string]string{
+			"name":  "c" + strconv.Itoa(i),
+			"image": image,
+		})
+	}
+
+	podSpec := map[string]any{"containers": containers}
+
+	// One nodeSelectorTerm per site, which is how the operator writes it: the
+	// terms are OR-ed, so the pod may run in any of them.
+	if len(sites) > 0 {
+		terms := make([]map[string]any, 0, len(sites))
+		for _, site := range sites {
+			terms = append(terms, map[string]any{
+				"matchExpressions": []map[string]any{{
+					"key":      "unbounded-cloud.io/site",
+					"operator": "In",
+					"values":   []string{site},
+				}},
+			})
+		}
+
+		podSpec["affinity"] = map[string]any{
+			"nodeAffinity": map[string]any{
+				"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+					"nodeSelectorTerms": terms,
+				},
+			},
+		}
+	}
+
+	return marshal(map[string]any{
+		"kind": "Deployment",
+		"metadata": map[string]any{
+			"uid":        workloadUID,
+			"generation": status.generation,
+		},
+		"spec": map[string]any{
+			"replicas": status.replicas,
+			"selector": map[string]any{"matchLabels": labels},
+			"template": map[string]any{"spec": podSpec},
+		},
+		"status": map[string]any{
+			"availableReplicas":  status.available,
+			"observedGeneration": status.observed,
+		},
+	})
+}
+
+// replicaSetList renders the ReplicaSets a Deployment owns. owned false gives
+// them a different owner, which is how a ReplicaSet belonging to some other
+// Deployment that happens to match the selector would look.
+func replicaSetList(owned bool) string {
+	owner := workloadUID
+	if !owned {
+		owner = "99999999-9999-9999-9999-999999999999"
+	}
+
+	return marshal(map[string]any{"items": []map[string]any{{
+		"metadata": map[string]any{
+			"uid":             replicaSetUID,
+			"name":            "metalman-controller-boulderlab-abc",
+			"ownerReferences": []map[string]any{{"kind": "Deployment", "uid": owner}},
+		},
+	}}})
+}
+
+// replicaSetPods renders pods owned by the ReplicaSet replicaSetList returns,
+// which is how a Deployment's pods are actually owned.
+func replicaSetPods(pods ...pod) string {
+	items := make([]map[string]any, 0, len(pods))
+
+	for _, p := range pods {
+		meta := map[string]any{
+			"name":            p.name,
+			"ownerReferences": []map[string]any{{"kind": "ReplicaSet", "uid": replicaSetUID}},
+		}
+		if p.terminating {
+			meta["deletionTimestamp"] = "2026-08-13T00:00:00Z"
+		}
+
+		spec := map[string]any{}
+		if p.node != "" {
+			spec["nodeName"] = p.node
+		}
+
+		items = append(items, map[string]any{
+			"metadata": meta,
+			"spec":     spec,
+			"status":   map[string]any{"phase": "Pending"},
+		})
+	}
+
+	return marshal(map[string]any{"items": items})
 }
 
 func renderWorkload(kind, selector string, images, initImages []string, status *dsStatus) string {
@@ -1560,10 +1695,14 @@ func TestRefusesToTolerateWhenAReachablePodIsUnhealthy(t *testing.T) {
 	requireNotContains(t, output, "tolerating the ds/gantry shortfall")
 }
 
-// TestNeverToleratesADeploymentShortfall covers the kind check. A Deployment
-// reschedules off a dead node, so a shortfall there is a scheduling problem,
-// not a stranded pod. The kind comes from the spec read before the wait, so
-// this must also cost no node query at all.
+// TestNeverToleratesADeploymentShortfall covers the kind check for an ordinary
+// Deployment: it reschedules off a dead node, so a shortfall there is a
+// scheduling problem, not a stranded pod. Site-scoped Deployments are the one
+// exception and are covered separately below.
+//
+// The kind comes from the spec read before the wait, and whether the workload
+// is pinned to a site comes from that same read, so this must still cost no
+// node query at all.
 func TestNeverToleratesADeploymentShortfall(t *testing.T) {
 	requireBash(t)
 	t.Parallel()
@@ -1581,6 +1720,249 @@ func TestNeverToleratesADeploymentShortfall(t *testing.T) {
 	requireCode(t, code, 1, output)
 	requireNotContains(t, output, "tolerating")
 	requireNotContains(t, f.calls(), "get nodes")
+}
+
+// TestNeverToleratesAnUnpinnedDeploymentShortfall is the one that actually
+// pins the ordering. The fixture above carries a DaemonSet-shaped status, so it
+// is refused on the replica count before the site pin is ever consulted; this
+// one is a well-formed Deployment that is genuinely short, and the ONLY reason
+// to refuse it is that nothing pins it to a site.
+//
+// The node query assertion is the point: whether a workload is site-scoped is
+// decided from the spec already in hand, so an ordinary Deployment must cost no
+// node list on any poll.
+func TestNeverToleratesAnUnpinnedDeploymentShortfall(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_machina-controller", reply{
+		stdout: siteDeployment("app=machina", pinnedShortfall, nil, gantryImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, "deploy/machina-controller")
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
+	requireNotContains(t, f.calls(), "get nodes")
+}
+
+// pinnedShortfall is a site-scoped Deployment that wants one replica and has
+// none: the shape metalman takes when every node of its site is unreachable.
+var pinnedShortfall = deployStatus{replicas: 1, available: 0, generation: 4, observed: 4}
+
+// unscheduledPod is the only pod such a Deployment has. It carries no nodeName
+// because there is nowhere for it to go.
+func unscheduledPod() string {
+	return replicaSetPods(pod{name: "metalman-controller-boulderlab-abc-xyz"})
+}
+
+// TestToleratesASiteScopedDeploymentWhoseSiteIsUnreachable is the Deployment
+// half of tolerance. The operator creates one Deployment per Site that enables
+// a component, pinned to that site by required affinity. When every node of
+// the site is unreachable it has nowhere to reschedule to, so it stalls the way
+// a DaemonSet does rather than the way a Deployment usually does.
+func TestToleratesASiteScopedDeploymentWhoseSiteIsUnreachable(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall, []string{"boulderlab"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	// Held open: without tolerance this wait runs to its timeout, which is the
+	// behaviour being replaced.
+	f.set("rollout", reply{sleep: "20"})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 0, output)
+	requireContains(t, output, "tolerating the deploy/metalman-controller-boulderlab shortfall")
+	requireContains(t, output, "short 1 of 1 replicas")
+	requireContains(t, output, "boulderlab[spark-3d37]")
+	requireContains(t, output, "OK: all workloads rolled out")
+	requireGroupsBalanced(t, output)
+}
+
+// TestRefusesASiteScopedDeploymentWhenASiteNodeIsReady is the condition that
+// keeps this narrow. One reachable node in the site means the workload could be
+// running there, so the shortfall is a real scheduling problem and the gate
+// must wait for it.
+func TestRefusesASiteScopedDeploymentWhenASiteNodeIsReady(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall, []string{"boulderlab"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: nodeList(
+		node{name: "node-a", site: "hq", ready: "True"},
+		node{name: "spark-3d37", site: "boulderlab", ready: "Unknown"},
+		node{name: "spark-2c24", site: "boulderlab", ready: "True"},
+	)})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
+}
+
+// TestRefusesASiteScopedDeploymentOnThePreviousRelease repeats the tag check on
+// the Deployment path. A dead site does not excuse gating a release the
+// operator has not rolled out yet.
+func TestRefusesASiteScopedDeploymentOnThePreviousRelease(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall, []string{"boulderlab"},
+			releaseRegistry+"/metalman:"+previousTag),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
+	requireNotContains(t, f.calls(), "get nodes")
+}
+
+// TestRefusesASiteScopedDeploymentWithAPodOnAReachableNode covers the
+// contradiction check. If the site really were unreachable this pod could not
+// exist, so its presence means the site labels and the pod's placement disagree
+// and nothing here can be trusted.
+func TestRefusesASiteScopedDeploymentWithAPodOnAReachableNode(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall, []string{"boulderlab"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: replicaSetPods(
+		pod{name: "metalman-controller-boulderlab-abc-xyz", node: "node-a"},
+	)})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
+}
+
+// TestRefusesASiteScopedDeploymentPinnedToASiteWithNoNodes covers a site that
+// no node claims. That is a label that matches nothing rather than a site that
+// is down, and it is indistinguishable from a typo, so it must not be excused.
+func TestRefusesASiteScopedDeploymentPinnedToASiteWithNoNodes(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall, []string{"atlantis"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating the")
+	requireContains(t, output, "pinned to site atlantis, which has no nodes")
+}
+
+// TestRefusesASiteScopedDeploymentWhenTooManyNodesAreNotReady keeps the
+// Deployment path under the same cap as the DaemonSet one. A site being down is
+// not licence to ignore how much of the cluster went with it.
+func TestRefusesASiteScopedDeploymentWhenTooManyNodesAreNotReady(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall, []string{"boulderlab"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: nodeList(
+		node{name: "node-a", site: "hq", ready: "True"},
+		node{name: "spark-3d37", site: "boulderlab", ready: "Unknown"},
+		node{name: "spark-2c24", site: "boulderlab", ready: "Unknown"},
+		node{name: "spark-1a11", site: "boulderlab", ready: "Unknown"},
+	)})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating the")
+	requireContains(t, output, "too many NotReady nodes")
+}
+
+// TestRefusesASiteScopedDeploymentWhoseReplicaSetsAreNotItsOwn is the
+// Deployment equivalent of scoping pods by owner. A Deployment does not own its
+// pods directly, so without a ReplicaSet that belongs to it there is no way to
+// tell its pods from anything else wearing the same labels.
+func TestRefusesASiteScopedDeploymentWhoseReplicaSetsAreNotItsOwn(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector, pinnedShortfall, []string{"boulderlab"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(false)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
+}
+
+// TestRefusesASiteScopedDeploymentThatIsNotShort guards the other direction: a
+// Deployment with every replica available has nothing to excuse, and tolerance
+// must leave the verdict to rollout status.
+func TestRefusesASiteScopedDeploymentThatIsNotShort(t *testing.T) {
+	requireBash(t)
+	t.Parallel()
+
+	f := newFake(t)
+	f.set("getjson-deploy_metalman-controller-boulderlab", reply{
+		stdout: siteDeployment(metalmanSelector,
+			deployStatus{replicas: 1, available: 1, generation: 4, observed: 4},
+			[]string{"boulderlab"}, metalmanImage),
+	})
+	f.set("getjson-nodes", reply{stdout: degradedNodes()})
+	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
+	f.set("pods", reply{stdout: unscheduledPod()})
+	f.set("rollout", reply{sleep: "3", exit: 1})
+
+	output, code := f.run(tolerating, metalmanTarget)
+
+	requireCode(t, code, 1, output)
+	requireNotContains(t, output, "tolerating")
 }
 
 func TestRefusesToTolerateWhenNodeReadinessCannotBeRead(t *testing.T) {


### PR DESCRIPTION
`unbounded-stable` has seven `boulderlab` nodes whose kubelets have stopped reporting. The release gate has failed every run since, so `v0.4.0` could only ship via `publish-forced` — which validates nothing, because `deploy` *fails* rather than skips and the smoke jobs never run.

Two checks judged those nodes wrongly.

## The problem

**`wait-rollouts.sh` tolerated a DaemonSet shortfall but never a Deployment's**, on the grounds stated in its header: *"a Deployment reschedules off a dead node"*. That stops being true when required affinity pins it to a site whose nodes are all gone — which is exactly what the operator creates, one per Site that enables a component:

```
0/16 nodes are available: 7 node(s) didn't match Pod's node affinity/selector,
9 node(s) had untolerated taint(s).
```

So the gate burned its full five-minute timeout on `metalman-controller-boulderlab`.

**`core-namespaces-ready.sh` then failed the same pod.** It classifies a stranded pod by looking up its node's readiness, and an unscheduled pod has no node — so it could never be classified as stranded, however dead its site was. That contradicts the convention at the top of that file, which says not to fail on workloads a site outage explains because the deploy gate has already decided.

## The solution

Both now excuse a workload on one rule: **every site it is pinned to has at least one node, and none of those nodes is Ready.**

Deliberately still refused:

| case | why |
|---|---|
| no site pin | an ordinary Deployment reschedules; a shortfall is real |
| a pinned site with a reachable node | it could be running there |
| a pinned site no node claims | a label matching nothing is a typo, not a dead site |
| preferred-only affinity | the scheduler may ignore it, so it could have run elsewhere |
| a term naming no site | terms are OR-ed, so it could have run wherever that term matches |

The gate additionally keeps its existing conditions: the workload must be on the release under test, within `MAX_NOTREADY_NODES`, and have no pod on a reachable node.

## Verification

Against the live cluster, the whole chain now passes, and the gate tolerates in **3.4s** where it previously ran to timeout:

```
1. deploy gate            exit=0
2. deploy-orca            exit=0
3. smoke core-namespaces  exit=0
```

Fourteen gate tests and thirteen smoke tests, all mutation-tested — removing any of the three new invariants turns tests red.

## Notes for reviewers

**gantry is fixed outside this PR.** It was the failure that actually tripped CI, before metalman was reached: `maxUnavailable` is a fleet-wide budget and pods on unreachable nodes count against it, so at `10%` of sixteen nodes seven dead nodes consumed it before the rollout began. An earlier revision raised that default and is reverted in `bf2d6d82` — `10%` is right for a healthy fleet, and users shouldn't inherit a change that exists to serve our soak cluster. `unbounded-stable` uses a component override instead, already applied.

**This must merge before a release run can pass.** The workflow takes `wait-rollouts.sh` and `hack/release/smoke/` from the default branch, not the deployed tag.

**The site logic is duplicated on purpose.** Smoke tests are meant to stand alone, so the two copies are kept structurally identical and each points at the other. That doesn't prevent drift, only makes it visible by diff; a shared helper is the alternative if you'd rather.

**Review found a fail-open in the first revision** — the OR case in the table above — now closed in both copies with a regression test. See `e930c1df`.
