### PR TITLE
spelling: use American spellings across the repo

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -78,7 +78,7 @@ jobs:
 
           # The dots are literal in the glob below but are any-char in the ERE,
           # so escape them for the grep. Not reachable given the validation
-          # above, but the neighbouring patterns are exact and this one should
+          # above, but the neighboring patterns are exact and this one should
           # be too.
           SERIES_ESCAPED="${SERIES//./\\.}"
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,7 @@ run:
 linters:
   enable:
     - goheader
+    - misspell
     - wsl_v5
   disable:
     # Unlikely to ever Enable
@@ -53,6 +54,12 @@ linters:
         - fieldalignment
       # Ensure also optional linters are enabled in Vet to provide extra consistency.
       enable-all: true
+    misspell:
+      # We write American English. This catches British spellings (behaviour,
+      # initialise, labelled) in comments and strings before review has to.
+      # Go files only; the same rule applies to Rust, docs, and shell, but
+      # nothing enforces it there.
+      locale: US
     nolintlint:
       # Disabling linters should be justified to make sure the problem cannot actually be resolved.
       require-explanation: true
@@ -82,6 +89,14 @@ linters:
           - errcheck
           - dupl
           - gosec
+      # hack/cmd/notice matches license files shipped by upstream third-party
+      # modules, and some of them spell it LICENCE. These are filenames on
+      # other people's disks, not our prose. Without this, `make fmt` rewrites
+      # the patterns to LICENSE and the scanner silently stops finding them.
+      - path: hack/cmd/notice/
+        linters:
+          - misspell
+        text: '`LICENCE` is a misspelling'
     paths:
       - examples$
       - hack/scratch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ unbounded-kube is organized into several directories:
 - Net-specific build tasks (container images, frontend, eBPF, render) are exposed via `net-` prefixed targets in the main `Makefile` (e.g., `make net-frontend`, `make net-ebpf-build`, `make net-ebpf-generate`, `make net-manifests`). Cluster deploy/undeploy targets live separately under `hack/net/` and are invoked via `make -C hack/net <target>` (e.g., `make -C hack/net deploy`). Run `make help` and `make -C hack/net help` for the full lists.
 - `make generate` runs `go generate ./...` to regenerate deepcopy, CRDs, and protobuf for all packages.
 - `make build` compiles all Go packages (`go build ./...`).
-- `make vulncheck` runs `govulncheck` and fails only on vulnerabilities that are both reachable from our code and have a published fix, since those are the ones a module bump resolves. Reachable ones with no fix available are reported and allowed through; acting on those means dropping or replacing the dependency, which is a judgement call rather than a build failure.
+- `make vulncheck` runs `govulncheck` and fails only on vulnerabilities that are both reachable from our code and have a published fix, since those are the ones a module bump resolves. Reachable ones with no fix available are reported and allowed through; acting on those means dropping or replacing the dependency, which is a judgment call rather than a build failure.
 - `make fmt` formats Go source (gofumpt + wsl_v5 blank-line rules); `make lint` runs golangci-lint; `make test` runs all tests.
 - `make lint` runs the same checks locally and in CI and does NOT auto-fix. Always run `make fmt` before committing to satisfy the linter (gofumpt and wsl_v5 are enforced by `make lint`/CI); do not hand-format.
 - Locally `test` implies `lint`. In CI (`CI=1`), each runs independently.
@@ -72,6 +72,16 @@ unbounded-kube is organized into several directories:
   share code between these packages, put it in `internal/`.
 - Do not use em-dashes (`—`) in comments, strings, or any source/config files. Use a plain ASCII hyphen (`-`)
   or rephrase the sentence instead.
+- Write American English, not British. Use `behavior`, `initialize`, `labeled`, `catalog`, `defense`, `judgment`,
+  not `behaviour`, `initialise`, `labelled`, `catalogue`, `defence`, `judgement`. This applies to comments, doc
+  strings, identifiers, user-facing strings, and Markdown, in every language in the repo.
+  `make lint` catches the common cases in Go via `misspell`, but its dictionary is not exhaustive: it misses
+  `judgement` and `acknowledgement`, and it does not look at Rust, shell, TLA+, or Markdown at all. Treat it as
+  a backstop, not the rule.
+  `make fmt` runs `golangci-lint --fix`, so `misspell` rewrites Go sources in place. When a British spelling is
+  deliberate, it needs an exclusion in `.golangci.yaml` or the next `make fmt` will silently undo it.
+  Exceptions are external contracts only, such as the GitHub Actions `cancelled()` expression and the
+  `LICENCE` filename patterns in `hack/cmd/notice` that match upstream third-party files.
 
 ## Testing Standards
 
@@ -90,7 +100,7 @@ unbounded-kube is organized into several directories:
       default may be unreachable.
     - Confirm a symbol is reachable before assuming it takes effect. An `-X` ldflag on a package the binary never
       imports is silently ignored.
-- Cite `file:line` for any claim about behaviour that a decision rests on. If a claim cannot be cited, say it is an
+- Cite `file:line` for any claim about behavior that a decision rests on. If a claim cannot be cited, say it is an
   inference.
 - When code and prose disagree, report both with citations rather than silently following either. The doc may be
   stale, or the code may be the bug, and which it is changes the work. Ask when the answer would change what gets

--- a/Makefile
+++ b/Makefile
@@ -624,7 +624,7 @@ inventory-agent: test inventory-agent-amd64 inventory-agent-arm64 ## Build inven
 	esac; \
 	ln -sf inventory-agent-$$ARCH $(INVENTORY_AGENT_BIN)
 
-# inventory-agent-build honours GOOS/GOARCH from the environment so the
+# inventory-agent-build honors GOOS/GOARCH from the environment so the
 # container image can cross-compile natively on the build host, matching the
 # other component -build targets. The -amd64/-arm64 variants stay for local
 # use, where both are wanted side by side.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -515,7 +515,7 @@ matters, the compliant route is also the better one: cherry-pick the fixes to a
 release branch and cut a patch, which is what the branch is for.
 
 What `main`'s numbering no longer expresses is "this release contains no
-behaviour change", because minor absorbs patch. That signal was never reliable:
+behavior change", because minor absorbs patch. That signal was never reliable:
 a release from `main` takes everything merged since, with no way to exclude it.
 Patches now come only from a release branch carrying a deliberate set of
 cherry-picks, so the patch signal means more than it used to, not less.
@@ -670,7 +670,7 @@ for each rather than treating them alike:
 | Override | What it bypasses | Command | Confirmation |
 |---|---|---|---|
 | [Tolerate more unreachable nodes](#tolerate-more-unreachable-nodes) | how many NotReady nodes are excusable | `relctl soak <tag> --max-notready-nodes N` | `y/N`, with a warning |
-| [Re-initialise the cluster](#re-initialise-the-soak-cluster) | `site init` instead of `upgrade-apply` | `relctl soak <tag> --force-init` | typed phrase |
+| [Re-initialize the cluster](#re-initialize-the-soak-cluster) | `site init` instead of `upgrade-apply` | `relctl soak <tag> --force-init` | typed phrase |
 | [Publish without a soak](#publish-without-a-soak) | deploy, Orca and smoke entirely | `relctl publish <tag> --reason ...` | typed phrase, no `--yes` |
 
 A typed phrase cannot be satisfied by `--yes`, so the last two are not reachable
@@ -706,7 +706,7 @@ This raises the ceiling only. A shortfall must still be entirely explained by
 NotReady nodes, and anything unhealthy on a reachable node still fails. State
 the number deliberately; it is a claim someone can review.
 
-### Re-initialise the soak cluster
+### Re-initialize the soak cluster
 
 `site init` instead of `upgrade-apply`, for a first-ever bootstrap:
 
@@ -724,7 +724,7 @@ gh workflow run release-upgrade.yaml --repo Azure/unbounded \
 
 </details>
 
-This is not a recovery tool. On a cluster that is already initialised, `site
+This is not a recovery tool. On a cluster that is already initialized, `site
 init` creates a fresh Site rather than migrating the existing one, which is why
 the workflow otherwise selects init mode only when it detects the pre-redesign
 layout, and why `relctl` asks for a typed phrase here and an ordinary prompt for

--- a/api/machina/v1alpha3/site_types.go
+++ b/api/machina/v1alpha3/site_types.go
@@ -222,7 +222,7 @@ type SiteStatus struct {
 // only catch a bug the compiler already prevents. What it would add is a
 // failure mode: a newer operator writing a value an older CRD's enum does not
 // list has its whole status patch rejected, taking every condition on the Site
-// with it, where an unrecognised value would otherwise simply be pruned. Every
+// with it, where an unrecognized value would otherwise simply be pruned. Every
 // enum elsewhere in this API is on a spec field, where the input is
 // user-supplied and rejecting it is the point.
 const (

--- a/cmd/agent/internal/attest/attest.go
+++ b/cmd/agent/internal/attest/attest.go
@@ -52,8 +52,8 @@ type AttestResult struct {
 
 // attestRequest is the JSON body sent to the attestation server.
 type attestRequest struct {
-	EKPub  []byte `json:"ekPub"`  // TPM2B_PUBLIC (marshalled)
-	SRKPub []byte `json:"srkPub"` // TPM2B_PUBLIC (marshalled)
+	EKPub  []byte `json:"ekPub"`  // TPM2B_PUBLIC (marshaled)
+	SRKPub []byte `json:"srkPub"` // TPM2B_PUBLIC (marshaled)
 }
 
 // attestResponse is the JSON body returned by the attestation server.

--- a/cmd/agent/internal/cmd/context.go
+++ b/cmd/agent/internal/cmd/context.go
@@ -21,7 +21,7 @@ import (
 //
 // Persistent flags are bound directly to this struct's exported fields in
 // Run(), and Setup() is called inside each subcommand's RunE — after cobra has
-// finished parsing — to initialise the Logger.
+// finished parsing — to initialize the Logger.
 type CommandContext struct {
 	Debug      bool
 	LogFormat  string
@@ -29,7 +29,7 @@ type CommandContext struct {
 	Logger     *slog.Logger
 }
 
-// Setup initialises the Logger from the current flag values.
+// Setup initializes the Logger from the current flag values.
 func (c *CommandContext) Setup() {
 	var lvl slog.LevelVar
 	if c.Debug {

--- a/cmd/agent/internal/daemon/daemon.go
+++ b/cmd/agent/internal/daemon/daemon.go
@@ -70,7 +70,7 @@ func (o *runOptions) validate() error {
 
 // Run is the main daemon entry point. It discovers the active nspawn
 // machine, builds a Kubernetes client, registers the Machine CR if needed,
-// and blocks until the context is cancelled.
+// and blocks until the context is canceled.
 func Run(ctx context.Context, log *slog.Logger) error {
 	return run(ctx, log, runOptions{})
 }

--- a/cmd/gantry/agent_metrics.go
+++ b/cmd/gantry/agent_metrics.go
@@ -159,7 +159,7 @@ func newPhase2Metrics(reg *metrics.Registry) *phase2Metrics {
 		}),
 		dhtProvideErr: reg.NewCounterVec("discovery", prometheus.CounterOpts{
 			Name: "p2p_dht_provide_error_total",
-			Help: "DHT Provide calls that errored, labelled by call site (advertise, peer_fetch_readvertise, cache_reannounce). Without the label a hung kad-dht is indistinguishable from a bad call site.",
+			Help: "DHT Provide calls that errored, labeled by call site (advertise, peer_fetch_readvertise, cache_reannounce). Without the label a hung kad-dht is indistinguishable from a bad call site.",
 		}, []string{"op"}),
 		dhtReconcile: reg.NewCounter("discovery", prometheus.CounterOpts{
 			Name: "p2p_dht_reconcile_total",
@@ -397,7 +397,7 @@ func newPhase3Metrics(reg *metrics.Registry, infl *inflight.Map) *phase3Metrics 
 		}),
 		coordUnauthorizedPeer: reg.NewCounterVec("coord", prometheus.CounterOpts{
 			Name: "p2p_coord_unauthorized_peer_total",
-			Help: "Inbound coord requests whose libp2p peer ID was not authorized against the membership view, labelled by reason: \"unrecognized\" (membership has published peer IDs but none match the dialing peer) or \"unevaluable\" (no member has published a peer ID yet, only reported in enforce mode). Fires in observe-only for recognized misses and in enforce mode for both. Verify peer-id annotations are published before using zero as an enforcement-readiness signal.",
+			Help: "Inbound coord requests whose libp2p peer ID was not authorized against the membership view, labeled by reason: \"unrecognized\" (membership has published peer IDs but none match the dialing peer) or \"unevaluable\" (no member has published a peer ID yet, only reported in enforce mode). Fires in observe-only for recognized misses and in enforce mode for both. Verify peer-id annotations are published before using zero as an enforcement-readiness signal.",
 		}, []string{"reason"}),
 		prefetchBatchesTotal: reg.NewCounter("coord", prometheus.CounterOpts{
 			Name: "p2p_prefetch_batches_total",
@@ -652,7 +652,7 @@ func newPhase9Metrics(reg *metrics.Registry) *phase9Metrics {
 		}),
 		originStreamStarted: reg.NewCounterVec("origin", prometheus.CounterOpts{
 			Name: "gantry_origin_stream_started_total",
-			Help: "Live mirror requests that entered the direct-origin stream-through path. Labelled by digest kind so manifest-vs-layer traffic stays distinguishable.",
+			Help: "Live mirror requests that entered the direct-origin stream-through path. Labeled by digest kind so manifest-vs-layer traffic stays distinguishable.",
 		}, []string{"kind"}),
 		originStreamCompleted: reg.NewCounterVec("origin", prometheus.CounterOpts{
 			Name: "gantry_origin_stream_completed_total",
@@ -660,7 +660,7 @@ func newPhase9Metrics(reg *metrics.Registry) *phase9Metrics {
 		}, []string{"kind"}),
 		originStreamFailed: reg.NewCounterVec("origin", prometheus.CounterOpts{
 			Name: "gantry_origin_stream_failed_total",
-			Help: "Live direct-origin stream-through attempts that failed before completion (origin-side error, truncated body, or digest mismatch). Labelled by digest kind.",
+			Help: "Live direct-origin stream-through attempts that failed before completion (origin-side error, truncated body, or digest mismatch). Labeled by digest kind.",
 		}, []string{"kind"}),
 		containerdCommitObserved: reg.NewCounter("storage", prometheus.CounterOpts{
 			Name: "gantry_containerd_commit_observed_total",

--- a/cmd/gantry/agent_shutdown.go
+++ b/cmd/gantry/agent_shutdown.go
@@ -16,7 +16,7 @@ import (
 // shutdownDeps bundles the subsystems the agent has to drain on
 // SIGTERM. coordStop and pullerPumpGate are optional and may be nil
 // (gracefulShutdown skips them when unset); every other field is
-// required and a nil value is undefined behaviour.
+// required and a nil value is undefined behavior.
 type shutdownDeps struct {
 	logger         *slog.Logger
 	mirrorSrv      *mirror.Server
@@ -61,7 +61,7 @@ func gracefulShutdown(d shutdownDeps) {
 	if err := d.mirrorStop(shutdownCtx); err != nil {
 		d.logger.Warn("mirror shutdown error", slog.Any("err", err))
 	}
-	// cdsub already cancelled by the outer ctx; wait briefly for its
+	// cdsub already canceled by the outer ctx; wait briefly for its
 	// pending advertise calls to flush.
 	select {
 	case <-d.cdsubDone:

--- a/cmd/gantry/main.go
+++ b/cmd/gantry/main.go
@@ -225,7 +225,7 @@ func runAgent(args []string) error {
 	// requires Kubernetes credentials (in-cluster or explicit
 	// kubeconfig); when neither is available we fall back to a
 	// single-self membership view that disables cold-start so the
-	// mirror keeps behaviour for local development. When
+	// mirror keeps behavior for local development. When
 	// production K8s env vars are set (GANTRY_NODE_NAME etc.)
 	// failure to start the informer is fatal - silently degrading
 	// to single-node mode in production would advertise a healthy
@@ -326,7 +326,7 @@ func runAgent(args []string) error {
 	// returning 2 would make health score capped at 0.5 even in a
 	// fully-converged 2-node cluster. Single-node carve-out returns
 	// 0 so the lone-agent health score is well-defined (matches
-	// bootstrapConvergenceTarget's behaviour).
+	// bootstrapConvergenceTarget's behavior).
 	const kademliaMaxRoutingTable = 256
 
 	if monitor := disco.Monitor(); monitor != nil {
@@ -718,7 +718,7 @@ func runAgent(args []string) error {
 	// channel after the send so the second select below (line ~684,
 	// the shutdown drain) returns immediately on every path:
 	//
-	// - Common case: signal-driven shutdown. ctx is cancelled
+	// - Common case: signal-driven shutdown. ctx is canceled
 	// here, cdSub.Run returns, the goroutine sends-then-closes,
 	// the second select reads the buffered value and proceeds.
 	// - Rare case: cdsub crashes early. The FIRST select below
@@ -755,7 +755,7 @@ func runAgent(args []string) error {
 	logger.Info("advertise: containerd-inventory reconcile loop started")
 
 	// Plan periodic sweep of expired Gantry-owned leases.
-	// Without this the lease catalogue grows monotonically (we never
+	// Without this the lease catalog grows monotonically (we never
 	// delete on the success path because we don't know when kubelet's
 	// Image reference will take over). Containerd's own gc.expire
 	// label gets the bytes back, but the lease metadata itself only
@@ -877,7 +877,7 @@ func runAgent(args []string) error {
 		}
 
 		if requireSelfAnnounce && noDialableTransferAddr.Load() {
-			// Same hazard, transfer-endpoint flavour. Wildcard
+			// Same hazard, transfer-endpoint flavor. Wildcard
 			// listen on the wrong family produces an undialable
 			// advertised transfer address; peers' transfer pulls
 			// would all connection-refused. Fix: align
@@ -1107,7 +1107,7 @@ func selfAnnounceRequiredForReadiness(c *config.Config) bool {
 }
 
 // buildMembers tries to construct a k8s-informer-backed Members
-// Manager. Behaviour depends on whether production-mode env vars
+// Manager. Behavior depends on whether production-mode env vars
 // signal that K8s membership is expected:
 //
 // - Dev mode (NodeName, PodName, and MembersNamespace all empty):
@@ -1669,7 +1669,7 @@ func runningMatchingPodCount(m ifaces.Members) int {
 //
 // Single-node carve-out: snapshotSize ≤ 1 -> 0 ("no peers to dial,
 // any positive target would loop forever"), matching
-// bootstrapConvergenceTarget's behaviour so the bootstrap loop and
+// bootstrapConvergenceTarget's behavior so the bootstrap loop and
 // the health score agree on what 'converged' means.
 func routingTableTarget(snapshotSize, maxSize int) int {
 	if snapshotSize <= 1 {
@@ -1868,7 +1868,7 @@ func advertisedTransferAddr(transferListen, podIP string) string {
 // and the listener's family != podIP family. The empty-host case
 // (`:port`) is Go's dual-stack default on Linux and is never a
 // mismatch. The non-K8s path (podIP == "") is never a mismatch
-// because advertising nothing is the intended behaviour there.
+// because advertising nothing is the intended behavior there.
 //
 // Pairs with advertisedTransferAddr: this returns true exactly when
 // the advertisedTransferAddr -> "" outcome was caused by a

--- a/cmd/gantry/origin_pull_test.go
+++ b/cmd/gantry/origin_pull_test.go
@@ -360,7 +360,7 @@ func TestPullerPumpSameDigestPiggybacksWhenSaturated(t *testing.T) {
 }
 
 func TestPullerPumpDeclinesWhenContextCanceled(t *testing.T) {
-	d := trackerDigestOf([]byte("cancelled"))
+	d := trackerDigestOf([]byte("canceled"))
 	originPuller := fakes.NewOriginPuller()
 	cache := contextAwareCache{}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -480,7 +480,7 @@ func TestPullerPumpDeclinesLateCallWhileShutdownWaits(t *testing.T) {
 
 	// Shutdown stops accepting, signals once that happened, then parks in Wait
 	// until the in-flight pull releases. Gating the late call on stopped keeps
-	// the test deterministic while still modelling shutdown's StopAccepting+Wait
+	// the test deterministic while still modeling shutdown's StopAccepting+Wait
 	// ordering (StopAccepting always precedes Wait in gracefulShutdown).
 	stopped := make(chan struct{})
 	waitReturned := make(chan struct{})

--- a/cmd/kubectl-unbounded/app/machine_manual_bootstrap.go
+++ b/cmd/kubectl-unbounded/app/machine_manual_bootstrap.go
@@ -578,7 +578,7 @@ func machineNameDisplay(name string) string {
 func (h *manualBootstrapHandler) renderScript(cfg *provision.UnboundedAgentConfig) (string, error) {
 	configJSON, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("marshalling agent config: %w", err)
+		return "", fmt.Errorf("marshaling agent config: %w", err)
 	}
 
 	data := manualBootstrapTemplateData{
@@ -607,7 +607,7 @@ func (h *manualBootstrapHandler) renderScript(cfg *provision.UnboundedAgentConfi
 func (h *manualBootstrapHandler) renderCloudInit(cfg *provision.UnboundedAgentConfig) (string, error) {
 	configJSON, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("marshalling agent config: %w", err)
+		return "", fmt.Errorf("marshaling agent config: %w", err)
 	}
 
 	data := manualBootstrapTemplateData{

--- a/cmd/kubectl-unbounded/app/machine_manual_bootstrap_test.go
+++ b/cmd/kubectl-unbounded/app/machine_manual_bootstrap_test.go
@@ -639,7 +639,7 @@ func TestManualBootstrapHandler_BuildAgentConfig_EmptyMachineName(t *testing.T) 
 	require.NoError(t, err)
 	require.Empty(t, cfg.MachineName)
 
-	// The agent resolves the name on the host at startup; the marshalled
+	// The agent resolves the name on the host at startup; the marshaled
 	// config carries an empty MachineName.
 	data, err := json.Marshal(cfg)
 	require.NoError(t, err)

--- a/cmd/kubectl-unbounded/app/machine_register.go
+++ b/cmd/kubectl-unbounded/app/machine_register.go
@@ -260,7 +260,7 @@ func (h *machineRegisterHandler) executeAfterValidation(ctx context.Context) err
 	// Marshal to YAML and apply via server-side apply.
 	data, err := yaml.Marshal(m)
 	if err != nil {
-		return fmt.Errorf("marshalling machine %s: %w", h.name, err)
+		return fmt.Errorf("marshaling machine %s: %w", h.name, err)
 	}
 
 	if err := kube.ApplyManifests(ctx, h.logger, h.kubeResourcesCli, fieldManagerID, data); err != nil {

--- a/cmd/kubectl-unbounded/app/overrides_test.go
+++ b/cmd/kubectl-unbounded/app/overrides_test.go
@@ -526,7 +526,7 @@ func indentBlock(block, indent string) string {
 // The overrides commands did not, and built their client through
 // ctrl.GetConfigOrDie, which reads a flag registered on the standard library's
 // flag.CommandLine that cobra never parses. So the documented flag was rejected
-// outright and only the ambient KUBECONFIG was ever honoured.
+// outright and only the ambient KUBECONFIG was ever honored.
 func TestOverridesCommandsAcceptKubeconfig(t *testing.T) {
 	for _, name := range []string{"list", "status", "validate"} {
 		t.Run(name, func(t *testing.T) {
@@ -867,7 +867,7 @@ func TestOverridesStatusCollapsesClusterSingletons(t *testing.T) {
 	}
 
 	if !strings.Contains(out.String(), "(all sites)") {
-		t.Fatalf("output = %q, want the collapsed row labelled", out.String())
+		t.Fatalf("output = %q, want the collapsed row labeled", out.String())
 	}
 }
 

--- a/cmd/kubectl-unbounded/app/overrides_validate.go
+++ b/cmd/kubectl-unbounded/app/overrides_validate.go
@@ -341,7 +341,7 @@ func splitYAMLDocuments(contents []byte) [][]byte {
 }
 
 // isBlankDocument reports whether a document carries nothing but whitespace and
-// comments, which is what a leading `---` or a licence header produces.
+// comments, which is what a leading `---` or a license header produces.
 func isBlankDocument(raw []byte) bool {
 	for _, line := range bytes.Split(raw, []byte("\n")) {
 		trimmed := bytes.TrimSpace(line)

--- a/cmd/orca/orca/orca.go
+++ b/cmd/orca/orca/orca.go
@@ -117,7 +117,7 @@ func serve(parent context.Context, configPath string) error {
 
 // resolveLogLevel determines the effective slog.Level by consulting
 // the ORCA_LOG_LEVEL environment variable first; if unset or empty,
-// falls back to the YAML-configured value. An unrecognised value
+// falls back to the YAML-configured value. An unrecognized value
 // (from either source) returns a parse error so misconfiguration is
 // surfaced at startup rather than silently degrading to info.
 func resolveLogLevel(yamlLevel string) (slog.Level, error) {

--- a/cmd/racer/ARCHITECTURE.md
+++ b/cmd/racer/ARCHITECTURE.md
@@ -90,7 +90,7 @@ periodic work, flush submissions/completions, then spin, yield, or park.
 Detached maintenance uses the same cooperative executor. A worker panic aborts
 the process.
 
-Kernel I/O is not cancelled when its Rust future is dropped. Its operation slot
+Kernel I/O is not canceled when its Rust future is dropped. Its operation slot
 and owned pool buffer remain detached until all completions arrive. An opaque
 ublk guest buffer cannot be retained that way, because it belongs to the kernel
 for one request, so operations naming one are counted instead and its request

--- a/cmd/racer/src/alloc.rs
+++ b/cmd/racer/src/alloc.rs
@@ -7,7 +7,7 @@
 //!
 //! The two classes differ deliberately. `Small` (4 KiB) carries a CRC in its mblock
 //! entry, verified on every read, so a page that does not match is never served; `Huge`
-//! (4 MiB) carries none, so ordering is its only defence against a torn or lost data
+//! (4 MiB) carries none, so ordering is its only defense against a torn or lost data
 //! write. Both write data before the entry naming it, but only the huge class needs
 //! that for the bytes' sake — `finish_small` gives the small class's own reason.
 //!
@@ -58,7 +58,7 @@ struct Core {
     /// Woken by every flush completion on this core. Waiters re-check their own
     /// condition, so a spurious wake costs one poll.
     waiters: Vec<Waker>,
-    /// 4 KiB mblock serialisation buffer per class, pre-held by `tick` so the flush
+    /// 4 KiB mblock serialization buffer per class, pre-held by `tick` so the flush
     /// path never has to await one.
     staging: [Option<PoolBuf>; 2],
     /// 4 MiB pages being reassembled from the pieces a transport split them into.
@@ -325,7 +325,7 @@ impl Allocator {
         }
     }
 
-    /// Serialise one mblock from its DRAM image and write the copy that is not
+    /// Serialize one mblock from its DRAM image and write the copy that is not
     /// current. Always a whole 4 KiB block: there is nothing to read first.
     async fn flush(&'static self, class: Class, li: u32) -> Result<(), Status> {
         let core = runtime::core();
@@ -535,7 +535,7 @@ impl Allocator {
         Ok(done.then_some(t.version))
     }
 
-    /// The 4 MiB member side. With no checksum the only defence against a torn or
+    /// The 4 MiB member side. With no checksum the only defense against a torn or
     /// lost data write is ordering, so the data must be durable before the entry that
     /// names it is issued.
     pub async fn accept_huge(
@@ -1802,11 +1802,11 @@ mod tests {
             "the huge page was supposed to be damaged"
         );
 
-        // Damage is contained to the page: its neighbours are untouched.
+        // Damage is contained to the page: its neighbors are untouched.
         let got = get_small(a, GlobalAddr::new(LWW, 0)).await?;
-        check!(got == pattern(0x5a, SMALL), "neighbour page damaged");
+        check!(got == pattern(0x5a, SMALL), "neighbor page damaged");
         let got = get_small(a, GlobalAddr::new(LWW, 2)).await?;
-        check!(got == pattern(2, SMALL), "neighbour page damaged");
+        check!(got == pattern(2, SMALL), "neighbor page damaged");
         Ok(())
     }
 

--- a/cmd/racer/src/alloc/shard.rs
+++ b/cmd/racer/src/alloc/shard.rs
@@ -9,7 +9,7 @@
 //! enumerate, so the guard rules, slot accounting and startup reconciliation are
 //! checked as production code rather than as a paraphrase.
 //!
-//! Not modelled: the anti-entropy accumulators and snapshot cursors. They hang off
+//! Not modeled: the anti-entropy accumulators and snapshot cursors. They hang off
 //! `Slab` because they must sit next to `entries`, but their policy lives in `heal.rs`
 //! and they are excluded from shard equality — see `mod cmp`.
 
@@ -82,7 +82,7 @@ impl Status {
         }
     }
 
-    /// A peer's error, back to a status. Anything unrecognised is `Io`: a remote error
+    /// A peer's error, back to a status. Anything unrecognized is `Io`: a remote error
     /// we cannot name is not one we should act on.
     pub fn from_wire(e: Errno) -> Status {
         match e {
@@ -948,7 +948,7 @@ impl Shard {
         }
     }
 
-    /// Snapshot one mblock for serialisation: the sequence this write will make
+    /// Snapshot one mblock for serialization: the sequence this write will make
     /// durable, the header to stamp on it, and the rows themselves. The generation is
     /// bumped here, before the write is issued, so the copy this lands in is
     /// `generation % 2`.
@@ -1304,7 +1304,7 @@ mod cmp {
     impl Slab {
         /// The sweep cursor counts up for ever but is only ever read modulo the stripe
         /// length, so that is what a state is. Without this the state space is infinite
-        /// for no behavioural reason.
+        /// for no behavioral reason.
         fn cursor(&self) -> u32 {
             self.sweep % self.local.max(1)
         }

--- a/cmd/racer/src/config.rs
+++ b/cmd/racer/src/config.rs
@@ -696,7 +696,7 @@ impl Config {
             return Err(bad("duplicate volume id"));
         }
         // Slots name volumes on the wire, so a collision would decode one LBA to two
-        // volumes. `volumes` is slot-sorted, so neighbours suffice.
+        // volumes. `volumes` is slot-sorted, so neighbors suffice.
         if self.volumes.windows(2).any(|w| w[0].slot == w[1].slot) {
             return Err(bad("duplicate volume slot"));
         }
@@ -1054,7 +1054,7 @@ impl Config {
     ///
     /// `#` starts a comment; blank lines are ignored; leading whitespace is not
     /// significant; a `key a=1 b=2` line sets the fields it names and defaults the rest.
-    /// A key the line does not recognise is an error, not a default.
+    /// A key the line does not recognize is an error, not a default.
     ///
     /// ```text
     /// generation 7
@@ -1777,7 +1777,7 @@ mod tests {
         assert!(Config::decode(&a.encode()[..3]).is_err());
     }
 
-    /// The file is sized to a node's neighbourhood, not the cluster.
+    /// The file is sized to a node's neighborhood, not the cluster.
     #[test]
     fn stays_small() {
         let mut c = sample();
@@ -1882,7 +1882,7 @@ mod tests {
         c.generation = 99;
         assert!(
             c.validate_against(&a).is_err(),
-            "a gap is not a licence to rehash"
+            "a gap is not a license to rehash"
         );
     }
 

--- a/cmd/racer/src/fabric.rs
+++ b/cmd/racer/src/fabric.rs
@@ -52,7 +52,7 @@ use crate::runtime::{Buf, Configurator, Disk, Durability, Errno};
 /// for exactly `BLK_STS_{NOSPC,TARGET,NOTSUPP,MEDIUM}` and sends the rest as
 /// `NVME_SC_INTERNAL`, which the initiator's `nvme_error_status()` turns back into
 /// `EIO`. So `EBADE`, `EILSEQ`, `EAGAIN`, `ENOLINK`, `EINVAL` all arrive as a bare
-/// `EIO`, which the rule "any unrecognised status is a transport failure" escalates
+/// `EIO`, which the rule "any unrecognized status is a transport failure" escalates
 /// into a spurious path failover.
 ///
 /// | here | NVMe status | initiator errno | `DNR` |
@@ -305,7 +305,7 @@ pub(crate) struct Frame {
     /// authoritatively rather than from your own copy. `k + 1` names member index `k`
     /// of the address's group — two bits hold both, because a group is three wide.
     ///
-    /// This generalises `ACCEPT`'s encoding, where zero means "you are the proposer,
+    /// This generalizes `ACCEPT`'s encoding, where zero means "you are the proposer,
     /// pick a ballot". On a `GET` it means "give me the linearizable value", which lets
     /// a node holding neither the slot table nor the catalog for a remote zone still
     /// take a confirmed read: it hands the whole round to the entry node, where the

--- a/cmd/racer/src/heal.rs
+++ b/cmd/racer/src/heal.rs
@@ -493,7 +493,7 @@ struct Core {
     busy: Cell<bool>,
     last: Cell<Option<Instant>>,
     /// Round-robin over the groups this core owns, so no group is starved by a noisy
-    /// neighbour and a long divergence is amortised over many passes.
+    /// neighbor and a long divergence is amortized over many passes.
     next: Cell<u32>,
     stats: RefCell<Stats>,
 }

--- a/cmd/racer/src/layout.rs
+++ b/cmd/racer/src/layout.rs
@@ -177,7 +177,7 @@ pub(crate) struct Header {
 /// Offset of the header CRC, computed over everything else in the block.
 const CRC_OFF: usize = 12;
 
-/// Serialise a whole mblock. `entries` must have exactly `class.k()` elements.
+/// Serialize a whole mblock. `entries` must have exactly `class.k()` elements.
 pub(crate) fn put_mblock(buf: &mut [u8], h: Header, entries: &[Entry]) {
     debug_assert_eq!(buf.len(), MBLOCK);
     debug_assert_eq!(entries.len(), h.class.k() as usize);
@@ -431,7 +431,7 @@ impl Geometry {
     }
 
     /// Byte offset of one copy of an mblock. Copies A and B sit a whole run apart
-    /// rather than adjacent, so one bad neighbourhood of the device cannot take both
+    /// rather than adjacent, so one bad neighborhood of the device cannot take both
     /// copies of a block.
     pub(crate) fn mblock_off(&self, class: Class, id: u32, copy: u8) -> u64 {
         let (e, first) = self

--- a/cmd/racer/src/paxos.rs
+++ b/cmd/racer/src/paxos.rs
@@ -225,7 +225,7 @@ struct Local {
     terms: BTreeMap<u32, Term>,
     seals: BTreeMap<ShardId, u32>,
     /// Addresses with a proposal in flight. The one-value-per-ballot rule, and the
-    /// write path's per-key serialisation, are the same table.
+    /// write path's per-key serialization, are the same table.
     inflight: BTreeSet<u64>,
     /// Groups we are still replaying. Set by the anti-entropy sweep when it finds our
     /// whole side of a group empty against a peer that has data, cleared when the
@@ -721,7 +721,7 @@ impl Paxos {
 
     /// Member indices for the data leg, adjacent ones first. The value is the only part
     /// of a read big enough to care which way it travels: a `GET` routed through a
-    /// neighbour crosses the wire twice and lands the page on a node with no use for it.
+    /// neighbor crosses the wire twice and lands the page on a node with no use for it.
     /// Metadata legs are a trailer each and route freely.
     fn nearest_first(&self, m: &[u32; 3]) -> [u8; 3] {
         nearest_first(m, |n| self.link_of(n).is_some())
@@ -925,7 +925,7 @@ impl Paxos {
     }
 
     /// However many peer accepts the quorum needs beside our own leg. The legs that lose
-    /// are abandoned, not cancelled: their futures are dropped and whatever they were
+    /// are abandoned, not canceled: their futures are dropped and whatever they were
     /// doing completes unobserved. `settle` forbids that, for a payload the caller does
     /// not own: a 4 MiB accept puts the guest's own request buffer on the wire, and that
     /// buffer goes back to the kernel the moment the request is answered.
@@ -1030,7 +1030,7 @@ impl Paxos {
         }
     }
 
-    /// The guard forbids pipelining two writes to one page, so the proposer serialises
+    /// The guard forbids pipelining two writes to one page, so the proposer serializes
     /// same-key proposals rather than letting them race and both lose. It is also the
     /// one-value-per-ballot rule: a second attempt at one version would have to reuse a
     /// ballot, which repair could then use to resurrect a value that was never chosen.

--- a/cmd/racer/src/runtime/exec.rs
+++ b/cmd/racer/src/runtime/exec.rs
@@ -146,7 +146,7 @@ where
         }
         let w = waker_for(id);
         let mut cx = Context::from_waker(&w);
-        // SAFETY: `used` means the slot holds an initialised future, and the slab is
+        // SAFETY: `used` means the slot holds an initialized future, and the slab is
         // boxed, so the future never moves before `assume_init_drop` below.
         let fut = unsafe { Pin::new_unchecked(&mut *s.fut.as_mut_ptr()) };
         match fut.poll(&mut cx) {

--- a/cmd/racer/src/runtime/io.rs
+++ b/cmd/racer/src/runtime/io.rs
@@ -467,7 +467,7 @@ impl OpSlab {
             return; // stale completion for a recycled slot
         }
         if is_timeout {
-            // -ETIME on the link CQE means the deadline fired and cancelled the op.
+            // -ETIME on the link CQE means the deadline fired and canceled the op.
             if res == -libc::ETIME {
                 s.timed_out = true;
             }
@@ -536,7 +536,7 @@ impl OpSlab {
 /// Awaits one operation.
 ///
 /// The op slot owns the in-flight IO, not this future: dropping it detaches the slot
-/// rather than cancelling anything, so abandoning a losing quorum leg is free. The
+/// rather than canceling anything, so abandoning a losing quorum leg is free. The
 /// kernel writes into the buffer until the op completes, so the slot keeps a
 /// `Pool::hold` on a pool buffer until its last CQE; a request buffer its ublk tag pins.
 struct OpFuture {

--- a/cmd/racer/src/runtime/worker.rs
+++ b/cmd/racer/src/runtime/worker.rs
@@ -54,7 +54,7 @@ const TICK_INTERVAL: Duration = Duration::from_millis(1);
 /// purpose — those jobs self-throttle, so this only supplies the wakeup.
 const PARK_TIMEOUT: Duration = Duration::from_millis(100);
 
-/// Op-slab utilisation above which completed requests are held back from
+/// Op-slab utilization above which completed requests are held back from
 /// `COMMIT_AND_FETCH_REQ`, throttling new arrivals.
 const COMMIT_DELAY_HIGH: f32 = 0.85;
 const COMMIT_DELAY_LOW: f32 = 0.60;

--- a/cmd/racer/src/server.rs
+++ b/cmd/racer/src/server.rs
@@ -1535,7 +1535,7 @@ mod tests {
         // and the wrong bytes come back as a successful read.
         assert_ne!(direct_read(&paths[2], 4 << 20, 4 << 20).unwrap(), huge);
 
-        // Damage is contained: neighbours are unaffected.
+        // Damage is contained: neighbors are unaffected.
         assert_eq!(direct_read(&paths[0], 0, 4096).unwrap(), small);
         assert_eq!(
             direct_read(&paths[0], 2 * 4096, 4096).unwrap(),

--- a/cmd/racer/src/sim.rs
+++ b/cmd/racer/src/sim.rs
@@ -112,7 +112,7 @@ enum What {
         len: u32,
         tries: u32,
     },
-    /// A result travelling back to the op's submitter, with the payload for a read.
+    /// A result traveling back to the op's submitter, with the payload for a read.
     Reply {
         who: Who,
         res: i32,
@@ -1246,8 +1246,8 @@ impl Sim {
         len: u32,
         tries: u32,
     ) {
-        // The command was cancelled — by its link timeout, or because its node went
-        // away. A cancelled command's buffer is the initiator's again, so nothing may
+        // The command was canceled — by its link timeout, or because its node went
+        // away. A canceled command's buffer is the initiator's again, so nothing may
         // be read out of it.
         if !self.s.live.borrow().contains(&from) {
             return;

--- a/cmd/racer/tests/dst.rs
+++ b/cmd/racer/tests/dst.rs
@@ -278,7 +278,7 @@ fn a_split_huge_page_written_to_a_bystander_still_replicates() {
 #[test]
 fn a_page_that_arrives_in_pieces_is_never_served_half_written() {
     // Pieces get lost, and a member can restart with some of them already on its disk.
-    // A 4 MiB page carries no checksum, so the only defence is that a page becomes a
+    // A 4 MiB page carries no checksum, so the only defense is that a page becomes a
     // version once it is whole and not a moment before.
     let mut sim = cluster(Options {
         nodes: 3,
@@ -707,7 +707,7 @@ fn churn(sim: &mut Sim, rng: &mut Rng, hurt: &mut Option<Hurt>) {
 
 /// The gate on consensus. Every page is read and written from all three nodes while
 /// frames drop, disks fail, bytes rot, a node comes and goes and a link is cut, and every
-/// read must be explainable by some serialisation of the writes still in flight.
+/// read must be explainable by some serialization of the writes still in flight.
 #[test]
 fn a_page_is_linearizable_under_faults() {
     // One seed drives both the fault and the operation stream, so `DST_SEED` re-runs a

--- a/cmd/racer/tests/paxos_model.rs
+++ b/cmd/racer/tests/paxos_model.rs
@@ -151,7 +151,7 @@ struct RegisterState {
 enum RegisterAction {
     /// A member issues a one-shot accept at its current term.
     Propose { member: u8, guard: u8 },
-    /// The accept reaches one acceptor. Losing a leg is modelled by never taking this.
+    /// The accept reaches one acceptor. Losing a leg is modeled by never taking this.
     Deliver { p: usize, a: u8 },
     /// The prepare phase of a repair at the responding subset.
     Prepare { respond: [bool; N] },
@@ -361,7 +361,7 @@ impl Model for Register {
             }
             RegisterAction::Prepare { respond } => {
                 // Every responder raises its own promise. A round whose responders land
-                // on different terms is dropped rather than modelled; the implementation
+                // on different terms is dropped rather than modeled; the implementation
                 // proposes at the highest of them instead.
                 let mut terms = Vec::new();
                 for (i, r) in respond.iter().enumerate() {

--- a/cmd/unbounded-net-controller/health_state.go
+++ b/cmd/unbounded-net-controller/health_state.go
@@ -79,7 +79,7 @@ type healthState struct {
 	kubeProxyMonitor *kubeProxyMonitor
 
 	// nodeWSRegistry tracks the active WS cancel function per node name.
-	// When a node reconnects, the previous connection is cancelled to avoid
+	// When a node reconnects, the previous connection is canceled to avoid
 	// duplicate connections consuming resources.
 	nodeWSMu       sync.Mutex
 	nodeWSRegistry map[string]context.CancelFunc
@@ -88,7 +88,7 @@ type healthState struct {
 const defaultMaxPullConcurrency = 20
 
 // registerNodeWS registers a WS connection for a node. If an existing
-// connection is registered for the same node, its context is cancelled
+// connection is registered for the same node, its context is canceled
 // to force it to close (preventing duplicate connections).
 func (h *healthState) registerNodeWS(nodeName string, cancel context.CancelFunc) {
 	if nodeName == "" {
@@ -267,7 +267,7 @@ func (h *healthState) getLeaderInfo(ctx context.Context) (*LeaderInfo, error) {
 // updateServiceEndpoints creates/updates the unbounded-net-controller Endpoints
 // and EndpointSlice to point to the leader's IP on the HTTPS serving port
 // (controller.healthPort). The port is published under the name "https", which
-// is how the operator's readiness gate recognises it.
+// is how the operator's readiness gate recognizes it.
 // Kubernetes 1.33 and earlier require Endpoints for APIService availability.
 func (h *healthState) updateServiceEndpoints(ctx context.Context) error {
 	port := int32(h.healthPort)

--- a/cmd/unbounded-net-controller/kube_proxy_monitor.go
+++ b/cmd/unbounded-net-controller/kube_proxy_monitor.go
@@ -37,7 +37,7 @@ func newKubeProxyMonitor(interval time.Duration) *kubeProxyMonitor {
 	}
 }
 
-// Start runs the monitor loop until the context is cancelled.
+// Start runs the monitor loop until the context is canceled.
 // If the interval is 0, the monitor does nothing.
 func (m *kubeProxyMonitor) Start(ctx context.Context) {
 	if m.interval <= 0 {

--- a/cmd/unbounded-net-controller/main.go
+++ b/cmd/unbounded-net-controller/main.go
@@ -479,7 +479,7 @@ func run(cfg *config.Config, forceNotLeader bool) error {
 	// runFunc creates and runs the controller - called only when becoming leader
 	// This ensures the allocator and informer are created fresh with current state
 	//
-	// It blocks until ctx is cancelled, and calls onReady once the site
+	// It blocks until ctx is canceled, and calls onReady once the site
 	// controller has synced its caches and seeded its CIDR allocators. That
 	// callback is what publishes this pod's Service endpoint, which the
 	// operator waits for before registering the webhooks and the APIService.

--- a/cmd/unbounded-net-controller/server.go
+++ b/cmd/unbounded-net-controller/server.go
@@ -628,7 +628,7 @@ func registerPushHandlers(mux *http.ServeMux, health *healthState, webhookServer
 					if closeStatus == websocket.StatusNormalClosure || closeStatus == websocket.StatusGoingAway {
 						logLevel = 4
 					} else if wsCtx.Err() != nil {
-						// Our own context was cancelled (controller shutting down)
+						// Our own context was canceled (controller shutting down)
 						logLevel = 4
 					} else if strings.Contains(readErr.Error(), "EOF") {
 						// TCP connection dropped without close frame (peer pod restarted)

--- a/cmd/unbounded-net-node/kube_proxy_monitor.go
+++ b/cmd/unbounded-net-node/kube_proxy_monitor.go
@@ -37,7 +37,7 @@ func newKubeProxyMonitor(interval time.Duration) *kubeProxyMonitor {
 	}
 }
 
-// Start runs the monitor loop until the context is cancelled.
+// Start runs the monitor loop until the context is canceled.
 // If the interval is 0, the monitor does nothing.
 func (m *kubeProxyMonitor) Start(ctx context.Context) {
 	if m.interval <= 0 {

--- a/cmd/unbounded-net-node/link_stats_monitor.go
+++ b/cmd/unbounded-net-node/link_stats_monitor.go
@@ -93,7 +93,7 @@ func newLinkStatsMonitor(interval time.Duration) *linkStatsMonitor {
 	}
 }
 
-// Start runs the monitor loop until the context is cancelled.
+// Start runs the monitor loop until the context is canceled.
 func (m *linkStatsMonitor) Start(ctx context.Context) {
 	klog.V(2).Infof("Link stats monitor started (interval %s)", m.interval)
 	// Collect baseline immediately so the first check has a reference.

--- a/cmd/unbounded-net-node/site_watch_reconcile.go
+++ b/cmd/unbounded-net-node/site_watch_reconcile.go
@@ -881,7 +881,7 @@ func waitForSiteMembership(ctx context.Context, sliceInformer, gatewayPoolInform
 		}
 	}()
 
-	// Wait for the node to appear or context to be cancelled
+	// Wait for the node to appear or context to be canceled
 	select {
 	case <-ctx.Done():
 		return "", ctx.Err()
@@ -2082,7 +2082,7 @@ func updateWireGuardFromSlices(ctx context.Context, dynamicClient dynamic.Interf
 		//
 		// On gateway nodes, also pull in every remote site's pod-CIDR pool
 		// and NodeCidr so packets to remote-site underlay IPs (e.g. kubelet
-		// probes to a peered site's gateway node) are funnelled through
+		// probes to a peered site's gateway node) are funneled through
 		// unbounded0 and the BPF program's per-gateway /32 entries get a
 		// chance to pin them to the correct WG tunnel. The gateway's own
 		// site NodeCidr is excluded because that traffic must keep using

--- a/cmd/unbounded-storage/ARCHITECTURE.md
+++ b/cmd/unbounded-storage/ARCHITECTURE.md
@@ -600,7 +600,7 @@ memory, the topology plan, the fabric max in-flight knob, and the local
 config `[startup]` section, see the CLI section), not reloadable config
 fields. Shard apply and page-cache-drain fan-in use one 60-second deadline
 for the complete worker set and report outstanding worker identities. A
-timeout, acknowledgement-channel disconnect, or partial broadcast send failure
+timeout, acknowledgment-channel disconnect, or partial broadcast send failure
 requests process shutdown: already-delivered commands may complete later, so
 retrying against the old controller snapshot would be unsafe.
 Peer availability failures are accepted as desired reconnect intent inside the
@@ -609,7 +609,7 @@ lifecycle/configuration failures; startup rejects them, while live apply
 requests fail-stop shutdown because remove/add mutations cannot be rolled back.
 All shard transports and fabric RPC handlers share one process-wide
 `RouteTableHandle`. The apply target is its only writer and publishes the new
-snapshot once, after shard acknowledgement, page-cache drain, and disk
+snapshot once, after shard acknowledgment, page-cache drain, and disk
 publication succeed. Disk open failures are returned after the realized subset
 is published, leaving the desired config retryable and routing on the prior
 snapshot. This keeps routing on the prior snapshot when an earlier

--- a/cmd/unbounded-storage/models/bufferpool-singleflight/BufferpoolSingleflight.cfg
+++ b/cmd/unbounded-storage/models/bufferpool-singleflight/BufferpoolSingleflight.cfg
@@ -30,7 +30,7 @@ CONSTRAINT StateConstraint
 \* prune successor states and thereby hide a real non-progress cycle. The run
 \* is still meaningful here for a specific structural reason: `cancels` is
 \* MONOTONICALLY non-decreasing (only LeaderCancel changes it, always +1), so
-\* `cancels <= MaxCancels` can only ever prune a FINITE SUFFIX of any behaviour
+\* `cancels <= MaxCancels` can only ever prune a FINITE SUFFIX of any behavior
 \* (the steps after the (MaxCancels+1)-th cancel). It never removes an internal
 \* transition, so it cannot manufacture or break a liveness cycle WITHIN the
 \* explored prefix. WaiterLiveness is thus genuinely exercised across all
@@ -48,7 +48,7 @@ CONSTANTS
   NONE              = NONE
 
 \* Deadlock detection is intentionally ON. Genuine task completion is
-\* modelled, and the legitimate "all tasks done" terminal carries an
+\* modeled, and the legitimate "all tasks done" terminal carries an
 \* explicit Done stutter self-loop, so the only states TLC can report as
 \* deadlocks are real wedges (a task still wanting progress with nothing
 \* enabled). The committed run checks the release/preserve-before-wake

--- a/cmd/unbounded-storage/models/bufferpool-singleflight/BufferpoolSingleflight.tla
+++ b/cmd/unbounded-storage/models/bufferpool-singleflight/BufferpoolSingleflight.tla
@@ -40,17 +40,17 @@
       only once the slot is in a terminal state (Ready/Error) AND
       consumer_holds == 0 (inflight.rs:64-66).
     * LeaderGuard (pool.rs:611-631) fires if the leader future is
-      CANCELLED (dropped) mid-load: it resets the slot to Idle and wakes
+      CANCELED (dropped) mid-load: it resets the slot to Idle and wakes
       the parked subscribers so one of them takes over leadership.
 
   -------------------------------------------------------------------------
   WAKE / RELEASE ORDERING
   -------------------------------------------------------------------------
-  When a leader is cancelled after it acquired a page, parked subscribers
+  When a leader is canceled after it acquired a page, parked subscribers
   are woken so one of them can retry leadership. The model keeps the page
   lifecycle explicit at that handoff: the page is either preserved on the
   slot for the next leader, or it is returned to the free list in the same
-  step that wakes subscribers. A wake-before-release ordering is modelled
+  step that wakes subscribers. A wake-before-release ordering is modeled
   separately with `ReleaseBeforeWake = FALSE`; it detaches the page into an
   orphan bucket whose return is delayed until the slot becomes terminal.
 
@@ -65,7 +65,7 @@
                          reusable-on-a-slot and orphaned (no double-free,
                          no lost page).
     * DEADLOCK-FREEDOM - encoded by leaving TLC's deadlock detection ON
-                         (CHECK_DEADLOCK TRUE) while modelling genuine task
+                         (CHECK_DEADLOCK TRUE) while modeling genuine task
                          completion: the only zero-successor states are
                          "every task done" states, which carry an explicit
                          Done stutter self-loop so they are NOT reported as
@@ -98,7 +98,7 @@ CONSTANTS
   StripePages,       \* model allocation unit for one logical key. Bounded by P.
   MaxCancels,        \* bound on total leader cancellations (keeps TLC finite)
   ReleaseBeforeWake, \* TRUE = release/preserve before wake; FALSE = wake first
-  PreserveOnCancel,  \* TRUE = a cancelled leader preserves its page index on
+  PreserveOnCancel,  \* TRUE = a canceled leader preserves its page index on
                      \* the slot for the next leader to reuse (pool.rs:621-624).
   NONE               \* opaque "absent" sentinel; a TLC model value so it
                      \* compares unequal to any Task without a typing error.
@@ -142,7 +142,7 @@ VARIABLES
   waitQ,       \* an ORDERED sequence of tasks parked in free.alloc().await
                 \* (the FIFO `waiters: VecDeque<Waker>`, free_list.rs:23). A
                 \* leader that finds fewer than StripePages free pages appends
-                \* itself; release wakes the HEAD (free_list.rs:53-62). Modelled
+                \* itself; release wakes the HEAD (free_list.rs:53-62). Modeled
                 \* as a sequence so FIFO service order can be checked.
   holds,       \* Keys -> Nat. The slot's live consumer_holds refcount
                \* (inflight.rs:64-66, ConsumerHold pool.rs:267-334). A reader
@@ -335,7 +335,7 @@ ReadError(t) ==
 (***************************************************************************
   LeaderOk(t): the leader's I/O succeeds. It marks the slot Ready and
   wakes all parked subscribers so they consume concurrently (pool.rs:578-
-  584). Waking is modelled by moving parked subscribers back to "want" so
+  584). Waking is modeled by moving parked subscribers back to "want" so
   they re-poll and hit ReadStart. The page stays attached until recycled,
   and a blockstore tee write-back is now pending for this Ready slot
   (teePending[k] := TRUE, pool.rs:586-595).
@@ -392,7 +392,7 @@ LeaderFault(t) ==
   holds a page (slotPage[k] = TRUE); a cancel before acquiring a page
   releases nothing and is uninteresting for this property.
 
-  PreserveOnCancel = TRUE (pool.rs:621-624): the cancelled leader leaves its
+  PreserveOnCancel = TRUE (pool.rs:621-624): the canceled leader leaves its
   page index ATTACHED to the slot (slotPage[k] stays TRUE)
   for the next leader to reuse directly, and resets the slot to Idle. The
   page is neither freed nor orphaned; it is recovered either by the next
@@ -458,7 +458,7 @@ TeeWrite(k) ==
 
 (***************************************************************************
   RecycleIdle(k): return a PRESERVED page from an idle slot to the free
-  list. Under PreserveOnCancel a cancelled leader leaves its page attached
+  list. Under PreserveOnCancel a canceled leader leaves its page attached
   to an Idle slot for reuse; if no leader ever picks the slot back up, the
   preserved page must still be reclaimable so it is not stranded across
   keys. This models the slot's eventual drop returning its page_idx to the
@@ -600,7 +600,7 @@ LeaderConsistency ==
   PAGE CONSERVATION (no double-free, no lost page). Free pages plus pages
   attached to slots plus pages temporarily orphaned by a wake-before-release cancel
   always sum to the fixed pool size, and no single page is both attached
-  and orphaned. This is the bufferpool analogue of EngineReclamation's
+  and orphaned. This is the bufferpool analog of EngineReclamation's
   Conservation and guards the free_list accounting (free_list.rs:21,
   53-62). A stranded page remains accounted for as an orphan, so the model
   distinguishes accounting safety from progress.
@@ -658,7 +658,7 @@ TeeSafety ==
   unconditional proof:
     (1) `cancels` is monotonically non-decreasing - only LeaderCancel ever
         writes it, always as cancels + 1 - so `cancels <= MaxCancels` can
-        only prune a FINITE SUFFIX of any behaviour (everything after the
+        only prune a FINITE SUFFIX of any behavior (everything after the
         (MaxCancels+1)-th cancel). It never deletes an internal transition,
         so it cannot fabricate or sever a liveness cycle inside the explored
         prefix.
@@ -674,7 +674,7 @@ StateConstraint == cancels <= MaxCancels
   Symmetry reduction. Tasks are fully interchangeable (no action breaks a
   tie over a specific task identity) and Keys are interchangeable (no
   CHOOSE over Keys with an order-dependent tie-break, unlike CowBtreeCrash's
-  MetaSlots). Permuting either set maps behaviours to behaviours. NOTE: this
+  MetaSlots). Permuting either set maps behaviors to behaviors. NOTE: this
   operator is deliberately NOT referenced by the committed .cfg, because TLC
   warns that symmetry reduction during LIVENESS checking can miss temporal
   violations; WaiterLiveness is therefore checked WITHOUT symmetry reduction,

--- a/cmd/unbounded-storage/models/chord-routing/ChordRouting.tla
+++ b/cmd/unbounded-storage/models/chord-routing/ChordRouting.tla
@@ -30,7 +30,7 @@
        measure that is bounded below by 0 and strictly decreases (except on
        the single final hop into an owner) cannot loop, so lookups
        terminate without relying on the TTL. The TTL (`MaxHops`) remains a
-       modelled backstop, and `NoHopLimit` asserts that under convergent
+       modeled backstop, and `NoHopLimit` asserts that under convergent
        views the backstop is never needed.
 
     2. OWNERSHIP UNIQUENESS. For every ring position exactly one node
@@ -62,14 +62,14 @@
     ring positions. The production code hashes NodeId onto the ring
     (ring.rs:41-43); the hash only fixes positions, which we fix directly. The
     arc-winner tie-break by topology / rendezvous / raw id (fingers.rs:203-221)
-    IS modelled (`Better`), with the topology metric and the rendezvous hash
+    IS modeled (`Better`), with the topology metric and the rendezvous hash
     abstracted to deterministic stand-ins but the lexicographic order intact.
 
-  * The k-arc finger table (fingers.rs:53-92) is modelled as a sparse table:
+  * The k-arc finger table (fingers.rs:53-92) is modeled as a sparse table:
     each node
     builds the genuine sparse `K`-arc table with one winner per arc
     (`Fingers` / `ArcWinner` / `ArcIndex`), and `closest_preceding` searches
-    that sparse table, so over/undershoot behaviour matches production rather
+    that sparse table, so over/undershoot behavior matches production rather
     than being hidden by a whole-view superset.
 
   * Per-node views may be reloaded mid-lookup (`Reload`, bounded by
@@ -278,7 +278,7 @@ NextHop(self, V, t) ==
   The views a single node may hold. Convergent (Divergent = FALSE): the one
   configuration in which the node sees the full cluster, the production
   stated assumption (fingers.rs:26-29). Divergent: any view that contains
-  the node itself and at least one peer, modelling the per-node config-reload
+  the node itself and at least one peer, modeling the per-node config-reload
   window in which views disagree.
  ***************************************************************************)
 AllowedNodeView(n) ==
@@ -345,7 +345,7 @@ Step(l) ==
   /\ UNCHANGED <<view, tgt, reloads>>
 
 (***************************************************************************
-  Reload: a single node swaps its membership view MID-LOOKUP, modelling
+  Reload: a single node swaps its membership view MID-LOOKUP, modeling
   the non-atomic per-node config reload that motivated this whole model. Every
   in-flight lookup keeps its own cur / tgt / hops, so requests that already
   passed some hops now continue over a changed topology, and concurrent

--- a/cmd/unbounded-storage/models/copy-on-write/CowBtreeCrash.tla
+++ b/cmd/unbounded-storage/models/copy-on-write/CowBtreeCrash.tla
@@ -11,7 +11,7 @@
       If the cache reports a hit for key K and returns bytes B, then B is
       bytes that some prior successful Fault committed for K.
 
-  Only leaf B+tree pages are modelled: internal pages share the same
+  Only leaf B+tree pages are modeled: internal pages share the same
   per-page checksum argument and add no states the invariant can
   distinguish.
  ***************************************************************************)

--- a/cmd/unbounded-storage/models/engine-reclamation/EngineReclamation.tla
+++ b/cmd/unbounded-storage/models/engine-reclamation/EngineReclamation.tla
@@ -39,7 +39,7 @@
   slot can become available to a future allocation. The slot is never returned
   to `free` while it is still reachable from the current root or pinned by
   any live data reader. Eviction (engine.rs:404-427) deletes the btree entry
-  before directly freeing unpinned victims, modelled by the Evict action
+  before directly freeing unpinned victims, modeled by the Evict action
   below.
 
   Properties proven (see invariants at the bottom):
@@ -234,7 +234,7 @@ Evict(k) ==
         /\ just_rebuilt' = FALSE
 
 (***************************************************************************
-  AliveRegister: the FIRST half of the modelled read open. A reader captures
+  AliveRegister: the FIRST half of the modeled read open. A reader captures
   the current root as its view and is counted in PinCount before publication.
   This closes the window where reclamation could free a slot a
   soon-to-publish reader will see. A fresh reader takes an unused identity.
@@ -248,7 +248,7 @@ AliveRegister ==
        /\ just_rebuilt' = FALSE
 
 (***************************************************************************
-  Publish: the SECOND half of the modelled read open. A previously registered
+  Publish: the SECOND half of the modeled read open. A previously registered
   reader publishes its view, making it visible to readers. Its data-page pin
   was already counted in PinCount, so there is no window in which a published
   reader is unprotected.
@@ -393,7 +393,7 @@ StateConstraint == cur_txn <= MaxTxn + 1
   interchangeable here: unlike CowBtreeCrash's MetaSlots, no LBA plays a
   privileged role (there is no CHOOSE over LBA in any tie-breaker) and reader
   ids are only ever picked by an unordered \E, so permuting any of the three
-  sets maps behaviours to behaviours.
+  sets maps behaviors to behaviors.
  ***************************************************************************)
 Symmetry == Permutations(Key) \cup Permutations(LBA) \cup Permutations(Reader)
 

--- a/cmd/unbounded-storage/models/fabric-completion/FabricCompletion.tla
+++ b/cmd/unbounded-storage/models/fabric-completion/FabricCompletion.tla
@@ -157,7 +157,7 @@ Init ==
   shutdown but ONLY once no request is still outstanding.  That last guard
   is the contract that teardown must drain / fail every in-flight op
   before the connection is declared Down, never leaving a pinned buffer
-  behind (analogue of the progress thread's refusal to tear down on
+  behind (analog of the progress thread's refusal to tear down on
   transient errors and strand in-flight ops, src/fabric/progress.rs:160-165).
  ***************************************************************************)
 Bringup ==
@@ -296,7 +296,7 @@ DeliverCqeNonZc(i) ==
   CANNOT drop yet.  We record that pending notification in `lateCqes`,
   stamped with the op's generation, and leave ringInflight untouched; the
   late CQE is drained later by DeliverLate.  In every other case (a NonZc
-  op, or a Zc op failed before its first CQE) the ring slot is cancelled
+  op, or a Zc op failed before its first CQE) the ring slot is canceled
   outright and ringInflight drops with inflight.
  ***************************************************************************)
 FailRequest(i) ==

--- a/cmd/unbounded-storage/src/backend/limiter.rs
+++ b/cmd/unbounded-storage/src/backend/limiter.rs
@@ -34,7 +34,7 @@ struct LimiterInner {
     available: usize,
     /// FIFO queue of parked acquirers. Each entry is `(id, waker)` where
     /// `id` uniquely identifies one `Acquire` future. Keying on a unique
-    /// id (rather than on the `Waker` value) lets a cancelled acquirer
+    /// id (rather than on the `Waker` value) lets a canceled acquirer
     /// remove exactly its own entry on drop, and lets a re-poll refresh
     /// its own waker in place, without disturbing other futures that may
     /// share the same `Waker` (e.g. several fetches driven by one task).
@@ -74,7 +74,7 @@ impl FetchLimiter {
 ///
 /// While parked it holds a uniquely-identified slot in the pool's waiter
 /// queue. The slot is removed when the future resolves *or* is dropped
-/// (cancelled), so a cancelled acquirer can never leave an orphaned
+/// (canceled), so a canceled acquirer can never leave an orphaned
 /// waker behind to swallow a later wake-up meant for a live waiter.
 pub struct Acquire {
     inner: Rc<RefCell<LimiterInner>>,
@@ -125,14 +125,14 @@ impl Future for Acquire {
 }
 
 impl Drop for Acquire {
-    /// Remove our parked slot, if any, so a cancelled acquire cannot
+    /// Remove our parked slot, if any, so a canceled acquire cannot
     /// leave an orphaned waker that a subsequent permit release would
     /// pop and wake to no effect, stranding a live waiter behind it.
     ///
     /// A permit release ([`FetchPermit::drop`]) frees a permit *and*
     /// pops one waiter to wake it, removing that waiter from the queue
     /// before it has re-polled to claim the permit. If that woken
-    /// acquirer is then cancelled before its next poll, the wake the
+    /// acquirer is then canceled before its next poll, the wake the
     /// queue was owed dies with it. So when we drop with a free permit
     /// visible, re-arm the next front waiter to hand the wake along.
     /// This covers the cancel-*after*-wake case that simply removing our
@@ -257,7 +257,7 @@ mod tests {
         assert_eq!(count.0.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 
-    /// A cancelled (dropped-while-parked) acquirer must not swallow the
+    /// A canceled (dropped-while-parked) acquirer must not swallow the
     /// wake a later release owes to a live waiter behind it. This is the
     /// cross-task case the limiter actually faces: concurrent shard-local
     /// fetches can carry distinct wakers. Regression for the orphaned-waker
@@ -291,7 +291,7 @@ mod tests {
         let mut c = Box::pin(limiter.acquire());
         assert!(matches!(c.as_mut().poll(&mut c_cx), Poll::Pending));
 
-        // B is cancelled while parked; its slot must be removed.
+        // B is canceled while parked; its slot must be removed.
         drop(b);
 
         // Releasing the permit must wake C, not waste the wake on the
@@ -304,7 +304,7 @@ mod tests {
 
     /// A release pops one waiter off the queue to wake it *before* that
     /// waiter has re-polled to claim the permit. If the woken acquirer is
-    /// then cancelled in that window, the wake the queue was owed must be
+    /// then canceled in that window, the wake the queue was owed must be
     /// handed to the next live waiter, not lost - otherwise it parks
     /// forever while a permit sits free. Regression for the
     /// cancel-*after*-wake lost wakeup (the reverse ordering of
@@ -343,7 +343,7 @@ mod tests {
         assert_eq!(b_count.0.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert_eq!(limiter.available(), 1);
 
-        // B is cancelled before re-polling. The permit is still free, so C
+        // B is canceled before re-polling. The permit is still free, so C
         // must be re-armed rather than left parked behind the departed B.
         drop(b);
         assert_eq!(c_count.0.load(std::sync::atomic::Ordering::SeqCst), 1);

--- a/cmd/unbounded-storage/src/backend/mod.rs
+++ b/cmd/unbounded-storage/src/backend/mod.rs
@@ -111,7 +111,7 @@ impl<T: Backend + ?Sized> Backend for Arc<T> {
 }
 
 /// Bridge a pool's [`RecvQuarantineHandle`] onto a shard's
-/// [`NetworkRing`], so a cancelled fixed-buffer RECV withholds its
+/// [`NetworkRing`], so a canceled fixed-buffer RECV withholds its
 /// destination bufferpool page from reuse until the kernel is done with
 /// it (its RECV CQE is reaped). Install once per shard, before serving
 /// begins, on the ring whose `recv_fixed` destinations are pool pages

--- a/cmd/unbounded-storage/src/bufferpool/free_list.rs
+++ b/cmd/unbounded-storage/src/bufferpool/free_list.rs
@@ -37,13 +37,13 @@ struct Inner {
     /// Reserved here so speculation cannot reclaim them.
     granted: Vec<(u64, u32)>,
     /// Pages withheld from reuse because a fixed-buffer RECV writing
-    /// into them was cancelled while still in flight. A quarantined
+    /// into them was canceled while still in flight. A quarantined
     /// page returns to circulation only once BOTH the kernel has
     /// finished with it (`kernel_done`, set when its RECV CQE is reaped)
     /// AND the owner has handed it back (`owner_released`, set by the
     /// normal [`FreeList::release`]). Until then it appears neither in
     /// `free` nor `granted`, so no allocation can hand the page out
-    /// while the kernel may still write into it. This makes cancelling
+    /// while the kernel may still write into it. This makes canceling
     /// a fixed RECV sound without blocking the dropping task.
     quarantined: HashMap<u32, QState>,
     next_id: u64,
@@ -185,7 +185,7 @@ impl FreeList {
     ///
     /// If the page is in recv-quarantine (its destination was withheld
     /// by [`FreeList::quarantine_recv`] because an in-flight RECV into
-    /// it was cancelled), this only marks the owner side done. The page
+    /// it was canceled), this only marks the owner side done. The page
     /// is handed back to circulation here only if the kernel has also
     /// already finished with it; otherwise it stays withheld until
     /// [`FreeList::reclaim_recv`] observes the RECV CQE.
@@ -215,7 +215,7 @@ impl FreeList {
     }
 
     /// Withhold `page_idx` from reuse until its in-flight fixed-buffer
-    /// RECV CQE is reaped. Called when such a RECV is cancelled on early
+    /// RECV CQE is reaped. Called when such a RECV is canceled on early
     /// drop while still owning `page_idx`: the kernel may still complete
     /// the RECV into the page after the dropping task returns, so the
     /// page must not be reused yet. Pairs with [`FreeList::reclaim_recv`]
@@ -270,7 +270,7 @@ impl FreeList {
 /// registered backing.
 ///
 /// It is handed to the ring layer (via a backend adapter implementing
-/// `ring::RecvQuarantine`) so a cancelled fixed-buffer RECV can withhold
+/// `ring::RecvQuarantine`) so a canceled fixed-buffer RECV can withhold
 /// its destination page until the kernel is done with it, without the
 /// ring needing to know the pool's generic parameters or page geometry.
 #[derive(Clone)]

--- a/cmd/unbounded-storage/src/bufferpool/pool.rs
+++ b/cmd/unbounded-storage/src/bufferpool/pool.rs
@@ -127,7 +127,7 @@ where
 
     /// Build a [`RecvQuarantineHandle`] over this pool's free list, for
     /// installing on the shard's `NetworkRing` (see
-    /// `backend::install_recv_quarantine`). It lets a cancelled
+    /// `backend::install_recv_quarantine`). It lets a canceled
     /// fixed-buffer RECV withhold its destination page from reuse until
     /// the kernel is done writing into it, keeping cancellation sound
     /// without blocking the dropping task.
@@ -1347,7 +1347,7 @@ where
 
 struct LeaderGuard<'a> {
     slot: &'a Rc<PageSlot>,
-    /// Free list, so a leader cancelled mid-flight with no subscriber
+    /// Free list, so a leader canceled mid-flight with no subscriber
     /// to take over can return its page instead of orphaning it.
     free: &'a FreeList,
     completed: bool,

--- a/cmd/unbounded-storage/src/bufferpool/tests.rs
+++ b/cmd/unbounded-storage/src/bufferpool/tests.rs
@@ -186,7 +186,7 @@ struct MockTransport {
 }
 
 /// Decrements `cur_in_flight` when a `do_bulk_get` future completes or
-/// is cancelled, so the high-water mark reflects true overlap.
+/// is canceled, so the high-water mark reflects true overlap.
 struct InFlightGuard<'a>(&'a MockTransport);
 
 impl Drop for InFlightGuard<'_> {

--- a/cmd/unbounded-storage/src/config/control.rs
+++ b/cmd/unbounded-storage/src/config/control.rs
@@ -72,7 +72,7 @@ pub struct ShardApply {
     pub ack: Sender<ShardAck>,
 }
 
-/// A shard's acknowledgement that it finished (or failed) applying a
+/// A shard's acknowledgment that it finished (or failed) applying a
 /// [`ShardCommand`].
 pub struct ShardAck {
     pub worker: WorkerIdx,
@@ -715,7 +715,7 @@ mod tests {
 
         let error = group
             .broadcast_apply(loaded(Config::default()), ConfigDiff::default())
-            .expect_err("missing acknowledgement must time out");
+            .expect_err("missing acknowledgment must time out");
         assert!(matches!(
             error,
             ApplyError::AckTimeout {
@@ -755,7 +755,7 @@ mod tests {
 
         let error = group
             .broadcast_drain_page_cache()
-            .expect_err("duplicate acknowledgement must not complete fan-in");
+            .expect_err("duplicate acknowledgment must not complete fan-in");
         assert!(matches!(
             error,
             ApplyError::AckTimeout {
@@ -777,7 +777,7 @@ mod tests {
 
         let error = group
             .broadcast_drain_page_cache()
-            .expect_err("dropped acknowledgement sender must disconnect fan-in");
+            .expect_err("dropped acknowledgment sender must disconnect fan-in");
         assert!(matches!(
             error,
             ApplyError::AckDisconnected {

--- a/cmd/unbounded-storage/src/fabric/connection.rs
+++ b/cmd/unbounded-storage/src/fabric/connection.rs
@@ -180,7 +180,7 @@ pub(crate) fn install_connection(
     // register all CQs: the progress group must not poll a CQ before its
     // endpoint's recvs are posted. On any arm failure, roll back the
     // publish so the table never exposes a partially-armed connection
-    // (dropping `conn` closes every endpoint/CQ, cancelling any recvs
+    // (dropping `conn` closes every endpoint/CQ, canceling any recvs
     // already posted on earlier endpoints).
     for &ep in conn.eps() {
         if let Err(e) = RecvPool::arm(

--- a/cmd/unbounded-storage/src/fabric/rpc.rs
+++ b/cmd/unbounded-storage/src/fabric/rpc.rs
@@ -480,7 +480,7 @@ struct Inflight {
     release: Option<PageRelease>,
 }
 
-/// Drive one handler stream to completion, signalling each landed page
+/// Drive one handler stream to completion, signaling each landed page
 /// to the requester. Dispatches to the provider-appropriate strategy:
 /// `verbs` carries the page-ack in the immediate of a single
 /// `fi_writedata` (the fast path being optimized), while the native

--- a/cmd/unbounded-storage/src/fabric/wire.rs
+++ b/cmd/unbounded-storage/src/fabric/wire.rs
@@ -9,7 +9,7 @@
 //! [`MsgHeader`] prefix: a one-byte [`MsgKind`] discriminant, three
 //! padding bytes, and a little-endian `u32` request id. The receiver
 //! reads this prefix to demultiplex (which is this message?) and to
-//! correlate acknowledgements back to the originating request stream.
+//! correlate acknowledgments back to the originating request stream.
 //!
 //! The header is serialized by hand (not via serde) so its size and
 //! layout are fixed and cheap to parse in the progress-thread hot path.

--- a/cmd/unbounded-storage/src/fanout/channel.rs
+++ b/cmd/unbounded-storage/src/fanout/channel.rs
@@ -83,7 +83,7 @@ pub enum FetchCommand {
     },
     /// Release one page pin established by a prior [`FetchEvent::Page`].
     /// Fire-and-forget: the coordinator issues this only after the NIC
-    /// has signalled `SEND_ZC` completion for that page, so the owner
+    /// has signaled `SEND_ZC` completion for that page, so the owner
     /// may drop the page guard immediately. Unknown tokens are ignored.
     Release { pin_token: u64 },
     /// Mark an emitted page pin as handed to a zero-copy send. A later

--- a/cmd/unbounded-storage/src/fanout/service.rs
+++ b/cmd/unbounded-storage/src/fanout/service.rs
@@ -13,7 +13,7 @@
 //!
 //! Each page stays pinned until the coordinator sends a matching
 //! [`FetchCommand::Release`], which it does only after the NIC has
-//! signalled `SEND_ZC` completion for that page. Releasing before that
+//! signaled `SEND_ZC` completion for that page. Releasing before that
 //! completion would let the pool recycle the page while the NIC is still
 //! reading it, so the release ordering is a hard correctness requirement
 //! enforced by the coordinator.

--- a/cmd/unbounded-storage/src/main.rs
+++ b/cmd/unbounded-storage/src/main.rs
@@ -737,13 +737,13 @@ fn run_shard(
     // order (see the drop sequence below).
     let pool = Rc::new(pool);
 
-    // Make cancelled fixed-buffer RECVs into pool pages sound without
-    // blocking the dropping task: a cancelled RECV's destination page is
+    // Make canceled fixed-buffer RECVs into pool pages sound without
+    // blocking the dropping task: a canceled RECV's destination page is
     // withheld from the free list until the kernel finishes with it (its
     // RECV CQE is reaped). Only the shard socket ring receives into pool
     // pages, so the quarantine is installed on it alone; the RPC worker
     // rings receive into their own scratch backing and keep the blocking
-    // drain fallback. Installed before serving begins so every cancelled
+    // drain fallback. Installed before serving begins so every canceled
     // RECV is covered.
     unbounded_storage::backend::install_recv_quarantine(&socket, pool.recv_quarantine_handle());
 

--- a/cmd/unbounded-storage/src/ring/core.rs
+++ b/cmd/unbounded-storage/src/ring/core.rs
@@ -61,7 +61,7 @@ pub(crate) struct RingSetup {
 /// Sink that defers reuse of a fixed-buffer page until the kernel is
 /// provably done touching it.
 ///
-/// When a fixed-buffer RECV or SEND_ZC is cancelled on early drop, the
+/// When a fixed-buffer RECV or SEND_ZC is canceled on early drop, the
 /// kernel may still write into or read from the page after the dropping
 /// task returns. Returning that page to a free list immediately is
 /// therefore unsound. Instead the ring calls [`RecvQuarantine::quarantine`]
@@ -116,12 +116,12 @@ pub(crate) struct RingCore {
     more_completions: Cell<u64>,
     setup: RingSetup,
     queue_depth: u32,
-    /// Optional sink that withholds a cancelled fixed-buffer RECV's
+    /// Optional sink that withholds a canceled fixed-buffer RECV's
     /// destination page until its CQE is reaped (see [`RecvQuarantine`]).
     /// `None` on rings whose RECV destinations are not pool-managed; such
     /// rings fall back to the blocking [`Self::cancel_and_drain`].
     recv_quarantine: RefCell<Option<Rc<dyn RecvQuarantine>>>,
-    /// Maps the `user_data` of a cancelled, quarantined fixed-buffer
+    /// Maps the `user_data` of a canceled, quarantined fixed-buffer
     /// RECV to its destination byte offset, so [`Self::progress`] can
     /// `reclaim` the page when the RECV's CQE is finally reaped.
     pending_recv_cancel: RefCell<HashMap<u64, usize>>,
@@ -192,7 +192,7 @@ impl Slot {
 /// Owned, heap-stable memory an in-flight op references. The kernel
 /// reads/writes through the raw pointer captured in the SQE until the
 /// op's CQE is reaped, so the backing allocation must outlive the op,
-/// not merely the awaiting future (which may be dropped/cancelled
+/// not merely the awaiting future (which may be dropped/canceled
 /// first). The slot keeps this in the slots map so the memory survives
 /// until [`RingCore::progress`] reaps the completion.
 ///
@@ -730,7 +730,7 @@ impl RingCore {
         }
     }
 
-    /// Install the sink used to defer reuse of a cancelled fixed-buffer
+    /// Install the sink used to defer reuse of a canceled fixed-buffer
     /// RECV's destination page until its CQE is reaped. Without it,
     /// [`Self::cancel_fixed_recv`] falls back to the blocking-but-sound
     /// [`Self::cancel_and_drain`].

--- a/cmd/unbounded-storage/src/ring/network.rs
+++ b/cmd/unbounded-storage/src/ring/network.rs
@@ -220,10 +220,10 @@ impl NetworkRing {
         self.core.register_buffer(base, len)
     }
 
-    /// Install the sink that defers reuse of a cancelled fixed-buffer
+    /// Install the sink that defers reuse of a canceled fixed-buffer
     /// RECV's destination page until its CQE is reaped (see
     /// [`RecvQuarantine`]). Install it before any `recv_fixed` is issued
-    /// so every cancelled RECV is covered. Without it, the drop path
+    /// so every canceled RECV is covered. Without it, the drop path
     /// falls back to the blocking [`RingCore::cancel_and_drain`].
     pub(crate) fn set_recv_quarantine(&self, q: Rc<dyn RecvQuarantine>) {
         self.core.set_recv_quarantine(q);
@@ -1252,7 +1252,7 @@ mod tests {
 
     /// With a quarantine sink installed, dropping a parked fixed RECV
     /// must NOT block to drain the op: the destination page is handed to
-    /// the sink (quarantined) and only reclaimed once the cancelled
+    /// the sink (quarantined) and only reclaimed once the canceled
     /// RECV's CQE is later reaped by `progress()`. This is the Phase 5
     /// soundness guarantee: the page is withheld from reuse for the whole
     /// window the kernel might still write to it, without a blocking drop.
@@ -1345,13 +1345,13 @@ mod tests {
             "the destination page must be quarantined on drop, not reclaimed",
         );
 
-        // Pump progress() until the cancelled RECV's CQE is reaped. Only
+        // Pump progress() until the canceled RECV's CQE is reaped. Only
         // then is the page reclaimed back to the free list.
         let mut spins = 0u32;
         while ring.core.in_flight() != 0 {
             ring.progress();
             spins += 1;
-            assert!(spins < 5_000_000, "cancelled RECV was never reaped");
+            assert!(spins < 5_000_000, "canceled RECV was never reaped");
         }
         assert_eq!(
             events.borrow().as_slice(),

--- a/cmd/unbounded-storage/src/shard_layer.rs
+++ b/cmd/unbounded-storage/src/shard_layer.rs
@@ -534,7 +534,7 @@ pub fn teardown_shard_layer(layer: ShardLayer) -> bool {
     // exited, so nothing observes a half-torn layer.
     drop(control);
     // Now retire the shared fabric endpoints. Each unit drops its RPC
-    // server first (signalling shutdown and joining the RPC worker
+    // server first (signaling shutdown and joining the RPC worker
     // pool), then its `Fabric`, which closes every memory region
     // registered against the domain: the shared RPC scratch and every
     // assigned shard's data backing. The shard threads have already

--- a/cmd/unbounded-storage/src/storage/alloc/mod.rs
+++ b/cmd/unbounded-storage/src/storage/alloc/mod.rs
@@ -148,7 +148,7 @@ impl Allocator {
     /// Mark `lba` free. Returns `OutOfRange` if `lba` is past the
     /// configured capacity. Idempotent: freeing an already-free
     /// LBA is a logic bug we surface via a debug_assert but the
-    /// release-build behaviour is a no-op so we don't corrupt the
+    /// release-build behavior is a no-op so we don't corrupt the
     /// `used` count.
     pub fn free(&self, lba: Lba) -> Result<(), Error> {
         if lba.0 >= self.capacity {
@@ -164,7 +164,7 @@ impl Allocator {
         g.words[w] &= !mask;
         g.used -= 1;
         // Keep the hint at the now-free slot so it gets picked
-        // again on the next alloc; this stabilises locality and
+        // again on the next alloc; this stabilizes locality and
         // helps the io_uring write coalescer.
         g.next = lba.0;
         Ok(())

--- a/cmd/unbounded-storage/src/storage/alloc/tests.rs
+++ b/cmd/unbounded-storage/src/storage/alloc/tests.rs
@@ -364,7 +364,7 @@ fn free_range_followed_by_alloc_contig_returns_same_start() {
     let a = Allocator::new(64);
     // Burn a prefix so the freed run isn't at LBA 0; this
     // proves alloc_contig honors the hint reset, not just the
-    // first-fit-from-zero behaviour.
+    // first-fit-from-zero behavior.
     for _ in 0..4 {
         a.alloc().unwrap();
     }

--- a/cmd/unbounded-storage/src/storage/types.rs
+++ b/cmd/unbounded-storage/src/storage/types.rs
@@ -131,8 +131,8 @@ pub enum Error {
     Corrupt,
     /// Allocator is out of free pages on this disk.
     OutOfSpace,
-    /// Operation was cancelled because the engine is shutting down.
-    Cancelled,
+    /// Operation was canceled because the engine is shutting down.
+    Canceled,
     /// Caller passed an LBA / index outside the device's capacity.
     OutOfRange,
 }
@@ -143,7 +143,7 @@ impl fmt::Display for Error {
             Error::Io(e) => write!(f, "storage io error: errno={e}"),
             Error::Corrupt => write!(f, "storage corruption detected"),
             Error::OutOfSpace => write!(f, "storage allocator out of space"),
-            Error::Cancelled => write!(f, "storage operation cancelled"),
+            Error::Canceled => write!(f, "storage operation canceled"),
             Error::OutOfRange => write!(f, "storage offset out of range"),
         }
     }

--- a/cmd/unbounded-storage/tests/bufferpool/tests.rs
+++ b/cmd/unbounded-storage/tests/bufferpool/tests.rs
@@ -43,15 +43,15 @@ proptest! {
                 ClientOutcome::Ok { got, expected } => {
                     prop_assert_eq!(got, expected, "client {} bytes mismatch", i);
                 }
-                ClientOutcome::Cancelled { got, expected, .. } => {
+                ClientOutcome::Canceled { got, expected, .. } => {
                     prop_assert!(
                         got.len() <= expected.len(),
-                        "client {} cancelled with got.len()={} > expected.len()={}",
+                        "client {} canceled with got.len()={} > expected.len()={}",
                         i, got.len(), expected.len(),
                     );
                     prop_assert_eq!(
                         &got[..], &expected[..got.len()],
-                        "client {} cancelled-prefix bytes mismatch", i,
+                        "client {} canceled-prefix bytes mismatch", i,
                     );
                 }
                 ClientOutcome::ReadErr(e) => {
@@ -147,7 +147,7 @@ proptest! {
         for (i, o) in report.outcomes.iter().enumerate() {
             match o {
                 ClientOutcome::Ok { .. }
-                | ClientOutcome::Cancelled { .. }
+                | ClientOutcome::Canceled { .. }
                 | ClientOutcome::FetchErr(_) => {}
                 ClientOutcome::ReadErr(e) => {
                     prop_assert!(
@@ -212,17 +212,17 @@ proptest! {
     fn invariant_drain_on_cancellation(seed in any::<u64>(), w in workload_strategy()) {
         let page_count = w.page_count;
         let report = run_workload(seed, w).expect("run completed");
-        // Bytes for cancelled clients must be a prefix of the oracle.
+        // Bytes for canceled clients must be a prefix of the oracle.
         for (i, o) in report.outcomes.iter().enumerate() {
-            if let ClientOutcome::Cancelled { got, expected, .. } = o {
+            if let ClientOutcome::Canceled { got, expected, .. } = o {
                 prop_assert!(
                     got.len() <= expected.len(),
-                    "client {} cancelled with got.len()={} > expected.len()={}",
+                    "client {} canceled with got.len()={} > expected.len()={}",
                     i, got.len(), expected.len(),
                 );
                 prop_assert_eq!(
                     &got[..], &expected[..got.len()],
-                    "client {} cancelled-prefix bytes mismatch", i,
+                    "client {} canceled-prefix bytes mismatch", i,
                 );
             }
         }
@@ -242,7 +242,7 @@ proptest! {
     /// still deliver pages strictly in global plan order. For every
     /// pipeline that finishes via `Ok`, the concatenated
     /// `PageGuard` bytes must equal the oracle bytes for the plan's
-    /// ordered `(key, offset, len)` slices. Cancelled pipelines must
+    /// ordered `(key, offset, len)` slices. Canceled pipelines must
     /// yield a prefix of the expected bytes (in-order truncation).
     /// `FetchErr` is tolerated only under fault injection; `ReadErr`
     /// only when it is `StreamLimit` (the pinned-high limit makes
@@ -260,15 +260,15 @@ proptest! {
                 ClientOutcome::Ok { got, expected } => {
                     prop_assert_eq!(got, expected, "pipeline {} bytes mismatch", i);
                 }
-                ClientOutcome::Cancelled { got, expected, .. } => {
+                ClientOutcome::Canceled { got, expected, .. } => {
                     prop_assert!(
                         got.len() <= expected.len(),
-                        "pipeline {} cancelled with got.len()={} > expected.len()={}",
+                        "pipeline {} canceled with got.len()={} > expected.len()={}",
                         i, got.len(), expected.len(),
                     );
                     prop_assert_eq!(
                         &got[..], &expected[..got.len()],
-                        "pipeline {} cancelled-prefix bytes mismatch", i,
+                        "pipeline {} canceled-prefix bytes mismatch", i,
                     );
                 }
                 ClientOutcome::ReadErr(e) => {
@@ -995,7 +995,7 @@ fn prefetch_evicts_idle_cached_pages() {
 
 /// Scenario test: a mix of clients where some drop their
 /// `ReadStream` mid-iteration. Asserts that cancellation drains
-/// cleanly even when the cancelling client never observes EOF.
+/// cleanly even when the canceling client never observes EOF.
 /// Pins the drain path so a regression that, say, forgot to
 /// release a leader's `consumer_holds` on early `ReadStream` drop
 /// would fail this test before the proptest sweep.
@@ -1052,19 +1052,19 @@ fn cancellation_drains_to_clean_state() {
     let report = run_workload(0xD1A1ED, w).expect("scenario run");
     assert_quiescent_accounting(&report, 4).expect("quiescent accounting");
 
-    let mut cancelled = 0;
+    let mut canceled = 0;
     for o in &report.outcomes {
         match o {
             ClientOutcome::Ok { got, expected } => assert_eq!(got, expected),
-            ClientOutcome::Cancelled { got, expected, .. } => {
-                cancelled += 1;
+            ClientOutcome::Canceled { got, expected, .. } => {
+                canceled += 1;
                 assert!(got.len() <= expected.len());
                 assert_eq!(&got[..], &expected[..got.len()]);
             }
             other => panic!("unexpected outcome: {other:?}"),
         }
     }
-    assert_eq!(cancelled, 3, "exactly three clients must have cancelled");
+    assert_eq!(canceled, 3, "exactly three clients must have canceled");
 }
 
 /// Scenario test: the windowed reader returns bytes in cursor order
@@ -1118,7 +1118,7 @@ fn windowed_read_in_order_and_drains() {
     assert_eq!(report.prefetch_inflight_at_end, 0);
 }
 
-/// Regression: windowed reader cancelled mid-stream under page
+/// Regression: windowed reader canceled mid-stream under page
 /// pressure used to strand a single-flight subscriber across a
 /// `Loading -> Idle -> Loading` re-lead, because `ParkOnSlot` only
 /// registered its waker on the first poll. The fix re-registers the
@@ -1239,7 +1239,7 @@ fn windowed_under_free_list_pressure_drains() {
         for o in &report.outcomes {
             match o {
                 ClientOutcome::Ok { got, expected } => assert_eq!(got, expected),
-                ClientOutcome::Cancelled { got, expected, .. } => {
+                ClientOutcome::Canceled { got, expected, .. } => {
                     assert!(got.len() <= expected.len());
                     assert_eq!(&got[..], &expected[..got.len()]);
                 }
@@ -1439,7 +1439,7 @@ fn pipelined_under_free_list_pressure_drains() {
         for o in &report.outcomes {
             match o {
                 ClientOutcome::Ok { got, expected } => assert_eq!(got, expected),
-                ClientOutcome::Cancelled { got, expected, .. } => {
+                ClientOutcome::Canceled { got, expected, .. } => {
                     assert!(got.len() <= expected.len());
                     assert_eq!(&got[..], &expected[..got.len()]);
                 }

--- a/cmd/unbounded-storage/tests/bufferpool/workload.rs
+++ b/cmd/unbounded-storage/tests/bufferpool/workload.rs
@@ -182,7 +182,7 @@ async fn consume<'p>(
     // path in the readers' `Drop`.
     if let Some(0) = cancel_after {
         drop(stream);
-        return ClientOutcome::Cancelled {
+        return ClientOutcome::Canceled {
             got: Vec::new(),
             expected,
             pages_read: 0,
@@ -212,7 +212,7 @@ async fn consume<'p>(
         }
         if should_cancel {
             drop(stream);
-            return ClientOutcome::Cancelled {
+            return ClientOutcome::Canceled {
                 got,
                 expected,
                 pages_read,
@@ -454,7 +454,7 @@ pub enum ClientOutcome {
     /// `next_page` calls. `got` is the concatenation of those page
     /// slices; `expected` is the full oracle slice (the assertion
     /// checks the prefix `expected[..got.len()]`).
-    Cancelled {
+    Canceled {
         got: Vec<u8>,
         expected: Vec<u8>,
         pages_read: u32,

--- a/cmd/unbounded-storage/tests/framework/executor.rs
+++ b/cmd/unbounded-storage/tests/framework/executor.rs
@@ -7,7 +7,7 @@
 //! gets a [`Waker`] that pushes its id onto a shared ready queue when
 //! woken. On every step the executor consults the seeded PRNG to pick
 //! one ready task uniformly at random and polls it once. All sources
-//! of non-determinism in a DST run are funnelled through the same
+//! of non-determinism in a DST run are funneled through the same
 //! [`SimState::rng`], so a `(seed, workload)` pair fully determines
 //! the schedule.
 

--- a/cmd/unbounded-storage/tests/p2p/workload.rs
+++ b/cmd/unbounded-storage/tests/p2p/workload.rs
@@ -148,7 +148,7 @@ fn client_strategy() -> impl Strategy<Value = ClientSpec> {
 // ---------------------------------------------------------------------------
 
 /// Build the initial peer list deterministically. Ring ids are
-/// produced by `splitmix64(i)` so neighbours on the ring are not
+/// produced by `splitmix64(i)` so neighbors on the ring are not
 /// adjacent in the input vector, exercising the finger table's arc
 /// math instead of trivial linear walks.
 pub fn build_peers(w: &Workload) -> Vec<PeerEntry> {

--- a/cmd/unbounded-storage/tests/storage/tests.rs
+++ b/cmd/unbounded-storage/tests/storage/tests.rs
@@ -147,7 +147,7 @@ proptest! {
     ///   counters must agree exactly: a regression that orphans
     ///   cache entries on overwrite (no `replace-LBA` reclaim in
     ///   `write_page`) breaks the equality immediately. Under
-    ///   faults two paths can desynchronise them:
+    ///   faults two paths can desynchronize them:
     ///   1. A failed eviction batch. `evict_if_over_watermark`
     ///      pops up to `EVICT_SWEEP_TARGET` victims from the LRU
     ///      and then attempts a batched btree delete; if that

--- a/deploy/gantry/README.md
+++ b/deploy/gantry/README.md
@@ -98,7 +98,7 @@ on its own; no restart needed.
 | Leases are being created on `please_pull` | `gantry_containerd_lease_created_total` increments during cold-start rollouts |
 | Origin fallback is rare | `p2p_origin_fallback_total` stays at ~0 |
 
-See `docs/detailed-design.md` §7.6 for the full metric catalogue.
+See `docs/detailed-design.md` §7.6 for the full metric catalog.
 
 ## Hardening overlays
 
@@ -139,7 +139,7 @@ Workflow:
 2. Copy the overlay into your own repository (or a Kustomize /
    Helm chart), edit every ipBlock marked "OPERATOR ACTION
    REQUIRED", and review against your CNI's hostPort SNAT
-   behaviour (`kubectl get nodes -o yaml | grep -A2 podCIDR`,
+   behavior (`kubectl get nodes -o yaml | grep -A2 podCIDR`,
    etc.).
 3. Apply with `kubectl apply -f your-overlay/networkpolicy.yaml`.
    Watch `/readyz` and any in-flight mirror pulls for at least one

--- a/deploy/gantry/daemonset.yaml.tmpl
+++ b/deploy/gantry/daemonset.yaml.tmpl
@@ -111,7 +111,7 @@ spec:
       # kubelet (DirectoryOrCreate) and we run the agent as a non-root
       # user (UID/GID 65532). Without this step the agent fails on its
       # first write to /var/lib/gantry/libp2p.
-      # fsGroup doesn't help here because hostPath volumes don't honour
+      # fsGroup doesn't help here because hostPath volumes don't honor
       # it, so we chown explicitly.
       #
       # We use busybox (not the gantry distroless image) because the
@@ -184,7 +184,7 @@ spec:
             # install namespace so an overlay that renames the namespace
             # (Kustomize, Helm, separate dev/prod installs) only has
             # to patch metadata.namespace on the DaemonSet - the env
-            # var follows automatically. Default install behaviour
+            # var follows automatically. Default install behavior
             # is identical because the DaemonSet ships in
             # unbounded-system.
             - name: GANTRY_MEMBERS_NAMESPACE

--- a/deploy/gantry/embed.go
+++ b/deploy/gantry/embed.go
@@ -12,7 +12,7 @@
 // fresh clone (before `make gantry-manifests` has run), so Go tooling
 // (`go build`, `go vet`, golangci-lint, gopls, ...) can load this package
 // without requiring the rendering step to have happened first. The
-// placeholder file is harmless at runtime: consumers that materialise the
+// placeholder file is harmless at runtime: consumers that materialize the
 // FS only apply *.yaml/*.yml files.
 package gantry
 

--- a/deploy/gantry/hosts.toml.template
+++ b/deploy/gantry/hosts.toml.template
@@ -8,7 +8,7 @@
 # resolves to the canonical hostname index.docker.io - use that as
 # the directory name.
 #
-# Behaviour:
+# Behavior:
 #   1. containerd tries 127.0.0.1:5000 (the gantry agent) FIRST. The
 #      agent serves cached / peer-fetched content with
 #      "Gantry-Mirrored: 1" so peer requests are distinguished from

--- a/deploy/machina/embed.go
+++ b/deploy/machina/embed.go
@@ -13,7 +13,7 @@
 // fresh clone (before `make machina-manifests` has run), so Go tooling
 // (`go build`, `go vet`, golangci-lint, gopls, ...) can load this package
 // without requiring the rendering step to have happened first. The
-// placeholder file is harmless at runtime: consumers that materialise the
+// placeholder file is harmless at runtime: consumers that materialize the
 // FS only apply *.yaml/*.yml files.
 package machina
 

--- a/deploy/net/embed.go
+++ b/deploy/net/embed.go
@@ -13,7 +13,7 @@
 // fresh clone (before `make net-manifests` has run), so Go tooling
 // (`go build`, `go vet`, golangci-lint, gopls, ...) can load this package
 // without requiring the rendering step to have happened first. The
-// placeholder file is harmless at runtime: consumers that materialise the
+// placeholder file is harmless at runtime: consumers that materialize the
 // FS only apply *.yaml/*.yml files.
 package net
 

--- a/deploy/unbounded-operator/examples/component-overrides.example.yaml
+++ b/deploy/unbounded-operator/examples/component-overrides.example.yaml
@@ -73,7 +73,7 @@ data:
       # container starting at all.
       #
       # The operator cannot tell whether a component accepts a flag. These
-      # components exit non-zero on an unrecognised one, so a typo here is a
+      # components exit non-zero on an unrecognized one, so a typo here is a
       # CrashLoopBackOff rather than a validation error. Check the component's
       # --help before adding anything.
       - component: metalman

--- a/designs/component-workload-overrides.md
+++ b/designs/component-workload-overrides.md
@@ -564,7 +564,7 @@ At least one of `patch` and `extraArgs` must be present.
 The `apiVersion` gate is only meaningful if parsing is deterministic, so the
 rules are fixed rather than inherited from whichever YAML library is used:
 
-| Rule | Behaviour |
+| Rule | Behavior |
 |---|---|
 | Unknown fields | **Rejected.** Strict decoding at every level, including inside `patch`, where an unknown field means a path outside the allowlist. |
 | Duplicate keys | **Rejected.** YAML permits them and most decoders silently take the last; a duplicate `patch` key would silently discard the first. |
@@ -630,7 +630,7 @@ they are combined:
 | Scalar set (`image`, `replicas`, `priorityClassName`, a `resources` leaf) | Last writer would win | Two contributors set the same path to **different** values. Identical values do not conflict. |
 | Map merge (`nodeSelector`, labels, annotations) | Keys union | Two contributors set the same key to different values |
 | List append (`tolerations`, `topologySpreadConstraints`) | Concatenate in contributor order | Never. Duplicates are permitted; the scheduler treats them as idempotent. |
-| `extraArgs` | Concatenate per container in contributor order | Two contributors supply `extraArgs` for the **same container**, identical or not. Appending the same argument twice is not idempotent, and which of two conflicting flags a component honours would otherwise be decided by ConfigMap key names. |
+| `extraArgs` | Concatenate per container in contributor order | Two contributors supply `extraArgs` for the **same container**, identical or not. Appending the same argument twice is not idempotent, and which of two conflicting flags a component honors would otherwise be decided by ConfigMap key names. |
 | Cartesian affinity ([§8.4](#84-additive-only-scheduling)) | Product of all contributors' term lists with the operator's | Never. The product is associative and order-independent. |
 | Merge-by-key list entry (`containers[name]`, `volumes[name]`, `env[name]`, `volumeMounts[mountPath]`) | Recurse into the entry and apply the rules above | Per the nested rule that applies |
 | `addContainers` / `addInitContainers` | Union of names | Two contributors declare the same name with **non-identical** container definitions |
@@ -660,10 +660,10 @@ adds nothing to `go.mod`.
 
 Strategic merge is schema-aware through the `patchStrategy` and `patchMergeKey`
 struct tags on the core types. The table below is **raw strategic-merge
-behaviour**, which the mechanism follows except where
+behavior**, which the mechanism follows except where
 [§8.4](#84-additive-only-scheduling) deliberately departs from it:
 
-| Field | Raw behaviour | Mechanism |
+| Field | Raw behavior | Mechanism |
 |---|---|---|
 | `containers`, `initContainers` | Merge by `name`. An unknown name adds a container. | As raw |
 | `volumes` | Merge by `name`, `retainKeys` | As raw, except operator-declared volumes ([§8.3](#83-protected)) |
@@ -719,7 +719,7 @@ merges:
 
 Nothing validates that the component accepts the flag. The operator knows
 nothing about any component's command line, and every one of them exits
-non-zero on an unrecognised flag, so a wrong flag here is a `CrashLoopBackOff`
+non-zero on an unrecognized flag, so a wrong flag here is a `CrashLoopBackOff`
 rather than a rejected document. This is documented rather than enforced for
 the same reason `dhcpAutoInterface` is: enforcing it would mean the operator
 understanding each component's flag semantics.
@@ -970,7 +970,7 @@ it should not depend on any single check being correct.
 An earlier revision of this document listed ServiceAccount annotations as a gap,
 on the premise that the operator applies component ServiceAccounts with
 `ForceOwnership` and therefore reverts them. **That premise was wrong**, and it
-is worth correcting rather than deleting, because the reasoning generalises.
+is worth correcting rather than deleting, because the reasoning generalizes.
 
 `ForceOwnership` resolves conflicts on fields the applier **declares**. It
 cannot remove a field the applier never mentions. The component ServiceAccounts
@@ -1030,9 +1030,9 @@ written, which is a real guarantee. Step 5 is where the honest limits are.
 Execution is explicitly non-transactional. The rules exist so that partial
 outcomes are predictable rather than arbitrary:
 
-| Property | Behaviour |
+| Property | Behavior |
 |---|---|
-| **Ordering** | Order is **inferred from the kind**, not declared. Writes ascend: namespaces, schema (CRDs, priority and storage classes), identity (ServiceAccounts and RBAC), config (ConfigMaps, Secrets, Services), custom resources, workloads, and **admission and API registration last**. Removals descend the same list, so a workload is deleted before the config it mounts. Declared `DependsOn` is honoured on top and can only push an operation later. Within a rank the order is deterministic: component registry order, then the order that component emitted its operations. |
+| **Ordering** | Order is **inferred from the kind**, not declared. Writes ascend: namespaces, schema (CRDs, priority and storage classes), identity (ServiceAccounts and RBAC), config (ConfigMaps, Secrets, Services), custom resources, workloads, and **admission and API registration last**. Removals descend the same list, so a workload is deleted before the config it mounts. Declared `DependsOn` is honored on top and can only push an operation later. Within a rank the order is deterministic: component registry order, then the order that component emitted its operations. |
 | **Continuation** | A failed operation does not abort the pass. Operations that do not depend on it still execute. Dependents are **skipped**, not attempted, so a failure does not cascade into a half-configured workload. |
 | **Gating** | Three things gate an operation, and only the first is declared: a failed `DependsOn`; a failed earlier operation on the same object; and a failed earlier tier **for the same component and Site**. The last is scoped deliberately, because skipping every workload in the cluster over one component's ConfigMap would turn a contained failure into an outage. A failed Namespace is the one exception and gates everything in it, whichever component planned it, since nothing can be written into a namespace that does not exist. |
 | **No rollback** | Completed operations are never undone. There is no compensating action, and none is attempted. |
@@ -1077,7 +1077,7 @@ recomputes the plan from current cluster state and re-executes it.
 The operator distinguishes four states, because conflating them turns a typo
 into an uninstall:
 
-| Snapshot state | Behaviour | Rationale |
+| Snapshot state | Behavior | Rationale |
 |---|---|---|
 | **Absent** | Execute the full plan with no overrides | Removing overrides is deliberate. Reverting to defaults is the requested outcome. |
 | **Present and valid** | Execute the full plan with overrides merged | |
@@ -1100,7 +1100,7 @@ be able to cause that.
 
 Dropping the operations instead leaves those workloads exactly as they are. The
 cluster holds the last good state because the operator does not write, which
-makes the behaviour **restart-safe by construction**. This matters concretely:
+makes the behavior **restart-safe by construction**. This matters concretely:
 the operator runs `replicas: 1` with `strategy: Recreate`
 (`deploy/unbounded-operator/04-deployment.yaml.tmpl:13-16`), so it restarts on
 every upgrade. An earlier revision cached last-known-good in memory, which that
@@ -1138,7 +1138,7 @@ rollout, one log line, and a Site still reporting `Ready=True`.
 | Parse: malformed YAML, duplicate keys, multiple documents, trailing content, merge keys ([§6.2](#62-parsing-rules)) | That ConfigMap key, and every `Overridable` operation | The key's entries were never read, so nothing is known about what they would have changed. Other keys still contribute their entries. |
 | Missing or unknown `apiVersion` | That ConfigMap key, and every `Overridable` operation | As above: the document was rejected before its entries were read. |
 | Schema violation, path outside the allowlist, protected path, `$` directive, explicit null | That entry's `component`, `kind` and `sites` | The entry is dropped from the merge and the workloads it could have resolved to are withheld. Every other workload applies with its own overrides. |
-| Any of the above on an entry naming no recognised `component` | Nothing | The entry could never have resolved to a workload, since resolution matches on component. |
+| Any of the above on an entry naming no recognized `component` | Nothing | The entry could never have resolved to a workload, since resolution matches on component. |
 | Resolution: container absent and not in `addContainers`, name in `addContainers` that already exists, `mountPath` collision, selector-label rewrite | That object only | That object's operation dropped; every other operation executes |
 | Conflict between contributors ([§6.5](#65-what-counts-as-a-conflict)) | That object only | As above |
 | `sites` naming a Site that does not exist | Nothing | Inert, reported ([§6.3](#63-resolution)) |
@@ -1328,7 +1328,7 @@ lists, so preserving their order is still stable across passes.
 ([§3.6](#3-constraints-from-the-current-design)) converge before the merge
 rather than at apply.
 
-Mapping the existing behaviour onto operation kinds:
+Mapping the existing behavior onto operation kinds:
 
 | Existing code | Operation |
 |---|---|
@@ -1401,7 +1401,7 @@ b.Watches(&corev1.ConfigMap{}, env.RequestSingleton(),
 **Fan-out is synchronous, inside the Site-less pass.** `Reconcile` has no queue
 handle; its signature returns only its own `ctrl.Result` (`reconciler.go:112`),
 so it cannot enqueue other Sites. Rather than introduce a `source.Channel` and
-its attendant acknowledgement and backpressure questions, the Site-less pass
+its attendant acknowledgment and backpressure questions, the Site-less pass
 plans and executes per-Site components inline for every Site it lists.
 
 **Concurrency is pinned explicitly.** The controller is configured with
@@ -1420,7 +1420,7 @@ What that does and does not buy:
 | Concern | Resolution |
 |---|---|
 | Two reconciles racing each other | Prevented. One pass runs at a time. |
-| Acknowledgement | Not needed. Work completes before the pass returns. |
+| Acknowledgment | Not needed. Work completes before the pass returns. |
 | Backpressure | Not needed. No queue is involved. |
 | Restart mid-pass | The next reconcile replans from current state. Every operation is idempotent. |
 | Partial failure | Per [§9.2](#92-execution-semantics). |
@@ -1605,7 +1605,7 @@ alongside the reaper's. Events fire on override hash change and on entry into
 
 **Through the CLI**, see [§12](#12-cli).
 
-Images are permitted with no additional gate. The signalling above is the whole
+Images are permitted with no additional gate. The signaling above is the whole
 of the friction: users asked for image overrides, and per
 [§4](#4-security-model) anyone able to set one could already run arbitrary code
 on every node by other means.
@@ -1755,7 +1755,7 @@ The operator restarts on every upgrade: it runs `replicas: 1` with
 `strategy: Recreate` (`deploy/unbounded-operator/04-deployment.yaml.tmpl:13-16`).
 Because the failure model holds no in-memory state
 ([§9.3](#93-invalid-overrides-skip-they-do-not-revert)), that restart changes
-nothing about override behaviour.
+nothing about override behavior.
 
 **Ordering.** The ConfigMap may be created before or after the Sites it names,
 and before or after the components it patches. Unmatched entries are inert and
@@ -1770,7 +1770,7 @@ what was built rather than a plan for building it. Commits, in order:
 |---|---|
 | `aa4c2b3c` | **Security hardening.** Delete the unused ConfigMap grant from the `machina-controller` Role. Verified against the controller's actual API calls and its cache configuration, not by inspection alone ([§4.4](#44-residual-risk-and-how-it-is-closed)). |
 | `abfc49ea` | **Operation plan and executor.** `Plan`, `Operation`, `OpKind`, dependency ordering, continuation, shared-key deduplication. No component changes. |
-| `8139c1e7` | **Plan-then-execute conversion** of all five components, with golden plan tests pinning the exact operations each produces. Behaviour-preserving. |
+| `8139c1e7` | **Plan-then-execute conversion** of all five components, with golden plan tests pinning the exact operations each produces. Behavior-preserving. |
 | `570587b4` | Golden plan ordering fix for gantry. |
 | `832cb381` | **Override schema, parsing and validation.** Everything that is a pure function of the document. |
 | `9d4082e7` | **Resolution, merge and hashing.** Everything that needs the rendered workload. |
@@ -1901,7 +1901,7 @@ scheduled onto the same nodes through any permitted override.
 in `addContainers` fails resolution rather than adding a container. A name in
 `addContainers` that already exists is rejected. A deliberately misspelled
 operator container name (`machina-contoller`) must fail rather than produce an
-image-less sidecar. `addInitContainers` is honoured separately from
+image-less sidecar. `addInitContainers` is honored separately from
 `addContainers`.
 
 **Parsing rules ([§6.2](#62-parsing-rules)).** Unknown fields at every nesting
@@ -1994,7 +1994,7 @@ unusable document where the operator drops all of them.
 
 It covers what the fake client cannot, because its Apply is a stub, its
 validation is negligible, and server-side apply ownership and `managedFields`
-are real apiserver behaviour:
+are real apiserver behavior:
 
 - An override applied and then removed restores the operator's own value, with
   the operator asserted present in `managedFields`, since that ownership is the
@@ -2039,7 +2039,7 @@ patching rather than on embedding a templating or overlay engine.
 - **Elastic Cloud on Kubernetes** exposes `podTemplate` as a
   `corev1.PodTemplateSpec` with `x-kubernetes-preserve-unknown-fields`, merged
   into a generated template. It is widely regarded as the best-in-class
-  ergonomics for this problem and is the closest analogue to this proposal.
+  ergonomics for this problem and is the closest analog to this proposal.
 - **Strimzi** exposes a trimmed `template` type covering pod, container, and
   metadata, deliberately smaller than the full `PodSpec` to keep the CRD
   tractable.
@@ -2084,7 +2084,7 @@ oversight.
   harness ([§15](#15-testing)).
 - *Where singleton override state is reported.* On every Site, since every Site
   depends on the singletons ([§11](#11-drift-visibility-and-observability)).
-- *Dedicated resource type instead of a ConfigMap.* Resolved in favour of the
+- *Dedicated resource type instead of a ConfigMap.* Resolved in favor of the
   ConfigMap. The argument rested on RBAC being unable to scope `create` by name.
   Admission policy can, the repository already relies on it, and in the one case
   that mattered no `create` grant needs to exist at all
@@ -2104,7 +2104,7 @@ cover, so where both describe the same thing the typed field decides. Until this
 was settled the override won: `spec.replicas` on metalman beat
 `spec.components.metalman.replicas`, so a user editing the supported field saw
 nothing happen. The path is now rejected at validation, naming the field to set
-instead, and re-stamped after the merge on the same defence-in-depth grounds as
+instead, and re-stamped after the merge on the same defense-in-depth grounds as
 identity ([§8.1](#81-permitted)).
 
 One case is documented rather than enforced: `dhcpAutoInterface` adds a
@@ -2129,7 +2129,7 @@ control that matches the threat model is the RBAC guidance in
 [§4.3](#43-required-posture-for-cluster-operators).
 
 **`siteSelector` stays deferred.** Label-based Site matching would express "all
-edge sites" without enumeration, but it needs a Site labelling convention that
+edge sites" without enumeration, but it needs a Site labeling convention that
 does not exist. It can be added alongside `sites` later with a documented
 precedence.
 

--- a/designs/machine-provider-operations-requirements.md
+++ b/designs/machine-provider-operations-requirements.md
@@ -726,7 +726,7 @@ If cancellation is advertised, the integration **MUST**:
 * report known residual effects when cancellation completes.
 
 The integration SHOULD declare cancellable stages and the point of no return.
-Cancelling a client request or watch should not implicitly cancel provider work.
+Canceling a client request or watch should not implicitly cancel provider work.
 
 ```json
 {

--- a/designs/orca/design.md
+++ b/designs/orca/design.md
@@ -508,7 +508,7 @@ listing becomes a requirement.
 | 502 | `OriginETagChanged` | `OriginETagChangedError` from `Origin.GetRange`; not retried | mid-flight overwrite caught by `If-Match` | yes (next request re-`Head`s) |
 | 502 | `OriginMissingETag` | `MissingETagError` from the fetch coordinator (cached negatively) | origin `Head` returned an empty ETag | no (operator must fix the origin config) |
 | 502 | `Unauthorized origin` | `origin.ErrAuth` | origin returned 401 / 403 | no (operator) |
-| 502 | `OriginUnreachable` | uncategorised origin error (5xx, timeouts past retry budget, DNS) | leader retry budget exhausted; cachestore failure during read | yes (origin may recover) |
+| 502 | `OriginUnreachable` | uncategorized origin error (5xx, timeouts past retry budget, DNS) | leader retry budget exhausted; cachestore failure during read | yes (origin may recover) |
 | 503 | (probe response) | replica `NotReady` | `/readyz` failing predicates | n/a (LB drain) |
 | (mid-stream abort) | n/a | post-header failure | origin disconnect, peer 5xx, cachestore failure after `Peek(1)` succeeded | S3 SDKs detect the Content-Length mismatch and retry |
 
@@ -1313,6 +1313,6 @@ TTFB win.
 
 ### Origin-semaphore starvation under cancellation storms
 
-A flood of cancelled requests can briefly hold origin slots
+A flood of canceled requests can briefly hold origin slots
 between acquire and the deferred release. Operational concern
 only; no observed incident. Need metrics first.

--- a/docs/content/reference/gpu/nvidia.md
+++ b/docs/content/reference/gpu/nvidia.md
@@ -17,7 +17,7 @@ Before the agent can expose GPUs, the **host VM** must have:
    `libcuda`, `libnvidia-ml`, and related libraries.
 3. **Fabric Manager running** (NVSwitch-based GPUs only). H100, H200, and
    multi-GPU ND A100 systems require the `nvidia-fabricmanager` service.
-   Without it, CUDA initialisation fails with error 802
+   Without it, CUDA initialization fails with error 802
    (`SYSTEM_DRIVER_MISMATCH`).
 4. **Persistence mode enabled.** `nvidia-smi -pm 1` keeps the driver loaded
    between GPU process invocations and avoids cold-start latency.

--- a/docs/content/reference/workload-overrides.md
+++ b/docs/content/reference/workload-overrides.md
@@ -53,7 +53,7 @@ Consequently:
 ## What is supported, and what is not
 
 **The mechanism is supported.** The document schema, gated by `apiVersion`, the
-merge semantics, the validation behaviour and the revert behaviour are all
+merge semantics, the validation behavior and the revert behavior are all
 maintained, and a document that is valid today keeps working within its declared
 `apiVersion`.
 
@@ -137,7 +137,7 @@ the container starting at all.
 
 **The operator cannot check that a component accepts a flag.** It knows nothing
 about any component's command line, and these components exit non-zero on an
-unrecognised flag, so a typo here is a `CrashLoopBackOff` rather than a
+unrecognized flag, so a typo here is a `CrashLoopBackOff` rather than a
 validation error. Check the component's `--help` before adding anything, and
 note that a setting exposed in a component's config file is often not exposed as
 a flag at all.
@@ -523,7 +523,7 @@ worth knowing before an incident.
 | Failure | What is withheld |
 |---|---|
 | An entry fails validation | Only the workloads that entry could have resolved to, matched on its `component`, `kind` and `sites`. |
-| An entry names a component that is not recognised | Nothing. Entries resolve by component, so it could never have matched a workload. |
+| An entry names a component that is not recognized | Nothing. Entries resolve by component, so it could never have matched a workload. |
 | A ConfigMap key fails to parse | **Every** overridable workload, on every Site. The entries in that key were never read, so there is no way to know what they would have changed. |
 | The ConfigMap cannot be read at all | As above. |
 
@@ -602,5 +602,5 @@ construction:
 
 `extraArgs` is the exception that looks additive and is not allowed to be. Two
 entries appending to the *same container* are rejected, because the arguments
-concatenate and which one a component honours would then depend on what the
+concatenate and which one a component honors would then depend on what the
 ConfigMap keys happen to be called. Split by container, not by argument.

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -175,17 +175,17 @@
 
     // Animation engine - returns a stop function
     function animate(el, seq) {
-      var cancelled = false;
-      function stop() { cancelled = true; }
+      var canceled = false;
+      function stop() { canceled = true; }
 
       function run() {
-        if (cancelled) return;
+        if (canceled) return;
         el.innerHTML = '';
         var idx = 0;
 
         function next() {
-          if (cancelled || idx >= seq.length) {
-            if (!cancelled) setTimeout(run, PAUSE_BEFORE_RESTART);
+          if (canceled || idx >= seq.length) {
+            if (!canceled) setTimeout(run, PAUSE_BEFORE_RESTART);
             return;
           }
           var item = seq[idx++];
@@ -230,7 +230,7 @@
         }
 
         function typeCmd(container, lineEl, text, i, cb) {
-          if (cancelled) return;
+          if (canceled) return;
           if (i >= text.length) { cb(); return; }
           lineEl.innerHTML = lineEl.innerHTML + escHtml(text[i]);
           container.scrollTop = container.scrollHeight;

--- a/e2e/gantry/harness_e2e.go
+++ b/e2e/gantry/harness_e2e.go
@@ -459,7 +459,7 @@ func (h *harness) waitForMetricIncrease(ctx context.Context, metric string, befo
 
 		select {
 		case <-ctx.Done():
-			h.t.Fatalf("ctx cancelled waiting for metric %s: %v", metric, ctx.Err())
+			h.t.Fatalf("ctx canceled waiting for metric %s: %v", metric, ctx.Err())
 		case <-time.After(5 * time.Second):
 		}
 	}
@@ -481,7 +481,7 @@ func (h *harness) waitForMetricIncreaseOnPod(ctx context.Context, pod, metric st
 
 		select {
 		case <-ctx.Done():
-			h.t.Fatalf("context cancelled waiting for metric %s on %s: %v", metric, pod, ctx.Err())
+			h.t.Fatalf("context canceled waiting for metric %s on %s: %v", metric, pod, ctx.Err())
 		case <-time.After(5 * time.Second):
 		}
 	}
@@ -828,7 +828,7 @@ func (h *harness) waitForRollout(ctx context.Context) {
 
 		select {
 		case <-ctx.Done():
-			h.t.Fatalf("ctx cancelled while waiting for rollout: %v", ctx.Err())
+			h.t.Fatalf("ctx canceled while waiting for rollout: %v", ctx.Err())
 		case <-time.After(5 * time.Second):
 		}
 	}
@@ -1025,7 +1025,7 @@ func (h *harness) waitForContainerdSocketReplacement(ctx context.Context, node, 
 
 		select {
 		case <-ctx.Done():
-			h.t.Fatalf("context cancelled waiting for containerd socket replacement: %v", ctx.Err())
+			h.t.Fatalf("context canceled waiting for containerd socket replacement: %v", ctx.Err())
 		case <-time.After(time.Second):
 		}
 	}

--- a/e2e/gantry/smoke_e2e_test.go
+++ b/e2e/gantry/smoke_e2e_test.go
@@ -48,7 +48,7 @@ func TestSmoke_DaemonSetBecomesReadyAndPullThrough(t *testing.T) {
 	h.bootCluster(ctx)
 	t.Cleanup(func() {
 		// Best-effort teardown; use a fresh ctx since the test's
-		// may already be cancelled by a Fatal.
+		// may already be canceled by a Fatal.
 		tdCtx, tdCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer tdCancel()
 
@@ -166,7 +166,7 @@ func TestE2E_ColdStartDesignatedOriginPuller(t *testing.T) {
 
 	// Cross-pod per-digest uniqueness - the real invariant. Extract
 	// every "please_pull served" log digest from both pods and assert
-	// no digest appears in both pods' logs. If HRW is honoured each
+	// no digest appears in both pods' logs. If HRW is honored each
 	// digest will appear in exactly one pod's log; if HRW failed for
 	// any digest, two pods will both have served the same digest and
 	// the intersection is non-empty.

--- a/e2e/operator/overrides_e2e_test.go
+++ b/e2e/operator/overrides_e2e_test.go
@@ -5,7 +5,7 @@
 // It exists because the properties that matter most cannot be tested with the
 // fake client. Server-side apply ownership, managedFields, what happens when
 // the operator stops declaring a field, and whether the apiserver accepts a
-// merged object at all are real apiserver behaviour; the fake client's Apply is
+// merged object at all are real apiserver behavior; the fake client's Apply is
 // a stub and its validation is nearly nonexistent.
 //
 // The whole SiteReconciler runs in-process against a real API server, in the
@@ -257,7 +257,7 @@ func (c registrationTestComponent) Plan(
 	return plan, component.Reconciled(), nil
 }
 
-// TestOverridesAgainstRealAPIServer covers the behaviour only a real apiserver
+// TestOverridesAgainstRealAPIServer covers the behavior only a real apiserver
 // exhibits, in one cluster to keep the suite's runtime reasonable.
 func TestOverridesAgainstRealAPIServer(t *testing.T) {
 	requireBins(t, "kind", "kubectl", "docker")
@@ -443,7 +443,7 @@ func assertRegistrationFollowsItsBackend(ctx context.Context, t *testing.T, cl c
 //
 // Removing an override must restore the operator's own value, which works only
 // because the operator declares the full object on every apply and therefore
-// owns those fields under server-side apply. That is real apiserver behaviour,
+// owns those fields under server-side apply. That is real apiserver behavior,
 // and asserting it against managedFields is the whole reason this runs on kind.
 func assertOverrideAppliesAndReverts(ctx context.Context, t *testing.T, f *overrideFixture) {
 	t.Helper()

--- a/frontend/src/components/network/Topology.tsx
+++ b/frontend/src/components/network/Topology.tsx
@@ -374,10 +374,10 @@ function Topology({
   const [reagraphModule, setReagraphModule] = useState<ReagraphModule | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
+    let canceled = false;
     import('reagraph')
       .then((module) => {
-        if (cancelled) return;
+        if (canceled) return;
         setReagraphModule({
           GraphCanvas: module.GraphCanvas as React.ComponentType<any>,
           darkTheme: module.darkTheme as Record<string, any>,
@@ -389,7 +389,7 @@ function Topology({
       });
 
     return () => {
-      cancelled = true;
+      canceled = true;
     };
   }, []);
 

--- a/hack/agent/azure-gpu-vm/install-nvidia-drivers.sh
+++ b/hack/agent/azure-gpu-vm/install-nvidia-drivers.sh
@@ -22,7 +22,7 @@
 #
 # Fabric Manager:
 #   NVSwitch-based multi-GPU systems (H100, H200, ND A100) require the NVIDIA
-#   Fabric Manager service. Without it, CUDA initialisation fails with error
+#   Fabric Manager service. Without it, CUDA initialization fails with error
 #   802 (SYSTEM_DRIVER_MISMATCH). The script installs and enables it when the
 #   SKU map indicates it is needed.
 #
@@ -46,7 +46,7 @@ set -euo pipefail
 # --------------------------------------------------------------------------- #
 # SKU -> driver configuration map
 #
-# Maps Azure VM SKU family prefixes to their GPU generation, driver flavour,
+# Maps Azure VM SKU family prefixes to their GPU generation, driver flavor,
 # and driver version. Add new entries here as Azure introduces new GPU SKUs.
 #
 # Format: SKU_PATTERN:GPU_NAME:DRIVER_TYPE:DRIVER_VERSION:NEEDS_FABRIC_MANAGER
@@ -161,7 +161,7 @@ install_open_dkms() {
 
 # Install the pre-built, pre-signed NVIDIA kernel module for the running
 # Azure kernel. These packages are signed by Canonical and work with Secure
-# Boot without any MOK enrolment.
+# Boot without any MOK enrollment.
 install_prebuilt_azure() {
     local gpu="$1" ver="$2" driver_type="$3"
     local kernel
@@ -215,7 +215,7 @@ install_fabric_manager() {
 
 # Configure a systemd service that enables GPU persistence mode after boot.
 # nvidia-smi -pm 1 must run after the NVIDIA kernel module is loaded and the
-# Fabric Manager (if applicable) has initialised.
+# Fabric Manager (if applicable) has initialized.
 install_persistence_mode_service() {
     local wants="multi-user.target"
     local after="multi-user.target"
@@ -271,7 +271,7 @@ else
 fi
 
 # Install Fabric Manager for NVSwitch-based multi-GPU systems (H100, H200,
-# ND A100). Without it, CUDA initialisation fails with error 802.
+# ND A100). Without it, CUDA initialization fails with error 802.
 if [[ "${NEEDS_FABRIC}" == "yes" ]]; then
     install_fabric_manager "${DRIVER_VERSION}"
 fi

--- a/hack/cmd/gantry-benchmark/enable_test.go
+++ b/hack/cmd/gantry-benchmark/enable_test.go
@@ -60,7 +60,7 @@ func TestRenderProxyManifest(t *testing.T) {
 }
 
 // The Gantry PodMonitor lives outside the proxy template because direct mode
-// installs no proxy but still needs gantry_benchmark-labelled agent samples.
+// installs no proxy but still needs gantry_benchmark-labeled agent samples.
 func TestRenderMonitoringManifest(t *testing.T) {
 	repoRoot, err := findRepoRoot()
 	if err != nil {

--- a/hack/cmd/gantry-benchmark/job.go
+++ b/hack/cmd/gantry-benchmark/job.go
@@ -309,7 +309,7 @@ func summarizePullProgress(raw []byte, expectedPods int) (pullProgress, error) {
 	return progress, nil
 }
 
-// startPullJobProgress streams pod-state counts until ctx is cancelled. The
+// startPullJobProgress streams pod-state counts until ctx is canceled. The
 // returned channel closes once the reporter has stopped, so the caller can
 // avoid interleaving output with whatever it prints next.
 func (b *benchmark) startPullJobProgress(ctx context.Context, jobName string, phaseStartedAt time.Time) <-chan struct{} {

--- a/hack/cmd/gantry-benchmark/performance_telemetry.go
+++ b/hack/cmd/gantry-benchmark/performance_telemetry.go
@@ -279,7 +279,7 @@ func classifyContainerdJournalEvent(message string) string {
 	case strings.Contains(message, "image unpacked"):
 		return "image_unpacked"
 	case strings.Contains(message, "cancel pulling image"):
-		return "pull_cancelled"
+		return "pull_canceled"
 	case strings.Contains(message, "Pulled image"):
 		return "pull_completed"
 	case strings.Contains(message, "PullImage "):

--- a/hack/cmd/gantry-benchmark/preflight.go
+++ b/hack/cmd/gantry-benchmark/preflight.go
@@ -450,7 +450,7 @@ func (b *benchmark) checkMonitoring(ctx context.Context, state benchmarkState) e
 
 	// Direct mode has no proxy, so there are no proxy samples to wait for. The
 	// Gantry scrape checks above already prove the benchmark PodMonitor is
-	// being honoured by Prometheus.
+	// being honored by Prometheus.
 	if !state.usesProxy() {
 		return nil
 	}

--- a/hack/cmd/notice/internal/license/copyright_test.go
+++ b/hack/cmd/notice/internal/license/copyright_test.go
@@ -4,6 +4,7 @@
 package license
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -154,5 +155,31 @@ func TestFindFile(t *testing.T) {
 func TestFindFile_Missing(t *testing.T) {
 	if _, err := FindFile(t.TempDir()); err == nil {
 		t.Errorf("expected error for empty dir")
+	}
+}
+
+// TestFindFile_BritishSpelling pins the LICENCE candidates. They look like a
+// typo in a repo that otherwise writes American English, so both a spell
+// checker's --fix and a well-meaning reviewer will try to "correct" them. They
+// are filenames on other people's disks: upstream modules that spell it LICENCE
+// would silently stop being attributed, and the only symptom would be a quietly
+// incomplete NOTICE.
+func TestFindFile_BritishSpelling(t *testing.T) {
+	for _, name := range []string{"LICENCE", "LICENCE.txt", "LICENCE.md"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := writeFile(dir, name, "x"); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := FindFile(dir)
+			if err != nil {
+				t.Fatalf("FindFile(%s): %v", name, err)
+			}
+
+			if filepath.Base(got) != name {
+				t.Errorf("got %q, want basename %q", got, name)
+			}
+		})
 	}
 }

--- a/hack/cmd/notice/internal/notice/document.go
+++ b/hack/cmd/notice/internal/notice/document.go
@@ -75,7 +75,7 @@ func Render(doc *Document) ([]byte, error) {
 	enc.SetIndent(2)
 
 	if err := enc.Encode(doc); err != nil {
-		return nil, fmt.Errorf("marshalling YAML: %w", err)
+		return nil, fmt.Errorf("marshaling YAML: %w", err)
 	}
 
 	if err := enc.Close(); err != nil {

--- a/hack/cmd/orcadev/orcadev/bench.go
+++ b/hack/cmd/orcadev/orcadev/bench.go
@@ -66,7 +66,7 @@ Two stop conditions, mutually exclusive:
                      deadline fires, no new requests are issued
                      but in-flight requests are allowed to drain
                      for up to --drain-timeout (default 10s)
-                     before being cancelled.
+                     before being canceled.
   --requests 1000    run until N requests have completed (no
                      drain phase).
 
@@ -108,7 +108,7 @@ expected steady-state latency distribution.`,
 	cmd.Flags().IntVar(&o.histBuckets, "hist-buckets", o.histBuckets, "latency histogram bucket count")
 	cmd.Flags().IntVar(&o.warmupRequests, "warmup-requests", o.warmupRequests, "single-worker requests issued before timing starts")
 	cmd.Flags().DurationVar(&o.drainTimeout, "drain-timeout", o.drainTimeout,
-		"how long to let in-flight requests finish after --duration expires before cancelling them")
+		"how long to let in-flight requests finish after --duration expires before canceling them")
 
 	return cmd
 }
@@ -160,7 +160,7 @@ type benchResultPayload struct {
 	// waiting for in-flight requests to finish. Zero for
 	// --requests N runs. Bounded above by DrainTimeoutSeconds; if
 	// the drain budget is exhausted, remaining in-flight requests
-	// are cancelled and counted as errors.
+	// are canceled and counted as errors.
 	DrainSeconds      float64             `json:"drain_seconds"`
 	ThroughputBytes   float64             `json:"throughput_bytes_per_second"`
 	RequestsPerSecond float64             `json:"requests_per_second"`
@@ -400,7 +400,7 @@ func (a *benchAcc) record(elapsed time.Duration, n int64, err error, code string
 // new-work admission to `duration`, while reqCtx bounds the
 // underlying HTTP calls to `duration + drainTimeout`. After the
 // gate closes, in-flight requests are given drainTimeout to
-// finish; any still pending past that get reqCtx-cancelled and
+// finish; any still pending past that get reqCtx-canceled and
 // counted as errors.
 func runBenchLoop(
 	ctx context.Context,
@@ -415,7 +415,7 @@ func runBenchLoop(
 
 	// gateCtx controls "may a worker start another request?". In
 	// --duration mode it expires at `duration`; in --requests mode
-	// it inherits ctx and is never deadline-cancelled (the issued
+	// it inherits ctx and is never deadline-canceled (the issued
 	// counter does the gating).
 	gateCtx := ctx
 
@@ -561,7 +561,7 @@ func runBenchLoop(
 	}
 
 	// In --requests mode, if no worker exited via the reqLimit
-	// path (e.g. parent ctx was cancelled before the limit was
+	// path (e.g. parent ctx was canceled before the limit was
 	// reached), gateClosedAt may still be zero. Treat the Wait
 	// return as the gate close so the caller can still compute a
 	// meaningful gate_seconds.

--- a/hack/cmd/orcadev/orcadev/preset.go
+++ b/hack/cmd/orcadev/orcadev/preset.go
@@ -76,7 +76,7 @@ const devOriginAWSS3Endpoint = "http://localhost:30200"
 // today; extension is one new applyPreset* + an entry here.
 var supportedPresets = []string{PresetDev, "none"}
 
-// validatePreset returns nil if name is a recognised preset.
+// validatePreset returns nil if name is a recognized preset.
 func validatePreset(name string) error {
 	for _, p := range supportedPresets {
 		if name == p {

--- a/hack/cmd/orcadev/orcadev/roundtrip.go
+++ b/hack/cmd/orcadev/orcadev/roundtrip.go
@@ -440,11 +440,11 @@ func fetchAndHash(ctx context.Context, edge *edgeClient, bucket, key, rangeSpec 
 	return hex.EncodeToString(h.Sum(nil)), resp.Status, n, resp.ETag, nil
 }
 
-// normalizeETag canonicalises an ETag value for comparison:
+// normalizeETag canonicalizes an ETag value for comparison:
 // strips surrounding whitespace, the weak-validator W/ or w/
 // prefix (along with any whitespace that follows it), and the
 // surrounding double quotes RFC 7232 mandates. Comparison after
-// normalisation is case-sensitive on the opaque tag body, matching
+// normalization is case-sensitive on the opaque tag body, matching
 // RFC 7232 section 2.3 ("Strong comparison").
 func normalizeETag(etag string) string {
 	etag = strings.TrimSpace(etag)

--- a/hack/cmd/orcadev/orcadev/upload.go
+++ b/hack/cmd/orcadev/orcadev/upload.go
@@ -20,7 +20,7 @@ import (
 
 // uploadOpts is the per-command flag set. Modes are mutually
 // exclusive: --file uploads a single named file; --generate
-// synthesises --count blobs of --size random bytes each.
+// synthesizes --count blobs of --size random bytes each.
 type uploadOpts struct {
 	// File mode.
 	file string
@@ -69,7 +69,7 @@ container. Two modes:
       filepath.Base(--file).
 
   orcadev upload --generate --count 5 --size 10MiB [--name foo]
-      Synthesise --count blobs of --size random bytes each, named
+      Synthesize --count blobs of --size random bytes each, named
       <name>1, <name>2, ... <name>N. Default --name is "synth"
       (so the default output is "synth1", "synth2", ...). Set
       --seed for reproducible content across runs.
@@ -86,7 +86,7 @@ uploaded bytes and prints the digest, useful for later verification.`,
 		"destination object name; in --generate mode the per-blob index "+
 			"is appended (defaults to basename of --file in file mode, "+
 			"or \"synth\" in --generate mode)")
-	cmd.Flags().BoolVar(&o.generate, "generate", false, "synthesise --count blobs instead of uploading a file")
+	cmd.Flags().BoolVar(&o.generate, "generate", false, "synthesize --count blobs instead of uploading a file")
 	cmd.Flags().StringVar(&o.sizeStr, "size", o.sizeStr, "per-blob size (e.g. 1MiB, 100MB, 1GiB)")
 	cmd.Flags().IntVar(&o.count, "count", o.count, "number of blobs to generate")
 	cmd.Flags().Int64Var(&o.seed, "seed", o.seed, "PRNG seed for deterministic content; 0 = crypto/rand")

--- a/hack/cmd/relctl/relctl/cmd_next_test.go
+++ b/hack/cmd/relctl/relctl/cmd_next_test.go
@@ -20,7 +20,7 @@ import (
 
 // tagRepo builds a repository with one final tag.
 //
-// The environment is neutralised for the same reason the version package's
+// The environment is neutralized for the same reason the version package's
 // fixtures are: a maintainer with commit.gpgsign, tag.gpgSign, a hooks path or
 // a commit template would otherwise fail these for reasons that have nothing to
 // do with relctl. Verified against a config setting all four.
@@ -289,7 +289,7 @@ func gitIn(t *testing.T, dir string, args ...string) {
 	}
 }
 
-// gitEnv neutralises the ambient git configuration and supplies an identity, so
+// gitEnv neutralizes the ambient git configuration and supplies an identity, so
 // a fixture needs no `git config` of its own and a maintainer with signing,
 // hooks or a commit template configured does not fail these for reasons that
 // have nothing to do with relctl.

--- a/hack/cmd/relctl/relctl/cmd_soak.go
+++ b/hack/cmd/relctl/relctl/cmd_soak.go
@@ -70,7 +70,7 @@ first-ever bootstrap and not for recovery.`,
 			if forceInit {
 				inputs["force_init"] = true
 				// Typed rather than --yes: site init on a cluster that is
-				// already initialised is not a retry.
+				// already initialized is not a retry.
 				confirm = "init " + tag
 
 				warnings = append(warnings,

--- a/hack/cmd/relctl/relctl/cmd_status.go
+++ b/hack/cmd/relctl/relctl/cmd_status.go
@@ -48,7 +48,7 @@ type draftInfo struct {
 	// that reason, and worth leaving alone.
 	//
 	// A pointer so an absent date is absent from the JSON rather than
-	// serialising as 0001-01-01, which reads as a real answer.
+	// serializing as 0001-01-01, which reads as a real answer.
 	Committed *time.Time `json:"committed,omitempty"`
 }
 

--- a/hack/cmd/relctl/relctl/dispatch_test.go
+++ b/hack/cmd/relctl/relctl/dispatch_test.go
@@ -207,7 +207,7 @@ func TestPublishRequiresAReason(t *testing.T) {
 }
 
 // TestSoakForceInitNeedsATypedPhrase keeps the other break-glass path out of
-// reach of --yes. A site init on an initialised cluster is not a retry.
+// reach of --yes. A site init on an initialized cluster is not a retry.
 func TestSoakForceInitNeedsATypedPhrase(t *testing.T) {
 	stub := &stubGitHub{}
 

--- a/hack/cmd/relctl/relctl/gh/client_test.go
+++ b/hack/cmd/relctl/relctl/gh/client_test.go
@@ -226,14 +226,14 @@ func fakeGH(t *testing.T, token string, exit int) string {
 	return dir + string(os.PathListSeparator) + os.Getenv("PATH")
 }
 
-// TestNewHonoursBaseURL exercises the option that exists so the command tests
+// TestNewHonorsBaseURL exercises the option that exists so the command tests
 // can point at an httptest server instead of api.github.com.
 //
 // Documented as "for tests" and previously used by none, which is how an option
 // quietly stops working: nothing would have noticed if go-github changed how a
 // base URL is applied, and the first symptom would have been a test suite
 // silently talking to the real API.
-func TestNewHonoursBaseURL(t *testing.T) {
+func TestNewHonorsBaseURL(t *testing.T) {
 	t.Parallel()
 
 	var gotPath string

--- a/hack/cmd/relctl/relctl/relctl.go
+++ b/hack/cmd/relctl/relctl/relctl.go
@@ -33,9 +33,9 @@ func Run() {
 }
 
 func run() int {
-	// Cancelled on the first signal; the second is left to the default handler
+	// Canceled on the first signal; the second is left to the default handler
 	// so a wedged poll loop can still be killed. Commands that dispatch a
-	// workflow honour it between the confirmation and the request, which is the
+	// workflow honor it between the confirmation and the request, which is the
 	// window where interrupting actually helps.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/hack/cmd/relctl/relctl/relctl_test.go
+++ b/hack/cmd/relctl/relctl/relctl_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// TestRootRejectsAnUnknownSubcommand pins behaviour that was silently wrong.
+// TestRootRejectsAnUnknownSubcommand pins behavior that was silently wrong.
 //
 // cobra skips argument validation entirely for a command it cannot run, so
 // Args: cobra.NoArgs did nothing on a root with no RunE, and `relctl bogus`

--- a/hack/cmd/relctl/relctl/version/fixture_test.go
+++ b/hack/cmd/relctl/relctl/version/fixture_test.go
@@ -12,13 +12,13 @@ import (
 
 // The one git fixture builder these tests use.
 //
-// There were three copies, none of which neutralised the ambient git
+// There were three copies, none of which neutralized the ambient git
 // configuration. hack/release/next_version_test.go already solved this for the
 // shell suite and said why; the Go port dropped the guard and reintroduced the
 // problem it describes:
 //
 //	The fixtures create throwaway repositories and tag them, so the ambient
-//	git configuration has to be neutralised: a maintainer with
+//	git configuration has to be neutralized: a maintainer with
 //	tag.gpgSign=true, or a commit template, or a hook path, would otherwise
 //	fail every case for reasons that have nothing to do with the resolver.
 //
@@ -77,7 +77,7 @@ func initRepo(t *testing.T) (dir, branch string) {
 
 	dir = t.TempDir()
 
-	// -b main explicitly: with the global config neutralised, init.defaultBranch
+	// -b main explicitly: with the global config neutralized, init.defaultBranch
 	// is unset and git falls back to master. The fixtures should look like the
 	// repository they stand in for, and a mismatch shows up as spurious
 	// branch-policy warnings rather than as anything obvious.

--- a/hack/cmd/relctl/relctl/version/git.go
+++ b/hack/cmd/relctl/relctl/version/git.go
@@ -64,7 +64,7 @@ func lines(out string) []string {
 // Errors are returned, not swallowed. The shell this replaces ended the same
 // query with `|| true`, which looks like it is absorbing "no tags match" - but
 // `git tag --merged HEAD --list <glob>` exits 0 with empty output when nothing
-// matches, and 128 only for an unborn HEAD, a missing repository or a cancelled
+// matches, and 128 only for an unborn HEAD, a missing repository or a canceled
 // context. So there is no legitimate absence to absorb, and swallowing here
 // would turn a real failure into "no tags", which is a floor of v0.0.0 that the
 // resolver would then compute a version from.
@@ -106,7 +106,7 @@ func (g *GitRepo) TagExists(tag string) (bool, error) {
 	}
 
 	// `rev-parse -q` is silent about an unknown ref and exits 1. A real failure
-	// exits 128: not a repository, a broken object store, a cancelled context.
+	// exits 128: not a repository, a broken object store, a canceled context.
 	// errors.As walks the chain, so run()'s wrapping is transparent here.
 	var exit *exec.ExitError
 	if errors.As(err, &exit) && exit.ExitCode() == 1 {

--- a/hack/cmd/relctl/relctl/version/git_test.go
+++ b/hack/cmd/relctl/relctl/version/git_test.go
@@ -165,7 +165,7 @@ func TestFakeRepoMatchesGit(t *testing.T) {
 	requireGit(t)
 	t.Parallel()
 
-	// Shapes chosen for the Repo behaviours the resolver leans on: glob
+	// Shapes chosen for the Repo behaviors the resolver leans on: glob
 	// matching, reachability scoping, existence-versus-reachability, candidates
 	// behind HEAD, and malformed tags that must match no pattern.
 	tagSets := [][]string{

--- a/hack/cmd/relctl/relctl/version/modes.go
+++ b/hack/cmd/relctl/relctl/version/modes.go
@@ -22,7 +22,7 @@ func (r *resolver) release() (string, error) {
 	}
 
 	// Cutting the version a live train is heading for is not a fork, it is that
-	// train being finalised the long way round, so only warn when they differ.
+	// train being finalized the long way round, so only warn when they differ.
 	if len(r.live) > 0 {
 		if slices.Contains(r.live, tag) {
 			r.warn("%s is the version its candidates were building toward, but mode=release cuts it from HEAD; use mode=promote to ship the tree that was soaked", tag)
@@ -71,7 +71,7 @@ func (r *resolver) prerelease() (string, error) {
 		// rc is the only suffix accepted. alpha and beta were
 		// previously used interchangeably with no defined meaning.
 		//
-		// Leading zeros are rejected rather than normalised, because the shell
+		// Leading zeros are rejected rather than normalized, because the shell
 		// this replaces read rc.08 as an octal literal and silently skipped it.
 		if !preShape.MatchString(pre) {
 			return "", fmt.Errorf(
@@ -143,7 +143,7 @@ func (r *resolver) prereleaseCore() (string, error) {
 	}
 }
 
-// promote finalises a candidate, at the commit that was actually soaked.
+// promote finalizes a candidate, at the commit that was actually soaked.
 func (r *resolver) promote() (tag, base string, err error) {
 	if r.req.Pre != "" {
 		return "", "", fmt.Errorf("pre is only valid with mode=prerelease")

--- a/hack/cmd/relctl/relctl/version/resolve.go
+++ b/hack/cmd/relctl/relctl/version/resolve.go
@@ -215,7 +215,7 @@ func (r *resolver) warn(format string, args ...any) {
 
 // Resolve works out which tag a release should mint, and at which commit.
 //
-// Why Base exists: promote finalises a candidate that was already built,
+// Why Base exists: promote finalizes a candidate that was already built,
 // deployed and smoke-tested, so tagging HEAD would ship a DIFFERENT tree under
 // a version whose only claim to being trustworthy is that soak. promote
 // resolves the candidate's commit; release and prerelease resolve HEAD.

--- a/hack/cmd/relctl/relctl/version/resolve_test.go
+++ b/hack/cmd/relctl/relctl/version/resolve_test.go
@@ -41,7 +41,7 @@ type resolveCase struct {
 	// Asserting only that an error happened would let every refusal collapse
 	// into one message and the suite would stay green, which matters more here
 	// than usual: 34 of these cases are refusals, and the reasons are the
-	// behaviour. Several are load-bearing scar tissue, like refusing a core
+	// behavior. Several are load-bearing scar tissue, like refusing a core
 	// whose final exists off this branch.
 	wantErr string
 	tags    []string

--- a/hack/cmd/relctl/relctl/version/trains_test.go
+++ b/hack/cmd/relctl/relctl/version/trains_test.go
@@ -15,7 +15,7 @@ import (
 // whether to start or continue from it, and promote refuses to guess between
 // entries. It is also the exact thing the shell got wrong. v0.1.24 reached
 // rc.18 and was orphaned when a v0.2.0 train started beside it, because promote
-// finalised the highest prerelease in the whole repository rather than the one
+// finalized the highest prerelease in the whole repository rather than the one
 // being worked on. There is still no v0.1.24 tag.
 //
 // A LIVE train is a core with candidates, no final of its own, AND newer than
@@ -55,7 +55,7 @@ func TestResolveReportsTrains(t *testing.T) {
 		{
 			// The v0.1.24 shape. Candidates exist, no final was ever cut, and a
 			// newer series has since shipped. Reporting this as live is what
-			// let promote finalise it months later.
+			// let promote finalize it months later.
 			name:       "candidates behind the latest final are stale",
 			tags:       []string{"v0.2.4", "v0.1.24-rc.1", "v0.1.24-rc.2"},
 			wantLatest: "v0.2.4",
@@ -143,7 +143,7 @@ func TestResolveReportsTrains(t *testing.T) {
 	}
 }
 
-// TestPrereleaseContinuesTheLiveTrain pins the behaviour the train model exists
+// TestPrereleaseContinuesTheLiveTrain pins the behavior the train model exists
 // to drive: a second candidate joins the train in flight rather than starting
 // another one, and the bump that would have started a different train is
 // ignored rather than obeyed.

--- a/hack/cmd/render-manifests/main.go
+++ b/hack/cmd/render-manifests/main.go
@@ -7,7 +7,7 @@
 // mirroring the source tree structure.
 //
 // Template data is supplied via repeatable --set key=value flags. Missing keys
-// evaluate to empty strings (text/template's missingkey=zero behaviour for map
+// evaluate to empty strings (text/template's missingkey=zero behavior for map
 // data), which lets templates rely on sprig's `default` function to supply
 // documented fallbacks.
 //

--- a/hack/cmd/vulncheck-gate/main.go
+++ b/hack/cmd/vulncheck-gate/main.go
@@ -14,7 +14,7 @@
 // upstream fix will pass this gate every day without anyone being forced to
 // look at it. The report exists so that "nobody was forced to" does not become
 // "nobody knew". Acting on those means dropping or replacing the dependency,
-// which is a judgement call this tool cannot make.
+// which is a judgment call this tool cannot make.
 //
 // Input is the JSON stream from `govulncheck -format json`. That format is the
 // documented programmatic interface; the human-readable output is not, and the

--- a/hack/gantry-benchmark/README.md
+++ b/hack/gantry-benchmark/README.md
@@ -29,7 +29,7 @@ Azure managed identities and short-lived ACR tokens.
 
 The workstation needs one valid Azure management-plane login before invoking
 `deploy.sh`; the script never invokes `az login`, `az acr login`, or workstation
-Podman. It publishes only the revision-labelled source carrier through an ACR
+Podman. It publishes only the revision-labeled source carrier through an ACR
 Task, creates Private Endpoints and disables public registry access, then
 bootstraps the private operator VM. Gantry and pull-probe images are built and
 pushed from that VM with its managed identity over Private Link.

--- a/hack/net/deploy-config.sh
+++ b/hack/net/deploy-config.sh
@@ -2,7 +2,7 @@
 # Apply the unbounded-net shared runtime configmap, optionally patching
 # LOG_LEVEL and AZURE_TENANT_ID into it.
 #
-# Behaviour:
+# Behavior:
 #   - Creates the configmap from the rendered manifest when missing.
 #   - Does NOT overwrite existing values when LOG_LEVEL/AZURE_TENANT_ID
 #     are unset; pass them explicitly to patch.

--- a/hack/orca/README.md
+++ b/hack/orca/README.md
@@ -137,7 +137,7 @@ Useful flags:
 ## 6. Run a canned scenario
 
 Scenarios are one-line invocations that string together upload +
-fetch + verify against a specific behaviour:
+fetch + verify against a specific behavior:
 
 ```bash
 bin/orcadev scenario cold-warm        # cold-vs-warm GET ratio
@@ -259,7 +259,7 @@ call, no commit.
 | `make -C hack/orca status` | `kubectl get pods` in the orca namespace. |
 | `make -C hack/orca logs` | Tail logs from all orca replicas. |
 | `make -C hack/orca port-forward` | Foreground forward localhost:8443 -> svc/orca. |
-| `bin/orcadev upload --generate --count N --size S` | Synthesise + upload N random blobs. |
+| `bin/orcadev upload --generate --count N --size S` | Synthesize + upload N random blobs. |
 | `bin/orcadev upload --file PATH` | Upload one real file. |
 | `bin/orcadev list` | Enumerate origin objects. |
 | `bin/orcadev delete [--prefix P] --yes` | Bulk delete origin objects. |

--- a/hack/orca/setup-orca.sh
+++ b/hack/orca/setup-orca.sh
@@ -135,7 +135,7 @@ usage() {
 }
 
 # kubectl_ctx runs kubectl with --context only when CONTEXT is non-empty,
-# matching kubectl's "current context" default behaviour.
+# matching kubectl's "current context" default behavior.
 kubectl_ctx() {
   if [[ -n "${CONTEXT}" ]]; then
     kubectl --context "${CONTEXT}" "$@"

--- a/hack/playbooks/aks-300-node-playbook.md
+++ b/hack/playbooks/aks-300-node-playbook.md
@@ -31,7 +31,7 @@ totalling 300 eligible nodes, split the cluster:
 | Pool | Mode | Nodes | VM size | Notes |
 |---|---|---:|---|---|
 | `system` | System | 298 | `Standard_D8ds_v6` | Benchmark workers |
-| `bench` | User | 2 | `Standard_D16ds_v6` | Labelled and tainted `gantry-benchmark-proxy=true`; hosts monitoring |
+| `bench` | User | 2 | `Standard_D16ds_v6` | Labeled and tainted `gantry-benchmark-proxy=true`; hosts monitoring |
 
 Set `BENCHMARK_NODE_COUNT=300` for that layout.
 

--- a/hack/playbooks/gantry-benchmark-playbook.md
+++ b/hack/playbooks/gantry-benchmark-playbook.md
@@ -576,7 +576,7 @@ Practical consequences:
 - The benchmark Job timeout is fixed at four hours to accommodate throttling
   and cross-region pulls at large scale.
 - Expect 429s in the baseline. Containerd retries them, which inflates baseline
-  latency. That is real-world ACR behaviour at cold start, but record it so the
+  latency. That is real-world ACR behavior at cold start, but record it so the
   comparison is read correctly.
 - Sample containerd logs on a node during the baseline to capture the evidence:
 

--- a/hack/release/forced-publish-notes.sh
+++ b/hack/release/forced-publish-notes.sh
@@ -7,7 +7,7 @@
 # Called by the publish-forced job in .github/workflows/release-upgrade.yaml.
 # It exists as a script, rather than inline in that job, because the bypass
 # notice is the durable record of a release that skipped its soak: it is read
-# long after the run log has expired, and it is the one artefact nobody
+# long after the run log has expired, and it is the one artifact nobody
 # exercises until an emergency. Two defects lived in it undetected precisely
 # because it could not be tested - a skipped smoke matrix was described as a
 # successful soak, and a re-run stacked a second notice onto the body.

--- a/hack/release/smoke/core-namespaces-ready.sh
+++ b/hack/release/smoke/core-namespaces-ready.sh
@@ -124,7 +124,7 @@ is_notready_node() {
 #   MAX_NOTREADY_NODES   how much of the cluster may be down is decided once,
 #                        by the gate.
 #   the image tag        whether the workload is on this release is likewise
-#                        the gate's judgement.
+#                        the gate's judgment.
 #
 # Both rest on the gate having passed minutes earlier, which is an assumption
 # rather than an invariant: nodes can go down in between, and a site that was

--- a/hack/release/smoke_core_namespaces_test.go
+++ b/hack/release/smoke_core_namespaces_test.go
@@ -327,7 +327,7 @@ func TestSmokeRefusesAPodWithOnlyPreferredAffinity(t *testing.T) {
 	requireContains(t, output, "::error::pod unbounded-system/soft not ready")
 }
 
-// TestSmokeRefusesAnUnreadyPodOnAReadyNode is the behaviour that existed before
+// TestSmokeRefusesAnUnreadyPodOnAReadyNode is the behavior that existed before
 // any of this and must survive it: a pod failing on a healthy node is the
 // regression a release smoke test exists to catch.
 func TestSmokeRefusesAnUnreadyPodOnAReadyNode(t *testing.T) {
@@ -343,7 +343,7 @@ func TestSmokeRefusesAnUnreadyPodOnAReadyNode(t *testing.T) {
 }
 
 // TestSmokeToleratesAnUnreadyPodOnANotReadyNode is the other pre-existing
-// behaviour. It also covers the pod shape that used to lose its nodeName to tab
+// behavior. It also covers the pod shape that used to lose its nodeName to tab
 // collapsing: no Ready condition at all, with a nodeName after it.
 func TestSmokeToleratesAnUnreadyPodOnANotReadyNode(t *testing.T) {
 	requireBash(t)

--- a/hack/release/wait-rollouts.sh
+++ b/hack/release/wait-rollouts.sh
@@ -193,7 +193,7 @@ GUARD_DISABLED=0
 declare -A IMAGE_FIRST_SEEN=()
 
 # cleanup reaps the background rollout watcher and closes any open log group.
-# Without it a cancelled run (nightly sets cancel-in-progress) leaves
+# Without it a canceled run (nightly sets cancel-in-progress) leaves
 # 'kubectl rollout status' running until its own timeout, and a failure exits
 # with the group still open, which hides the failure in a collapsed section.
 cleanup() {
@@ -808,7 +808,7 @@ daemonset_tolerance() {
 
   # Scopes the pod list to what this workload owns. Without a uid there is no
   # way to tell its pods from anything else wearing the same labels, which is
-  # not a judgement this check may make on a guess.
+  # not a judgment this check may make on a guess.
   owner_uid="$(printf '%s' "$obj_json" | jq -r '.metadata.uid // ""' 2>"${WORKDIR}/jq.err")" || return 1
   [[ -n "$owner_uid" ]] || return 1
 
@@ -880,7 +880,7 @@ site_entirely_unreachable() {
 # payload: which nodes are NotReady, and how many nodes each pinned site has.
 # Asking twice would cost a second full node list on every poll.
 #
-# hack/release/smoke/core-namespaces-ready.sh makes the same judgement about the
+# hack/release/smoke/core-namespaces-ready.sh makes the same judgment about the
 # pod this Deployment could not schedule, from a separate copy of this logic: a
 # smoke test is meant to stand alone. They answer the same question, so change
 # them together.
@@ -956,7 +956,7 @@ site_deployment_tolerance() {
 
   # A Deployment does not own its pods directly, so the ReplicaSets it owns are
   # resolved first. Without them there is no way to tell its pods from anything
-  # else wearing the same labels, which is not a judgement this check may make
+  # else wearing the same labels, which is not a judgment this check may make
   # on a guess.
   owner_uid="$(printf '%s' "$obj_json" | jq -r '.metadata.uid // ""' 2>"${WORKDIR}/jq.err")" || return 1
   [[ -n "$owner_uid" ]] || return 1

--- a/hack/release/wait_rollouts_test.go
+++ b/hack/release/wait_rollouts_test.go
@@ -1197,7 +1197,7 @@ func TestToleratesAShortfallExplainedByUnreachableNodes(t *testing.T) {
 	f.set("getjson-nodes", reply{stdout: degradedNodes()})
 	f.set("pods", reply{stdout: strandedFleet(gantryImage)})
 	// Held open: without tolerance this wait would run to its timeout, which is
-	// the behaviour being replaced.
+	// the behavior being replaced.
 	f.set("rollout", reply{sleep: "20"})
 
 	output, code := f.run(tolerating, target)
@@ -1812,7 +1812,7 @@ func TestToleratesASiteScopedDeploymentWhoseSiteIsUnreachable(t *testing.T) {
 	f.set("getjson-replicasets", reply{stdout: replicaSetList(true)})
 	f.set("pods", reply{stdout: unscheduledPod()})
 	// Held open: without tolerance this wait runs to its timeout, which is the
-	// behaviour being replaced.
+	// behavior being replaced.
 	f.set("rollout", reply{sleep: "20"})
 
 	output, code := f.run(tolerating, metalmanTarget)
@@ -1926,7 +1926,7 @@ func TestRefusesASiteScopedDeploymentPinnedToASiteWithNoNodes(t *testing.T) {
 
 // TestRefusesASiteScopedDeploymentWhenTooManyNodesAreNotReady keeps the
 // Deployment path under the same cap as the DaemonSet one. A site being down is
-// not licence to ignore how much of the cluster went with it.
+// not license to ignore how much of the cluster went with it.
 func TestRefusesASiteScopedDeploymentWhenTooManyNodesAreNotReady(t *testing.T) {
 	requireBash(t)
 	t.Parallel()

--- a/internal/executil/exec.go
+++ b/internal/executil/exec.go
@@ -49,7 +49,7 @@ var defaultTextBusyPolicy = retryPolicy{
 	maxDelay:     100 * time.Millisecond,
 }
 
-// retryPolicy is a parameter so tests can pin the clamping behaviour. With the
+// retryPolicy is a parameter so tests can pin the clamping behavior. With the
 // production values the difference clamping makes is at most one maxDelay,
 // which is too small to distinguish from scheduling noise on a loaded machine;
 // a test policy whose delay dwarfs its budget makes it unmistakable.

--- a/internal/executil/exec_test.go
+++ b/internal/executil/exec_test.go
@@ -213,9 +213,9 @@ func TestRunCmdBuildsOneCommandPerAttempt(t *testing.T) {
 	}
 }
 
-// TestRetryWhileTextFileBusyHonoursContext confirms a cancelled pass stops
+// TestRetryWhileTextFileBusyHonorsContext confirms a canceled pass stops
 // retrying rather than running out the budget.
-func TestRetryWhileTextFileBusyHonoursContext(t *testing.T) {
+func TestRetryWhileTextFileBusyHonorsContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	attempts := 0

--- a/internal/gantry/advertise/advertise.go
+++ b/internal/gantry/advertise/advertise.go
@@ -177,7 +177,7 @@ func New(inv Inventory, dht ifaces.DHT, opts ...Option) *Advertiser {
 	return a
 }
 
-// Run drives the reconcile loop until ctx is cancelled. Triggers one
+// Run drives the reconcile loop until ctx is canceled. Triggers one
 // reconcile pass immediately so startup converges fast, then ticks at
 // the configured interval with ±25% jitter to spread cluster-wide load.
 func (a *Advertiser) Run(ctx context.Context) error {

--- a/internal/gantry/cdsub/cdsub.go
+++ b/internal/gantry/cdsub/cdsub.go
@@ -72,7 +72,7 @@ type ImageSource interface {
 	// Subscribe streams ImageEvents for the lifetime of the returned
 	// context. Closing the channel signals "disconnected - caller should
 	// reconnect after backoff". Subscribe MUST exit cleanly when ctx is
-	// cancelled.
+	// canceled.
 	Subscribe(ctx context.Context) (<-chan ImageEvent, error)
 }
 
@@ -154,7 +154,7 @@ func WithNotifier(fn func(ctx context.Context, d digest.Digest, present bool)) O
 	}
 }
 
-// New builds a Subscriber. Run drives the loop until ctx is cancelled.
+// New builds a Subscriber. Run drives the loop until ctx is canceled.
 // dht may be nil when WithNotifier is supplied.
 func New(src ImageSource, dht ifaces.DHT, opts ...Option) *Subscriber {
 	s := &Subscriber{
@@ -173,7 +173,7 @@ func New(src ImageSource, dht ifaces.DHT, opts ...Option) *Subscriber {
 	return s
 }
 
-// Run blocks until ctx is cancelled. On each iteration:
+// Run blocks until ctx is canceled. On each iteration:
 //
 // 1. Run reconciliation: List -> notify/provide every digest.
 // 2. Subscribe and process events as they arrive.

--- a/internal/gantry/cdsub/noop.go
+++ b/internal/gantry/cdsub/noop.go
@@ -17,7 +17,7 @@ type NoOpSource struct{}
 // List always returns an empty event slice.
 func (NoOpSource) List(_ context.Context) ([]ImageEvent, error) { return nil, nil }
 
-// Subscribe returns a channel that is closed only when ctx is cancelled.
+// Subscribe returns a channel that is closed only when ctx is canceled.
 func (NoOpSource) Subscribe(ctx context.Context) (<-chan ImageEvent, error) {
 	ch := make(chan ImageEvent)
 

--- a/internal/gantry/cdsub/source_containerd.go
+++ b/internal/gantry/cdsub/source_containerd.go
@@ -277,7 +277,7 @@ func (s *ContainerdSource) List(ctx context.Context) ([]ImageEvent, error) {
 
 // Subscribe streams ImageEvents for the lifetime of ctx. Implements
 // ImageSource. Closes the returned channel when the underlying
-// containerd subscription errors or ctx is cancelled - the Subscriber
+// containerd subscription errors or ctx is canceled - the Subscriber
 // reconnect loop then handles backoff + reconciliation.
 func (s *ContainerdSource) Subscribe(ctx context.Context) (<-chan ImageEvent, error) {
 	ctx = namespaces.WithNamespace(ctx, s.namespace)

--- a/internal/gantry/cdsub/walk.go
+++ b/internal/gantry/cdsub/walk.go
@@ -31,7 +31,7 @@ import (
 // resulting digest set is guaranteed to be serveable from the local
 // content store at probe time. This enforces the plan invariant
 // "advertise only present-and-serveable from containerd" instead of
-// the prior "referenced by manifest" behaviour, which produced phantom
+// the prior "referenced by manifest" behavior, which produced phantom
 // DHT provider records the transfer endpoint then 404'd on.
 //
 // Tolerates errdefs.IsNotFound errors from both images.Children and

--- a/internal/gantry/coldstart/coldstart.go
+++ b/internal/gantry/coldstart/coldstart.go
@@ -634,7 +634,7 @@ func (r *Resolver) probe(ctx context.Context, d digest.Digest, kind ifaces.Origi
 
 		return nil, prefix(expandLabel, "rule7_cooldown"), ErrCooldownActive
 	default:
-		// PleasePullUnspecified or an unrecognised enum value: the
+		// PleasePullUnspecified or an unrecognized enum value: the
 		// puller did not commit to starting a pull, so the DHT
 		// provider record may never appear. Polling for the full
 		// stall budget would be a multi-second wait for nothing;

--- a/internal/gantry/coldstart/coldstart_test.go
+++ b/internal/gantry/coldstart/coldstart_test.go
@@ -1202,7 +1202,7 @@ func (s *stubLocalPull) StartLocalPull(_ context.Context, registry, repository s
 // which hrw.TopK(nodes, d, k) puts self at index 0. HRW is
 // deterministic, so this terminates quickly for any non-degenerate
 // cluster - the search just needs to find a (digest, nodeID) pair
-// whose double-hash maximises among the cluster. We try byte values
+// whose double-hash maximizes among the cluster. We try byte values
 // 'a'…'z' and '0'…'9' before giving up so the test never spins
 // forever on a buggy hash.
 func findDigestWhereSelfIsRank0(t *testing.T, nodes []ifaces.Node, self ifaces.NodeID, k int) digest.Digest {
@@ -1781,7 +1781,7 @@ func digestBatchSizes(batches [][]digest.Digest) []int {
 // TestPrefetchLayers_NilLocalPullStillSkipsSelf is a guardrail: when
 // LocalPull is NOT configured (e.g. unit tests, or a deployment that
 // hasn't wired the embedded coordinator yet), self-digests must
-// continue to be silently skipped. This is the legacy behaviour
+// continue to be silently skipped. This is the legacy behavior
 // preserved by the seventh-review #5 fix so that
 // LocalPull-less callers keep working unchanged.
 func TestPrefetchLayers_NilLocalPullStillSkipsSelf(t *testing.T) {
@@ -2152,7 +2152,7 @@ func TestPullerSelectionIgnoresResponderRank(t *testing.T) {
 	requesterRank2 := top[2].Node.ID
 	// Pre-fix, lying about responder rank steered selection.
 	intents := map[ifaces.NodeID]ifaces.PullIntent{
-		top[0].Node.ID: {RecipientRank: 99}, // true rank 0, lies as 99 (would be deprioritised)
+		top[0].Node.ID: {RecipientRank: 99}, // true rank 0, lies as 99 (would be deprioritized)
 		top[1].Node.ID: {RecipientRank: -1}, // true rank 1, lies as unknown
 		top[2].Node.ID: {RecipientRank: 0},  // true rank 2, lies as rank 0 (would WIN pre-fix)
 	}
@@ -2199,7 +2199,7 @@ func TestPullerSelectionIgnoresResponderRank(t *testing.T) {
 //
 // Why this matters: cold-start metrics
 // (gantry_coldstart_duration_seconds, gantry_hrw_rank_mismatch_total,
-// gantry_designated_puller_takeover_total) are labelled by `kind`,
+// gantry_designated_puller_takeover_total) are labeled by `kind`,
 // and a typical image pull traverses manifest -> config -> layer*.
 // If KindConfig collapses into "layer" the config fetch (a small,
 // usually fast pull) drags the layer p99 down and hides regressions

--- a/internal/gantry/coldstart/prefetch.go
+++ b/internal/gantry/coldstart/prefetch.go
@@ -102,7 +102,7 @@ func coordinatesRemotePrefetch(self ifaces.NodeID, candidates []ifaces.Node, key
 // value returns ErrPrefetchInvalid without issuing any RPC.
 //
 // All digests passed via PrefetchLayers are sent as KindBlob; this
-// is a back-compat shim that pre-dates per-kind labelling. New
+// is a back-compat shim that pre-dates per-kind labeling. New
 // callers should use PrefetchChildren which preserves the
 // config-vs-layer kind end-to-end through the wire so per-kind
 // metrics ("manifest | config | layer") remain honest.
@@ -184,7 +184,7 @@ func (r *Resolver) prefetchChildren(ctx context.Context, coordinationKey digest.
 	candidates := hrw.Candidates(cluster, r.opts.HrwScope, r.opts.SelfZone)
 	if r.opts.HrwScope == hrw.ScopeZone && len(candidates) == 0 {
 		// Zone empty -> fall back to cluster mode (mirrors Resolve's
-		// behaviour, the design doc).
+		// behavior, the design doc).
 		candidates = cluster
 	}
 
@@ -385,7 +385,7 @@ func (r *Resolver) prefetchChildren(ctx context.Context, coordinationKey digest.
 	// batches so a slow LocalPull doesn't gate remote dispatch - and
 	// so a slow peer doesn't gate the local pull. All branches are
 	// bounded by QueryTimeout so PrefetchChildren's overall latency
-	// matches the pre-split PrefetchLayers behaviour.
+	// matches the pre-split PrefetchLayers behavior.
 	for _, k := range selfKinds {
 		digests := selfByKind[k]
 		if len(digests) == 0 {

--- a/internal/gantry/coldstart/prefetch_test.go
+++ b/internal/gantry/coldstart/prefetch_test.go
@@ -801,7 +801,7 @@ func TestPrefetchChildren_DistinctPullersBatchedPerKind(t *testing.T) {
 
 // TestPrefetchLayers_BackCompatTagsAllAsKindBlob proves the
 // PrefetchLayers wrapper preserves its historical "every digest is a
-// blob" behaviour even though it now delegates to PrefetchChildren.
+// blob" behavior even though it now delegates to PrefetchChildren.
 // Important for older callers (and for the implicit assumption
 // PrefetchLayers' kind is KindBlob inside other tests).
 func TestPrefetchLayers_BackCompatTagsAllAsKindBlob(t *testing.T) {

--- a/internal/gantry/config/config.go
+++ b/internal/gantry/config/config.go
@@ -35,7 +35,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Recognised StorageMode values.
+// Recognized StorageMode values.
 const (
 	// StorageModeContainerd routes reads/writes through the local
 	// containerd content store (plan). This is the only
@@ -238,7 +238,7 @@ type Config struct {
 	ContainerdLeaseTTL time.Duration `yaml:"containerd_lease_ttl"`
 
 	// ContainerdLeaseCleanupInterval is the period at which the agent
-	// scans containerd's lease catalogue and deletes expired
+	// scans containerd's lease catalog and deletes expired
 	// Gantry-owned leases. Defaults to ContainerdLeaseTTL/2 if zero.
 	ContainerdLeaseCleanupInterval time.Duration `yaml:"containerd_lease_cleanup_interval"`
 
@@ -363,7 +363,7 @@ type Config struct {
 	NF5JitterBase time.Duration `yaml:"nf5_jitter_base"`
 
 	// NF5JitterCap is a hard ceiling on the computed jitter window.
-	// Zero means no cap (original behaviour). Set this to bound worst-case
+	// Zero means no cap (original behavior). Set this to bound worst-case
 	// cold-start latency on large clusters: at N=300 the uncapped window is
 	// ~17s; a cap of 10s limits the maximum additional delay imposed by NF5
 	// regardless of cluster size. The configured NF5JitterBase still
@@ -499,7 +499,7 @@ func NewDefault() *Config {
 		AdvertiseReconcileInterval:  time.Minute,
 
 		NF5JitterBase:               3 * time.Second,
-		NF5JitterCap:                0, // no cap by default (original behaviour)
+		NF5JitterCap:                0, // no cap by default (original behavior)
 		NF5PerNodeRateLimit:         2,
 		BootstrapWindow:             30 * time.Second,
 		BootstrapRoutingTablePct:    25,

--- a/internal/gantry/containerdstore/lease.go
+++ b/internal/gantry/containerdstore/lease.go
@@ -22,7 +22,7 @@
 // gantry.io/digest=<digest>
 // containerd.io/gc.expire=<RFC3339 timestamp>
 // The `containerd.io/gc.expire` label is what containerd's
-// lease manager recognises for TTL expiration - leases.
+// lease manager recognizes for TTL expiration - leases.
 // WithExpiration sets it under the hood. The returned guard is
 // released on failed ingest; AttachLease is retained as a compatibility
 // wrapper for tests and older call sites.
@@ -141,7 +141,7 @@ func (g *LeaseGuard) Release(ctx context.Context) error {
 // the intended protection as soon as the content appears.
 //
 // source is the upstream registry hostname; repository is the OCI
-// repository path. Both are stamped as labels so the lease catalogue
+// repository path. Both are stamped as labels so the lease catalog
 // is self-describing without cross-referencing inflight state.
 func (s *Store) CreateLease(ctx context.Context, d gdigest.Digest, source, repository string) (*LeaseGuard, error) {
 	if s.leases == nil {
@@ -195,7 +195,7 @@ func (s *Store) AttachLease(ctx context.Context, d gdigest.Digest, source, repos
 // CleanupExpiredLeases removes every Gantry-managed lease whose
 // creation timestamp + configured TTL is in the past, returning the
 // number of leases deleted. Used by a periodic background task in
-// cmd/gantry to keep the lease catalogue from growing unbounded.
+// cmd/gantry to keep the lease catalog from growing unbounded.
 //
 // We rely on our own LabelCreated rather than parsing containerd's
 // containerd.io/gc.expire because the latter is internal-format and
@@ -272,7 +272,7 @@ func (s *Store) LeaseTTL() time.Duration {
 // the the gantry_containerd_lease_active gauge sampler. Returns
 // ErrNoLeaseManager when this Store was built without WithLeaseManager.
 //
-// This is a best-effort snapshot - the catalogue may have changed by
+// This is a best-effort snapshot - the catalog may have changed by
 // the time the caller observes the slice. Callers that need exact
 // counts should rely on the counters (created/released) instead.
 func (s *Store) ListManagedLeases(ctx context.Context) ([]leases.Lease, error) {

--- a/internal/gantry/containerdstore/store.go
+++ b/internal/gantry/containerdstore/store.go
@@ -51,7 +51,7 @@ import (
 )
 
 // DefaultNamespace is the containerd namespace kubelet places pod
-// containers in when it uses containerd as its CRI runtime. Centralised
+// containers in when it uses containerd as its CRI runtime. Centralized
 // here so multiple subsystems (cdsub, containerdstore, advertise) cannot
 // drift on what namespace they bind to.
 const DefaultNamespace = "k8s.io"
@@ -171,7 +171,7 @@ func New(cs content.Store, opts ...Option) *Store {
 	return s
 }
 
-// withNS attaches the configured namespace to ctx. Centralised so
+// withNS attaches the configured namespace to ctx. Centralized so
 // every code path goes through the same wrapper and we cannot
 // accidentally call the content store with an unscoped context (which
 // containerd silently treats as namespace "default" - the wrong

--- a/internal/gantry/containerdstore/store_test.go
+++ b/internal/gantry/containerdstore/store_test.go
@@ -401,7 +401,7 @@ func TestStore_WriterCommitDigestMismatch(t *testing.T) {
 	if err := w.Commit(context.Background()); err == nil {
 		t.Fatal("Commit returned nil err on digest mismatch; want non-nil")
 	} else if !strings.Contains(err.Error(), "Commit") && !strings.Contains(err.Error(), "mismatch") {
-		t.Errorf("Commit err = %v, want digest-mismatch flavour", err)
+		t.Errorf("Commit err = %v, want digest-mismatch flavor", err)
 	}
 
 	has, err := s.Has(context.Background(), declared)

--- a/internal/gantry/coord/coord.go
+++ b/internal/gantry/coord/coord.go
@@ -60,7 +60,7 @@ import (
 const ProtocolID protocol.ID = "/gantry/coord/1.1.0"
 
 // errUnauthorizedPeer is the sentinel returned by dispatch when peer
-// authorization is in enforce mode and the dialing peer is not a recognised
+// authorization is in enforce mode and the dialing peer is not a recognized
 // member. handleStream skips the stream-error metric for it because the
 // rejection is already counted, by reason, in p2p_coord_unauthorized_peer_total.
 var errUnauthorizedPeer = errors.New("coord: unauthorized peer")
@@ -88,7 +88,7 @@ const DefaultStreamHandshakeTimeout = 5 * time.Second
 // DefaultMaxConcurrentStreams caps simultaneous inbound coord streams. A
 // hostile or buggy peer can open thousands of streams; without a cap each
 // consumes a goroutine for up to streamHandshakeTimeout. libp2p's resource
-// manager is the next defence layer; this is a cheap, predictable, server-
+// manager is the next defense layer; this is a cheap, predictable, server-
 // local gate.
 const DefaultMaxConcurrentStreams = 512
 
@@ -276,10 +276,10 @@ func WithMaxConcurrentStreams(n int) Option {
 //
 // Authorization compares the dialing peer's libp2p peer ID against the
 // PeerID values published in the current membership view. When enforce is
-// false (the default) an unrecognised peer is recorded via
+// false (the default) an unrecognized peer is recorded via
 // MetricsHooks.OnUnauthorizedPeer and still served, so operators can size
 // the false-positive rate before flipping enforcement on. When enforce is
-// true an unrecognised peer is rejected before its request is dispatched.
+// true an unrecognized peer is rejected before its request is dispatched.
 func WithPeerAuthz(enforce bool) Option {
 	return func(s *Server) { s.authzEnforce = enforce }
 }
@@ -461,7 +461,7 @@ func (s *Server) dispatch(ctx context.Context, remote peer.ID, in *coordv1.Envel
 	}
 }
 
-// authorizePeer reports whether remote is a recognised cluster member.
+// authorizePeer reports whether remote is a recognized cluster member.
 //
 // It compares remote's libp2p peer ID against the PeerID values published
 // in the supplied membership snapshot. Membership is treated as telemetry
@@ -529,7 +529,7 @@ func (s *Server) snapshotMembers() []ifaces.Node {
 	return s.members.Snapshot()
 }
 
-// recordUnauthorized fires the unauthorized-peer metric (labelled by reason)
+// recordUnauthorized fires the unauthorized-peer metric (labeled by reason)
 // for every occurrence and emits a rate-limited warning. The metric carries
 // exact counts; the log is only a human-facing heads-up, so a flood of
 // unrecognized peers (rolling upgrade, annotation lag, or a hostile peer)
@@ -679,7 +679,7 @@ func (s *Server) computeLocalIntent(ctx context.Context, d digest.Digest, nodes 
 //
 // Returns one PleasePullOutcome per input digest. A nil/zero pump (no
 // WithPullerPump option) yields PleasePullUnspecified entries; that
-// matches the server-side behaviour and is what the cold-start
+// matches the server-side behavior and is what the cold-start
 // resolver expects when origin-pull is disabled.
 func (s *Server) StartLocalPull(ctx context.Context, registry, repository string, kind ifaces.OriginRefKind, digests []digest.Digest) ([]ifaces.PleasePullOutcome, error) {
 	if registry == "" || repository == "" {

--- a/internal/gantry/discovery/health.go
+++ b/internal/gantry/discovery/health.go
@@ -131,7 +131,7 @@ func NewMonitor(opts MonitorOptions) *Monitor {
 
 // ObserveLatency records the duration of a successful DHT lookup.
 // Failed lookups should be recorded via the self-test path instead;
-// per-call failures are not penalised here so a single slow node
+// per-call failures are not penalized here so a single slow node
 // can't tank the score.
 func (m *Monitor) ObserveLatency(d time.Duration) {
 	if d < 0 {
@@ -343,7 +343,7 @@ func (m *Monitor) evictOldLatenciesLocked(now time.Time) {
 }
 
 // RunSelfTestLoop drives the periodic self-test cycle. It blocks
-// until ctx is cancelled. `selfTest` should perform one Provide ->
+// until ctx is canceled. `selfTest` should perform one Provide ->
 // FindProviders round-trip and return whether it succeeded.
 // Failures are debounced: a failed cycle only contributes to the
 // score, the loop itself always continues.

--- a/internal/gantry/discovery/health_test.go
+++ b/internal/gantry/discovery/health_test.go
@@ -281,7 +281,7 @@ func TestMonitor_BootstrapWindowRoutingTable(t *testing.T) {
 }
 
 // TestMonitor_RunSelfTestLoopExits asserts the loop exits when the
-// context is cancelled.
+// context is canceled.
 func TestMonitor_RunSelfTestLoopExits(t *testing.T) {
 	m := discovery.NewMonitor(discovery.MonitorOptions{
 		RoutingTableSize:   func() int { return 100 },

--- a/internal/gantry/ifaces/ifaces.go
+++ b/internal/gantry/ifaces/ifaces.go
@@ -155,7 +155,7 @@ type OriginRef struct {
 // fetches when reading dashboards or traces.
 type OriginRefKind int
 
-// Recognised OriginRefKind values.
+// Recognized OriginRefKind values.
 const (
 	KindBlob     OriginRefKind = 0
 	KindManifest OriginRefKind = 1
@@ -270,7 +270,7 @@ func (e *OriginError) Unwrap() error { return e.Err }
 // callers don't import the generated package.
 type FailureClass string
 
-// Recognised the design doc failure classifications.
+// Recognized the design doc failure classifications.
 const (
 	FailureUnspecified FailureClass = ""
 	FailureAuth        FailureClass = "auth"
@@ -366,7 +366,7 @@ type PleasePullOutcome struct {
 // PleasePullStatus mirrors coordv1.PleasePullResponse.Result.Outcome.
 type PleasePullStatus int
 
-// Recognised PleasePull outcome values.
+// Recognized PleasePull outcome values.
 const (
 	PleasePullUnspecified PleasePullStatus = iota
 	PleasePullAlreadyPulling

--- a/internal/gantry/members/members.go
+++ b/internal/gantry/members/members.go
@@ -62,7 +62,7 @@ type Options struct {
 	Namespace string
 
 	// LabelSelector is the K8s label selector identifying peer agents.
-	// Required (empty selector would enrol every pod in the cluster).
+	// Required (empty selector would enroll every pod in the cluster).
 	LabelSelector string
 
 	// ZoneLabelKey is the node label that exposes the topology zone.
@@ -196,7 +196,7 @@ func (m *Manager) Stop() {
 func (m *Manager) Self() ifaces.NodeID { return m.self }
 
 // WaitForSync blocks until both informers have completed initial list+watch
-// or ctx is cancelled.
+// or ctx is canceled.
 func (m *Manager) WaitForSync(ctx context.Context) error {
 	if !cache.WaitForCacheSync(ctx.Done(), m.podInf.HasSynced, m.nodeInf.HasSynced) {
 		if err := ctx.Err(); err != nil {

--- a/internal/gantry/mirror/mirror.go
+++ b/internal/gantry/mirror/mirror.go
@@ -591,7 +591,7 @@ func WithNF5(c *DirectOriginFallbackController) Option {
 	return func(s *Server) { s.nf5 = c }
 }
 
-// LayerPrefetcher is the speculative wire-level optimisation hook
+// LayerPrefetcher is the speculative wire-level optimization hook
 // (the design doc detailed-design.md L332 / architecture.md L180). After the
 // mirror serves a manifest successfully the mirror invokes
 // OnManifestServed in a goroutine so an implementation can fetch
@@ -938,7 +938,7 @@ func (s *Server) serveLocalHit(ctx context.Context, w http.ResponseWriter, r *ht
 		// fallback) would otherwise be octet-stream and containerd
 		// CRI fails with "Target.MediaType must be set".
 		// - kind == KindManifest: a manifest LIST/index body would
-		// otherwise be labelled as a single OCI manifest and
+		// otherwise be labeled as a single OCI manifest and
 		// containerd fails the unpack with "expected manifest but
 		// found index".
 		br := bufio.NewReader(rc)
@@ -1146,11 +1146,11 @@ func (s *Server) serveFromOrigin(ctx context.Context, w http.ResponseWriter, d d
 	// Peek the origin body so writeBlobHeaders can label content with
 	// the right Content-Type for two cases:
 	// - kind == KindBlob: a manifest that arrived via origin's
-	// /blobs/->/manifests/ fallback would otherwise be labelled
+	// /blobs/->/manifests/ fallback would otherwise be labeled
 	// octet-stream, and containerd CRI rejects the unpacked
 	// content as "Target.MediaType must be set".
 	// - kind == KindManifest: a manifest LIST/index body must be
-	// labelled with the matching list/index media type, otherwise
+	// labeled with the matching list/index media type, otherwise
 	// containerd fails the unpack with "expected manifest but
 	// found index" when it later resolves children.
 	// The peek consumes nothing (bufio buffers the bytes).
@@ -2389,7 +2389,7 @@ func classifyOriginFailureClass(err error) ifaces.FailureClass {
 
 // recordNegCacheFailure routes a terminal direct-origin failure into
 // the optional the design doc negative-cache recorder. Nil-safe: leaves the
-// pre-behaviour untouched when no recorder is
+// pre-behavior untouched when no recorder is
 // wired. Symmetric with the puller-pump path's recordOriginFailure
 // (cmd/gantry/main.go) which seeds the same cache for the
 // please_pull-coordinated path.
@@ -2555,7 +2555,7 @@ func sniffManifestContentType(prefix []byte) string {
 	case bytes.Contains(prefix, []byte("application/vnd.docker.distribution.manifest.v2+json")):
 		return "application/vnd.docker.distribution.manifest.v2+json"
 	}
-	// Schema-version-2 envelope without a recognisable mediaType: use
+	// Schema-version-2 envelope without a recognizable mediaType: use
 	// the OCI manifest content type as a safe default (containerd's
 	// unpacker will pick the right schema from the envelope itself).
 	if bytes.Contains(prefix, []byte("\"schemaVersion\"")) || bytes.Contains(prefix, []byte("\"schemaVersion\":")) {

--- a/internal/gantry/mirror/mirror_coldstart_test.go
+++ b/internal/gantry/mirror/mirror_coldstart_test.go
@@ -276,7 +276,7 @@ func TestMirror_ColdStart_WarmPathSkipsResolver(t *testing.T) {
 
 // newMirrorWithColdStart is a variant of newMirrorWithPeer that wires
 // WithColdStart. The cold-start resolver may be nil, in which case
-// fallthrough behaviour is preserved.
+// fallthrough behavior is preserved.
 func newMirrorWithColdStart(t *testing.T, originBlobs map[digest.Digest][]byte, providers map[digest.Digest][]ifaces.Provider, cs mirror.ColdStartResolver) (*httptest.Server, *int32, *int32) {
 	t.Helper()
 	srv, _, _, originHits, peerFetches := newMirrorWithPeer(t, originBlobs, providers)

--- a/internal/gantry/mirror/mirror_head_test.go
+++ b/internal/gantry/mirror/mirror_head_test.go
@@ -173,7 +173,7 @@ func newHeadTestStack(t *testing.T, originBlobs map[digest.Digest][]byte, provid
 // and trigger an HRW-designated puller to origin-pull the digest. A
 // HEAD is supposed to be a no-side-effects metadata probe.
 //
-// Required behaviour:
+// Required behavior:
 // - cold-start invocations = 0
 // - peer fetches = 0
 // - origin.Pull starts = 0 (p2p_origin_pull_total)

--- a/internal/gantry/mirror/mirror_nf5_integration_test.go
+++ b/internal/gantry/mirror/mirror_nf5_integration_test.go
@@ -102,7 +102,7 @@ func buildMirrorWithNF5(t *testing.T, originBlobs map[digest.Digest][]byte, cs m
 }
 
 // TestMirror_NF5_ColdStartExhaustedNoNF5_Returns503 confirms the
-// default behaviour: cold-start exhausted + no direct-origin-fallback wired -> 5xx.
+// default behavior: cold-start exhausted + no direct-origin-fallback wired -> 5xx.
 func TestMirror_NF5_ColdStartExhaustedNoNF5_Returns503(t *testing.T) {
 	body := []byte("origin would-have-served")
 	d := digestOf(body)
@@ -251,7 +251,7 @@ func TestMirror_NF5_BootstrapWindowSuppresses_Returns503(t *testing.T) {
 }
 
 // TestMirror_NF5_RecheckHitAbortsAfterJitter covers the
-// post-jitter recheck: if a provider materialised while direct-origin-fallback was
+// post-jitter recheck: if a provider materialized while direct-origin-fallback was
 // sleeping, direct-origin-fallback declines and the request 5xxs (client retries through
 // the warm path).
 func TestMirror_NF5_RecheckHitAbortsAfterJitter(t *testing.T) {

--- a/internal/gantry/mirror/mirror_startup_gate_test.go
+++ b/internal/gantry/mirror/mirror_startup_gate_test.go
@@ -29,7 +29,7 @@ import (
 // the response status that lets containerd's hosts.toml mirror chain
 // fall through to the next entry rather than failing the pull. 404
 // or 5xx-without-Docker-Distribution-API-Version would not produce
-// the same fall-through behaviour.
+// the same fall-through behavior.
 func TestMirror_StartupGate_Returns503UntilMarkReady(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/gantry/mirror/mirror_test.go
+++ b/internal/gantry/mirror/mirror_test.go
@@ -1013,7 +1013,7 @@ func TestMirror_LiveStreamThrough_PeerBypassesLocalWriterAndReadvertise(t *testi
 // the mirror-direct the design doc integration tests below. It records the call
 // sequence so the test can assert WHICH digests entered cooldown and
 // WHICH succeeded - the contract that distinguishes the new direct-
-// origin negative-cache integration from the pre-// behaviour (where the mirror direct path emitted only metrics and
+// origin negative-cache integration from the pre-// behavior (where the mirror direct path emitted only metrics and
 // never seeded a cooldown).
 type fakeNegCacheRecorder struct {
 	mu        sync.Mutex

--- a/internal/gantry/mirror/nf5.go
+++ b/internal/gantry/mirror/nf5.go
@@ -27,11 +27,11 @@
 // 4. **Per-node token bucket.** Replenishes at
 // `nf5_per_node_rate_limit` tokens/minute (default 2). Empty
 // bucket -> decline (5xx).
-// 5. **Jitter `[0, nf5_jitter_base × ln(N))`.** Randomises direct-origin-fallback
+// 5. **Jitter `[0, nf5_jitter_base × ln(N))`.** Randomizes direct-origin-fallback
 // timing across the cluster so the first node to complete an
 // origin pull can publish its provider record before others
 // fire their own fallback.
-// 6. **Re-check after jitter.** If the warm path materialised
+// 6. **Re-check after jitter.** If the warm path materialized
 // during the jitter window (peer published a provider record),
 // cancel and let the caller retry via the warm path.
 //
@@ -106,7 +106,7 @@ type DirectOriginFallbackOptions struct {
 	Inflight *inflight.Map
 
 	// Recheck performs a final DHT + cache + peer probe at the end
-	// of the jitter window. Returns true if a provider materialised
+	// of the jitter window. Returns true if a provider materialized
 	// during jitter (direct-origin-fallback cancels and the caller retries the warm
 	// path).
 	Recheck func(context.Context, digest.Digest) bool
@@ -118,7 +118,7 @@ type DirectOriginFallbackOptions struct {
 	// OnDecline reports the reason direct-origin-fallback declined a request. Useful
 	// for ops dashboards. reason ∈ {"bootstrap_window",
 	// "dht_unhealthy", "in_flight", "rate_limited", "recheck_hit",
-	// "context_cancelled"}. Optional.
+	// "context_canceled"}. Optional.
 	OnDecline func(reason string)
 }
 
@@ -227,15 +227,15 @@ func (n *DirectOriginFallbackController) Allow(ctx context.Context, d digest.Dig
 		case <-ctx.Done():
 			t.Stop()
 			release()
-			n.decline("context_cancelled")
+			n.decline("context_canceled")
 
 			return false, nil, ctx.Err()
 		case <-t.C:
 		}
 	}
 
-	// Final re-check: the warm path may have materialised during
-	// jitter. Cancelling here keeps `p2p_origin_fallback_total`
+	// Final re-check: the warm path may have materialized during
+	// jitter. Canceling here keeps `p2p_origin_fallback_total`
 	// near zero even under chaos scenarios.
 	if n.opts.Recheck != nil && n.opts.Recheck(ctx, d) {
 		release()

--- a/internal/gantry/mirror/nf5_test.go
+++ b/internal/gantry/mirror/nf5_test.go
@@ -215,7 +215,7 @@ func TestNF5_TokenBucketExhausts(t *testing.T) {
 }
 
 // TestNF5_DeclinesAfterRecheckHit asserts that if Recheck reports
-// a provider materialised during jitter, direct-origin-fallback cancels.
+// a provider materialized during jitter, direct-origin-fallback cancels.
 func TestNF5_DeclinesAfterRecheckHit(t *testing.T) {
 	ctrl := mirror.NewDirectOriginFallback(mirror.DirectOriginFallbackOptions{
 		Inflight:      nf5Inflight(),
@@ -302,7 +302,7 @@ func TestNF5_ContextCancelledDuringJitter(t *testing.T) {
 
 	proceed, _, err := ctrl.Allow(ctx, nf5Digest(t, '3'), ifaces.KindBlob, 0)
 	if proceed {
-		t.Fatalf("proceed=true; want false (ctx cancelled)")
+		t.Fatalf("proceed=true; want false (ctx canceled)")
 	}
 
 	if !errors.Is(err, context.Canceled) {

--- a/internal/inventory/agent/db.go
+++ b/internal/inventory/agent/db.go
@@ -26,7 +26,7 @@ const (
 )
 
 // DeviceRecord is the central schema for all inventory items. Every collected
-// hardware component is normalised into this structure so that heterogeneous
+// hardware component is normalized into this structure so that heterogeneous
 // device data can be stored and queried uniformly.
 type DeviceRecord struct {
 	DeviceType     DeviceType      `json:"device_type"`
@@ -71,8 +71,8 @@ func (r *Inventory) localDWriter(ctx context.Context, dbPath string) (retErr err
 	return nil
 }
 
-// mustMarshal serialises v to JSON. Panics on error (attribute structs are
-// simple value types so marshalling cannot realistically fail).
+// mustMarshal serializes v to JSON. Panics on error (attribute structs are
+// simple value types so marshaling cannot realistically fail).
 func mustMarshal(v any) json.RawMessage {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/internal/inventory/aggregator/collector.go
+++ b/internal/inventory/aggregator/collector.go
@@ -47,7 +47,7 @@ func Run(ctx context.Context, cfg Config) error {
 	grpcServer := grpc.NewServer()
 	inventoryv1.RegisterInventoryAggregatorServer(grpcServer, NewServer(db))
 
-	// Shut down gracefully when the context is cancelled.
+	// Shut down gracefully when the context is canceled.
 	go func() {
 		<-ctx.Done()
 		slog.Info("shutting down gRPC server")

--- a/internal/inventory/viewer/execute.go
+++ b/internal/inventory/viewer/execute.go
@@ -45,7 +45,7 @@ type NeighborRow struct {
 }
 
 // Execute starts the inventory viewer web server and blocks until the context
-// is cancelled.
+// is canceled.
 func Execute(ctx context.Context, cfg Config) error {
 	connector, err := pq.NewConnectorConfig(cfg.DbConn)
 	if err != nil {

--- a/internal/net/certmanager/certmanager.go
+++ b/internal/net/certmanager/certmanager.go
@@ -217,7 +217,7 @@ func (cm *CertManager) HMACKey() []byte {
 
 // RunRotationMonitor runs a loop that checks the current certificate every 24
 // hours and rotates it if it is within 30 days of expiry. It blocks until the
-// context is cancelled.
+// context is canceled.
 func (cm *CertManager) RunRotationMonitor(ctx context.Context) {
 	ticker := time.NewTicker(monitorInterval)
 	defer ticker.Stop()

--- a/internal/net/config/config_watcher.go
+++ b/internal/net/config/config_watcher.go
@@ -19,7 +19,7 @@ import (
 // dynamically updates the klog verbosity when the common.logLevel field
 // changes. Kubernetes ConfigMap volume mounts use symlink swaps, so we
 // watch the parent directory for reliable notification. The function
-// blocks until ctx is cancelled.
+// blocks until ctx is canceled.
 func WatchConfigLogLevel(ctx context.Context, configPath string) {
 	dir := filepath.Dir(configPath)
 

--- a/internal/net/healthcheck/listener.go
+++ b/internal/net/healthcheck/listener.go
@@ -60,7 +60,7 @@ func (l *Listener) SetHandler(h packetHandler) {
 }
 
 // Start begins listening for health check packets. It blocks until ctx is
-// cancelled or Stop is called.
+// canceled or Stop is called.
 func (l *Listener) Start(ctx context.Context) error {
 	if l.conn == nil {
 		addr := fmt.Sprintf(":%d", l.port)

--- a/internal/net/netlink/route_manager.go
+++ b/internal/net/netlink/route_manager.go
@@ -124,7 +124,7 @@ type UnifiedRouteManager struct {
 
 // NewUnifiedRouteManager creates a new route manager.
 //
-// linkName is the primary interface used for metrics labelling; actual
+// linkName is the primary interface used for metrics labeling; actual
 // route interfaces come from each DesiredNexthop.LinkIndex.
 //
 // defaultTable is the routing table ID used for routes whose Table field

--- a/internal/net/netlink/route_manager_test.go
+++ b/internal/net/netlink/route_manager_test.go
@@ -839,7 +839,7 @@ func TestBuildKernelRoute_PreferredSource(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Dedicated table behaviour
+// Dedicated table behavior
 // ---------------------------------------------------------------------------
 
 // TestSyncRoutes_DedicatedTable verifies that routes with Table==0 get keyed

--- a/internal/net/webhook/server_test.go
+++ b/internal/net/webhook/server_test.go
@@ -191,7 +191,7 @@ func TestRefreshAggregatedClientCAsFromConfigMap(t *testing.T) {
 }
 
 // TestRegisterHandlers_ContextCancel tests that the CA refresh goroutine
-// started by RegisterHandlers exits when the context is cancelled.
+// started by RegisterHandlers exits when the context is canceled.
 func TestRegisterHandlers_ContextCancel(t *testing.T) {
 	clientset := fake.NewClientset()
 	s := &Server{

--- a/internal/operator/component/order.go
+++ b/internal/operator/component/order.go
@@ -27,7 +27,7 @@ package component
 // webhooks, which are failurePolicy: Ignore, silently passed everything
 // through.
 //
-// DependsOn is still honoured, and is still the way to express an ordering that
+// DependsOn is still honored, and is still the way to express an ordering that
 // does not follow from the kinds involved.
 type tier int
 
@@ -69,7 +69,7 @@ const (
 //
 // Kinds are matched by name rather than by group so that a kind is placed
 // correctly whether it arrives as a typed object or as unstructured YAML from a
-// manifest, and so an unrecognised kind lands in tierInstance, after its CRD.
+// manifest, and so an unrecognized kind lands in tierInstance, after its CRD.
 var tierByKind = map[string]tier{
 	"Namespace": tierNamespace,
 
@@ -118,7 +118,7 @@ func tierOf(op Operation) tier {
 		return known
 	}
 
-	// An unrecognised kind is treated as a custom resource, which is what it
+	// An unrecognized kind is treated as a custom resource, which is what it
 	// almost always is here. That places it after CRDs, and before workloads
 	// in case a workload consumes it.
 	return tierInstance

--- a/internal/operator/component/order_test.go
+++ b/internal/operator/component/order_test.go
@@ -316,7 +316,7 @@ func TestExecuteAliasesDoNotLeakBetweenOperationsOnTheSameObject(t *testing.T) {
 	}
 
 	// The shared create still reports to both contributors, which is the
-	// behaviour the aliasing exists for.
+	// behavior the aliasing exists for.
 	var createSites []string
 
 	for _, r := range result.Results {

--- a/internal/operator/components/net/net_test.go
+++ b/internal/operator/components/net/net_test.go
@@ -992,7 +992,7 @@ func TestServiceHasEndpointFallsBackToEndpoints(t *testing.T) {
 	}
 
 	if !serving {
-		t.Fatal("a ready legacy Endpoints subset was not recognised as serving")
+		t.Fatal("a ready legacy Endpoints subset was not recognized as serving")
 	}
 
 	// An existing not-ready slice is authoritative even if a legacy object has

--- a/internal/operator/imagecoverage_test.go
+++ b/internal/operator/imagecoverage_test.go
@@ -160,7 +160,7 @@ func repoRoot(t *testing.T) string {
 }
 
 // stepPushes reports whether a build-push-action step actually pushes. Two
-// spellings are in use and both must be honoured: `push: true`, and an
+// spellings are in use and both must be honored: `push: true`, and an
 // `outputs:` entry carrying push=true. The net image steps use only the latter,
 // so keying on `push` alone silently misses them.
 func stepPushes(push any, outputs string) bool {

--- a/internal/operator/migrate.go
+++ b/internal/operator/migrate.go
@@ -236,7 +236,7 @@ type LegacyReaper struct {
 func (*LegacyReaper) NeedLeaderElection() bool { return true }
 
 // Start runs the migrate-then-reap loop until everything is drained or the
-// context is cancelled (manager shutdown). It is the manager.Runnable entry
+// context is canceled (manager shutdown). It is the manager.Runnable entry
 // point; context cancellation is a clean stop, not an error.
 func (r *LegacyReaper) Start(ctx context.Context) error {
 	if err := r.RunToCompletion(ctx); err != nil && ctx.Err() == nil {
@@ -247,7 +247,7 @@ func (r *LegacyReaper) Start(ctx context.Context) error {
 }
 
 // RunToCompletion performs idempotent translate-migrate-reap passes until every
-// legacy namespace is drained and deleted, the context is cancelled, or an
+// legacy namespace is drained and deleted, the context is canceled, or an
 // unexpected error occurs. It returns nil only once fully reaped.
 func (r *LegacyReaper) RunToCompletion(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName("legacy-reaper")

--- a/internal/operator/migrate_test.go
+++ b/internal/operator/migrate_test.go
@@ -1639,7 +1639,7 @@ func TestMigrationGatesAcceptRunningReplicas(t *testing.T) {
 }
 
 // TestMachinaGateRejectsZeroReplicaTarget drives the same defect through the
-// gate that actually authorises the delete, rather than the helper alone.
+// gate that actually authorizes the delete, rather than the helper alone.
 func TestMachinaGateRejectsZeroReplicaTarget(t *testing.T) {
 	const target = "unbounded-system"
 

--- a/internal/operator/override/apply.go
+++ b/internal/operator/override/apply.go
@@ -165,7 +165,7 @@ func applyTarget(plan *component.Plan, target Target) WorkloadResult {
 	// The hash is computed first, from the contributor set alone, so it is
 	// reported whether or not the merge succeeds. Leaving it empty on failure
 	// made a failed workload indistinguishable in status from one no override
-	// targets at all, and the CLI labelled it "no override": the exact opposite
+	// targets at all, and the CLI labeled it "no override": the exact opposite
 	// of the truth, on the single most important row it prints.
 	hash, err := contributorHash(target.Contributors)
 	if err != nil {

--- a/internal/operator/override/apply_test.go
+++ b/internal/operator/override/apply_test.go
@@ -780,7 +780,7 @@ func TestApplyPreservesPodAntiAffinity(t *testing.T) {
 // Unlike a patch leaf, extraArgs concatenates, so two contributors do not
 // overwrite one another: both lists land, ordered by sorted ConfigMap key. Two
 // teams appending --log-level=debug and --log-level=warn both got their way,
-// and which one the component honoured was decided by its own flag parsing.
+// and which one the component honored was decided by its own flag parsing.
 // That is exactly the silent precedence the deterministic ordering exists to
 // avoid rather than to provide.
 func TestApplyRejectsTwoContributorsAppendingToOneContainer(t *testing.T) {

--- a/internal/operator/override/compose.go
+++ b/internal/operator/override/compose.go
@@ -84,7 +84,7 @@ func checkConflicts(contributors []SourcedEntry) []error {
 // makes the outcome depend on what the keys happen to be called, which is
 // exactly the silent precedence the deterministic ordering exists to avoid
 // rather than to provide. Two teams appending --log-level=debug and
-// --log-level=warn both get their way, and which one the component honours is
+// --log-level=warn both get their way, and which one the component honors is
 // decided by its own flag parsing.
 //
 // Identical lists are rejected too, which is where this differs from the

--- a/internal/operator/override/merge_test.go
+++ b/internal/operator/override/merge_test.go
@@ -608,7 +608,7 @@ func TestApplyTopologySpreadIsAdditive(t *testing.T) {
 	}
 }
 
-// TestMergeRestampsPathsATypedSiteFieldOwns is the defence-in-depth half of the
+// TestMergeRestampsPathsATypedSiteFieldOwns is the defense-in-depth half of the
 // precedence rule.
 //
 // Validation rejects a patch that sets an owned path, so in a running operator

--- a/internal/operator/override/validate_test.go
+++ b/internal/operator/override/validate_test.go
@@ -496,7 +496,7 @@ func TestPermittedAndProtectedPathsAreExported(t *testing.T) {
 	}
 
 	// No path may be both permitted and protected, or the surface contradicts
-	// itself and behaviour depends on evaluation order.
+	// itself and behavior depends on evaluation order.
 	protectedSet := map[string]bool{}
 	for _, path := range protected {
 		protectedSet[path] = true

--- a/internal/operator/override_examples_test.go
+++ b/internal/operator/override_examples_test.go
@@ -225,7 +225,7 @@ var unverifiableExampleFlags = map[string]bool{}
 // flag the component actually accepts.
 //
 // Container names being right is not enough. These components are cobra and
-// clap programs, and every one of them exits non-zero on an unrecognised flag,
+// clap programs, and every one of them exits non-zero on an unrecognized flag,
 // so a wrong flag in a documented example is a CrashLoopBackOff for anyone who
 // copies it. The operator cannot check this at runtime, which is exactly why
 // the examples have to be checked here.
@@ -267,7 +267,7 @@ func assertExampleExtraArgsResolve(t *testing.T, example overrideExample, entry 
 
 			if build().Flags().Lookup(name) == nil {
 				t.Errorf("%s appends %q, but %s registers no --%s flag; "+
-					"an unrecognised flag makes the component exit non-zero",
+					"an unrecognized flag makes the component exit non-zero",
 					example.source, arg, entry.Entry.Component, name)
 			}
 		}

--- a/internal/orca/app/app_test.go
+++ b/internal/orca/app/app_test.go
@@ -84,7 +84,7 @@ func TestOpsHandler_Readyz_ReadyReturns200(t *testing.T) {
 }
 
 // TestApp_IsReady_RequiresCachestoreReady locks the AND-gating
-// behaviour of isReady. When cachestoreReady is false, isReady must
+// behavior of isReady. When cachestoreReady is false, isReady must
 // short-circuit and return false without touching the Cluster
 // pointer. Without that short-circuit a self-test failure that
 // leaves Cluster nil would panic the /readyz handler.
@@ -131,10 +131,10 @@ func TestApp_Wait_DrainsErrChOnCtxCancel(t *testing.T) {
 	a.errCh <- errors.New("ops boom")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // ctx already cancelled when Wait starts
+	cancel() // ctx already canceled when Wait starts
 
 	if err := a.Wait(ctx); err != nil {
-		t.Errorf("Wait err = %v, want nil (ctx cancelled)", err)
+		t.Errorf("Wait err = %v, want nil (ctx canceled)", err)
 	}
 
 	out := buf.String()

--- a/internal/orca/cachestore/s3/s3.go
+++ b/internal/orca/cachestore/s3/s3.go
@@ -336,7 +336,7 @@ func (d *Driver) PutChunk(ctx context.Context, k chunk.Key, size int64, r io.Rea
 		// guard, a buggy caller passing a Reader of length M with
 		// size=N would either be rejected by S3 (ContentLength
 		// mismatch) or upload a truncated / overlong blob,
-		// depending on backend behaviour. The wire-format boundary
+		// depending on backend behavior. The wire-format boundary
 		// already rejects size <= 0; this catches the size > 0 but
 		// mismatched-bytes case at the driver entry point.
 		end, err := body.Seek(0, io.SeekEnd)
@@ -520,7 +520,7 @@ func isNotFound(err error) bool {
 	return false
 }
 
-// mapErr normalises driver errors to the cachestore sentinel
+// mapErr normalizes driver errors to the cachestore sentinel
 // taxonomy. AccessDenied / Forbidden / Unauthorized are surfaced by
 // the SDK with stable smithy.APIError codes so we keep that match
 // path; everything else routes through HTTP status code on the

--- a/internal/orca/chunk/chunk.go
+++ b/internal/orca/chunk/chunk.go
@@ -103,7 +103,7 @@ func writeLP(h hash.Hash, s string) {
 //     should not invoke IndexRange; the server short-circuits to
 //     200 + empty body upstream.
 //
-// Clamping behaviour:
+// Clamping behavior:
 //   - end >= objectSize is clamped to objectSize - 1.
 //   - end < 0 is defensively clamped to 0 (returns first=0, last=0,
 //     meaning "chunk 0" - the caller must already have prevented

--- a/internal/orca/cluster/cluster.go
+++ b/internal/orca/cluster/cluster.go
@@ -118,7 +118,7 @@ func WithPeerSource(s PeerSource) Option {
 // WithHTTPClient overrides the internal-RPC HTTP client. TEST-ONLY:
 // production constructs the default client from cfg via newHTTPClient.
 // Used by unit tests that need to inject a client with custom timeouts
-// or transport behaviour for deterministic deadline coverage.
+// or transport behavior for deterministic deadline coverage.
 func WithHTTPClient(c *http.Client) Option {
 	return func(cl *Cluster) { cl.httpClient = c }
 }
@@ -211,7 +211,7 @@ func New(parent context.Context, cfg config.Cluster, opts ...Option) (*Cluster, 
 // Close stops the refresh goroutine and waits for it to exit. If ctx
 // is canceled before the goroutine exits (e.g. an in-flight DNS
 // lookup is taking longer than the caller can tolerate) Close returns
-// the context error. The underlying cancellation is always signalled,
+// the context error. The underlying cancellation is always signaled,
 // so the goroutine will exit eventually even if the caller stops
 // waiting.
 func (c *Cluster) Close(ctx context.Context) error {
@@ -437,7 +437,7 @@ func (c *Cluster) refreshLoop(ctx context.Context) {
 func (c *Cluster) refresh(ctx context.Context) {
 	peers, err := c.source.Peers(ctx)
 	if err != nil {
-		// A cancelled parent ctx (process shutdown) is not a
+		// A canceled parent ctx (process shutdown) is not a
 		// discovery failure: it means the refresh loop is exiting.
 		// Bumping the streak counter on the way out would push the
 		// final snapshot into the self-only fallback path and emit

--- a/internal/orca/cluster/cluster_test.go
+++ b/internal/orca/cluster/cluster_test.go
@@ -474,7 +474,7 @@ func TestFillFromPeer_CtxDeadlineHonored(t *testing.T) {
 
 // TestWithHTTPClient_Overrides verifies the test seam: tests can
 // inject an alternate http.Client (used to give a deterministic
-// short timeout or custom transport behaviour).
+// short timeout or custom transport behavior).
 func TestWithHTTPClient_Overrides(t *testing.T) {
 	t.Parallel()
 
@@ -502,7 +502,7 @@ func TestWithHTTPClient_Overrides(t *testing.T) {
 	}
 }
 
-// TestWithLogger_OverridesDefault verifies the cluster honours the
+// TestWithLogger_OverridesDefault verifies the cluster honors the
 // injected slog.Logger so cluster.refresh's warn-level
 // retain-snapshot message and the debug-level emissions route to
 // the caller's configured handler rather than slog.Default.
@@ -650,7 +650,7 @@ func TestCoordinator_EmitsDebugSelection(t *testing.T) {
 }
 
 // TestRefresh_CtxCanceledDoesNotBumpErrorCounter verifies that a
-// refresh call whose ctx has been cancelled (the normal shutdown
+// refresh call whose ctx has been canceled (the normal shutdown
 // path) does not bump consecutiveRefreshErrors or churn the stored
 // peer-set into the self-only fallback. Without this guard the
 // final refresh during graceful shutdown produces a 'discovery

--- a/internal/orca/config/config.go
+++ b/internal/orca/config/config.go
@@ -96,7 +96,7 @@ type OriginRetry struct {
 // Page and Append blobs are unconditionally rejected at Head: their
 // random-access mutation model is incompatible with the chunked,
 // immutable cache contract orca relies on. There is no configuration
-// switch for this behaviour.
+// switch for this behavior.
 type Azureblob struct {
 	Account    string `yaml:"account"`
 	AccountKey string `yaml:"account_key"`
@@ -523,7 +523,7 @@ func validateChunkingTiers(tiers []ChunkTier) error {
 // ParseLogLevel maps an orca log-level string to slog.Level. Returns
 // an error for unknown values. Empty string is treated as the
 // configured default ("info"). Used both by config.validate at YAML
-// parse time and by the cmd/orca entrypoint to honour the
+// parse time and by the cmd/orca entrypoint to honor the
 // ORCA_LOG_LEVEL environment override.
 func ParseLogLevel(s string) (slog.Level, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {

--- a/internal/orca/config/config_test.go
+++ b/internal/orca/config/config_test.go
@@ -572,7 +572,7 @@ func TestParseLogLevel(t *testing.T) {
 	}
 }
 
-// TestValidate_RejectsInvalidLogLevel verifies that an unrecognised
+// TestValidate_RejectsInvalidLogLevel verifies that an unrecognized
 // logging.level value is caught at config.Load time rather than at
 // process startup.
 func TestValidate_RejectsInvalidLogLevel(t *testing.T) {

--- a/internal/orca/metadata/metadata.go
+++ b/internal/orca/metadata/metadata.go
@@ -124,7 +124,7 @@ func (c *Cache) lookup(originID, bucket, key string) (origin.ObjectInfo, bool, e
 // fetch and caches the result with the appropriate TTL.
 //
 // Singleflight tradeoff: the first caller (leader) drives fetch with
-// its own ctx. If the leader's ctx is cancelled mid-fetch, joiners
+// its own ctx. If the leader's ctx is canceled mid-fetch, joiners
 // observe the leader's resulting ctx-error rather than their own
 // (still-valid) ctx. This is the standard singleflight contract; a
 // joiner can re-issue after seeing ctx.Err on a closed sfe.done if

--- a/internal/orca/origin/azureblob/azureblob.go
+++ b/internal/orca/origin/azureblob/azureblob.go
@@ -266,7 +266,7 @@ func validateBlobType(container, key string, blobType *blob.BlobType) error {
 	}
 }
 
-// unwrapAzcoreETag normalises an *azcore.ETag from the Azure SDK
+// unwrapAzcoreETag normalizes an *azcore.ETag from the Azure SDK
 // to the unquoted form orca uses internally. The Azure REST API
 // returns entity tags as quoted-strings per RFC 7232; the SDK
 // preserves the quotes, and orca strips them at the boundary so

--- a/internal/orca/origin/azureblob/azureblob_test.go
+++ b/internal/orca/origin/azureblob/azureblob_test.go
@@ -95,7 +95,7 @@ func TestValidateBlobType_NonBlockBlob_AlwaysRejected(t *testing.T) {
 // TestGetRange_QuotesIfMatchHeader verifies that the If-Match header
 // emitted on a conditional GetRange is the etag value wrapped in
 // double quotes per RFC 7232. The internal representation strips
-// quotes on Head (drivers normalise to unquoted), so this is the
+// quotes on Head (drivers normalize to unquoted), so this is the
 // re-wrap point on egress. Without the wrap an upstream that
 // strictly enforces RFC 7232 entity-tag syntax would reject the
 // precondition or treat it as never-matched.

--- a/internal/orca/server/server.go
+++ b/internal/orca/server/server.go
@@ -90,7 +90,7 @@ func (h *EdgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if key == "" {
 			// Both HEAD / and HEAD /{bucket}/ are reported as
 			// HeadBucket. HEAD / is not a real S3 operation, but
-			// labelling it HeadBucket keeps the surface uniform and
+			// labeling it HeadBucket keeps the surface uniform and
 			// makes the 501 self-explanatory.
 			h.notImplemented(w, r, "HeadBucket")
 			return
@@ -410,7 +410,7 @@ type readaheadJob struct {
 //     consumer as an early channel close; the consumer treats that
 //     as a mid-stream abort and returns cleanly.
 //   - Context cancellation from the caller (client disconnect)
-//     propagates through prefetchCtx, cancelling in-flight
+//     propagates through prefetchCtx, canceling in-flight
 //     GetChunk calls and causing the producer to exit.
 func (h *EdgeHandler) streamRemainingChunksReadahead(
 	ctx context.Context,
@@ -513,7 +513,7 @@ func (h *EdgeHandler) streamRemainingChunksReadahead(
 	if expectedIdx <= lastIdx {
 		// Channel closed before all chunks were delivered. The
 		// producer either panicked (already logged) or its context
-		// was cancelled (client disconnect or earlier mid-stream
+		// was canceled (client disconnect or earlier mid-stream
 		// abort - the latter would have returned above). Surface as
 		// a mid-stream warning so operators see truncated responses.
 		h.log.LogAttrs(ctx, slog.LevelWarn, "readahead truncated response",
@@ -589,9 +589,9 @@ func (h *EdgeHandler) prefetchChunks(
 			rc := make(chan pendingChunk, 1)
 
 			// Spawn worker first so the result channel always
-			// receives a write, even if ctx is cancelled while we
+			// receives a write, even if ctx is canceled while we
 			// block on the queue push below. The worker's
-			// GetChunk call will short-circuit on a cancelled ctx
+			// GetChunk call will short-circuit on a canceled ctx
 			// with err != nil and rc == nil, satisfying the
 			// "always write" invariant.
 			go func(idx int64, rc chan<- pendingChunk) {

--- a/internal/storagesupervisor/peers.go
+++ b/internal/storagesupervisor/peers.go
@@ -127,7 +127,7 @@ func newPeerWatcher(cfg Config, cs kubernetes.Interface) (*peerWatcher, error) {
 }
 
 // Start begins the informer's list-and-watch and blocks until the initial
-// sync completes or ctx is cancelled.
+// sync completes or ctx is canceled.
 func (w *peerWatcher) Start(ctx context.Context) error {
 	w.factory.Start(w.stopCh)
 
@@ -207,7 +207,7 @@ func nodesFromInformerObjects(objs []any) []*corev1.Node {
 	return nodes
 }
 
-// computeRing is the pure core of peer discovery: given the ring-labelled
+// computeRing is the pure core of peer discovery: given the ring-labeled
 // nodes, this node's name, the ring label key, and the shared fabric port, it
 // produces the ringState to inject into the config. It is separated from the
 // informer plumbing so the membership logic is unit-testable.

--- a/internal/storagesupervisor/peers_test.go
+++ b/internal/storagesupervisor/peers_test.go
@@ -111,7 +111,7 @@ func TestComputeRingPeersSortedByName(t *testing.T) {
 	assert.Equal(t, "zeta", ring.peers[2].GetName())
 }
 
-func TestComputeRingSelfNotLabelled(t *testing.T) {
+func TestComputeRingSelfNotLabeled(t *testing.T) {
 	// self carries no ring label: inactive, per-node config left untouched.
 	nodes := []*corev1.Node{
 		node("self", "", "10.0.0.1"),

--- a/internal/storagesupervisor/run.go
+++ b/internal/storagesupervisor/run.go
@@ -29,7 +29,7 @@ const nodeSyncTimeout = 30 * time.Second
 // cfg.ConfigPath, then watches both the source directory and cluster nodes and
 // re-renders on change. The daemon owns reacting to the rewritten file (it has
 // its own watcher and manages its own restarts), so this loop is render-only.
-// It blocks until ctx is cancelled.
+// It blocks until ctx is canceled.
 func Run(ctx context.Context, cfg Config) error {
 	watcher, err := newPeerWatcher(cfg, nil)
 	if err != nil {
@@ -78,7 +78,7 @@ func Run(ctx context.Context, cfg Config) error {
 	return watchLoop(ctx, cfg, fsWatcher, watcher)
 }
 
-// watchLoop drives the debounced render loop until ctx is cancelled. It folds
+// watchLoop drives the debounced render loop until ctx is canceled. It folds
 // two change sources, ConfigMap projection events (fsWatcher) and node
 // membership events (peerWatcher), into a single debounced reconcile. It is
 // split out from Run so the watcher wiring stays separate from the event

--- a/pkg/agent/goalstates/resolve_test.go
+++ b/pkg/agent/goalstates/resolve_test.go
@@ -94,7 +94,7 @@ func TestResolveOCIImage_DisableEnvVar(t *testing.T) {
 		{"true", "true", ""},
 		{"1", "1", ""},
 		{"TRUE", "TRUE", ""},
-		// Falsy or unrecognised values should NOT disable; expect the default image.
+		// Falsy or unrecognized values should NOT disable; expect the default image.
 		{"false", "false", DefaultOCIImage},
 		{"0", "0", DefaultOCIImage},
 		{"empty", "", DefaultOCIImage},

--- a/pkg/agent/phases/phases.go
+++ b/pkg/agent/phases/phases.go
@@ -82,7 +82,7 @@ func (s *serial) Do(ctx context.Context) error {
 
 // Parallel returns a Task that executes the given tasks concurrently.
 // All tasks are started at once. On the first error the context passed to
-// remaining tasks is cancelled and the first error is returned.
+// remaining tasks is canceled and the first error is returned.
 // The provided logger is used to emit a wide log line for each task.
 func Parallel(log *slog.Logger, tasks ...Task) Task {
 	return &parallel{log: log, tasks: tasks}

--- a/pkg/agent/phases/rootfs/nspawn_render_test.go
+++ b/pkg/agent/phases/rootfs/nspawn_render_test.go
@@ -421,7 +421,7 @@ func requireBPFFSExecStartPreOrder(t *testing.T, out, bpffsPath string) {
 // TestAdditionalHostMounts_ConfigToNSpawn exercises the full AdditionalHostMounts
 // pipeline from a JSON agent config through to the rendered nspawn.conf content.
 // It validates that:
-//   - The AdditionalHostMounts field survives JSON round-trip unmarshalling.
+//   - The AdditionalHostMounts field survives JSON round-trip unmarshaling.
 //   - ValidateAdditionalHostMounts accepts the entries.
 //   - ResolveMachine defaults an omitted Target to the Source path.
 //   - The resolved mounts render to the correct Bind / BindReadOnly directives.


### PR DESCRIPTION
The repo mixed British and American spellings with no rule written down and nothing enforcing either, so `behaviour`/`behavior` and `initialise`/`initialize` both accumulated. This converts the British ones and adds a guard.

~370 occurrences across Go, Rust, Markdown, shell, TLA+, TSX, HTML, and YAML: the `-our` family, the `-ise`/`-isation` family, the doubled-consonant family, and stragglers (`defence`, `licence`, `catalogue`, `analogue`, `judgement`, `acknowledgement`, `artefact`, `enrol`). Three test functions are renamed; no test is removed. Everything else is comments, docs, and a few help/error strings that nothing asserts on.

Enables the `misspell` linter with `locale: US`, and states the rule in `AGENTS.md` since misspell's dictionary is not exhaustive (it misses `judgement` and `acknowledgement`) and it does not read Rust, shell, TLA+, or Markdown.

### Two things worth a reviewer's attention

**`misspell --fix` broke the NOTICE tooling.** `make fmt` runs `golangci-lint --fix`, which "corrected" the `LICENCE` glob patterns in `hack/cmd/notice`, producing a duplicate `"LICENSE*"` and a duplicate candidate list. Upstream crates that spell it `LICENCE` would have silently dropped out of NOTICE with no error. Patterns restored, misspell exclusion added, and `TestFindFile_BritishSpelling` now pins them (verified it fails when the candidates are "corrected").

**`cancelled` is included.** It was going to be skipped as an accepted US variant, but misspell flags it and `--fix` rewrites it regardless, so keeping it would have meant a hole in the linter. `.github/workflows/release-upgrade.yaml` is the one exception: `cancelled()` is a GitHub Actions expression and `CANCELLED` a GitHub API status.

### Verification

`make fmt` (idempotent), `make lint` 0 issues, `make test` 139/139 packages, `actionlint` clean, `go generate ./api/...` produced no CRD or deepcopy diff, racer `cargo test --all-targets` 84 tests pass.

Not run: the `cmd/unbounded-storage` test suite. `liburing-dev` is unavailable locally so the libfabric build fails. `cargo check --locked --all-targets` passes, which type-checks the `Error::Cancelled` -> `Canceled` rename and all match arms including test code, but the DST suite is unexecuted and needs CI.

Two pre-existing failures on `main`, confirmed against a clean worktree and untouched here: `cargo fmt --check` drift in `cmd/unbounded-storage/src/backend/s3_sigv4.rs:204`, and three `tsc` errors in `frontend/src/App.tsx` about `nodeK8sStatusMap`.