### PR TITLE
Support annotated public IPs in the controller

### DIFF
--- a/api/net/v1alpha1/types.go
+++ b/api/net/v1alpha1/types.go
@@ -19,9 +19,14 @@ const (
 	// and read intentionally until then.
 	SiteLabelKey = "net.unbounded-cloud.io/site"
 
-	// NodeDiscoveredPublicIPAnnotation contains the public IP discovered by the
-	// unbounded-net node agent.
+	// NodeDiscoveredPublicIPAnnotation contains the translated source IP
+	// discovered by the node agent. It does not prove that the WireGuard port is
+	// reachable through symmetric NAT or CGNAT.
 	NodeDiscoveredPublicIPAnnotation = "net.unbounded-cloud.io/discovered-public-ip"
+
+	// NodeDiscoveredPublicIPExpiresAtAnnotation bounds how long the controller
+	// trusts the agent-discovered public IP.
+	NodeDiscoveredPublicIPExpiresAtAnnotation = "net.unbounded-cloud.io/discovered-public-ip-expires-at"
 
 	// NodeDeclaredPublicIPAnnotation contains a public IP declared by an
 	// administrator. The node agent must not modify this annotation.

--- a/api/net/v1alpha1/types.go
+++ b/api/net/v1alpha1/types.go
@@ -18,6 +18,14 @@ const (
 	// marked with the godoc Deprecated: convention because it is still written
 	// and read intentionally until then.
 	SiteLabelKey = "net.unbounded-cloud.io/site"
+
+	// NodeDiscoveredPublicIPAnnotation contains the public IP discovered by the
+	// unbounded-net node agent.
+	NodeDiscoveredPublicIPAnnotation = "net.unbounded-cloud.io/discovered-public-ip"
+
+	// NodeDeclaredPublicIPAnnotation contains a public IP declared by an
+	// administrator. The node agent must not modify this annotation.
+	NodeDeclaredPublicIPAnnotation = "net.unbounded-cloud.io/declared-public-ip"
 )
 
 // PodCidrAssignment defines a pod CIDR allocation rule for nodes in a site.

--- a/cmd/unbounded-net-controller/cluster_status.go
+++ b/cmd/unbounded-net-controller/cluster_status.go
@@ -436,12 +436,12 @@ func fetchClusterStatus(ctx context.Context, health *healthState, pullEnabled bo
 			}
 		}
 
-		if len(nodeStatus.NodeInfo.ExternalIPs) == 0 {
-			externalIPs, _, err := controller.ResolveNodeExternalIPsAt(node, status.Timestamp)
-			if err == nil && len(externalIPs) > 0 {
-				nodeStatus.NodeInfo.ExternalIPs = externalIPs
-			}
+		externalIPs, _, resolveErr := controller.ResolveNodeExternalIPsAt(node, status.Timestamp)
+		if resolveErr != nil {
+			externalIPs = nil
 		}
+
+		nodeStatus.NodeInfo.ExternalIPs = externalIPs
 
 		if (nodeStatus.NodeInfo.WireGuard == nil || nodeStatus.NodeInfo.WireGuard.PublicKey == "") && node.Annotations != nil {
 			if pubKey := node.Annotations[controller.WireGuardPubKeyAnnotation]; pubKey != "" {
@@ -513,6 +513,8 @@ func fetchClusterStatus(ctx context.Context, health *healthState, pullEnabled bo
 		if _, exists := nodeNameSet[name]; exists {
 			continue // already emitted above
 		}
+
+		nodeStatus.NodeInfo.ExternalIPs = nil
 
 		if poolSet := gatewayPoolsByNode[name]; len(poolSet) > 0 {
 			nodeStatus.NodeInfo.IsGateway = true

--- a/cmd/unbounded-net-controller/cluster_status.go
+++ b/cmd/unbounded-net-controller/cluster_status.go
@@ -422,28 +422,23 @@ func fetchClusterStatus(ctx context.Context, health *healthState, pullEnabled bo
 			}
 		}
 
-		if len(nodeStatus.NodeInfo.InternalIPs) == 0 || len(nodeStatus.NodeInfo.ExternalIPs) == 0 {
+		if len(nodeStatus.NodeInfo.InternalIPs) == 0 {
 			internalIPs := make([]string, 0)
-			externalIPs := make([]string, 0)
 
 			for _, addr := range node.Status.Addresses {
-				switch addr.Type {
-				case corev1.NodeInternalIP:
-					if addr.Address != "" {
-						internalIPs = append(internalIPs, addr.Address)
-					}
-				case corev1.NodeExternalIP:
-					if addr.Address != "" {
-						externalIPs = append(externalIPs, addr.Address)
-					}
+				if addr.Type == corev1.NodeInternalIP && addr.Address != "" {
+					internalIPs = append(internalIPs, addr.Address)
 				}
 			}
 
-			if len(nodeStatus.NodeInfo.InternalIPs) == 0 && len(internalIPs) > 0 {
+			if len(internalIPs) > 0 {
 				nodeStatus.NodeInfo.InternalIPs = internalIPs
 			}
+		}
 
-			if len(nodeStatus.NodeInfo.ExternalIPs) == 0 && len(externalIPs) > 0 {
+		if len(nodeStatus.NodeInfo.ExternalIPs) == 0 {
+			externalIPs, _, err := controller.ResolveNodeExternalIPsAt(node, status.Timestamp)
+			if err == nil && len(externalIPs) > 0 {
 				nodeStatus.NodeInfo.ExternalIPs = externalIPs
 			}
 		}

--- a/cmd/unbounded-net-controller/cluster_status_cache.go
+++ b/cmd/unbounded-net-controller/cluster_status_cache.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+
+	"github.com/Azure/unbounded/internal/net/controller"
 )
 
 // ClusterStatusCache maintains a pre-built ClusterStatusResponse in memory,
@@ -69,7 +71,10 @@ func (c *ClusterStatusCache) Rebuild(ctx context.Context) {
 
 // PatchNode updates a single node's cached status in-place without a full
 // rebuild.
-func (c *ClusterStatusCache) PatchNode(nodeName string, nodeStatus *NodeStatusResponse) {
+func (c *ClusterStatusCache) PatchNode(nodeName string, nodeStatus NodeStatusResponse) {
+	now := time.Now()
+	nodeStatus.NodeInfo.ExternalIPs = c.resolveNodeExternalIPs(nodeName, now)
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -78,8 +83,9 @@ func (c *ClusterStatusCache) PatchNode(nodeName string, nodeStatus *NodeStatusRe
 	}
 
 	if i, ok := c.nodeIndex[nodeName]; ok && i < len(c.status.Nodes) {
-		// Preserve controller-enriched fields that the node agent doesn't set
+		// Preserve controller-enriched fields across node-agent status updates.
 		existing := c.status.Nodes[i]
+
 		if nodeStatus.StatusSource == "" {
 			nodeStatus.StatusSource = existing.StatusSource
 		}
@@ -128,16 +134,34 @@ func (c *ClusterStatusCache) PatchNode(nodeName string, nodeStatus *NodeStatusRe
 			nodeStatus.NodePodInfo = existing.NodePodInfo
 		}
 
-		c.status.Nodes[i] = nodeStatus
+		c.status.Nodes[i] = &nodeStatus
 	} else {
 		c.nodeIndex[nodeName] = len(c.status.Nodes)
-		c.status.Nodes = append(c.status.Nodes, nodeStatus)
+		c.status.Nodes = append(c.status.Nodes, &nodeStatus)
 		c.status.NodeCount = len(c.status.Nodes)
 	}
 
 	c.seq++
 	c.status.Seq = c.seq
-	c.status.Timestamp = time.Now()
+	c.status.Timestamp = now
+}
+
+func (c *ClusterStatusCache) resolveNodeExternalIPs(nodeName string, now time.Time) []string {
+	if c.health == nil || c.health.nodeLister == nil {
+		return nil
+	}
+
+	node, err := c.health.nodeLister.Get(nodeName)
+	if err != nil {
+		return nil
+	}
+
+	externalIPs, _, err := controller.ResolveNodeExternalIPsAt(node, now)
+	if err != nil {
+		return nil
+	}
+
+	return externalIPs
 }
 
 // MarkDirty signals that a node status changed. The cached response is

--- a/cmd/unbounded-net-controller/cluster_status_cache.go
+++ b/cmd/unbounded-net-controller/cluster_status_cache.go
@@ -5,11 +5,15 @@ package main
 
 import (
 	"context"
+	"reflect"
+	"slices"
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
 	"github.com/Azure/unbounded/internal/net/controller"
 )
 
@@ -41,6 +45,45 @@ func NewClusterStatusCache(health *healthState) *ClusterStatusCache {
 		fullRebuildCh: make(chan struct{}, 1),
 		nodeUpdateCh:  make(chan struct{}, 1),
 	}
+}
+
+func nodeUpdateAffectsClusterStatus(oldNode, newNode *corev1.Node, now time.Time) bool {
+	if oldNode == nil || newNode == nil ||
+		!reflect.DeepEqual(oldNode.Labels, newNode.Labels) ||
+		!reflect.DeepEqual(oldNode.Spec, newNode.Spec) ||
+		!reflect.DeepEqual(oldNode.Status, newNode.Status) ||
+		!nodeAnnotationsEqualExceptDiscoveredPublicIPExpiry(oldNode.Annotations, newNode.Annotations) {
+		return true
+	}
+
+	oldExternalIPs, _, oldErr := controller.ResolveNodeExternalIPsAt(oldNode, now)
+	newExternalIPs, _, newErr := controller.ResolveNodeExternalIPsAt(newNode, now)
+
+	return (oldErr == nil) != (newErr == nil) || !slices.Equal(oldExternalIPs, newExternalIPs)
+}
+
+func nodeAnnotationsEqualExceptDiscoveredPublicIPExpiry(oldAnnotations, newAnnotations map[string]string) bool {
+	for key, oldValue := range oldAnnotations {
+		if key == unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation {
+			continue
+		}
+
+		if newValue, ok := newAnnotations[key]; !ok || oldValue != newValue {
+			return false
+		}
+	}
+
+	for key := range newAnnotations {
+		if key == unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation {
+			continue
+		}
+
+		if _, ok := oldAnnotations[key]; !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Rebuild rebuilds the full status from scratch. Called on startup and

--- a/cmd/unbounded-net-controller/cluster_status_cache_test.go
+++ b/cmd/unbounded-net-controller/cluster_status_cache_test.go
@@ -18,6 +18,92 @@ import (
 	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
 )
 
+func TestNodeUpdateAffectsClusterStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	base := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "node-a",
+			ResourceVersion: "1",
+			Labels:          map[string]string{"site": "edge"},
+			Annotations: map[string]string{
+				unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation:          "203.0.113.10",
+				unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation: now.Add(time.Hour).Format(time.RFC3339),
+			},
+		},
+		Spec: corev1.NodeSpec{ProviderID: "provider-a"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.10"}},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*corev1.Node)
+		want   bool
+	}{
+		{
+			name: "resource version only",
+			mutate: func(node *corev1.Node) {
+				node.ResourceVersion = "2"
+			},
+		},
+		{
+			name: "fresh expiry extension",
+			mutate: func(node *corev1.Node) {
+				node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation] = now.Add(2 * time.Hour).Format(time.RFC3339)
+			},
+		},
+		{
+			name: "fresh discovery expires",
+			mutate: func(node *corev1.Node) {
+				node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation] = now.Add(-time.Second).Format(time.RFC3339)
+			},
+			want: true,
+		},
+		{
+			name: "discovered address",
+			mutate: func(node *corev1.Node) {
+				node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation] = "203.0.113.11"
+			},
+			want: true,
+		},
+		{
+			name: "label",
+			mutate: func(node *corev1.Node) {
+				node.Labels["site"] = "other"
+			},
+			want: true,
+		},
+		{
+			name: "status",
+			mutate: func(node *corev1.Node) {
+				node.Status.Addresses[0].Address = "10.0.0.11"
+			},
+			want: true,
+		},
+		{
+			name: "other annotation",
+			mutate: func(node *corev1.Node) {
+				node.Annotations["example.com/value"] = "changed"
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updated := base.DeepCopy()
+			tt.mutate(updated)
+
+			if got := nodeUpdateAffectsClusterStatus(base, updated, now); got != tt.want {
+				t.Fatalf("nodeUpdateAffectsClusterStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestClusterStatusCacheNewReturnsNilStatus verifies that a newly created
 // cache returns nil from Get before any Rebuild.
 func TestClusterStatusCacheNewReturnsNilStatus(t *testing.T) {

--- a/cmd/unbounded-net-controller/cluster_status_cache_test.go
+++ b/cmd/unbounded-net-controller/cluster_status_cache_test.go
@@ -5,10 +5,17 @@ package main
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
 )
 
 // TestClusterStatusCacheNewReturnsNilStatus verifies that a newly created
@@ -47,6 +54,81 @@ func TestClusterStatusCacheRebuild(t *testing.T) {
 	got = c.Get()
 	if got.Seq != 2 {
 		t.Fatalf("expected seq=2 after second Rebuild, got %d", got.Seq)
+	}
+}
+
+func TestClusterStatusCachePatchNodeResolvesControllerOwnedExternalIPs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		existing []string
+		want     []string
+	}{
+		{
+			name: "existing entry is refreshed from provider address",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{
+					Type: corev1.NodeExternalIP, Address: "203.0.113.10",
+				}}},
+			},
+			existing: []string{"192.0.2.10"},
+			want:     []string{"203.0.113.10"},
+		},
+		{
+			name:     "existing entry is cleared without a source",
+			node:     &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+			existing: []string{"192.0.2.10"},
+		},
+		{
+			name: "new entry uses discovered address",
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name: "node-a",
+				Annotations: map[string]string{
+					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation:          "203.0.113.11",
+					unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation: time.Now().Add(time.Hour).Format(time.RFC3339),
+				},
+			}},
+			want: []string{"203.0.113.11"},
+		},
+		{
+			name: "new entry is cleared when Kubernetes Node is missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tt.node != nil {
+				if err := indexer.Add(tt.node); err != nil {
+					t.Fatalf("add Node: %v", err)
+				}
+			}
+
+			c := NewClusterStatusCache(&healthState{nodeLister: corev1listers.NewNodeLister(indexer)})
+
+			c.status = &ClusterStatusResponse{}
+			if tt.existing != nil {
+				c.status.Nodes = []*NodeStatusResponse{{NodeInfo: NodeInfo{Name: "node-a", ExternalIPs: tt.existing}}}
+				c.nodeIndex["node-a"] = 0
+			}
+
+			incoming := NodeStatusResponse{NodeInfo: NodeInfo{
+				Name:        "node-a",
+				ExternalIPs: []string{"198.51.100.10"},
+			}}
+			c.PatchNode("node-a", incoming)
+
+			if got := c.Get().Nodes[0].NodeInfo.ExternalIPs; !slices.Equal(got, tt.want) {
+				t.Fatalf("ExternalIPs = %#v, want %#v", got, tt.want)
+			}
+
+			if !slices.Equal(incoming.NodeInfo.ExternalIPs, []string{"198.51.100.10"}) {
+				t.Fatalf("PatchNode mutated incoming status: %#v", incoming.NodeInfo.ExternalIPs)
+			}
+		})
 	}
 }
 

--- a/cmd/unbounded-net-controller/cluster_status_test.go
+++ b/cmd/unbounded-net-controller/cluster_status_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
 	controllerpkg "github.com/Azure/unbounded/internal/net/controller"
 )
 
@@ -51,7 +52,9 @@ func TestFetchClusterStatusFromCacheAndInformers(t *testing.T) {
 				"role":                                "gateway",
 			},
 			Annotations: map[string]string{
-				controllerpkg.WireGuardPubKeyAnnotation: "pub-key-a",
+				controllerpkg.WireGuardPubKeyAnnotation:                        "pub-key-a",
+				unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation:          "203.0.113.10",
+				unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation: time.Now().Add(time.Hour).Format(time.RFC3339),
 			},
 		},
 		Spec: corev1.NodeSpec{
@@ -68,7 +71,7 @@ func TestFetchClusterStatusFromCacheAndInformers(t *testing.T) {
 				OperatingSystem: "linux",
 			},
 			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue, LastHeartbeatTime: metav1.NewTime(time.Now())}},
-			Addresses:  []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.10"}, {Type: corev1.NodeExternalIP, Address: "52.1.2.3"}},
+			Addresses:  []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.10"}},
 		},
 	}
 	if err := nodeIndexer.Add(node); err != nil {
@@ -146,6 +149,10 @@ func TestFetchClusterStatusFromCacheAndInformers(t *testing.T) {
 
 	if len(nodeStatus.NodeInfo.PodCIDRs) == 0 || nodeStatus.NodeInfo.PodCIDRs[0] != "10.244.1.0/24" {
 		t.Fatalf("expected pod CIDRs to be populated from node spec, got %#v", nodeStatus.NodeInfo.PodCIDRs)
+	}
+
+	if !slices.Equal(nodeStatus.NodeInfo.ExternalIPs, []string{"203.0.113.10"}) {
+		t.Fatalf("expected discovered public IP from node annotations, got %#v", nodeStatus.NodeInfo.ExternalIPs)
 	}
 
 	if nodeStatus.NodeInfo.WireGuard == nil || nodeStatus.NodeInfo.WireGuard.PublicKey != "pub-key-a" {

--- a/cmd/unbounded-net-controller/cluster_status_test.go
+++ b/cmd/unbounded-net-controller/cluster_status_test.go
@@ -106,7 +106,12 @@ func TestFetchClusterStatusFromCacheAndInformers(t *testing.T) {
 
 	cacheStore := NewNodeStatusCache()
 	cacheStore.StoreFull("node-a", NodeStatusResponse{
-		NodeInfo: NodeInfo{Name: "node-a", SiteName: "site-a", WireGuard: &WireGuardStatusInfo{Interface: "wg51820"}},
+		NodeInfo: NodeInfo{
+			Name:        "node-a",
+			SiteName:    "site-a",
+			ExternalIPs: []string{"198.51.100.10"},
+			WireGuard:   &WireGuardStatusInfo{Interface: "wg51820"},
+		},
 	}, "push")
 
 	health := &healthState{
@@ -161,6 +166,36 @@ func TestFetchClusterStatusFromCacheAndInformers(t *testing.T) {
 
 	if nodeStatus.NodePodInfo == nil || nodeStatus.NodePodInfo.PodName != "unbounded-net-node-a" {
 		t.Fatalf("expected node pod info to be attached, got %#v", nodeStatus.NodePodInfo)
+	}
+}
+
+func TestFetchClusterStatusClearsExternalIPsForMissingNode(t *testing.T) {
+	t.Parallel()
+
+	clientset := k8sfake.NewClientset()
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	statusCache := NewNodeStatusCache()
+	statusCache.StoreFull("missing-node", NodeStatusResponse{NodeInfo: NodeInfo{
+		Name:        "missing-node",
+		ExternalIPs: []string{"198.51.100.10"},
+	}}, "push")
+
+	health := &healthState{
+		clientset:      clientset,
+		nodeLister:     corev1listers.NewNodeLister(nodeIndexer),
+		siteInformer:   cache.NewSharedIndexInformer(&cache.ListWatch{}, &unstructured.Unstructured{}, 0, cache.Indexers{}),
+		statusCache:    statusCache,
+		staleThreshold: time.Minute,
+		tokenAuth:      &tokenAuthenticator{tokenReviewer: clientset},
+	}
+
+	status := fetchClusterStatus(t.Context(), health, false)
+	if len(status.Nodes) != 1 {
+		t.Fatalf("status Nodes = %d, want 1", len(status.Nodes))
+	}
+
+	if got := status.Nodes[0].NodeInfo.ExternalIPs; len(got) != 0 {
+		t.Fatalf("missing Node ExternalIPs = %#v, want empty", got)
 	}
 }
 

--- a/cmd/unbounded-net-controller/main.go
+++ b/cmd/unbounded-net-controller/main.go
@@ -570,10 +570,9 @@ func run(cfg *config.Config, forceNotLeader bool) error {
 				healthState.clusterStatusCache.MarkFullRebuildNeeded()
 			}
 		}
-		markDirtyUpdate := func(_, newObj interface{}) { markDirty(newObj) }
 		dirtyHandler := cache.ResourceEventHandlerFuncs{
 			AddFunc:    markDirty,
-			UpdateFunc: markDirtyUpdate,
+			UpdateFunc: func(_, newObj interface{}) { markDirty(newObj) },
 			DeleteFunc: markDirty,
 		}
 
@@ -588,7 +587,20 @@ func run(cfg *config.Config, forceNotLeader bool) error {
 			}
 		}
 
-		if _, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(dirtyHandler); err != nil {
+		nodeDirtyHandler := cache.ResourceEventHandlerFuncs{
+			AddFunc: markDirty,
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				oldNode, oldOK := oldObj.(*corev1.Node)
+
+				newNode, newOK := newObj.(*corev1.Node)
+				if !oldOK || !newOK || nodeUpdateAffectsClusterStatus(oldNode, newNode, time.Now()) {
+					markDirty(newObj)
+				}
+			},
+			DeleteFunc: markDirty,
+		}
+
+		if _, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(nodeDirtyHandler); err != nil {
 			klog.Warningf("Failed to register node dirty watcher for cluster status: %v", err)
 		}
 

--- a/cmd/unbounded-net-controller/server.go
+++ b/cmd/unbounded-net-controller/server.go
@@ -109,14 +109,16 @@ func startServer(ctx context.Context, healthPort int, requireDashboardAuth bool,
 	go broadcaster.Run(context.Background())
 	// Node status changes patch the pre-built cache in-place and notify the broadcaster.
 	health.statusCache.SetOnChange(func(nodeName string, status *NodeStatusResponse) {
+		statusCopy := *status
+
 		// Set StatusSource from the cache entry's source (ws, push, etc.)
-		if status.StatusSource == "" {
+		if statusCopy.StatusSource == "" {
 			if cached, ok := health.statusCache.Get(nodeName); ok && cached.Source != "" {
-				status.StatusSource = cached.Source
+				statusCopy.StatusSource = cached.Source
 			}
 		}
 
-		clusterStatusCache.PatchNode(nodeName, status)
+		clusterStatusCache.PatchNode(nodeName, statusCopy)
 		clusterStatusCache.MarkDirty()
 		broadcaster.Notify()
 	})

--- a/internal/net/controller/gatewaypool_controller.go
+++ b/internal/net/controller/gatewaypool_controller.go
@@ -128,7 +128,7 @@ func NewGatewayPoolController(
 			if !labels.Equals(labels.Set(oldNode.Labels), labels.Set(newNode.Labels)) ||
 				!nodeExternalIPsEqual(oldNode, newNode) ||
 				!nodeInternalIPsEqual(oldNode, newNode) ||
-				nodeAnnotationChanged(oldNode, newNode, unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation) ||
+				discoveredPublicIPChangeAffectsPools(oldNode, newNode, time.Now()) ||
 				nodeAnnotationChanged(oldNode, newNode, unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation) ||
 				nodeAnnotationChanged(oldNode, newNode, WireGuardPubKeyAnnotation) ||
 				nodeAnnotationChanged(oldNode, newNode, WireGuardPortAnnotation) ||
@@ -468,24 +468,31 @@ func (gc *GatewayPoolController) syncPool(ctx context.Context, poolName string) 
 	// Find matching nodes
 	var matchingNodes []unboundednetv1alpha1.GatewayNodeInfo
 
+	var nextPublicIPExpiry time.Time
+
 	selector := labels.SelectorFromSet(pool.Spec.NodeSelector)
 	poolType := normalizeGatewayPoolType(pool.Spec.Type)
+	now := time.Now()
 
 	for _, node := range nodes {
-		preferredPool, ok := gc.preferredGatewayPoolForNode(node)
-		if !ok || preferredPool != poolName {
-			continue
-		}
-
 		// Check if node matches the selector
 		if !selector.Matches(labels.Set(node.Labels)) {
 			continue
 		}
 
-		// Get external IPs
-		externalIPs, externalIPErr := resolveNodeExternalIPs(node)
-		if externalIPErr != nil {
+		externalIPs, expiresAt, externalIPErr := ResolveNodeExternalIPsAt(node, now)
+		if externalIPErr != nil && poolType == gatewayPoolTypeExternal {
 			klog.Warningf("GatewayPool %s: node %s has invalid public IP configuration: %v", poolName, node.Name, externalIPErr)
+		}
+
+		if expiresAt.After(now) &&
+			(nextPublicIPExpiry.IsZero() || expiresAt.Before(nextPublicIPExpiry)) {
+			nextPublicIPExpiry = expiresAt
+		}
+
+		preferredPool, ok := gc.preferredGatewayPoolForNode(node, now)
+		if !ok || preferredPool != poolName {
+			continue
 		}
 
 		if poolType == gatewayPoolTypeExternal && len(externalIPs) == 0 {
@@ -529,8 +536,12 @@ func (gc *GatewayPoolController) syncPool(ctx context.Context, poolName string) 
 		}
 	}
 
-	if err := gc.cleanupStaleGatewayPoolNodes(ctx, pool, matchingNodes); err != nil {
+	if err := gc.cleanupStaleGatewayPoolNodes(ctx, pool, matchingNodes, now); err != nil {
 		klog.Warningf("GatewayPool %s: failed to clean up stale GatewayPoolNodes: %v", poolName, err)
+	}
+
+	if !nextPublicIPExpiry.IsZero() {
+		gc.workqueue.AddAfter(poolName, time.Until(nextPublicIPExpiry))
 	}
 
 	// Manage protection finalizer: add when nodes match, remove when no
@@ -585,7 +596,7 @@ func (gc *GatewayPoolController) syncPool(ctx context.Context, poolName string) 
 			retain := false
 
 			if currentNode, exists := nodeByName[node.Name]; exists {
-				if preferredPool, ok := gc.preferredGatewayPoolForNode(currentNode); ok && preferredPool != "" {
+				if preferredPool, ok := gc.preferredGatewayPoolForNode(currentNode, now); ok && preferredPool != "" {
 					retain = true
 				}
 			}
@@ -712,7 +723,7 @@ func normalizeGatewayPoolType(poolType string) string {
 	return poolType
 }
 
-func nodeEligibleForGatewayPool(node *corev1.Node, pool *unboundednetv1alpha1.GatewayPool) bool {
+func nodeEligibleForGatewayPool(node *corev1.Node, pool *unboundednetv1alpha1.GatewayPool, now time.Time) bool {
 	if node == nil || pool == nil {
 		return false
 	}
@@ -724,7 +735,7 @@ func nodeEligibleForGatewayPool(node *corev1.Node, pool *unboundednetv1alpha1.Ga
 
 	poolType := normalizeGatewayPoolType(pool.Spec.Type)
 	if poolType == gatewayPoolTypeExternal {
-		externalIPs, err := resolveNodeExternalIPs(node)
+		externalIPs, _, err := ResolveNodeExternalIPsAt(node, now)
 		if err != nil {
 			return false
 		}
@@ -751,7 +762,7 @@ func nodeEligibleForGatewayPool(node *corev1.Node, pool *unboundednetv1alpha1.Ga
 // preferredGatewayPoolForNode returns the deterministic pool assignment for a node.
 // A node may only belong to one pool, so the lexicographically first eligible
 // pool name wins.
-func (gc *GatewayPoolController) preferredGatewayPoolForNode(node *corev1.Node) (string, bool) {
+func (gc *GatewayPoolController) preferredGatewayPoolForNode(node *corev1.Node, now time.Time) (string, bool) {
 	if node == nil {
 		return "", false
 	}
@@ -764,7 +775,7 @@ func (gc *GatewayPoolController) preferredGatewayPoolForNode(node *corev1.Node) 
 	eligible := make([]string, 0, len(pools))
 	for i := range pools {
 		pool := &pools[i]
-		if nodeEligibleForGatewayPool(node, pool) {
+		if nodeEligibleForGatewayPool(node, pool, now) {
 			eligible = append(eligible, pool.Name)
 		}
 	}
@@ -795,32 +806,46 @@ func getNodeExternalIPs(node *corev1.Node) []string {
 	return externalIPs
 }
 
-// resolveNodeExternalIPs returns declared, provider, or discovered addresses
-// in precedence order.
-func resolveNodeExternalIPs(node *corev1.Node) ([]string, error) {
+// ResolveNodeExternalIPsAt returns declared, provider, or unexpired discovered
+// addresses in precedence order.
+func ResolveNodeExternalIPsAt(node *corev1.Node, now time.Time) ([]string, time.Time, error) {
 	if raw, exists := node.Annotations[unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation]; exists {
 		ip, err := normalizeNodePublicIP(raw, "annotation "+unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation)
 		if err != nil {
-			return nil, err
+			return nil, time.Time{}, err
 		}
 
-		return []string{ip}, nil
+		return []string{ip}, time.Time{}, nil
 	}
 
 	if externalIPs := getNodeExternalIPs(node); len(externalIPs) > 0 {
-		return externalIPs, nil
+		return externalIPs, time.Time{}, nil
 	}
 
 	if raw, exists := node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation]; exists {
 		ip, err := normalizeNodePublicIP(raw, "annotation "+unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation)
 		if err != nil {
-			return nil, err
+			return nil, time.Time{}, err
 		}
 
-		return []string{ip}, nil
+		rawExpiry, exists := node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation]
+		if !exists {
+			return nil, time.Time{}, fmt.Errorf("annotation %s is required with %s", unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation, unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation)
+		}
+
+		expiresAt, err := time.Parse(time.RFC3339, rawExpiry)
+		if err != nil {
+			return nil, time.Time{}, fmt.Errorf("annotation %s must contain an RFC3339 timestamp", unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation)
+		}
+
+		if !expiresAt.After(now) {
+			return nil, expiresAt, nil
+		}
+
+		return []string{ip}, expiresAt, nil
 	}
 
-	return nil, nil
+	return nil, time.Time{}, nil
 }
 
 func normalizeNodePublicIP(raw, source string) (string, error) {
@@ -875,6 +900,31 @@ func nodeAnnotationChanged(oldNode, newNode *corev1.Node, key string) bool {
 	newValue, newExists := newNode.Annotations[key]
 
 	return oldExists != newExists || oldValue != newValue
+}
+
+func discoveredPublicIPChangeAffectsPools(oldNode, newNode *corev1.Node, now time.Time) bool {
+	if nodeAnnotationChanged(oldNode, newNode, unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation) {
+		return true
+	}
+
+	if !nodeAnnotationChanged(oldNode, newNode, unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation) {
+		return false
+	}
+
+	oldExpiry, oldValid := validDiscoveredPublicIPExpiry(oldNode, now)
+
+	newExpiry, newValid := validDiscoveredPublicIPExpiry(newNode, now)
+	if oldValid != newValid || !oldValid {
+		return true
+	}
+
+	return newExpiry.Before(oldExpiry)
+}
+
+func validDiscoveredPublicIPExpiry(node *corev1.Node, now time.Time) (time.Time, bool) {
+	expiresAt, err := time.Parse(time.RFC3339, node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation])
+
+	return expiresAt, err == nil && expiresAt.After(now)
 }
 
 // nodeInternalIPsEqual checks if two nodes have the same internal IPs.
@@ -1006,7 +1056,8 @@ func (gc *GatewayPoolController) ensureGatewayPoolNode(ctx context.Context, pool
 		return createErr
 	}
 
-	existing := existingObj.(*unstructured.Unstructured) //nolint:errcheck
+	existing := existingObj.(*unstructured.Unstructured)                                    //nolint:errcheck
+	previousPool, _, _ := unstructured.NestedString(existing.Object, "spec", "gatewayPool") //nolint:errcheck
 
 	// Carry the canonical labels forward and actively clear the deprecated site
 	// label key so GatewayPoolNodes created before the rename are migrated.
@@ -1058,16 +1109,19 @@ func (gc *GatewayPoolController) ensureGatewayPoolNode(ctx context.Context, pool
 		return err
 	}
 
+	if previousPool != "" && previousPool != pool.Name {
+		gc.workqueue.Add(previousPool)
+	}
+
 	return nil
 }
 
-func (gc *GatewayPoolController) cleanupStaleGatewayPoolNodes(ctx context.Context, pool *unboundednetv1alpha1.GatewayPool, matchingNodes []unboundednetv1alpha1.GatewayNodeInfo) error {
+func (gc *GatewayPoolController) cleanupStaleGatewayPoolNodes(ctx context.Context, pool *unboundednetv1alpha1.GatewayPool, matchingNodes []unboundednetv1alpha1.GatewayNodeInfo, now time.Time) error {
 	if pool == nil || pool.Name == "" {
 		return nil
 	}
 
 	poolName := pool.Name
-	selector := labels.SelectorFromSet(pool.Spec.NodeSelector)
 
 	keep := make(map[string]struct{}, len(matchingNodes))
 	for _, n := range matchingNodes {
@@ -1094,15 +1148,17 @@ func (gc *GatewayPoolController) cleanupStaleGatewayPoolNodes(ctx context.Contex
 			continue
 		}
 
-		// Be conservative with deletes: if the backing node still exists and still
-		// matches this pool selector, keep the GatewayPoolNode to avoid transient
-		// delete/recreate churn while node annotations/IPs converge.
+		// Be conservative with deletes: keep the GatewayPoolNode while the backing
+		// node belongs to any pool so the preferred pool can update it in place.
 		if node, err := gc.nodeLister.Get(name); err == nil && node != nil {
-			if selector.Matches(labels.Set(node.Labels)) {
-				if preferredPool, ok := gc.preferredGatewayPoolForNode(node); ok && preferredPool == poolName {
-					klog.V(2).Infof("GatewayPool %s: preserving GatewayPoolNode %s during transient eligibility changes", poolName, name)
-					continue
+			if preferredPool, ok := gc.preferredGatewayPoolForNode(node, now); ok && preferredPool != "" {
+				if preferredPool != poolName {
+					gc.workqueue.Add(preferredPool)
 				}
+
+				klog.V(2).Infof("GatewayPool %s: preserving GatewayPoolNode %s for preferred pool %s", poolName, name, preferredPool)
+
+				continue
 			}
 		}
 

--- a/internal/net/controller/gatewaypool_controller.go
+++ b/internal/net/controller/gatewaypool_controller.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/netip"
 	"reflect"
 	"sort"
 	"strconv"
@@ -123,12 +124,14 @@ func NewGatewayPoolController(
 		UpdateFunc: func(old, new interface{}) {
 			oldNode := old.(*corev1.Node) //nolint:errcheck
 			newNode := new.(*corev1.Node) //nolint:errcheck
-			// Re-process if labels changed, internal/external IPs changed, WireGuard pubkey/port changed, or podCIDRs changed
+
 			if !labels.Equals(labels.Set(oldNode.Labels), labels.Set(newNode.Labels)) ||
 				!nodeExternalIPsEqual(oldNode, newNode) ||
 				!nodeInternalIPsEqual(oldNode, newNode) ||
-				getNodeAnnotation(oldNode, WireGuardPubKeyAnnotation) != getNodeAnnotation(newNode, WireGuardPubKeyAnnotation) ||
-				getNodeAnnotation(oldNode, WireGuardPortAnnotation) != getNodeAnnotation(newNode, WireGuardPortAnnotation) ||
+				nodeAnnotationChanged(oldNode, newNode, unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation) ||
+				nodeAnnotationChanged(oldNode, newNode, unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation) ||
+				nodeAnnotationChanged(oldNode, newNode, WireGuardPubKeyAnnotation) ||
+				nodeAnnotationChanged(oldNode, newNode, WireGuardPortAnnotation) ||
 				!stringSlicesEqual(oldNode.Spec.PodCIDRs, newNode.Spec.PodCIDRs) {
 				gc.enqueuePoolsForNodes(oldNode, newNode)
 			}
@@ -480,7 +483,11 @@ func (gc *GatewayPoolController) syncPool(ctx context.Context, poolName string) 
 		}
 
 		// Get external IPs
-		externalIPs := getNodeExternalIPs(node)
+		externalIPs, externalIPErr := resolveNodeExternalIPs(node)
+		if externalIPErr != nil {
+			klog.Warningf("GatewayPool %s: node %s has invalid public IP configuration: %v", poolName, node.Name, externalIPErr)
+		}
+
 		if poolType == gatewayPoolTypeExternal && len(externalIPs) == 0 {
 			klog.V(2).Infof("GatewayPool %s: node %s not added to external pool because it has no external IPs", poolName, node.Name)
 			continue
@@ -716,9 +723,17 @@ func nodeEligibleForGatewayPool(node *corev1.Node, pool *unboundednetv1alpha1.Ga
 	}
 
 	poolType := normalizeGatewayPoolType(pool.Spec.Type)
-	if poolType == gatewayPoolTypeExternal && len(getNodeExternalIPs(node)) == 0 {
-		klog.V(2).Infof("GatewayPool %s: node %s not eligible for external pool because it has no external IPs", pool.Name, node.Name)
-		return false
+	if poolType == gatewayPoolTypeExternal {
+		externalIPs, err := resolveNodeExternalIPs(node)
+		if err != nil {
+			return false
+		}
+
+		if len(externalIPs) == 0 {
+			klog.V(2).Infof("GatewayPool %s: node %s not eligible for external pool because it has no external IPs", pool.Name, node.Name)
+
+			return false
+		}
 	}
 
 	wgPubKey := ""
@@ -780,6 +795,47 @@ func getNodeExternalIPs(node *corev1.Node) []string {
 	return externalIPs
 }
 
+// resolveNodeExternalIPs returns declared, provider, or discovered addresses
+// in precedence order.
+func resolveNodeExternalIPs(node *corev1.Node) ([]string, error) {
+	if raw, exists := node.Annotations[unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation]; exists {
+		ip, err := normalizeNodePublicIP(raw, "annotation "+unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation)
+		if err != nil {
+			return nil, err
+		}
+
+		return []string{ip}, nil
+	}
+
+	if externalIPs := getNodeExternalIPs(node); len(externalIPs) > 0 {
+		return externalIPs, nil
+	}
+
+	if raw, exists := node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation]; exists {
+		ip, err := normalizeNodePublicIP(raw, "annotation "+unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation)
+		if err != nil {
+			return nil, err
+		}
+
+		return []string{ip}, nil
+	}
+
+	return nil, nil
+}
+
+func normalizeNodePublicIP(raw, source string) (string, error) {
+	ip, err := netip.ParseAddr(raw)
+	if err != nil {
+		return "", fmt.Errorf("%s has an invalid IP address", source)
+	}
+
+	if ip.Zone() != "" {
+		return "", fmt.Errorf("%s must not contain an IPv6 zone", source)
+	}
+
+	return ip.Unmap().String(), nil
+}
+
 // getNodeInternalIPs returns the internal IPs of a node.
 func getNodeInternalIPs(node *corev1.Node) []string {
 	var internalIPs []string
@@ -812,6 +868,13 @@ func nodeExternalIPsEqual(a, b *corev1.Node) bool {
 	}
 
 	return true
+}
+
+func nodeAnnotationChanged(oldNode, newNode *corev1.Node, key string) bool {
+	oldValue, oldExists := oldNode.Annotations[key]
+	newValue, newExists := newNode.Annotations[key]
+
+	return oldExists != newExists || oldValue != newValue
 }
 
 // nodeInternalIPsEqual checks if two nodes have the same internal IPs.

--- a/internal/net/controller/gatewaypool_helpers_test.go
+++ b/internal/net/controller/gatewaypool_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,15 @@ type fakeInformer struct {
 
 func (f *fakeInformer) GetStore() cache.Store { return f.store }
 func (f *fakeInformer) HasSynced() bool       { return true }
+
+type recordingRateLimitingQueue struct {
+	workqueue.TypedRateLimitingInterface[string]
+	delayed map[string]time.Duration
+}
+
+func (q *recordingRateLimitingQueue) AddAfter(item string, duration time.Duration) {
+	q.delayed[item] = duration
+}
 
 func toGatewayPoolUnstructured(t *testing.T, pool *unboundednetv1alpha1.GatewayPool) *unstructured.Unstructured {
 	t.Helper()
@@ -101,6 +111,8 @@ func TestParseAndNormalizeGatewayPoolHelpers(t *testing.T) {
 
 // TestNodeEligibilityAndPreferredPoolHelpers tests node eligibility and preferred pool helpers.
 func TestNodeEligibilityAndPreferredPoolHelpers(t *testing.T) {
+	now := time.Now()
+
 	poolExternalA := &unboundednetv1alpha1.GatewayPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "pool-b"},
 		Spec: unboundednetv1alpha1.GatewayPoolSpec{
@@ -123,34 +135,36 @@ func TestNodeEligibilityAndPreferredPoolHelpers(t *testing.T) {
 		},
 	}
 
-	if nodeEligibleForGatewayPool(nil, poolExternalA) || nodeEligibleForGatewayPool(makeGatewayNode("n", nil, true, "pub"), nil) {
+	if nodeEligibleForGatewayPool(nil, poolExternalA, now) || nodeEligibleForGatewayPool(makeGatewayNode("n", nil, true, "pub"), nil, now) {
 		t.Fatalf("expected nil node/pool to be ineligible")
 	}
 
-	if nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "worker"}, true, "pub"), poolExternalA) {
+	if nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "worker"}, true, "pub"), poolExternalA, now) {
 		t.Fatalf("expected selector mismatch to be ineligible")
 	}
 
-	if nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway"}, false, "pub"), poolExternalA) {
+	if nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway"}, false, "pub"), poolExternalA, now) {
 		t.Fatalf("expected external pool without external IP to be ineligible")
 	}
 
 	discovered := makeGatewayNode("n", map[string]string{"role": "gateway"}, false, "pub")
 
 	discovered.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation] = "203.0.113.10"
-	if !nodeEligibleForGatewayPool(discovered, poolExternalA) {
+
+	discovered.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation] = now.Add(time.Hour).Format(time.RFC3339)
+	if !nodeEligibleForGatewayPool(discovered, poolExternalA, now) {
 		t.Fatal("expected STUN-discovered IP to make the node eligible")
 	}
 
-	if nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway"}, true, ""), poolExternalA) {
+	if nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway"}, true, ""), poolExternalA, now) {
 		t.Fatalf("expected missing wireguard key to be ineligible")
 	}
 
-	if !nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway", canonicalSiteLabelKey: "site-a"}, true, "pub"), poolExternalA) {
+	if !nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway", canonicalSiteLabelKey: "site-a"}, true, "pub"), poolExternalA, now) {
 		t.Fatalf("expected eligible external gateway node")
 	}
 
-	if !nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway", canonicalSiteLabelKey: "site-a"}, false, "pub"), poolInternal) {
+	if !nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway", canonicalSiteLabelKey: "site-a"}, false, "pub"), poolInternal, now) {
 		t.Fatalf("expected internal gateway pool to allow node without external IP")
 	}
 
@@ -158,13 +172,80 @@ func TestNodeEligibilityAndPreferredPoolHelpers(t *testing.T) {
 		poolsCache: []unboundednetv1alpha1.GatewayPool{*poolExternalA, *poolExternalB},
 	}
 
-	chosen, ok := controller.preferredGatewayPoolForNode(makeGatewayNode("node-a", map[string]string{"role": "gateway", canonicalSiteLabelKey: "site-a"}, true, "pub"))
+	chosen, ok := controller.preferredGatewayPoolForNode(makeGatewayNode("node-a", map[string]string{"role": "gateway", canonicalSiteLabelKey: "site-a"}, true, "pub"), now)
 	if !ok || chosen != "pool-a" {
 		t.Fatalf("expected lexicographically first eligible pool, got ok=%v chosen=%s", ok, chosen)
 	}
 
-	if _, ok := controller.preferredGatewayPoolForNode(nil); ok {
+	if _, ok := controller.preferredGatewayPoolForNode(nil, now); ok {
 		t.Fatalf("expected nil node to be ineligible")
+	}
+}
+
+func TestSyncPoolSchedulesDiscoveryExpiryForFallbackPool(t *testing.T) {
+	expiresAt := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	node := makeGatewayNode("node-a", map[string]string{"role": "gateway"}, false, "pub")
+	node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation] = "203.0.113.10"
+	node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation] = expiresAt.Format(time.RFC3339)
+
+	externalPool := &unboundednetv1alpha1.GatewayPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-a"},
+		Spec: unboundednetv1alpha1.GatewayPoolSpec{
+			Type:         gatewayPoolTypeExternal,
+			NodeSelector: map[string]string{"role": "gateway"},
+		},
+	}
+	internalPool := &unboundednetv1alpha1.GatewayPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-b"},
+		Spec: unboundednetv1alpha1.GatewayPoolSpec{
+			Type:         gatewayPoolTypeInternal,
+			NodeSelector: map[string]string{"role": "gateway"},
+		},
+	}
+
+	poolStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, pool := range []*unboundednetv1alpha1.GatewayPool{externalPool, internalPool} {
+		if err := poolStore.Add(toGatewayPoolUnstructured(t, pool)); err != nil {
+			t.Fatalf("add gateway pool %s: %v", pool.Name, err)
+		}
+	}
+
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := nodeIndexer.Add(node); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer queue.ShutDown()
+
+	recordingQueue := &recordingRateLimitingQueue{
+		TypedRateLimitingInterface: queue,
+		delayed:                    map[string]time.Duration{},
+	}
+	gc := &GatewayPoolController{
+		dynamicClient: fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+			gatewayNodeGVR: "GatewayPoolNodeList",
+		}),
+		nodeLister:          corev1listers.NewNodeLister(nodeIndexer),
+		gatewayPoolInformer: &fakeInformer{store: poolStore},
+		gatewayNodeInformer: &fakeInformer{store: cache.NewStore(cache.MetaNamespaceKeyFunc)},
+		workqueue:           recordingQueue,
+	}
+
+	if err := gc.syncPool(t.Context(), internalPool.Name); err != nil {
+		t.Fatalf("sync fallback pool: %v", err)
+	}
+
+	if delay, ok := recordingQueue.delayed[internalPool.Name]; !ok || delay <= 0 {
+		t.Fatalf("fallback pool expiry delay = %v, scheduled = %v", delay, ok)
+	}
+
+	if preferred, ok := gc.preferredGatewayPoolForNode(node, expiresAt.Add(-time.Minute)); !ok || preferred != externalPool.Name {
+		t.Fatalf("preferred pool before expiry = %q, ok = %v", preferred, ok)
+	}
+
+	if preferred, ok := gc.preferredGatewayPoolForNode(node, expiresAt); !ok || preferred != internalPool.Name {
+		t.Fatalf("preferred pool at expiry = %q, ok = %v", preferred, ok)
 	}
 }
 
@@ -227,97 +308,98 @@ func TestGatewayNodeIPAndEqualityHelpers(t *testing.T) {
 func TestResolveNodeExternalIPs(t *testing.T) {
 	t.Parallel()
 
+	now := time.Date(2026, time.August, 22, 0, 0, 0, 0, time.UTC)
+	validExpiry := now.Add(time.Hour)
+	expired := now.Add(-time.Minute)
+	declaredKey := unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation
+	discoveredKey := unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation
+	expiresAtKey := unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation
+	node := func(externalIP string, annotations map[string]string) *corev1.Node {
+		result := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+		if externalIP != "" {
+			result.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: externalIP}}
+		}
+
+		return result
+	}
+
 	tests := []struct {
-		name    string
-		node    *corev1.Node
-		want    []string
-		wantErr bool
+		name       string
+		node       *corev1.Node
+		want       []string
+		wantExpiry time.Time
+		wantErr    bool
 	}{
 		{
 			name: "declared address takes precedence over provider and discovery",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation:   "203.0.113.20",
-					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
-				}},
-				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "2001:0db8:0:0::10"}}},
-			},
+			node: node("2001:0db8:0:0::10", map[string]string{declaredKey: "203.0.113.20", discoveredKey: "203.0.113.30"}),
 			want: []string{"203.0.113.20"},
 		},
 		{
 			name: "provider takes precedence over discovery",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
-				}},
-				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "2001:0db8:0:0::10"}}},
-			},
+			node: node("2001:0db8:0:0::10", map[string]string{discoveredKey: "203.0.113.30", expiresAtKey: validExpiry.Format(time.RFC3339)}),
 			want: []string{"2001:0db8:0:0::10"},
 		},
 		{
 			name: "provider address preserves legacy behavior",
-			node: &corev1.Node{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{
-				Type: corev1.NodeExternalIP, Address: "not-an-ip",
-			}}}},
+			node: node("not-an-ip", nil),
 			want: []string{"not-an-ip"},
 		},
 		{
-			name: "discovery is used without a declared or provider address",
-			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "2001:0db8:0:0::10",
-			}}},
-			want: []string{"2001:db8::10"},
+			name:       "discovery is used without a declared or provider address",
+			node:       node("", map[string]string{discoveredKey: "2001:0db8:0:0::10", expiresAtKey: validExpiry.Format(time.RFC3339)}),
+			want:       []string{"2001:db8::10"},
+			wantExpiry: validExpiry,
 		},
 		{
 			name: "declared address takes precedence over discovery",
-			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation:   "203.0.113.20",
-				unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
-			}}},
+			node: node("", map[string]string{declaredKey: "203.0.113.20", discoveredKey: "203.0.113.30"}),
 			want: []string{"203.0.113.20"},
 		},
 		{
 			name: "IPv4-mapped IPv6 declared address is normalized",
-			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation: "::ffff:192.0.2.10",
-			}}},
+			node: node("", map[string]string{declaredKey: "::ffff:192.0.2.10"}),
 			want: []string{"192.0.2.10"},
 		},
 		{
-			name: "invalid declared address blocks provider and discovery fallback",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation:   "not-an-ip",
-					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
-				}},
-				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "192.0.2.20"}}},
-			},
+			name:    "invalid declared address blocks provider and discovery fallback",
+			node:    node("192.0.2.20", map[string]string{declaredKey: "not-an-ip", discoveredKey: "203.0.113.30"}),
 			wantErr: true,
 		},
 		{
-			name: "IPv6 zone is rejected",
-			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation: "fe80::1%eth0",
-			}}},
+			name:    "IPv6 zone is rejected",
+			node:    node("", map[string]string{declaredKey: "fe80::1%eth0"}),
 			wantErr: true,
 		},
 		{
-			name: "long invalid declared address has a bounded error",
-			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation: strings.Repeat("x", 4096),
-			}}},
+			name:    "long invalid declared address has a bounded error",
+			node:    node("", map[string]string{declaredKey: strings.Repeat("x", 4096)}),
 			wantErr: true,
 		},
 		{
-			name: "empty declared address blocks provider and discovery fallback",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation:   "",
-					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
-				}},
-				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "192.0.2.20"}}},
-			},
+			name:    "empty declared address blocks provider and discovery fallback",
+			node:    node("192.0.2.20", map[string]string{declaredKey: "", discoveredKey: "203.0.113.30"}),
 			wantErr: true,
+		},
+		{
+			name:    "discovery without expiry is rejected",
+			node:    node("", map[string]string{discoveredKey: "203.0.113.30"}),
+			wantErr: true,
+		},
+		{
+			name:    "discovery with invalid expiry is rejected",
+			node:    node("", map[string]string{discoveredKey: "203.0.113.30", expiresAtKey: "not-a-time"}),
+			wantErr: true,
+		},
+		{
+			name:    "long invalid expiry has a bounded error",
+			node:    node("", map[string]string{discoveredKey: "203.0.113.30", expiresAtKey: strings.Repeat("x", 4096)}),
+			wantErr: true,
+		},
+		{
+			name:       "expired discovery is ignored",
+			node:       node("", map[string]string{discoveredKey: "203.0.113.30", expiresAtKey: expired.Format(time.RFC3339)}),
+			wantExpiry: expired,
 		},
 	}
 
@@ -325,32 +407,69 @@ func TestResolveNodeExternalIPs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := resolveNodeExternalIPs(tt.node)
+			got, expiry, err := ResolveNodeExternalIPsAt(tt.node, now)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("resolveNodeExternalIPs() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("ResolveNodeExternalIPsAt() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if err != nil && len(err.Error()) > 256 {
-				t.Fatalf("resolveNodeExternalIPs() error length = %d, want at most 256: %v", len(err.Error()), err)
+				t.Fatalf("ResolveNodeExternalIPsAt() error length = %d, want at most 256: %v", len(err.Error()), err)
 			}
 
 			if !slices.Equal(got, tt.want) {
-				t.Fatalf("resolveNodeExternalIPs() = %#v, want %#v", got, tt.want)
+				t.Fatalf("ResolveNodeExternalIPsAt() = %#v, want %#v", got, tt.want)
+			}
+
+			if !expiry.Equal(tt.wantExpiry) {
+				t.Fatalf("expiry = %s, want %s", expiry, tt.wantExpiry)
 			}
 		})
 	}
 }
 
-func TestNodeAnnotationChangedDetectsPresence(t *testing.T) {
+func TestDiscoveredPublicIPChangeAffectsPools(t *testing.T) {
 	t.Parallel()
 
-	oldNode := &corev1.Node{}
-	newNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-		unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation: "",
-	}}}
+	now := time.Date(2026, time.August, 22, 0, 0, 0, 0, time.UTC)
+	node := func(ip string, expiry time.Time) *corev1.Node {
+		annotations := map[string]string{}
 
-	if !nodeAnnotationChanged(oldNode, newNode, unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation) {
-		t.Fatal("adding an empty declared address must be detected")
+		if ip != "" {
+			annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation] = ip
+		}
+
+		if !expiry.IsZero() {
+			annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation] = expiry.Format(time.RFC3339)
+		}
+
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+	}
+	emptyIP := node("", time.Time{})
+	emptyIP.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation] = ""
+
+	tests := []struct {
+		name string
+		old  *corev1.Node
+		new  *corev1.Node
+		want bool
+	}{
+		{name: "IP changed", old: node("203.0.113.10", now.Add(time.Hour)), new: node("203.0.113.11", now.Add(time.Hour)), want: true},
+		{name: "empty IP added", old: node("", time.Time{}), new: emptyIP, want: true},
+		{name: "expiry added", old: node("203.0.113.10", time.Time{}), new: node("203.0.113.10", now.Add(time.Hour)), want: true},
+		{name: "valid expiry extended", old: node("203.0.113.10", now.Add(time.Hour)), new: node("203.0.113.10", now.Add(2*time.Hour))},
+		{name: "valid expiry shortened", old: node("203.0.113.10", now.Add(2*time.Hour)), new: node("203.0.113.10", now.Add(time.Hour)), want: true},
+		{name: "expired to valid", old: node("203.0.113.10", now.Add(-time.Minute)), new: node("203.0.113.10", now.Add(time.Hour)), want: true},
+		{name: "unchanged", old: node("203.0.113.10", now.Add(time.Hour)), new: node("203.0.113.10", now.Add(time.Hour))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := discoveredPublicIPChangeAffectsPools(tt.old, tt.new, now); got != tt.want {
+				t.Fatalf("discoveredPublicIPChangeAffectsPools() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -665,11 +784,11 @@ func TestCleanupStaleGatewayPoolNodesNilPool(t *testing.T) {
 	gwNodeInformer := &fakeInformer{store: gwNodeIndexer}
 	gc := &GatewayPoolController{dynamicClient: client, gatewayNodeInformer: gwNodeInformer}
 
-	if err := gc.cleanupStaleGatewayPoolNodes(context.Background(), nil, nil); err != nil {
+	if err := gc.cleanupStaleGatewayPoolNodes(context.Background(), nil, nil, time.Now()); err != nil {
 		t.Fatalf("cleanupStaleGatewayPoolNodes(nil) error = %v", err)
 	}
 
-	if err := gc.cleanupStaleGatewayPoolNodes(context.Background(), &unboundednetv1alpha1.GatewayPool{}, nil); err != nil {
+	if err := gc.cleanupStaleGatewayPoolNodes(context.Background(), &unboundednetv1alpha1.GatewayPool{}, nil, time.Now()); err != nil {
 		t.Fatalf("cleanupStaleGatewayPoolNodes(empty pool) error = %v", err)
 	}
 
@@ -677,7 +796,7 @@ func TestCleanupStaleGatewayPoolNodesNilPool(t *testing.T) {
 	gc.nodeLister = corev1listers.NewNodeLister(nodeIndexer)
 
 	pool := &unboundednetv1alpha1.GatewayPool{ObjectMeta: metav1.ObjectMeta{Name: "pool-a"}, Spec: unboundednetv1alpha1.GatewayPoolSpec{NodeSelector: map[string]string{"role": "gw"}}}
-	if err := gc.cleanupStaleGatewayPoolNodes(context.Background(), pool, []unboundednetv1alpha1.GatewayNodeInfo{{Name: "kept"}}); err != nil {
+	if err := gc.cleanupStaleGatewayPoolNodes(context.Background(), pool, []unboundednetv1alpha1.GatewayNodeInfo{{Name: "kept"}}, time.Now()); err != nil {
 		t.Fatalf("cleanupStaleGatewayPoolNodes(non-empty) error = %v", err)
 	}
 }
@@ -733,9 +852,27 @@ func TestEnsureGatewayPoolNodeCreatePatchAndNoOp(t *testing.T) {
 		gatewayNodeGVR: "GatewayPoolNodeList",
 	}, existingObj)
 
-	gcPatch := &GatewayPoolController{dynamicClient: clientPatch, gatewayNodeInformer: patchNodeInformer}
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer queue.ShutDown()
+
+	gcPatch := &GatewayPoolController{dynamicClient: clientPatch, gatewayNodeInformer: patchNodeInformer, workqueue: queue}
 	if err := gcPatch.ensureGatewayPoolNode(context.Background(), pool, node, "site-a"); err != nil {
 		t.Fatalf("ensureGatewayPoolNode(patch) error = %v", err)
+	}
+
+	if got := queue.Len(); got != 1 {
+		t.Fatalf("queued pools after ownership change = %d, want 1", got)
+	}
+
+	queuedPool, shutdown := queue.Get()
+	if shutdown {
+		t.Fatal("workqueue shut down before previous pool was retrieved")
+	}
+
+	queue.Done(queuedPool)
+
+	if queuedPool != "old-pool" {
+		t.Fatalf("queued pool after ownership change = %q, want %q", queuedPool, "old-pool")
 	}
 
 	patched, err := clientPatch.Resource(gatewayNodeGVR).Get(context.Background(), "node-a", metav1.GetOptions{})
@@ -759,6 +896,10 @@ func TestEnsureGatewayPoolNodeCreatePatchAndNoOp(t *testing.T) {
 
 	if actions := clientPatch.Actions(); len(actions) != 0 {
 		t.Fatalf("converged GatewayPoolNode emitted API actions: %#v", actions)
+	}
+
+	if got := queue.Len(); got != 0 {
+		t.Fatalf("converged GatewayPoolNode queued %d pools, want 0", got)
 	}
 
 	withoutSite := patched.DeepCopy()
@@ -853,7 +994,7 @@ func TestCleanupStaleGatewayPoolNodesDeleteAndPreserve(t *testing.T) {
 		gatewayNodeInformer: gwNodeInf,
 	}
 
-	if err := gc.cleanupStaleGatewayPoolNodes(context.Background(), pool, nil); err != nil {
+	if err := gc.cleanupStaleGatewayPoolNodes(context.Background(), pool, nil, time.Now()); err != nil {
 		t.Fatalf("cleanupStaleGatewayPoolNodes() error = %v", err)
 	}
 
@@ -863,5 +1004,96 @@ func TestCleanupStaleGatewayPoolNodesDeleteAndPreserve(t *testing.T) {
 
 	if _, err := client.Resource(gatewayNodeGVR).Get(context.Background(), "stale-preserve", metav1.GetOptions{}); err != nil {
 		t.Fatalf("expected stale-preserve gateway pool node to be retained, got %v", err)
+	}
+}
+
+func TestCleanupStaleGatewayPoolNodesPreservesPreferredPoolHandoff(t *testing.T) {
+	now := time.Date(2026, time.August, 22, 0, 0, 0, 0, time.UTC)
+	externalPool := &unboundednetv1alpha1.GatewayPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-a"},
+		Spec: unboundednetv1alpha1.GatewayPoolSpec{
+			Type:         gatewayPoolTypeExternal,
+			NodeSelector: map[string]string{"role": "gw"},
+		},
+	}
+	internalPool := &unboundednetv1alpha1.GatewayPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-b"},
+		Spec: unboundednetv1alpha1.GatewayPoolSpec{
+			Type:         gatewayPoolTypeInternal,
+			NodeSelector: map[string]string{"role": "gw"},
+		},
+	}
+	node := makeGatewayNode("node-a", map[string]string{"role": "gw"}, false, "pub")
+	node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation] = "203.0.113.10"
+	node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation] = now.Format(time.RFC3339)
+
+	existing := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "net.unbounded-cloud.io/v1alpha1",
+		"kind":       "GatewayPoolNode",
+		"metadata":   map[string]interface{}{"name": node.Name},
+		"spec":       map[string]interface{}{"gatewayPool": externalPool.Name},
+	}}
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		gatewayNodeGVR: "GatewayPoolNodeList",
+	}, existing)
+
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := nodeIndexer.Add(node); err != nil {
+		t.Fatalf("add node: %v", err)
+	}
+
+	gatewayNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := gatewayNodeIndexer.Add(existing); err != nil {
+		t.Fatalf("add GatewayPoolNode: %v", err)
+	}
+
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer queue.ShutDown()
+
+	gc := &GatewayPoolController{
+		dynamicClient:       client,
+		nodeLister:          corev1listers.NewNodeLister(nodeIndexer),
+		poolsCache:          []unboundednetv1alpha1.GatewayPool{*externalPool, *internalPool},
+		gatewayNodeInformer: &fakeInformer{store: gatewayNodeIndexer},
+		workqueue:           queue,
+	}
+	if preferred, ok := gc.preferredGatewayPoolForNode(node, now); !ok || preferred != internalPool.Name {
+		t.Fatalf("preferred pool at expiry = %q, ok = %v", preferred, ok)
+	}
+
+	if err := gc.cleanupStaleGatewayPoolNodes(t.Context(), externalPool, nil, now); err != nil {
+		t.Fatalf("clean up old pool: %v", err)
+	}
+
+	if _, err := client.Resource(gatewayNodeGVR).Get(t.Context(), node.Name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("GatewayPoolNode was deleted during handoff: %v", err)
+	}
+
+	if got := queue.Len(); got != 1 {
+		t.Fatalf("queued pools = %d, want 1", got)
+	}
+
+	queuedPool, shutdown := queue.Get()
+	if shutdown {
+		t.Fatal("workqueue shut down before preferred pool was retrieved")
+	}
+
+	queue.Done(queuedPool)
+
+	if queuedPool != internalPool.Name {
+		t.Fatalf("queued pool = %q, want %q", queuedPool, internalPool.Name)
+	}
+
+	if err := gc.ensureGatewayPoolNode(t.Context(), internalPool, node, ""); err != nil {
+		t.Fatalf("update GatewayPoolNode for fallback pool: %v", err)
+	}
+
+	updated, err := client.Resource(gatewayNodeGVR).Get(t.Context(), node.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated GatewayPoolNode: %v", err)
+	}
+
+	if got, _, _ := unstructured.NestedString(updated.Object, "spec", "gatewayPool"); got != internalPool.Name {
+		t.Fatalf("spec.gatewayPool = %q, want %q", got, internalPool.Name)
 	}
 }

--- a/internal/net/controller/gatewaypool_helpers_test.go
+++ b/internal/net/controller/gatewaypool_helpers_test.go
@@ -6,6 +6,8 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"slices"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -133,6 +135,13 @@ func TestNodeEligibilityAndPreferredPoolHelpers(t *testing.T) {
 		t.Fatalf("expected external pool without external IP to be ineligible")
 	}
 
+	discovered := makeGatewayNode("n", map[string]string{"role": "gateway"}, false, "pub")
+
+	discovered.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation] = "203.0.113.10"
+	if !nodeEligibleForGatewayPool(discovered, poolExternalA) {
+		t.Fatal("expected STUN-discovered IP to make the node eligible")
+	}
+
 	if nodeEligibleForGatewayPool(makeGatewayNode("n", map[string]string{"role": "gateway"}, true, ""), poolExternalA) {
 		t.Fatalf("expected missing wireguard key to be ineligible")
 	}
@@ -212,6 +221,136 @@ func TestGatewayNodeIPAndEqualityHelpers(t *testing.T) {
 	nodesB[0].PodCIDRs = []string{"10.244.2.0/24"}
 	if gatewayNodesEqual(nodesA, nodesB) {
 		t.Fatalf("expected changed gateway node slices to differ")
+	}
+}
+
+func TestResolveNodeExternalIPs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		node    *corev1.Node
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "declared address takes precedence over provider and discovery",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation:   "203.0.113.20",
+					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
+				}},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "2001:0db8:0:0::10"}}},
+			},
+			want: []string{"203.0.113.20"},
+		},
+		{
+			name: "provider takes precedence over discovery",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
+				}},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "2001:0db8:0:0::10"}}},
+			},
+			want: []string{"2001:0db8:0:0::10"},
+		},
+		{
+			name: "provider address preserves legacy behavior",
+			node: &corev1.Node{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{
+				Type: corev1.NodeExternalIP, Address: "not-an-ip",
+			}}}},
+			want: []string{"not-an-ip"},
+		},
+		{
+			name: "discovery is used without a declared or provider address",
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "2001:0db8:0:0::10",
+			}}},
+			want: []string{"2001:db8::10"},
+		},
+		{
+			name: "declared address takes precedence over discovery",
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation:   "203.0.113.20",
+				unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
+			}}},
+			want: []string{"203.0.113.20"},
+		},
+		{
+			name: "IPv4-mapped IPv6 declared address is normalized",
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation: "::ffff:192.0.2.10",
+			}}},
+			want: []string{"192.0.2.10"},
+		},
+		{
+			name: "invalid declared address blocks provider and discovery fallback",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation:   "not-an-ip",
+					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
+				}},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "192.0.2.20"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "IPv6 zone is rejected",
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation: "fe80::1%eth0",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "long invalid declared address has a bounded error",
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation: strings.Repeat("x", 4096),
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "empty declared address blocks provider and discovery fallback",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation:   "",
+					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.30",
+				}},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "192.0.2.20"}}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveNodeExternalIPs(tt.node)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveNodeExternalIPs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err != nil && len(err.Error()) > 256 {
+				t.Fatalf("resolveNodeExternalIPs() error length = %d, want at most 256: %v", len(err.Error()), err)
+			}
+
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("resolveNodeExternalIPs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeAnnotationChangedDetectsPresence(t *testing.T) {
+	t.Parallel()
+
+	oldNode := &corev1.Node{}
+	newNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation: "",
+	}}}
+
+	if !nodeAnnotationChanged(oldNode, newNode, unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation) {
+		t.Fatal("adding an empty declared address must be detected")
 	}
 }
 

--- a/internal/net/controller/kubeproxy_controller.go
+++ b/internal/net/controller/kubeproxy_controller.go
@@ -104,25 +104,42 @@ func NewManagedKubeProxyController(
 		),
 	}
 
-	handler := cache.ResourceEventHandlerFuncs{
+	enqueueAllHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(any) { c.enqueueAll() },
 		UpdateFunc: func(any, any) { c.enqueueAll() },
 		DeleteFunc: func(any) { c.enqueueAll() },
 	}
 
-	if _, err := nodeInformer.Informer().AddEventHandler(handler); err != nil {
+	nodeHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(any) { c.enqueueAll() },
+		UpdateFunc: func(oldObj, newObj any) {
+			if managedKubeProxyNodeUpdateAffectsReconcile(oldObj, newObj) {
+				c.enqueueAll()
+			}
+		},
+		DeleteFunc: func(any) { c.enqueueAll() },
+	}
+
+	if _, err := nodeInformer.Informer().AddEventHandler(nodeHandler); err != nil {
 		return nil, fmt.Errorf("add node event handler: %w", err)
 	}
 
-	if _, err := dsInformer.Informer().AddEventHandler(handler); err != nil {
+	if _, err := dsInformer.Informer().AddEventHandler(enqueueAllHandler); err != nil {
 		return nil, fmt.Errorf("add daemonset event handler: %w", err)
 	}
 
-	if _, err := siteInformer.AddEventHandler(handler); err != nil {
+	if _, err := siteInformer.AddEventHandler(enqueueAllHandler); err != nil {
 		return nil, fmt.Errorf("add site event handler: %w", err)
 	}
 
 	return c, nil
+}
+
+func managedKubeProxyNodeUpdateAffectsReconcile(oldObj, newObj any) bool {
+	oldNode, oldOK := oldObj.(*corev1.Node)
+	newNode, newOK := newObj.(*corev1.Node)
+
+	return !oldOK || !newOK || !labels.Equals(labels.Set(oldNode.Labels), labels.Set(newNode.Labels))
 }
 
 // Run starts the managed kube-proxy controller.

--- a/internal/net/controller/kubeproxy_controller_test.go
+++ b/internal/net/controller/kubeproxy_controller_test.go
@@ -38,6 +38,61 @@ func TestShouldManageKubeProxyForNode(t *testing.T) {
 	}
 }
 
+func TestManagedKubeProxyNodeUpdateAffectsReconcile(t *testing.T) {
+	t.Parallel()
+
+	oldNode := nodeWithLabels(map[string]string{canonicalSiteLabelKey: "site-a"})
+
+	tests := []struct {
+		name string
+		old  any
+		new  any
+		want bool
+	}{
+		{
+			name: "unchanged labels",
+			old:  oldNode,
+			new:  oldNode.DeepCopy(),
+		},
+		{
+			name: "annotation only",
+			old:  oldNode,
+			new: func() *corev1.Node {
+				node := oldNode.DeepCopy()
+				node.Annotations = map[string]string{"net.unbounded-cloud.io/discovered-public-ip": "203.0.113.10"}
+
+				return node
+			}(),
+		},
+		{
+			name: "label value changed",
+			old:  oldNode,
+			new:  nodeWithLabels(map[string]string{canonicalSiteLabelKey: "site-b"}),
+			want: true,
+		},
+		{
+			name: "label added",
+			old:  oldNode,
+			new:  nodeWithLabels(map[string]string{canonicalSiteLabelKey: "site-a", "provider": "covered"}),
+			want: true,
+		},
+		{
+			name: "unexpected object",
+			old:  oldNode,
+			new:  &corev1.Pod{},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := managedKubeProxyNodeUpdateAffectsReconcile(tt.old, tt.new); got != tt.want {
+				t.Fatalf("managedKubeProxyNodeUpdateAffectsReconcile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProviderKubeProxyDaemonSetsIgnoresManagedDaemonSets(t *testing.T) {
 	dsList := []*appsv1.DaemonSet{
 		{ObjectMeta: metav1.ObjectMeta{Name: "kube-proxy"}, Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "kube-proxy", Image: "kube-proxy:v1"}}}}}},


### PR DESCRIPTION
Allow the network controller to use a public IP from Node annotations when the cloud provider does not report a `NodeExternalIP`.

The controller now selects addresses in this order:

1. Provider `NodeExternalIP`
2. Administrator override
3. Non-expired discovered address

Discovered addresses expire automatically and affected GatewayPools reconcile at the expiry time, including handoffs to fallback pools. Cluster status reports the same resolved address and does not accept ExternalIPs supplied by node agents.

The administrator override is protected from changes by the Unbounded service accounts. Expiry-only refreshes also avoid unnecessary cluster-status and managed kube-proxy work.

Existing provider address behavior remains unchanged. This PR adds controller-side support only; it does not enable STUN discovery or configure a STUN endpoint.
