### PR TITLE
Protect the controller-owned WireGuard port annotation from node-agent changes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -358,6 +358,15 @@ notices:
     license:
       - name: MIT License
         link: https://github.com/golang-jwt/jwt/blob/v5.3.1/LICENSE
+  - dependency: github.com/google/cel-go
+    ecosystem: go
+    copyright:
+      - Copyright (c) 2018 The Go Authors. All rights reserved.
+    license:
+      - name: Apache License, Version 2.0
+        link: https://github.com/google/cel-go/blob/v0.26.0/LICENSE
+      - name: BSD 3-Clause License
+        link: https://github.com/google/cel-go/blob/v0.26.0/LICENSE
   - dependency: github.com/google/go-github/v75
     ecosystem: go
     copyright:

--- a/deploy/net/controller/09-vap.yaml.tmpl
+++ b/deploy/net/controller/09-vap.yaml.tmpl
@@ -99,6 +99,15 @@ spec:
         object.spec.all(k, k in ['podCIDR', 'podCIDRs'] || (k in oldObject.spec && object.spec[k] == oldObject.spec[k])) &&
         oldObject.spec.all(k, k in ['podCIDR', 'podCIDRs'] || (k in object.spec && oldObject.spec[k] == object.spec[k]))
       message: "unbounded-net may only modify spec.podCIDR and spec.podCIDRs on nodes"
+    - expression: >-
+        request.userInfo.username != 'system:serviceaccount:{{ default "unbounded-system" .Namespace }}:unbounded-net-node' ||
+        (((!has(object.metadata.annotations) || !('net.unbounded-cloud.io/wireguard-port' in object.metadata.annotations)) &&
+          (!has(oldObject.metadata.annotations) || !('net.unbounded-cloud.io/wireguard-port' in oldObject.metadata.annotations))) ||
+        (has(object.metadata.annotations) && has(oldObject.metadata.annotations) &&
+          'net.unbounded-cloud.io/wireguard-port' in object.metadata.annotations &&
+          'net.unbounded-cloud.io/wireguard-port' in oldObject.metadata.annotations &&
+          object.metadata.annotations['net.unbounded-cloud.io/wireguard-port'] == oldObject.metadata.annotations['net.unbounded-cloud.io/wireguard-port']))
+      message: "unbounded-net-node may not modify the controller-owned WireGuard port annotation"
     # Labels: only net.unbounded-cloud.io/ prefix labels and the canonical
     # unbounded-cloud.io/site label may be added, changed, or removed. The
     # canonical site label is dual-written alongside the deprecated

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-logr/logr v1.4.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/cel-go v0.26.0
 	github.com/google/go-github/v75 v75.0.0
 	github.com/google/go-tpm v0.9.8
 	github.com/google/go-tpm-tools v0.4.9
@@ -96,6 +97,7 @@ require (
 )
 
 require (
+	cel.dev/expr v0.25.2 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	filippo.io/bigmod v0.1.1-0.20260103110540-f8a47775ebe5 // indirect
 	filippo.io/keygen v0.0.0-20260114151900-8e2790ea4c5b // indirect
@@ -106,6 +108,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // indirect
 	github.com/Microsoft/hcsshim v0.15.0-rc.1 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/apex/log v1.9.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.37 // indirect
@@ -286,6 +289,7 @@ require (
 	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
+	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
 	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect

--- a/internal/operator/components/net/vap_test.go
+++ b/internal/operator/components/net/vap_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package net
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+)
+
+const (
+	wireGuardPortAnnotation          = "net.unbounded-cloud.io/wireguard-port"
+	nodeServiceAccountUsername       = "system:serviceaccount:unbounded-system:unbounded-net-node"
+	controllerServiceAccountUsername = "system:serviceaccount:unbounded-system:unbounded-net-controller"
+)
+
+func TestNodeFieldPolicyProtectsWireGuardPort(t *testing.T) {
+	t.Parallel()
+
+	policy := plannedNetObject(t, "ValidatingAdmissionPolicy", "unbounded-net-node-field-restriction")
+	expression := policyValidationExpression(t, policy, "unbounded-net-node may not modify the controller-owned WireGuard port annotation")
+
+	tests := []struct {
+		name           string
+		username       string
+		oldAnnotations map[string]string
+		annotations    map[string]string
+		wantAllowed    bool
+	}{
+		{name: "node absent", username: nodeServiceAccountUsername, wantAllowed: true},
+		{
+			name:           "node unchanged",
+			username:       nodeServiceAccountUsername,
+			oldAnnotations: map[string]string{wireGuardPortAnnotation: "51821"},
+			annotations:    map[string]string{wireGuardPortAnnotation: "51821"},
+			wantAllowed:    true,
+		},
+		{
+			name:           "node changes another annotation",
+			username:       nodeServiceAccountUsername,
+			oldAnnotations: map[string]string{wireGuardPortAnnotation: "51821"},
+			annotations: map[string]string{
+				wireGuardPortAnnotation:             "51821",
+				"net.unbounded-cloud.io/tunnel-mtu": "1400",
+			},
+			wantAllowed: true,
+		},
+		{name: "node adds", username: nodeServiceAccountUsername, annotations: map[string]string{wireGuardPortAnnotation: "51821"}},
+		{
+			name:           "node changes",
+			username:       nodeServiceAccountUsername,
+			oldAnnotations: map[string]string{wireGuardPortAnnotation: "51821"},
+			annotations:    map[string]string{wireGuardPortAnnotation: "51822"},
+		},
+		{name: "node removes", username: nodeServiceAccountUsername, oldAnnotations: map[string]string{wireGuardPortAnnotation: "51821"}},
+		{name: "controller adds", username: controllerServiceAccountUsername, annotations: map[string]string{wireGuardPortAnnotation: "51821"}, wantAllowed: true},
+		{
+			name:           "controller changes",
+			username:       controllerServiceAccountUsername,
+			oldAnnotations: map[string]string{wireGuardPortAnnotation: "51821"},
+			annotations:    map[string]string{wireGuardPortAnnotation: "51822"},
+			wantAllowed:    true,
+		},
+		{name: "controller removes", username: controllerServiceAccountUsername, oldAnnotations: map[string]string{wireGuardPortAnnotation: "51821"}, wantAllowed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := evalCEL(t, expression, map[string]any{
+				"oldObject": nodeAdmissionObject(tt.oldAnnotations),
+				"object":    nodeAdmissionObject(tt.annotations),
+				"request": map[string]any{
+					"userInfo": map[string]any{"username": tt.username},
+				},
+			})
+			if got != tt.wantAllowed {
+				t.Fatalf("allowed = %v, want %v", got, tt.wantAllowed)
+			}
+		})
+	}
+}
+
+func plannedNetObject(t *testing.T, kind, name string) *unstructured.Unstructured {
+	t.Helper()
+
+	plan, _, err := (Component{}).Plan(t.Context(), testEnv(t), []unboundedv1alpha3.Site{{ObjectMeta: metav1.ObjectMeta{Name: "edge"}}})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	for _, op := range plan.Operations {
+		if op.Object.GetKind() == kind && op.Object.GetName() == name {
+			return op.Object
+		}
+	}
+
+	t.Fatalf("plan does not contain %s/%s", kind, name)
+
+	return nil
+}
+
+func policyValidationExpression(t *testing.T, policy *unstructured.Unstructured, message string) string {
+	t.Helper()
+
+	validations, found, err := unstructured.NestedSlice(policy.Object, "spec", "validations")
+	if err != nil || !found {
+		t.Fatalf("read spec.validations: found=%v err=%v", found, err)
+	}
+
+	for _, validation := range validations {
+		fields := validation.(map[string]any) //nolint:errcheck
+		if fields["message"] == message {
+			return fields["expression"].(string) //nolint:errcheck
+		}
+	}
+
+	t.Fatalf("policy has no validation with message %q", message)
+
+	return ""
+}
+
+func nodeAdmissionObject(annotations map[string]string) map[string]any {
+	metadata := map[string]any{}
+	if annotations != nil {
+		metadata["annotations"] = annotations
+	}
+
+	return map[string]any{"metadata": metadata}
+}
+
+func evalCEL(t *testing.T, expression string, activation map[string]any) bool {
+	t.Helper()
+
+	env, err := cel.NewEnv(
+		cel.Variable("object", cel.DynType),
+		cel.Variable("oldObject", cel.DynType),
+		cel.Variable("request", cel.DynType),
+	)
+	if err != nil {
+		t.Fatalf("create CEL environment: %v", err)
+	}
+
+	ast, issues := env.Compile(expression)
+	if issues.Err() != nil {
+		t.Fatalf("compile CEL expression %q: %v", expression, issues.Err())
+	}
+
+	program, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("create CEL program: %v", err)
+	}
+
+	result, _, err := program.Eval(activation)
+	if err != nil {
+		t.Fatalf("evaluate CEL expression %q: %v", expression, err)
+	}
+
+	allowed, ok := result.Value().(bool)
+	if !ok {
+		t.Fatalf("CEL result = %T(%v), want bool", result.Value(), result.Value())
+	}
+
+	return allowed
+}


### PR DESCRIPTION
The node agent can update networking annotations on Nodes, but the WireGuard port is assigned and managed by the controller. The admission policy now prevents the node agent from adding, changing, or removing that annotation, while still allowing the controller to manage it.

The tests compile and evaluate the rendered admission expression, covering allowed and denied add, change, remove, and unchanged cases.
