### PR TITLE
Reduce unnecessary work in the GatewayPool controller

### DIFF
--- a/internal/net/controller/gatewaypool_controller.go
+++ b/internal/net/controller/gatewaypool_controller.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -84,8 +85,7 @@ type GatewayPoolController struct {
 	gwPortAllocated map[int32]string // port -> node name
 	gwPortByNode    map[string]int32 // node name -> port
 
-	// hasSynced indicates whether the informer caches have completed initial sync
-	hasSynced bool
+	hasSynced atomic.Bool
 }
 
 // NewGatewayPoolController creates a new gateway pool controller.
@@ -117,7 +117,7 @@ func NewGatewayPoolController(
 	// Set up event handlers for nodes
 	if _, err := nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			gc.enqueueAllPools()
+			gc.enqueuePoolsForNodes(obj.(*corev1.Node)) //nolint:errcheck
 		},
 		UpdateFunc: func(old, new interface{}) {
 			oldNode := old.(*corev1.Node) //nolint:errcheck
@@ -129,11 +129,16 @@ func NewGatewayPoolController(
 				getNodeAnnotation(oldNode, WireGuardPubKeyAnnotation) != getNodeAnnotation(newNode, WireGuardPubKeyAnnotation) ||
 				getNodeAnnotation(oldNode, WireGuardPortAnnotation) != getNodeAnnotation(newNode, WireGuardPortAnnotation) ||
 				!stringSlicesEqual(oldNode.Spec.PodCIDRs, newNode.Spec.PodCIDRs) {
-				gc.enqueueAllPools()
+				gc.enqueuePoolsForNodes(oldNode, newNode)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			gc.enqueueAllPools()
+			node := nodeFromDeleteEvent(obj)
+			if node == nil {
+				return
+			}
+
+			gc.enqueuePoolsForNodes(node)
 		},
 	}); err != nil {
 		return nil, fmt.Errorf("failed to add node event handler: %w", err)
@@ -157,6 +162,24 @@ func NewGatewayPoolController(
 	return gc, nil
 }
 
+func nodeFromDeleteEvent(obj interface{}) *corev1.Node {
+	if node, ok := obj.(*corev1.Node); ok {
+		return node
+	}
+
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		return nil
+	}
+
+	node, ok := tombstone.Obj.(*corev1.Node)
+	if !ok {
+		return nil
+	}
+
+	return node
+}
+
 // Run starts the gateway pool controller.
 func (gc *GatewayPoolController) Run(ctx context.Context, workers int) error {
 	defer utilruntime.HandleCrash()
@@ -171,7 +194,7 @@ func (gc *GatewayPoolController) Run(ctx context.Context, workers int) error {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
-	gc.hasSynced = true
+	gc.hasSynced.Store(true)
 
 	// Update pools cache
 	gc.updatePoolsCache()
@@ -235,9 +258,8 @@ func (gc *GatewayPoolController) enqueuePool(obj interface{}) {
 	gc.workqueue.Add(unstr.GetName())
 }
 
-// enqueueAllPools adds all gateway pools to the workqueue.
-func (gc *GatewayPoolController) enqueueAllPools() {
-	if !gc.hasSynced {
+func (gc *GatewayPoolController) enqueuePoolsForNodes(nodes ...*corev1.Node) {
+	if !gc.hasSynced.Load() {
 		return
 	}
 
@@ -247,7 +269,14 @@ func (gc *GatewayPoolController) enqueueAllPools() {
 	defer gc.poolsCacheLock.RUnlock()
 
 	for _, pool := range gc.poolsCache {
-		gc.workqueue.Add(pool.Name)
+		selector := labels.SelectorFromSet(pool.Spec.NodeSelector)
+		for _, node := range nodes {
+			if node != nil && selector.Matches(labels.Set(node.Labels)) {
+				gc.workqueue.Add(pool.Name)
+
+				break
+			}
+		}
 	}
 }
 

--- a/internal/net/controller/gatewaypool_controller.go
+++ b/internal/net/controller/gatewaypool_controller.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -406,9 +407,13 @@ func (gc *GatewayPoolController) releaseGatewayPort(nodeName string) {
 }
 
 // setWireGuardPortAnnotation patches the node to set the wireguard-port annotation.
-func (gc *GatewayPoolController) setWireGuardPortAnnotation(ctx context.Context, nodeName string, port int32) error {
+func (gc *GatewayPoolController) setWireGuardPortAnnotation(ctx context.Context, node *corev1.Node, port int32) error {
+	if node == nil || node.Annotations[WireGuardPortAnnotation] == strconv.FormatInt(int64(port), 10) {
+		return nil
+	}
+
 	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%d"}}}`, WireGuardPortAnnotation, port))
-	_, err := gc.clientset.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patch, metav1.PatchOptions{})
+	_, err := gc.clientset.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 
 	return err
 }
@@ -592,7 +597,7 @@ func (gc *GatewayPoolController) syncPool(ctx context.Context, poolName string) 
 
 	// Annotate each matching node with its assigned WireGuard port.
 	for _, node := range matchingNodes {
-		if err := gc.setWireGuardPortAnnotation(ctx, node.Name, node.GatewayWireguardPort); err != nil {
+		if err := gc.setWireGuardPortAnnotation(ctx, nodeByName[node.Name], node.GatewayWireguardPort); err != nil {
 			klog.Warningf("GatewayPool %s: failed to annotate node %s with wireguard port %d: %v", poolName, node.Name, node.GatewayWireguardPort, err)
 		}
 	}
@@ -948,6 +953,25 @@ func (gc *GatewayPoolController) ensureGatewayPoolNode(ctx context.Context, pool
 	}
 
 	patchLabels[deprecatedSiteLabelKey] = nil
+
+	existingLabels := existing.GetLabels()
+	labelsMatch := true
+
+	for key, value := range obj.GetLabels() {
+		if existingLabels[key] != value {
+			labelsMatch = false
+
+			break
+		}
+	}
+
+	_, hasDeprecatedSiteLabel := existingLabels[deprecatedSiteLabelKey]
+
+	if labelsMatch && !hasDeprecatedSiteLabel &&
+		reflect.DeepEqual(existing.GetOwnerReferences(), obj.GetOwnerReferences()) &&
+		reflect.DeepEqual(existing.Object["spec"], obj.Object["spec"]) {
+		return nil
+	}
 
 	patch := map[string]interface{}{
 		"metadata": map[string]interface{}{

--- a/internal/net/controller/gatewaypool_helpers_test.go
+++ b/internal/net/controller/gatewaypool_helpers_test.go
@@ -365,22 +365,95 @@ func TestEnqueueHelpersAndPoolsCacheUpdate(t *testing.T) {
 		t.Fatalf("expected queue length 1 after enqueuePool valid object, got %d", got)
 	}
 
-	gc.hasSynced = false
-	gc.enqueueAllPools()
-
-	if got := q.Len(); got != 1 {
-		t.Fatalf("expected no additional enqueues while unsynced, got queue length %d", got)
-	}
-
-	gc.hasSynced = true
-	gc.enqueueAllPools()
-
-	if got := q.Len(); got != 1 {
-		t.Fatalf("expected deduplicated queue to remain length 1, got %d", got)
-	}
+	gc.updatePoolsCache()
 
 	if len(gc.poolsCache) != 1 || gc.poolsCache[0].Name != "pool-a" {
 		t.Fatalf("expected only valid gateway pool cached, got %#v", gc.poolsCache)
+	}
+}
+
+func TestNodeFromDeleteEvent(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+
+	for _, tt := range []struct {
+		name string
+		obj  interface{}
+		want *corev1.Node
+	}{
+		{
+			name: "node",
+			obj:  node,
+			want: node,
+		},
+		{
+			name: "tombstone",
+			obj:  cache.DeletedFinalStateUnknown{Obj: node},
+			want: node,
+		},
+		{
+			name: "malformed tombstone",
+			obj:  cache.DeletedFinalStateUnknown{Obj: &corev1.Pod{}},
+		},
+		{
+			name: "unexpected object",
+			obj:  &corev1.Pod{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nodeFromDeleteEvent(tt.obj); got != tt.want {
+				t.Fatalf("nodeFromDeleteEvent() = %p, want %p", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnqueuePoolsForNodesUsesOldAndNewSelectors(t *testing.T) {
+	q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer q.ShutDown()
+
+	informer := cache.NewSharedIndexInformer(&cache.ListWatch{}, &unstructured.Unstructured{}, 0, cache.Indexers{})
+
+	for name, role := range map[string]string{
+		"pool-old":   "old",
+		"pool-new":   "new",
+		"pool-other": "other",
+	} {
+		pool := &unboundednetv1alpha1.GatewayPool{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       unboundednetv1alpha1.GatewayPoolSpec{NodeSelector: map[string]string{"role": role}},
+		}
+		if err := informer.GetStore().Add(toGatewayPoolUnstructured(t, pool)); err != nil {
+			t.Fatalf("add %s to store: %v", name, err)
+		}
+	}
+
+	gc := &GatewayPoolController{workqueue: q, gatewayPoolInformer: informer}
+	gc.enqueuePoolsForNodes(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"role": "old"}}})
+
+	if got := q.Len(); got != 0 {
+		t.Fatalf("queued %d pools before informer sync, want 0", got)
+	}
+
+	gc.hasSynced.Store(true)
+	gc.enqueuePoolsForNodes(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"role": "old"}}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"role": "new"}}},
+	)
+
+	if got := q.Len(); got != 2 {
+		t.Fatalf("queued pools = %d, want 2", got)
+	}
+
+	queued := map[string]bool{}
+
+	for range 2 {
+		key, _ := q.Get()
+		queued[key] = true
+		q.Done(key)
+	}
+
+	if !queued["pool-old"] || !queued["pool-new"] || queued["pool-other"] {
+		t.Fatalf("queued pools = %v, want pool-old and pool-new", queued)
 	}
 }
 

--- a/internal/net/controller/gatewaypool_helpers_test.go
+++ b/internal/net/controller/gatewaypool_helpers_test.go
@@ -299,10 +299,11 @@ func TestGatewayPortAllocationReleaseAndSeed(t *testing.T) {
 
 // TestSetAndRemoveWireGuardPortAnnotation tests set and remove wire guard port annotation.
 func TestSetAndRemoveWireGuardPortAnnotation(t *testing.T) {
-	client := kubefake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+	sourceNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+	client := kubefake.NewClientset(sourceNode)
 	gc := &GatewayPoolController{clientset: client}
 
-	if err := gc.setWireGuardPortAnnotation(context.Background(), "node-a", 51821); err != nil {
+	if err := gc.setWireGuardPortAnnotation(context.Background(), sourceNode, 51821); err != nil {
 		t.Fatalf("setWireGuardPortAnnotation() error = %v", err)
 	}
 
@@ -313,6 +314,16 @@ func TestSetAndRemoveWireGuardPortAnnotation(t *testing.T) {
 
 	if got := node.Annotations[WireGuardPortAnnotation]; got != "51821" {
 		t.Fatalf("expected annotation value 51821, got %q", got)
+	}
+
+	client.ClearActions()
+
+	if err := gc.setWireGuardPortAnnotation(context.Background(), node, 51821); err != nil {
+		t.Fatalf("setWireGuardPortAnnotation() no-op error = %v", err)
+	}
+
+	if actions := client.Actions(); len(actions) != 0 {
+		t.Fatalf("unchanged wireguard port emitted API actions: %#v", actions)
 	}
 
 	if err := gc.removeWireGuardPortAnnotation(context.Background(), "node-a"); err != nil {
@@ -532,8 +543,7 @@ func TestCleanupStaleGatewayPoolNodesNilPool(t *testing.T) {
 	}
 }
 
-// TestEnsureGatewayPoolNodeCreateAndPatch tests ensure gateway pool node create and patch.
-func TestEnsureGatewayPoolNodeCreateAndPatch(t *testing.T) {
+func TestEnsureGatewayPoolNodeCreatePatchAndNoOp(t *testing.T) {
 	scheme := runtime.NewScheme()
 	pool := &unboundednetv1alpha1.GatewayPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "pool-a", UID: "pool-uid"},
@@ -568,6 +578,9 @@ func TestEnsureGatewayPoolNodeCreateAndPatch(t *testing.T) {
 		"kind":       "GatewayPoolNode",
 		"metadata": map[string]interface{}{
 			"name": "node-a",
+			"labels": map[string]interface{}{
+				"example.com/unowned": "preserved",
+			},
 		},
 		"spec": map[string]interface{}{
 			"gatewayPool": "old-pool",
@@ -593,6 +606,39 @@ func TestEnsureGatewayPoolNodeCreateAndPatch(t *testing.T) {
 
 	if got, _, _ := unstructured.NestedString(patched.Object, "spec", "gatewayPool"); got != "pool-a" {
 		t.Fatalf("expected patched spec.gatewayPool=pool-a, got %q", got)
+	}
+
+	if err := patchNodeIndexer.Update(patched); err != nil {
+		t.Fatalf("update informer cache: %v", err)
+	}
+
+	clientPatch.ClearActions()
+
+	if err := gcPatch.ensureGatewayPoolNode(context.Background(), pool, node, "site-a"); err != nil {
+		t.Fatalf("ensureGatewayPoolNode(no-op) error = %v", err)
+	}
+
+	if actions := clientPatch.Actions(); len(actions) != 0 {
+		t.Fatalf("converged GatewayPoolNode emitted API actions: %#v", actions)
+	}
+
+	withoutSite := patched.DeepCopy()
+	if err := unstructured.SetNestedField(withoutSite.Object, "", "spec", "site"); err != nil {
+		t.Fatalf("clear informer site: %v", err)
+	}
+
+	if err := patchNodeIndexer.Update(withoutSite); err != nil {
+		t.Fatalf("update informer cache without site: %v", err)
+	}
+
+	clientPatch.ClearActions()
+
+	if err := gcPatch.ensureGatewayPoolNode(context.Background(), pool, node, ""); err != nil {
+		t.Fatalf("ensureGatewayPoolNode(empty site no-op) error = %v", err)
+	}
+
+	if actions := clientPatch.Actions(); len(actions) != 0 {
+		t.Fatalf("empty site name rewrote existing canonical site label: %#v", actions)
 	}
 
 	gcNil := &GatewayPoolController{dynamicClient: clientCreate, gatewayNodeInformer: emptyNodeInformer}


### PR DESCRIPTION
Node changes now reconcile only the pools they can affect, and the controller avoids API updates when resources already have the expected values. GatewayPool selection and membership rules remain unchanged.

## Changes

      - Reconcile only pools that match the affected Node.
      - Check both old and new Node labels when a Node changes.
      - Safely handle normal Node deletions and informer tombstones.
      - Ignore malformed deletion events.
      - Make the informer startup state safe to access concurrently.
      - Skip unchanged WireGuard port annotation updates.
      - Skip unchanged `GatewayPoolNode` updates.
      - Preserve unrelated labels and continue removing deprecated site labels.