### PR TITLE
ci: run Gantry end-to-end tests

### DIFF
--- a/.github/workflows/gantry-e2e.yaml
+++ b/.github/workflows/gantry-e2e.yaml
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: gantry e2e
+
+on:
+  pull_request:
+    paths:
+      - cmd/gantry/**
+      - internal/gantry/**
+      - deploy/gantry/**
+      - images/gantry/**
+      - e2e/gantry/**
+      - hack/cmd/render-manifests/**
+      - go.mod
+      - go.sum
+      - Makefile
+      - .github/workflows/gantry-e2e.yaml
+  push:
+    branches:
+      - main
+      - release-*
+    paths:
+      - cmd/gantry/**
+      - internal/gantry/**
+      - deploy/gantry/**
+      - images/gantry/**
+      - e2e/gantry/**
+      - hack/cmd/render-manifests/**
+      - go.mod
+      - go.sum
+      - Makefile
+      - .github/workflows/gantry-e2e.yaml
+  schedule:
+    - cron: "41 8 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: gantry-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CONTAINER_ENGINE: docker
+  KIND_EXPERIMENTAL_PROVIDER: docker
+
+jobs:
+  gantry-e2e:
+    name: gantry e2e (kind)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 130
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Install kind
+        run: go install sigs.k8s.io/kind@v0.30.0
+
+      # The suite skips when prerequisites are absent. Verify them first so CI
+      # cannot report success without creating a cluster.
+      - name: Verify e2e prerequisites
+        run: |
+          set -euo pipefail
+          for bin in kind kubectl "$CONTAINER_ENGINE"; do
+            command -v "$bin" >/dev/null 2>&1 || { echo "missing required binary: $bin" >&2; exit 1; }
+          done
+          "$CONTAINER_ENGINE" info >/dev/null
+
+      - name: Run Gantry e2e
+        run: make e2e-gantry
+
+      - name: Upload Gantry e2e logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gantry-e2e-logs
+          path: e2e/.artifacts/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ NET_FRONTEND_CACHE_FILE    := $(NET_FRONTEND_DIST_DIR)/.frontend-build-key
 # Frontend build toggle (dev builds produce unminified output with sourcemaps).
 REACT_DEV ?= false
 
-.PHONY: all help fmt lint lint-actions test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build install-tools install-protoc generate kubectl-unbounded forge agent-artifacts-builder agent-artifacts-builder-build orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push unbounded-operator unbounded-operator-build unbounded-operator-manifests playpen-manifests e2e-playpen gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build gantry-manifests inventory-manifests
+.PHONY: all help fmt lint lint-actions test build vulncheck check-deps kubectl-unbounded kubectl-unbounded-build install-tools install-protoc generate kubectl-unbounded forge agent-artifacts-builder agent-artifacts-builder-build orcadev unbounded-agent machina machina-build machina-oci machina-oci-push machina-manifests machine-ops-controller machine-ops-controller-build machine-ops-controller-oci machine-ops-controller-oci-push machine-ops-manifests metalman metalman-build metalman-oci metalman-oci-push unbounded-operator unbounded-operator-build unbounded-operator-manifests playpen-manifests e2e-gantry e2e-playpen gomod docs-serve unbounded-net-controller unbounded-net-controller-build unbounded-net-node unbounded-net-node-build unbounded-net-routeplan-debug unping unping-build unroute unroute-build notice notice-check gantry gantry-build gantry-manifests inventory-manifests
 .PHONY: net-frontend net-frontend-clean net-ebpf-build net-ebpf-generate net-ebpf-verify net-manifests release-bom release-manifests unbounded-operator-release-manifest
 .PHONY: image-machina-local image-machine-ops-controller-local image-metalman-local image-unbounded-operator-local image-unbounded-operator-push image-playpen-local image-net-controller-local image-net-node-local image-gantry-local image-gantry-push images-local
 .PHONY: image-net-controller-push image-net-node-push images-net-all images-net-all-push
@@ -299,6 +299,8 @@ help: ## Show this help
 	@echo "  generate                         Run go generate (deepcopy, CRDs, protobuf)"
 	@echo "  vulncheck                        Run govulncheck; fails only on fixable vulnerabilities"
 	@echo "  gomod                            go mod tidy"
+	@echo "  e2e-gantry                       Run the kind-based Gantry e2e suite"
+	@echo "  e2e-playpen                      Run the kind-based playpen e2e suite"
 	@echo "  notice                           Regenerate NOTICE from Go, npm, Cargo, and native dependencies"
 	@echo "  notice-check                     Verify NOTICE is in sync with dependencies"
 	@echo "  toolchain-shell                  Drop into the toolchain container with the repo mounted at /project (set TOOLCHAIN_FLAVOR=fedora|ubuntu to pick a flavor)"
@@ -528,6 +530,10 @@ test: lint machina-manifests machine-ops-manifests playpen-manifests net-manifes
 	$(GOTEST) ./...
 
 endif
+
+e2e-gantry: ## Run the kind-based Gantry e2e suite
+	CONTAINER_ENGINE="$(CONTAINER_ENGINE)" KIND_EXPERIMENTAL_PROVIDER="$(CONTAINER_ENGINE)" PATH="$(CURDIR)/bin:$$PATH" \
+		$(GOTEST) -tags=e2e -count=1 -timeout=120m -v ./e2e/gantry
 
 e2e-playpen: ## Run the kind-based playpen e2e suite
 	$(GOTEST) -tags=e2e ./e2e/playpen -v -timeout=10m

--- a/e2e/gantry/README.md
+++ b/e2e/gantry/README.md
@@ -43,26 +43,25 @@ Additional scenarios listed below should each land as their own commit.
 
 The harness shells out to standard CLIs; no extra Go deps. Install:
 
-- [Docker](https://docs.docker.com/get-docker/) (engine running)
+- [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/) (engine running)
 - [kind](https://kind.sigs.k8s.io/) ≥ 0.20
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) ≥ 1.28
 - Go ≥ 1.26 (matching root `go.mod`)
 
-`make tools-e2e` checks every binary is on `$PATH` and fails loud if
-anything is missing.
-
 ## Running
 
 ```sh
-make tools-e2e        # one-time prereq check
-make e2e              # boot kind, build+load image, deploy, run tests, tear down
+make e2e-gantry       # boot kind, build+load image, deploy, run tests, tear down
 ```
+
+The root Makefile defaults `CONTAINER_ENGINE` to `podman`. Set
+`CONTAINER_ENGINE=docker` to use Docker instead.
 
 To keep the cluster running after the test (for debugging), set
 `E2E_KEEP=1`:
 
 ```sh
-E2E_KEEP=1 make e2e
+E2E_KEEP=1 make e2e-gantry
 # ...
 kind delete cluster --name gantry-e2e
 ```
@@ -78,7 +77,7 @@ prereq CLIs:
 | Step | What it does |
 | --- | --- |
 | `bootCluster()` | `kind create cluster --config kind-config.yaml` |
-| `buildAndLoadImage()` | builds `images/gantry/Containerfile` as `gantry:e2e`, then runs `kind load docker-image gantry:e2e` |
+| `buildAndLoadImage()` | builds `images/gantry/Containerfile` as `docker.io/library/gantry:e2e`, saves an image archive, then loads the archive into kind |
 | `applyManifests()` | renders `deploy/gantry/*.yaml.tmpl`, rewrites the DaemonSet image policy for the side-loaded image, and applies the core manifests (NetworkPolicy is intentionally not applied) |
 | `waitForRollout()` | polls `kubectl rollout status ds/gantry -n unbounded-system` |
 | `checkReadyz()` | port-forwards one Gantry pod and curls `/readyz` on port 9095 |
@@ -101,10 +100,10 @@ All e2e files carry `//go:build e2e`. Default `go test ./...` skips
 them. Run with:
 
 ```sh
-go test -tags=e2e ./e2e/... -v -timeout=10m
+go test -tags=e2e -count=1 -timeout=120m -v ./e2e/gantry
 ```
 
-The `make e2e` target sets `-tags=e2e` and a generous timeout for you.
+The `make e2e-gantry` target sets `-tags=e2e` and a generous timeout for you.
 
 ## Future scenarios
 

--- a/e2e/gantry/auth_registry_test.go
+++ b/e2e/gantry/auth_registry_test.go
@@ -4,10 +4,20 @@ package e2e
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
 	"strings"
 	"testing"
 	"time"
 
+	godigest "github.com/opencontainers/go-digest"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -15,25 +25,13 @@ const (
 	// In-cluster auth registry test fixtures. The registry is deployed
 	// in the unbounded-system namespace so it can be reached via the
 	// well-known cluster-DNS name without RBAC churn.
-	authRegistryNS     = "unbounded-system"
-	authRegistryName   = "auth-registry"
-	authRegistryHost   = "auth-registry.unbounded-system.svc.cluster.local"
-	authRegistryUser   = "testuser"
-	authRegistryPass   = "testpass"
-	authRegistryImage  = "registry:2"
-	authRegistrySkopeo = "quay.io/skopeo/stable:latest"
-	// authRegistryDigest is the manifest list digest of
-	// registry.k8s.io/e2e-test-images/agnhost:2.39. agnhost is a frozen
-	// e2e image so this digest is stable. The skopeo seed Job copies
-	// with --multi-arch=all so this exact digest is preserved in the
-	// in-cluster auth registry. We reference the image by digest in the
-	// pull pod so containerd asks gantry's mirror for a digest manifest
-	// (which gantry serves through please_pull -> origin with creds),
-	// rather than a tag manifest (which gantry returns 503 for by
-	// design, causing containerd to fall through to direct unauth
-	// access).
-	authRegistryDigest   = "sha256:7e8bdd271312fd25fc5ff5a8f04727be84044eb3d7d8d03611972a6752e2e11e"
-	authRegistryRef      = authRegistryHost + ":5000/agnhost@" + authRegistryDigest
+	authRegistryNS       = "unbounded-system"
+	authRegistryName     = "auth-registry"
+	authRegistryHost     = "auth-registry.unbounded-system.svc.cluster.local"
+	authRegistryUser     = "testuser"
+	authRegistryPass     = "testpass"
+	authRegistryImage    = "registry:2"
+	authRegistrySkopeo   = "quay.io/skopeo/stable:latest"
 	authRegistryRefShort = "auth-registry.unbounded-system.svc.cluster.local:5000"
 	// authRegistryCredsKey is the Secret data key (and on-disk filename
 	// under /etc/gantry/registry/) holding the Basic-auth credentials
@@ -95,10 +93,13 @@ func TestE2E_PrivateAuthRegistry(t *testing.T) {
 	// protected registry. If this fails the rest of the test cannot
 	// proceed, so fail loud.
 	h.populateAuthRegistry(ctx)
+	authRegistryDigest := h.inspectAuthRegistryDigest(ctx)
+	authRegistryRef := authRegistryHost + ":5000/agnhost@" + authRegistryDigest
 
 	// Project the credentials into gantry pods via the existing
 	// optional Secret hook.
 	h.installRegistryCredentials(ctx)
+	h.configureGantryAuthRegistryCA(ctx)
 
 	// Re-patch the gantry ConfigMap to add the auth registry with
 	// credentials_path. Default e2e ConfigMap is replaced (not merged)
@@ -116,7 +117,7 @@ func TestE2E_PrivateAuthRegistry(t *testing.T) {
 
 	// Configure containerd on each node with hosts.toml for our
 	// in-cluster registry routing through Gantry's mirror.
-	h.installMirrorHostsFor(ctx, authRegistryRefShort, "http://"+authRegistryRefShort)
+	h.installMirrorHostsFor(ctx, authRegistryRefShort, "https://"+authRegistryRefShort)
 
 	workers := h.workerNodes(ctx)
 
@@ -138,30 +139,87 @@ func TestE2E_PrivateAuthRegistry(t *testing.T) {
 	// retry can take several minutes to settle even on a fast pull.
 	h.waitForPodReadyTimeout(ctx, "gantry-e2e-authpull", "600s")
 
-	// Confirm gantry actually fetched from the auth registry rather
-	// than containerd having served bytes from somewhere else. We use
-	// the puller node's gantry log as the proof: please_pull_served
-	// events for the auth-registry image's digest demonstrate that
-	// containerd routed through gantry, gantry talked to the auth
-	// registry, and auth succeeded end-to-end. We intentionally do
-	// not assert on a numeric metric - the relevant counter only
-	// bumps on origin.Pull starts, which can be skipped in subsequent
-	// runs when the content store already holds the bytes.
-	pullerGantry := h.gantryPodOnNode(ctx, workers[0])
+	// Confirm Gantry actually fetched from the auth registry rather than
+	// containerd serving bytes from elsewhere. HRW selects a puller per child
+	// digest, so inspect every peer and match the registry identity rather than
+	// requiring the top-level index digest on the requester node.
+	served := false
+	for _, pod := range h.gantryPods(ctx) {
+		logs, err := h.runOut(ctx, "kubectl", "-n", namespace, "logs", pod, "-c", "gantry", "--tail=500")
+		if err != nil {
+			t.Fatalf("read gantry pod %s logs: %v", pod, err)
+		}
 
-	logs, err := h.runOut(ctx, "kubectl", "-n", namespace, "logs", pullerGantry,
-		"--tail=500")
+		for _, line := range strings.Split(logs, "\n") {
+			if strings.Contains(line, "please_pull served") &&
+				strings.Contains(line, `"registry":"`+authRegistryRefShort+`"`) {
+				served = true
+
+				break
+			}
+		}
+	}
+
+	if !served {
+		h.dumpDiagnostics(ctx)
+		t.Fatalf("no Gantry peer logged a please_pull served event for registry %s", authRegistryRefShort)
+	}
+}
+
+// inspectAuthRegistryDigest resolves the digest that the seed Job actually
+// wrote. The upstream tag is external state and may be rebound, so pinning a
+// digest in this test eventually turns a credential test into a 404 test.
+func (h *harness) inspectAuthRegistryDigest(ctx context.Context) string {
+	h.t.Helper()
+
+	jobName := "skopeo-inspect-" + strings.ToLower(time.Now().Format("150405"))
+	manifest := strings.Join([]string{
+		"apiVersion: batch/v1",
+		"kind: Job",
+		"metadata:",
+		"  name: " + jobName,
+		"  namespace: " + authRegistryNS,
+		"spec:",
+		"  backoffLimit: 2",
+		"  ttlSecondsAfterFinished: 600",
+		"  template:",
+		"    spec:",
+		"      restartPolicy: Never",
+		"      containers:",
+		"        - name: skopeo",
+		"          image: " + authRegistrySkopeo,
+		"          command:",
+		"            - skopeo",
+		"            - inspect",
+		"            - --tls-verify=false",
+		"            - --creds",
+		"            - " + authRegistryUser + ":" + authRegistryPass,
+		"            - --format",
+		"            - '{{.Digest}}'",
+		"            - docker://" + authRegistryHost + ":5000/agnhost:2.39",
+		"",
+	}, "\n")
+	if err := h.runWithInput(ctx, manifest, "kubectl", "apply", "-f", "-"); err != nil {
+		h.t.Fatalf("apply skopeo inspect job: %v", err)
+	}
+
+	if err := h.run(ctx, "kubectl", "-n", authRegistryNS, "wait",
+		"--for=condition=complete", "job/"+jobName, "--timeout=180s"); err != nil {
+		out, _ := h.runOut(ctx, "kubectl", "-n", authRegistryNS, "logs", "job/"+jobName, "--tail=200")
+		h.t.Fatalf("skopeo inspect job did not complete: %v\nlogs:\n%s", err, out)
+	}
+
+	out, err := h.runOut(ctx, "kubectl", "-n", authRegistryNS, "logs", "job/"+jobName, "--tail=20")
 	if err != nil {
-		h.dumpDiagnostics(ctx)
-		t.Fatalf("read gantry pod logs: %v", err)
+		h.t.Fatalf("read skopeo inspect output: %v", err)
 	}
 
-	if !strings.Contains(logs, authRegistryDigest) ||
-		!strings.Contains(logs, "please_pull served") {
-		h.dumpDiagnostics(ctx)
-		t.Fatalf("expected gantry pod %s to log a please_pull served event for digest %s; tail:\n%s",
-			pullerGantry, authRegistryDigest, lastLines(logs, 40))
+	d, err := godigest.Parse(strings.TrimSpace(out))
+	if err != nil {
+		h.t.Fatalf("parse seeded registry digest %q: %v", strings.TrimSpace(out), err)
 	}
+
+	return d.String()
 }
 
 // deployAuthRegistry creates the in-cluster registry:2 + htpasswd
@@ -178,6 +236,7 @@ func (h *harness) deployAuthRegistry(ctx context.Context) {
 	}
 
 	htpasswd := authRegistryUser + ":" + string(hash)
+	certPEM, keyPEM := newAuthRegistryCertificate(h.t)
 
 	manifest := strings.Join([]string{
 		"apiVersion: v1",
@@ -188,6 +247,17 @@ func (h *harness) deployAuthRegistry(ctx context.Context) {
 		"type: Opaque",
 		"stringData:",
 		"  htpasswd: " + htpasswd,
+		"---",
+		"apiVersion: v1",
+		"kind: Secret",
+		"metadata:",
+		"  name: " + authRegistryName + "-tls",
+		"  namespace: " + authRegistryNS,
+		"type: Opaque",
+		"data:",
+		"  tls.crt: " + base64.StdEncoding.EncodeToString(certPEM),
+		"  tls.key: " + base64.StdEncoding.EncodeToString(keyPEM),
+		"  ca.crt: " + base64.StdEncoding.EncodeToString(certPEM),
 		"---",
 		"apiVersion: apps/v1",
 		"kind: Deployment",
@@ -216,16 +286,26 @@ func (h *harness) deployAuthRegistry(ctx context.Context) {
 		"              value: /auth/htpasswd",
 		"            - name: REGISTRY_HTTP_ADDR",
 		"              value: \":5000\"",
+		"            - name: REGISTRY_HTTP_TLS_CERTIFICATE",
+		"              value: /tls/tls.crt",
+		"            - name: REGISTRY_HTTP_TLS_KEY",
+		"              value: /tls/tls.key",
 		"          ports:",
 		"            - containerPort: 5000",
 		"          volumeMounts:",
 		"            - name: htpasswd",
 		"              mountPath: /auth",
 		"              readOnly: true",
+		"            - name: tls",
+		"              mountPath: /tls",
+		"              readOnly: true",
 		"      volumes:",
 		"        - name: htpasswd",
 		"          secret:",
 		"            secretName: " + authRegistryName + "-htpasswd",
+		"        - name: tls",
+		"          secret:",
+		"            secretName: " + authRegistryName + "-tls",
 		"---",
 		"apiVersion: v1",
 		"kind: Service",
@@ -247,14 +327,101 @@ func (h *harness) deployAuthRegistry(ctx context.Context) {
 	}
 }
 
+func newAuthRegistryCertificate(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate auth registry key: %v", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate auth registry certificate serial: %v", err)
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: authRegistryHost},
+		DNSNames:              []string{authRegistryHost},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create auth registry certificate: %v", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal auth registry key: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM
+}
+
+// configureGantryAuthRegistryCA mounts the fixture's self-signed certificate
+// as Gantry's root bundle. Basic credentials are intentionally HTTPS-only.
+func (h *harness) configureGantryAuthRegistryCA(ctx context.Context) {
+	h.t.Helper()
+
+	patch, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{map[string]any{
+						"name": "gantry",
+						"env": []any{map[string]any{
+							"name":  "SSL_CERT_FILE",
+							"value": "/etc/gantry/auth-ca/ca.crt",
+						}},
+						"volumeMounts": []any{map[string]any{
+							"name":      "auth-registry-ca",
+							"mountPath": "/etc/gantry/auth-ca",
+							"readOnly":  true,
+						}},
+					}},
+					"volumes": []any{map[string]any{
+						"name": "auth-registry-ca",
+						"secret": map[string]any{
+							"secretName": authRegistryName + "-tls",
+							"items": []any{map[string]any{
+								"key":  "ca.crt",
+								"path": "ca.crt",
+							}},
+						},
+					}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		h.t.Fatalf("marshal Gantry CA patch: %v", err)
+	}
+
+	if err := h.run(ctx, "kubectl", "-n", namespace, "patch", "daemonset/"+dsName,
+		"--type=strategic", "--patch", string(patch)); err != nil {
+		h.t.Fatalf("patch Gantry auth registry CA: %v", err)
+	}
+}
+
 // populateAuthRegistry runs a one-off skopeo Job that copies
 // registry.k8s.io/e2e-test-images/agnhost into the in-cluster auth
 // registry. Waits for the Job to complete successfully.
 func (h *harness) populateAuthRegistry(ctx context.Context) {
 	h.t.Helper()
-	// The skopeo image is reasonably small (~30MB) and supports
-	// `--dest-creds` for Basic auth. We use --dest-tls-verify=false
-	// because our in-cluster registry serves cleartext on :5000.
+	// The skopeo image supports `--dest-creds` for Basic auth. We use
+	// --dest-tls-verify=false because the fixture has a generated self-signed
+	// certificate; Gantry separately receives that certificate as a trusted CA.
 	jobName := "skopeo-seed-" + strings.ReplaceAll(strings.ToLower(time.Now().Format("150405")), ":", "")
 
 	manifest := strings.Join([]string{
@@ -275,12 +442,11 @@ func (h *harness) populateAuthRegistry(ctx context.Context) {
 		"          command:",
 		"            - skopeo",
 		"            - copy",
-		// --multi-arch=all preserves the full manifest list so the
-		// in-cluster registry stores the exact same digest as the
-		// source. Without it skopeo only copies the single platform
-		// manifest and the manifest list digest disappears, which
-		// breaks our digest-pinned pull below.
-		"            - --multi-arch=all",
+		// The kind workflow runs on amd64. Copy only that platform: the test
+		// exercises auth, not multi-platform replication, and copying every
+		// platform makes unrelated source-registry blob failures fatal.
+		"            - --override-os=linux",
+		"            - --override-arch=amd64",
 		"            - --dest-tls-verify=false",
 		"            - --dest-creds",
 		"            - " + authRegistryUser + ":" + authRegistryPass,
@@ -368,7 +534,7 @@ func (h *harness) applyConfigMapWithAuthRegistry(ctx context.Context) {
 		"      - name: \"" + e2eRegistry + "\"",
 		"        endpoint: \"" + e2eRegistryServer + "\"",
 		"      - name: \"" + authRegistryRefShort + "\"",
-		"        endpoint: \"http://" + authRegistryRefShort + "\"",
+		"        endpoint: \"https://" + authRegistryRefShort + "\"",
 		"        credentials_path: \"/etc/gantry/registry/" + authRegistryCredsKey + "\"",
 		"",
 	}, "\n")
@@ -392,7 +558,7 @@ func (h *harness) installMirrorHostsFor(ctx context.Context, registryHost, serve
 
 		cmd := "mkdir -p " + shellQuote("/etc/containerd/certs.d/"+registryHost) +
 			" && cat > " + shellQuote(path)
-		if err := h.runWithInput(ctx, content, "docker", "exec", "-i", node, "sh", "-c", cmd); err != nil {
+		if err := h.runWithInput(ctx, content, h.containerEngine, "exec", "-i", node, "sh", "-c", cmd); err != nil {
 			h.t.Fatalf("install hosts.toml for %s on %s: %v", registryHost, node, err)
 		}
 	}

--- a/e2e/gantry/auth_registry_test.go
+++ b/e2e/gantry/auth_registry_test.go
@@ -144,6 +144,7 @@ func TestE2E_PrivateAuthRegistry(t *testing.T) {
 	// digest, so inspect every peer and match the registry identity rather than
 	// requiring the top-level index digest on the requester node.
 	served := false
+
 	for _, pod := range h.gantryPods(ctx) {
 		logs, err := h.runOut(ctx, "kubectl", "-n", namespace, "logs", pod, "-c", "gantry", "--tail=500")
 		if err != nil {
@@ -199,6 +200,7 @@ func (h *harness) inspectAuthRegistryDigest(ctx context.Context) string {
 		"            - docker://" + authRegistryHost + ":5000/agnhost:2.39",
 		"",
 	}, "\n")
+
 	if err := h.runWithInput(ctx, manifest, "kubectl", "apply", "-f", "-"); err != nil {
 		h.t.Fatalf("apply skopeo inspect job: %v", err)
 	}

--- a/e2e/gantry/harness_e2e.go
+++ b/e2e/gantry/harness_e2e.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	clusterName       = "gantry-e2e"
-	imageTag          = "gantry:e2e"
+	imageTag          = "docker.io/library/gantry:e2e"
 	namespace         = "unbounded-system"
 	dsName            = "gantry"
 	e2eRegistry       = "registry.k8s.io"
@@ -45,11 +45,12 @@ const (
 // harness bundles the setup/teardown lifecycle for one e2e run. One
 // instance is shared across the test functions in this package.
 type harness struct {
-	t           *testing.T
-	repoRoot    string
-	artifacts   string
-	manifests   string
-	keepCluster bool
+	t               *testing.T
+	repoRoot        string
+	artifacts       string
+	manifests       string
+	containerEngine string
+	keepCluster     bool
 }
 
 // newHarness resolves the repository root and renders the current Gantry
@@ -73,27 +74,42 @@ func newHarness(t *testing.T) *harness {
 	}
 
 	return &harness{
-		t:           t,
-		repoRoot:    root,
-		artifacts:   artifacts,
-		manifests:   manifests,
-		keepCluster: os.Getenv("E2E_KEEP") == "1",
+		t:               t,
+		repoRoot:        root,
+		artifacts:       artifacts,
+		manifests:       manifests,
+		containerEngine: resolveContainerEngine(t),
+		keepCluster:     os.Getenv("E2E_KEEP") == "1",
 	}
 }
 
+func resolveContainerEngine(t *testing.T) string {
+	t.Helper()
+
+	engine := strings.TrimSpace(os.Getenv("CONTAINER_ENGINE"))
+	if engine == "" {
+		return "docker"
+	}
+
+	if engine != "docker" && engine != "podman" {
+		t.Fatalf("unsupported CONTAINER_ENGINE %q; use docker or podman", engine)
+	}
+
+	return engine
+}
+
 // checkPrereqs fails the test fast if any required CLI is missing or
-// docker isn't running.
+// the configured container engine isn't running.
 func (h *harness) checkPrereqs() {
 	h.t.Helper()
 
-	for _, bin := range []string{"docker", "kind", "kubectl"} {
+	for _, bin := range []string{h.containerEngine, "kind", "kubectl"} {
 		if _, err := exec.LookPath(bin); err != nil {
 			h.t.Skipf("e2e prereq %q missing on PATH; skipping suite", bin)
 		}
 	}
-	// docker info is the canonical "is the engine actually running?" probe.
-	if err := h.run(context.Background(), "docker", "info"); err != nil {
-		h.t.Skipf("docker engine unreachable (%v); skipping suite", err)
+	if err := h.run(context.Background(), h.containerEngine, "info"); err != nil {
+		h.t.Skipf("%s engine unreachable (%v); skipping suite", h.containerEngine, err)
 	}
 }
 
@@ -135,12 +151,17 @@ func (h *harness) buildAndLoadImage(ctx context.Context) {
 
 	platform := fmt.Sprintf("linux/%s", goArchForDocker(runtime.GOARCH))
 
-	if err := h.run(ctx, "docker", "build", "--platform", platform, "--tag", imageTag,
+	if err := h.run(ctx, h.containerEngine, "build", "--platform", platform, "--tag", imageTag,
 		"--file", filepath.Join(h.repoRoot, "images", "gantry", "Containerfile"), "."); err != nil {
 		h.t.Fatalf("build image: %v", err)
 	}
 
-	if err := h.run(ctx, "kind", "load", "docker-image", imageTag, "--name", clusterName); err != nil {
+	archive := filepath.Join(h.t.TempDir(), "gantry-e2e.tar")
+	if err := h.run(ctx, h.containerEngine, "save", "--output", archive, imageTag); err != nil {
+		h.t.Fatalf("save image archive: %v", err)
+	}
+
+	if err := h.run(ctx, "kind", "load", "image-archive", archive, "--name", clusterName); err != nil {
 		h.t.Fatalf("kind load: %v", err)
 	}
 }
@@ -204,7 +225,7 @@ func (h *harness) installMirrorHosts(ctx context.Context) {
 		path := "/etc/containerd/certs.d/" + e2eRegistry + "/hosts.toml"
 
 		cmd := "mkdir -p " + shellQuote(filepath.Dir(path)) + " && cat > " + shellQuote(path)
-		if err := h.runWithInput(ctx, content, "docker", "exec", "-i", node, "sh", "-c", cmd); err != nil {
+		if err := h.runWithInput(ctx, content, h.containerEngine, "exec", "-i", node, "sh", "-c", cmd); err != nil {
 			h.t.Fatalf("install hosts.toml on %s: %v", node, err)
 		}
 	}
@@ -303,6 +324,8 @@ func (h *harness) waitForPodReadyTimeout(ctx context.Context, name, timeout stri
 
 	if err := h.run(ctx, "kubectl", "wait", "--for=condition=Ready", "pod/"+name, "--timeout="+timeout); err != nil {
 		h.dumpDiagnostics(ctx)
+		h.dumpKubectlArtifact(ctx, "describe", "pod/"+name)
+		h.dumpKubectlArtifact(ctx, "get", "events", "--field-selector", "involvedObject.kind=Pod,involvedObject.name="+name, "--sort-by=.lastTimestamp")
 		h.t.Fatalf("wait for pod %s ready: %v", name, err)
 	}
 }
@@ -324,7 +347,7 @@ func (h *harness) removePullImageFromNodes(ctx context.Context) {
 	for _, node := range h.kindNodes(ctx) {
 		cmd := "crictl rmi " + shellQuote(e2ePullImage) + " >/dev/null 2>&1 || true; " +
 			"ctr -n k8s.io images rm " + shellQuote(e2ePullImage) + " >/dev/null 2>&1 || true"
-		if err := h.run(ctx, "docker", "exec", node, "sh", "-c", cmd); err != nil {
+		if err := h.run(ctx, h.containerEngine, "exec", node, "sh", "-c", cmd); err != nil {
 			h.t.Fatalf("remove cached test image from %s: %v", node, err)
 		}
 	}
@@ -858,32 +881,38 @@ func (h *harness) dumpDiagnostics(ctx context.Context) {
 	for _, args := range [][]string{
 		{"-n", namespace, "get", "pods", "-o", "wide"},
 		{"-n", namespace, "describe", "ds/" + dsName},
-		{"-n", namespace, "logs", "ds/" + dsName, "--all-containers", "--tail=200"},
 		{"get", "pods", "-A", "-o", "wide"},
 	} {
-		out, runErr := h.runOut(ctx, "kubectl", args...)
-		if runErr != nil {
-			// Partial output is still worth keeping, so the error joins the
-			// artifact rather than discarding what the command did produce.
-			out += "\n\ncommand failed: " + runErr.Error() + "\n"
-		}
-
-		// Sanitize args for the filename - kubectl args can contain
-		// '/' (e.g. ds/gantry, pod/foo) which os.WriteFile would
-		// silently fail on because the parent dir does not exist.
-		safe := strings.ReplaceAll(strings.Join(args, "_"), "/", "_")
-		dst := filepath.Join(h.artifacts, fmt.Sprintf("%s_%s.log", h.t.Name(), safe))
-		//#nosec G306 -- test artifact
-		if err := os.WriteFile(dst, []byte(out), 0o644); err != nil {
-			// The comment above exists because this silently failed once
-			// already; saying so beats writing nothing and reporting success.
-			h.t.Logf("diagnostics: could not write %s: %v", dst, err)
-
-			continue
-		}
-
-		h.t.Logf("diagnostics: wrote %s", dst)
+		h.dumpKubectlArtifact(ctx, args...)
 	}
+
+	for _, pod := range h.gantryPods(ctx) {
+		h.dumpKubectlArtifact(ctx, "-n", namespace, "logs", "pod/"+pod, "-c", "gantry", "--tail=500")
+	}
+}
+
+func (h *harness) dumpKubectlArtifact(ctx context.Context, args ...string) {
+	h.t.Helper()
+
+	out, runErr := h.runOut(ctx, "kubectl", args...)
+	if runErr != nil {
+		// Partial output is still worth keeping, so the error joins the
+		// artifact rather than discarding what the command did produce.
+		out += "\n\ncommand failed: " + runErr.Error() + "\n"
+	}
+
+	// Sanitize args for the filename - kubectl args can contain '/'
+	// (e.g. pod/foo), which would otherwise create a nonexistent path.
+	safe := strings.NewReplacer("/", "_", ",", "_", "=", "_").Replace(strings.Join(args, "_"))
+	dst := filepath.Join(h.artifacts, fmt.Sprintf("%s_%s.log", h.t.Name(), safe))
+	//#nosec G306 -- test artifact
+	if err := os.WriteFile(dst, []byte(out), 0o644); err != nil {
+		h.t.Logf("diagnostics: could not write %s: %v", dst, err)
+
+		return
+	}
+
+	h.t.Logf("diagnostics: wrote %s", dst)
 }
 
 // evictImageFromNode simulates kubelet eviction by deleting the
@@ -916,31 +945,17 @@ func (h *harness) evictImageFromNode(ctx context.Context, nodeName string, image
 		// Force a content GC sweep so blobs no longer referenced by
 		// any image or lease are reclaimed before the next pull.
 		"ctr -n k8s.io content prune references >/dev/null 2>&1 || true"
-	if err := h.run(ctx, "docker", "exec", nodeName, "sh", "-c", cmd); err != nil {
+	if err := h.run(ctx, h.containerEngine, "exec", nodeName, "sh", "-c", cmd); err != nil {
 		h.t.Fatalf("evict image from %s: %v", nodeName, err)
 	}
 }
 
-// verifyContainerdSocketAccess confirms that a gantry pod can access
-// the node's containerd socket with proper read/write permissions.
-// The gantry image is distroless (no shell, no stat), so we probe
-// indirectly through the gantry agent itself: on successful socket
-// connect it logs "connected to containerd" at startup, and the
-// /readyz HTTP endpoint only flips to OK once the containerd-backed
-// content store is wired up. We check both signals here.
+// verifyContainerdSocketAccess confirms that a Gantry pod has a live
+// containerd-backed store. The image is distroless, so use the operational
+// contract: /readyz performs a containerd content-store Ping and the storage
+// mode metric confirms that the active backend is containerd.
 func (h *harness) verifyContainerdSocketAccess(ctx context.Context, pod string) {
 	h.t.Helper()
-
-	logs, err := h.runOut(ctx, "kubectl", "-n", namespace, "logs", pod, "-c", "gantry", "--tail=200")
-	if err != nil {
-		h.dumpDiagnostics(ctx)
-		h.t.Fatalf("read pod %s logs: %v", pod, err)
-	}
-
-	if !strings.Contains(logs, "connected to containerd") {
-		h.dumpDiagnostics(ctx)
-		h.t.Fatalf("pod %s did not log 'connected to containerd' - socket access likely broken", pod)
-	}
 
 	body, err := h.fetchPodPath(ctx, pod, "/readyz")
 	if err != nil {
@@ -951,6 +966,11 @@ func (h *harness) verifyContainerdSocketAccess(ctx context.Context, pod string) 
 	if b := strings.ToLower(strings.TrimSpace(body)); b != "ready" && b != "ok" {
 		h.dumpDiagnostics(ctx)
 		h.t.Fatalf("pod %s /readyz body = %q, want 'ready' or 'ok' (socket-backed content store not wired)", pod, body)
+	}
+
+	if got := h.metricSumOnPod(ctx, pod, "gantry_storage_mode_info", `mode="containerd"`); got != 1 {
+		h.dumpDiagnostics(ctx)
+		h.t.Fatalf("pod %s gantry_storage_mode_info{mode=\"containerd\"} = %.0f, want 1", pod, got)
 	}
 }
 
@@ -985,7 +1005,7 @@ func (h *harness) podRestartCount(ctx context.Context, pod string) int {
 func (h *harness) containerdSocketID(ctx context.Context, node string) string {
 	h.t.Helper()
 
-	out, err := h.runOut(ctx, "docker", "exec", node, "stat", "-Lc", "%d:%i", "/run/containerd/containerd.sock")
+	out, err := h.runOut(ctx, h.containerEngine, "exec", node, "stat", "-Lc", "%d:%i", "/run/containerd/containerd.sock")
 	if err != nil {
 		h.t.Fatalf("stat containerd socket on %s: %v", node, err)
 	}
@@ -996,7 +1016,7 @@ func (h *harness) containerdSocketID(ctx context.Context, node string) string {
 func (h *harness) restartContainerd(ctx context.Context, node string) {
 	h.t.Helper()
 
-	if err := h.run(ctx, "docker", "exec", node, "systemctl", "restart", "containerd"); err != nil {
+	if err := h.run(ctx, h.containerEngine, "exec", node, "systemctl", "restart", "containerd"); err != nil {
 		h.t.Fatalf("restart containerd on %s: %v", node, err)
 	}
 }
@@ -1006,7 +1026,7 @@ func (h *harness) waitForContainerdSocketReplacement(ctx context.Context, node, 
 
 	deadline := time.Now().Add(time.Minute)
 	for time.Now().Before(deadline) {
-		out, err := h.runOut(ctx, "docker", "exec", node, "stat", "-Lc", "%d:%i", "/run/containerd/containerd.sock")
+		out, err := h.runOut(ctx, h.containerEngine, "exec", node, "stat", "-Lc", "%d:%i", "/run/containerd/containerd.sock")
 		if err == nil {
 			if id := strings.TrimSpace(out); id != "" && id != oldID {
 				return

--- a/e2e/gantry/harness_e2e.go
+++ b/e2e/gantry/harness_e2e.go
@@ -108,6 +108,7 @@ func (h *harness) checkPrereqs() {
 			h.t.Skipf("e2e prereq %q missing on PATH; skipping suite", bin)
 		}
 	}
+
 	if err := h.run(context.Background(), h.containerEngine, "info"); err != nil {
 		h.t.Skipf("%s engine unreachable (%v); skipping suite", h.containerEngine, err)
 	}
@@ -540,17 +541,6 @@ func (h *harness) gantryPodOnNode(ctx context.Context, nodeName string) string {
 	}
 
 	return pods[0]
-}
-
-// lastLines returns the last n newline-separated lines of s. Used to
-// keep failure logs in test output bounded.
-func lastLines(s string, n int) string {
-	lines := strings.Split(s, "\n")
-	if len(lines) <= n {
-		return s
-	}
-
-	return strings.Join(lines[len(lines)-n:], "\n")
 }
 
 func (h *harness) fetchPodMetrics(ctx context.Context, pod string) string {

--- a/e2e/gantry/harness_patch_test.go
+++ b/e2e/gantry/harness_patch_test.go
@@ -9,6 +9,25 @@ import (
 	"testing"
 )
 
+func TestResolveContainerEngine(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "default", want: "docker"},
+		{name: "podman", env: "podman", want: "podman"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CONTAINER_ENGINE", tc.env)
+
+			if got := resolveContainerEngine(t); got != tc.want {
+				t.Fatalf("resolveContainerEngine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestPatchDaemonSetForE2E_TargetsGantryContainerOnly is the
 // regression test for the twelfth-review finding: the harness's
 // previous strings.Replace(..., 1) on the bare "imagePullPolicy:

--- a/e2e/gantry/kind-config.yaml
+++ b/e2e/gantry/kind-config.yaml
@@ -14,16 +14,17 @@
 # runAsUser the agent fails readiness because containerd is its sole
 # storage backend.
 #
-# Smoke-test scope: e2e/smoke_e2e_test.go validates DaemonSet
-# rollout and per-pod /readyz convergence ONLY. It does NOT exercise
-# the mirror/transfer HTTP paths or the cdsub event stream, so a
-# cdsub fallback to NoOpSource is invisible to this suite. Real
-# containerd pull-through coverage (hosts.toml + a workload pod that
-# actually pulls through the mirror) is a separate, larger e2e
-# investment.
+# The kind node image does not enable certs.d registry configuration by
+# default. Tests install hosts.toml files dynamically, so point the CRI plugin
+# at that directory before containerd starts. kindest/node:v1.34.0 currently
+# ships containerd v2 with config format 2 and the legacy CRI plugin key below.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: gantry-e2e
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
 nodes:
   - role: control-plane
   - role: worker

--- a/e2e/gantry/lease_lifecycle_test.go
+++ b/e2e/gantry/lease_lifecycle_test.go
@@ -49,7 +49,7 @@ func TestE2E_LeaseLifecycle(t *testing.T) {
 	h.installMirrorHosts(ctx)
 	h.removePullImageFromNodes(ctx)
 	workers := h.workerNodes(ctx)
-	puller := workers[0]
+	requester := workers[0]
 
 	// Trigger a background ingest by scheduling a workload that pulls
 	// through the mirror. Containerd's pull goes through gantry; gantry
@@ -58,9 +58,11 @@ func TestE2E_LeaseLifecycle(t *testing.T) {
 	// freshly committed blobs from containerd's GC until the kubelet's
 	// Image reference takes over.
 	h.deletePod(ctx, "gantry-e2e-lease")
-	h.applyPullPod(ctx, "gantry-e2e-lease", puller)
+	h.applyPullPod(ctx, "gantry-e2e-lease", requester)
 
-	// Wait for at least one gantry lease to appear on the puller node.
+	// Wait for at least one gantry lease to appear on any Gantry node. HRW
+	// selects a puller independently for each digest, so the requester is not
+	// necessarily the node that performs the background origin ingest.
 	// This proves the end-to-end primitive that fakes cannot prove:
 	//   - the lease manager accepts our LabelManaged / LabelCreated
 	//     labels and LeasePrefix-formatted ID without error,
@@ -69,11 +71,12 @@ func TestE2E_LeaseLifecycle(t *testing.T) {
 	//     dotted/slashed key quoting),
 	//   - the cleanup loop can therefore identify gantry-owned
 	//     leases for periodic expiration.
-	if !h.waitForGantryLease(ctx, puller, 2*time.Minute) {
+	leaseNode, ok := h.waitForGantryLease(ctx, h.kindNodes(ctx), 2*time.Minute)
+	if !ok {
 		h.dumpDiagnostics(ctx)
-		t.Fatalf("no gantry-prefixed lease appeared on %s within 2m; "+
-			"either ingest never happened (check mirror logs) or the "+
-			"lease creation/labeling path is broken on real containerd", puller)
+		t.Fatalf("no gantry-prefixed lease appeared on any kind node within 2m; " +
+			"either ingest never happened (check mirror logs) or the " +
+			"lease creation/labeling path is broken on real containerd")
 	}
 
 	h.waitForPodReady(ctx, "gantry-e2e-lease")
@@ -82,16 +85,16 @@ func TestE2E_LeaseLifecycle(t *testing.T) {
 	// still be present (by design - TTL is 60m) and they SHOULD match
 	// the `gantry-sha256:...-<ts>` ID shape that containerdstore.LeasePrefix
 	// emits.
-	leases := h.listGantryLeases(ctx, puller)
+	leases := h.listGantryLeases(ctx, leaseNode)
 	if len(leases) == 0 {
 		// This would be surprising - we just observed leases above -
 		// but it would point to an eager-release path we don't have.
 		t.Fatalf("gantry leases on %s vanished between observation and pod-ready; "+
-			"this implies an unexpected early release path", puller)
+			"this implies an unexpected early release path", leaseNode)
 	}
 
 	t.Logf("observed %d gantry-managed lease(s) on %s after pull (held for TTL by design): %v",
-		len(leases), puller, leases)
+		len(leases), leaseNode, leases)
 
 	// Sanity check: every lease ID must start with the LeasePrefix and
 	// contain a sha256 digest component. Catches accidental ID format
@@ -111,7 +114,7 @@ func (h *harness) listGantryLeases(ctx context.Context, nodeName string) []strin
 	// `ctr -n k8s.io leases list` prints a header row plus one row per
 	// lease. We filter for IDs starting with `gantry-` (matching
 	// containerdstore.LeasePrefix).
-	out, err := h.runOut(ctx, "docker", "exec", nodeName,
+	out, err := h.runOut(ctx, h.containerEngine, "exec", nodeName,
 		"ctr", "-n", "k8s.io", "leases", "list")
 	if err != nil {
 		h.t.Fatalf("list leases on %s: %v", nodeName, err)
@@ -139,24 +142,25 @@ func (h *harness) listGantryLeases(ctx context.Context, nodeName string) []strin
 	return ids
 }
 
-// waitForGantryLease polls listGantryLeases until at least one gantry
-// lease is seen on nodeName, or the deadline expires. Returns true if
-// a lease was observed.
-func (h *harness) waitForGantryLease(ctx context.Context, nodeName string, timeout time.Duration) bool {
+// waitForGantryLease polls every node until at least one Gantry lease is seen
+// or the deadline expires. It returns the node that owns the observed lease.
+func (h *harness) waitForGantryLease(ctx context.Context, nodes []string, timeout time.Duration) (string, bool) {
 	h.t.Helper()
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if leases := h.listGantryLeases(ctx, nodeName); len(leases) > 0 {
-			return true
+		for _, node := range nodes {
+			if leases := h.listGantryLeases(ctx, node); len(leases) > 0 {
+				return node, true
+			}
 		}
 
 		select {
 		case <-ctx.Done():
-			return false
+			return "", false
 		case <-time.After(1 * time.Second):
 		}
 	}
 
-	return false
+	return "", false
 }

--- a/e2e/gantry/smoke_e2e_test.go
+++ b/e2e/gantry/smoke_e2e_test.go
@@ -254,7 +254,9 @@ func TestE2E_EvictionRecovery(t *testing.T) {
 
 	h.deletePod(ctx, "gantry-e2e-evict-pull")
 	h.applyPullPod(ctx, "gantry-e2e-evict-pull", workers[1])
-	h.waitForPodReady(ctx, "gantry-e2e-evict-pull")
+	// The production config keeps rediscovering peer seeds for up to 5m before
+	// returning round 0's origin-fallback decision. Wait beyond that budget.
+	h.waitForPodReadyTimeout(ctx, "gantry-e2e-evict-pull", "600s")
 
 	// Assert: origin fallback worked.
 	originPullAfter := h.metricSum(ctx, "p2p_origin_pull_total")


### PR DESCRIPTION
## Summary

- add a dedicated Gantry kind E2E workflow for relevant pull requests, pushes to `main` and `release-*`, a daily schedule, and manual dispatch
- repair the Gantry harness for the current repository layout, Docker/Podman providers, portable image loading, and containerd `certs.d` routing
- make auth, lease, eviction, socket-access, and failure diagnostics match the production behavior they exercise

## Testing

- `make e2e-gantry` - all tests passed in 1042.887s
- `go test -tags=e2e ./e2e/gantry -run 'TestResolveContainerEngine|TestPatch|TestNonExistent' -count=1`\n- `actionlint -shellcheck= -pyflakes= .github/workflows/gantry-e2e.yaml`