### PR TITLE
Add opt-in STUN public IP discovery to the network node agent.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -501,6 +501,13 @@ notices:
     license:
       - name: MIT License
         link: https://github.com/pin/tftp/blob/v3.2.0/LICENSE
+  - dependency: github.com/pion/stun/v3
+    ecosystem: go
+    copyright:
+      - Copyright (c) 2026 The Pion community <https://pion.ly>
+    license:
+      - name: MIT License
+        link: https://github.com/pion/stun/blob/v3.1.5/LICENSE
   - dependency: github.com/prometheus/client_golang
     ecosystem: go
     copyright:

--- a/cmd/unbounded-net-node/main.go
+++ b/cmd/unbounded-net-node/main.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -722,6 +724,14 @@ func run(cfg *config) error {
 		klog.Fatalf("Failed to create dynamic Kubernetes client: %v", err)
 	}
 
+	publicIPConfig := publicIPDiscoveryConfig{
+		Enabled:              cfg.STUNEnabled,
+		Server:               net.JoinHostPort(cfg.STUNHost, strconv.Itoa(cfg.STUNPort)),
+		RecheckInterval:      cfg.STUNRecheckInterval,
+		InitialDelayLimit:    min(publicIPDiscoveryDelayLimit, cfg.STUNRecheckInterval),
+		CleanupRetryInterval: publicIPDiscoveryCleanupRetryInterval,
+	}
+
 	// Generate WireGuard keys and annotate node
 	pubKey, err := ensureWireGuardKeys(cfg)
 	if err != nil {
@@ -746,6 +756,8 @@ func run(cfg *config) error {
 			klog.Infof("Node annotated with tunnel MTU %d (detected default route MTU %d - %d overhead)", wgMTU, detectedMTU, unboundednetnetlink.WireGuardMTUOverhead)
 		}
 	}
+
+	go runPublicIPDiscovery(ctx, clientset, cfg.NodeName, publicIPConfig, stunPublicIPDiscoverer{})
 
 	// Watch the config file for dynamic log level changes.
 	go configpkg.WatchConfigLogLevel(ctx, cfg.ConfigFile)

--- a/cmd/unbounded-net-node/main.go
+++ b/cmd/unbounded-net-node/main.go
@@ -73,6 +73,10 @@ type config struct {
 	KubeconfigPath                string
 	ApiserverURL                  string // Override Kubernetes API server URL (empty = use default)
 	NodeName                      string
+	STUNEnabled                   bool
+	STUNHost                      string
+	STUNPort                      int
+	STUNRecheckInterval           time.Duration
 	CNIConfDir                    string
 	CNIConfFile                   string
 	BridgeName                    string
@@ -165,6 +169,15 @@ var gatewayPoolPeeringGVR = schema.GroupVersionResource{
 }
 
 const (
+	defaultSTUNEnabled         = false
+	defaultSTUNHost            = ""
+	defaultSTUNPort            = 3478
+	defaultSTUNRecheckInterval = time.Hour
+
+	publicIPDiscoveryTimeout              = 5 * time.Second
+	publicIPDiscoveryDelayLimit           = 5 * time.Minute
+	publicIPDiscoveryCleanupRetryInterval = 10 * time.Minute
+
 	// WireGuard public key annotation on the node
 	WireGuardPubKeyAnnotation = "net.unbounded-cloud.io/wg-pubkey"
 
@@ -192,6 +205,10 @@ func main() {
 
 	cfg := &config{
 		ConfigFile:                    "/etc/unbounded-net/config.yaml",
+		STUNEnabled:                   defaultSTUNEnabled,
+		STUNHost:                      defaultSTUNHost,
+		STUNPort:                      defaultSTUNPort,
+		STUNRecheckInterval:           defaultSTUNRecheckInterval,
 		CNIConfDir:                    "/etc/cni/net.d",
 		CNIConfFile:                   "10-unbounded.conflist",
 		BridgeName:                    "cbr0",
@@ -263,6 +280,10 @@ then annotates the node with the public key.`,
 	flags.StringVar(&cfg.KubeconfigPath, "kubeconfig", "", "Path to kubeconfig file (uses in-cluster config if not specified)")
 	flags.StringVar(&cfg.ApiserverURL, "apiserver-url", "", "Override Kubernetes API server URL (empty = use default from kubeconfig or in-cluster config)")
 	flags.StringVar(&cfg.NodeName, "node-name", os.Getenv("NODE_NAME"), "Name of this node (defaults to NODE_NAME env var)")
+	flags.BoolVar(&cfg.STUNEnabled, "stun-enabled", defaultSTUNEnabled, "Discover the node's public IP with STUN when no override or provider ExternalIP exists")
+	flags.StringVar(&cfg.STUNHost, "stun-host", defaultSTUNHost, "STUN server host used for public IP discovery (required when enabled)")
+	flags.IntVar(&cfg.STUNPort, "stun-port", defaultSTUNPort, "STUN server port used for public IP discovery")
+	flags.DurationVar(&cfg.STUNRecheckInterval, "stun-recheck-interval", defaultSTUNRecheckInterval, "Interval between STUN public IP rechecks")
 	flags.IntVar(&cfg.HealthPort, "health-port", 9998, "Port for health check HTTP server (0 to disable)")
 	flags.DurationVar(&cfg.InformerResyncPeriod, "informer-resync-period", 600*time.Second, "Resync period for Kubernetes informers")
 
@@ -346,6 +367,27 @@ func applyNodeRuntimeConfig(cmd *cobra.Command, cfg *config) error {
 
 	if !flags.Changed("node-name") && nodeCfg.NodeName != "" {
 		cfg.NodeName = nodeCfg.NodeName
+	}
+
+	if !flags.Changed("stun-enabled") && nodeCfg.STUNEnabled != nil {
+		cfg.STUNEnabled = *nodeCfg.STUNEnabled
+	}
+
+	if !flags.Changed("stun-host") && nodeCfg.STUNHost != "" {
+		cfg.STUNHost = nodeCfg.STUNHost
+	}
+
+	if !flags.Changed("stun-port") && nodeCfg.STUNPort != nil {
+		cfg.STUNPort = *nodeCfg.STUNPort
+	}
+
+	if !flags.Changed("stun-recheck-interval") && nodeCfg.STUNRecheckInterval != "" {
+		d, parseErr := configpkg.ParseDurationField(nodeCfg.STUNRecheckInterval, "node.stunRecheckInterval")
+		if parseErr != nil {
+			return parseErr
+		}
+
+		cfg.STUNRecheckInterval = d
 	}
 
 	if !flags.Changed("cni-conf-dir") && nodeCfg.CNIConfDir != "" {
@@ -591,6 +633,20 @@ func applyNodeRuntimeConfig(cmd *cobra.Command, cfg *config) error {
 
 	if cfg.MTU < 0 {
 		return fmt.Errorf("node MTU must be >= 0")
+	}
+
+	if cfg.STUNRecheckInterval <= 0 {
+		return fmt.Errorf("node STUN recheck interval must be greater than zero")
+	}
+
+	if cfg.STUNEnabled {
+		if cfg.STUNHost == "" {
+			return fmt.Errorf("node STUN host must not be empty")
+		}
+
+		if cfg.STUNPort < 1 || cfg.STUNPort > 65535 {
+			return fmt.Errorf("node STUN port must be between 1 and 65535")
+		}
 	}
 
 	// Apply common config.

--- a/cmd/unbounded-net-node/main_config_test.go
+++ b/cmd/unbounded-net-node/main_config_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,10 @@ func newNodeConfigTestCommand(cfg *config) *cobra.Command {
 	flags := cmd.Flags()
 	flags.DurationVar(&cfg.InformerResyncPeriod, "informer-resync-period", 3600*time.Second, "")
 	flags.StringVar(&cfg.NodeName, "node-name", "", "")
+	flags.BoolVar(&cfg.STUNEnabled, "stun-enabled", defaultSTUNEnabled, "")
+	flags.StringVar(&cfg.STUNHost, "stun-host", defaultSTUNHost, "")
+	flags.IntVar(&cfg.STUNPort, "stun-port", defaultSTUNPort, "")
+	flags.DurationVar(&cfg.STUNRecheckInterval, "stun-recheck-interval", defaultSTUNRecheckInterval, "")
 	flags.StringVar(&cfg.CNIConfDir, "cni-conf-dir", "/etc/cni/net.d", "")
 	flags.StringVar(&cfg.CNIConfFile, "cni-conf-file", "10-unbounded.conflist", "")
 	flags.StringVar(&cfg.BridgeName, "bridge-name", "cbr0", "")
@@ -52,6 +57,10 @@ func TestApplyNodeRuntimeConfig(t *testing.T) {
 		ConfigFile:                    "",
 		InformerResyncPeriod:          3600 * time.Second,
 		NodeName:                      "node-from-flag",
+		STUNEnabled:                   defaultSTUNEnabled,
+		STUNHost:                      defaultSTUNHost,
+		STUNPort:                      defaultSTUNPort,
+		STUNRecheckInterval:           defaultSTUNRecheckInterval,
 		CNIConfDir:                    "/etc/cni/net.d",
 		CNIConfFile:                   "10-unbounded.conflist",
 		BridgeName:                    "cbr0",
@@ -85,6 +94,9 @@ func TestApplyNodeRuntimeConfig(t *testing.T) {
 	runtimeYAML := []byte("node:\n" +
 		"  informerResyncPeriod: 30s\n" +
 		"  nodeName: node-from-config\n" +
+		"  stunEnabled: true\n" +
+		"  stunHost: stun.example.com\n" +
+		"  stunRecheckInterval: 12h\n" +
 		"  cniConfDir: /tmp/cni\n" +
 		"  cniConfFile: 20-test.conflist\n" +
 		"  bridgeName: cbr-test\n" +
@@ -121,6 +133,10 @@ func TestApplyNodeRuntimeConfig(t *testing.T) {
 
 	if cfg.InformerResyncPeriod != 30*time.Second || cfg.NodeName != "node-from-config" {
 		t.Fatalf("expected resync period and node name from runtime config, got period=%s node=%q", cfg.InformerResyncPeriod, cfg.NodeName)
+	}
+
+	if !cfg.STUNEnabled || cfg.STUNHost != "stun.example.com" || cfg.STUNPort != defaultSTUNPort || cfg.STUNRecheckInterval != 12*time.Hour {
+		t.Fatalf("expected STUN settings from runtime config, got enabled=%v host=%q port=%d recheckInterval=%s", cfg.STUNEnabled, cfg.STUNHost, cfg.STUNPort, cfg.STUNRecheckInterval)
 	}
 
 	if cfg.CNIConfDir != "/tmp/cni" || cfg.CNIConfFile != "20-test.conflist" || cfg.BridgeName != "cbr-test" {
@@ -181,6 +197,10 @@ func TestApplyNodeRuntimeConfigRespectsChangedFlags(t *testing.T) {
 	runtimeYAML := []byte("node:\n" +
 		"  nodeName: from-config\n" +
 		"  healthPort: 11000\n" +
+		"  stunEnabled: false\n" +
+		"  stunHost: config.example.com\n" +
+		"  stunPort: 5349\n" +
+		"  stunRecheckInterval: 12h\n" +
 		"  statusWsKeepaliveFailureCount: 6\n")
 	if err := os.WriteFile(cfg.ConfigFile, runtimeYAML, 0o644); err != nil {
 		t.Fatalf("failed to write runtime config fixture: %v", err)
@@ -199,6 +219,17 @@ func TestApplyNodeRuntimeConfigRespectsChangedFlags(t *testing.T) {
 		t.Fatalf("failed setting status-ws-keepalive-failure-count flag: %v", err)
 	}
 
+	for _, flag := range []struct{ name, value string }{
+		{name: "stun-enabled", value: "true"},
+		{name: "stun-host", value: "flag.example.com"},
+		{name: "stun-port", value: "3479"},
+		{name: "stun-recheck-interval", value: "24h"},
+	} {
+		if err := cmd.Flags().Set(flag.name, flag.value); err != nil {
+			t.Fatalf("failed setting %s flag: %v", flag.name, err)
+		}
+	}
+
 	if err := applyNodeRuntimeConfig(cmd, cfg); err != nil {
 		t.Fatalf("applyNodeRuntimeConfig returned error: %v", err)
 	}
@@ -209,5 +240,54 @@ func TestApplyNodeRuntimeConfigRespectsChangedFlags(t *testing.T) {
 
 	if cfg.StatusWSKeepaliveFailureCount != 4 {
 		t.Fatalf("expected changed keepalive failure count flag to win over runtime config, got %d", cfg.StatusWSKeepaliveFailureCount)
+	}
+
+	if !cfg.STUNEnabled || cfg.STUNHost != "flag.example.com" || cfg.STUNPort != 3479 || cfg.STUNRecheckInterval != 24*time.Hour {
+		t.Fatalf("expected changed STUN flags to win over runtime config, got enabled=%v host=%q port=%d recheckInterval=%s", cfg.STUNEnabled, cfg.STUNHost, cfg.STUNPort, cfg.STUNRecheckInterval)
+	}
+}
+
+func TestApplyNodeRuntimeConfigValidatesSTUNSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		yaml       string
+		enableSTUN bool
+		wantErr    string
+	}{
+		{name: "invalid recheck interval", yaml: "node:\n  stunHost: stun.example.com\n  stunRecheckInterval: invalid\n", wantErr: "node.stunRecheckInterval"},
+		{name: "zero recheck interval when disabled", yaml: "node:\n  stunRecheckInterval: 0s\n", wantErr: "recheck interval must be greater than zero"},
+		{name: "empty host", yaml: "node: {}\n", enableSTUN: true, wantErr: "host must not be empty"},
+		{name: "invalid port", yaml: "node:\n  stunHost: stun.example.com\n  stunPort: 0\n", enableSTUN: true, wantErr: "port must be between 1 and 65535"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config{
+				ConfigFile:               filepath.Join(t.TempDir(), "config.yaml"),
+				GeneveInterfaceName:      "geneve0",
+				VXLANInterfaceName:       "vxlan0",
+				IPIPInterfaceName:        "ipip0",
+				WireGuardInterfacePrefix: "wg",
+			}
+			if err := os.WriteFile(cfg.ConfigFile, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			cmd := newNodeConfigTestCommand(cfg)
+			if tt.enableSTUN {
+				if err := cmd.Flags().Set("stun-enabled", "true"); err != nil {
+					t.Fatalf("enable STUN: %v", err)
+				}
+			}
+
+			err := applyNodeRuntimeConfig(cmd, cfg)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("applyNodeRuntimeConfig() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/cmd/unbounded-net-node/metrics.go
+++ b/cmd/unbounded-net-node/metrics.go
@@ -28,6 +28,12 @@ var (
 	}, []string{metrics.LabelResult})
 )
 
+var nodePublicIPDiscoveryFailures = promauto.NewCounter(prometheus.CounterOpts{
+	Namespace: nodeMetricsNamespace,
+	Name:      "public_ip_discovery_failures_total",
+	Help:      "Total public IP discovery or annotation failures.",
+})
+
 // Status push metrics.
 var (
 	nodeStatusPushTotal = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/cmd/unbounded-net-node/public_ip_discovery.go
+++ b/cmd/unbounded-net-node/public_ip_discovery.go
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"net/netip"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
+)
+
+type publicIPDiscoveryConfig struct {
+	Enabled              bool
+	Server               string
+	RecheckInterval      time.Duration
+	InitialDelayLimit    time.Duration
+	CleanupRetryInterval time.Duration
+}
+
+type publicIPDiscoverer interface {
+	DiscoverPublicIP(ctx context.Context, server string) (netip.Addr, error)
+}
+
+func runPublicIPDiscovery(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeName string,
+	cfg publicIPDiscoveryConfig,
+	discoverer publicIPDiscoverer,
+) {
+	initialDelay := time.Duration(0)
+	if cfg.Enabled {
+		initialDelay = publicIPDiscoveryInitialDelay(nodeName, cfg.InitialDelayLimit)
+	}
+
+	timer := time.NewTimer(initialDelay)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		err := discoverAndAnnotateNodePublicIP(
+			ctx,
+			clientset,
+			nodeName,
+			cfg,
+			discoverer,
+			time.Second,
+			2*time.Second,
+		)
+		if err != nil {
+			nodePublicIPDiscoveryFailures.Inc()
+			klog.Warningf("Public IP discovery failed: %v", err)
+		}
+
+		if !cfg.Enabled && err == nil {
+			return
+		}
+
+		recheckInterval := cfg.RecheckInterval
+		if !cfg.Enabled {
+			recheckInterval = cfg.CleanupRetryInterval
+			if recheckInterval <= 0 {
+				recheckInterval = publicIPDiscoveryCleanupRetryInterval
+			}
+		}
+
+		timer.Reset(recheckInterval)
+	}
+}
+
+func publicIPDiscoveryInitialDelay(nodeName string, limit time.Duration) time.Duration {
+	if limit <= 0 {
+		return 0
+	}
+
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(nodeName))
+
+	return time.Duration(hash.Sum64() % uint64(limit))
+}
+
+func discoverAndAnnotateNodePublicIP(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeName string,
+	cfg publicIPDiscoveryConfig,
+	discoverer publicIPDiscoverer,
+	retryBackoffs ...time.Duration,
+) error {
+	apiCtx, cancel := context.WithTimeout(ctx, publicIPDiscoveryTimeout)
+	node, err := clientset.CoreV1().Nodes().Get(apiCtx, nodeName, metav1.GetOptions{})
+
+	cancel()
+
+	if err != nil {
+		return fmt.Errorf("get node %s before public IP discovery: %w", nodeName, err)
+	}
+
+	_, hasDeclaredIP := node.Annotations[unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation]
+	if !cfg.Enabled || hasDeclaredIP || nodeHasExternalIP(node) {
+		apiCtx, cancel = context.WithTimeout(ctx, publicIPDiscoveryTimeout)
+		defer cancel()
+
+		return removeDiscoveredNodePublicIP(apiCtx, clientset, node)
+	}
+
+	publicIP, err := discoverPublicIPWithRetry(ctx, discoverer, cfg.Server, retryBackoffs...)
+	if err != nil {
+		return fmt.Errorf("query STUN server %s: %w", cfg.Server, err)
+	}
+
+	publicIPString := publicIP.String()
+
+	// Keep the last confirmed address through two missed rechecks.
+	expiresAt := time.Now().UTC().Add(3 * cfg.RecheckInterval).Format(time.RFC3339Nano)
+
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation:          publicIPString,
+				unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation: expiresAt,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal public IP annotation patch: %w", err)
+	}
+
+	apiCtx, cancel = context.WithTimeout(ctx, publicIPDiscoveryTimeout)
+	defer cancel()
+
+	if _, err := clientset.CoreV1().Nodes().Patch(apiCtx, nodeName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("annotate node %s with discovered public IP: %w", nodeName, err)
+	}
+
+	klog.Infof("Annotated node %s with STUN-discovered public IP %s", nodeName, publicIPString)
+
+	return nil
+}
+
+func discoverPublicIPWithRetry(
+	ctx context.Context,
+	discoverer publicIPDiscoverer,
+	server string,
+	retryBackoffs ...time.Duration,
+) (netip.Addr, error) {
+	var err error
+
+	for attempt := 0; attempt <= len(retryBackoffs); attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, publicIPDiscoveryTimeout)
+		publicIP, discoverErr := discoverer.DiscoverPublicIP(attemptCtx, server)
+
+		cancel()
+
+		if discoverErr == nil {
+			return publicIP, nil
+		}
+
+		err = discoverErr
+
+		if ctx.Err() != nil {
+			return netip.Addr{}, ctx.Err()
+		}
+
+		if attempt == len(retryBackoffs) {
+			break
+		}
+
+		timer := time.NewTimer(retryBackoffs[attempt])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return netip.Addr{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return netip.Addr{}, fmt.Errorf("STUN discovery failed after %d attempts: %w", len(retryBackoffs)+1, err)
+}
+
+func nodeHasExternalIP(node *corev1.Node) bool {
+	for _, address := range node.Status.Addresses {
+		if address.Type == corev1.NodeExternalIP {
+			return true
+		}
+	}
+
+	return false
+}
+
+func removeDiscoveredNodePublicIP(ctx context.Context, clientset kubernetes.Interface, node *corev1.Node) error {
+	_, hasIP := node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation]
+
+	_, hasExpiry := node.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation]
+	if !hasIP && !hasExpiry {
+		return nil
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation:          nil,
+				unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation: nil,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal public IP annotation cleanup patch: %w", err)
+	}
+
+	if _, err := clientset.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("remove discovered public IP from node %s: %w", node.Name, err)
+	}
+
+	klog.Infof("Removed STUN-discovered public IP from node %s", node.Name)
+
+	return nil
+}

--- a/cmd/unbounded-net-node/public_ip_discovery_test.go
+++ b/cmd/unbounded-net-node/public_ip_discovery_test.go
@@ -1,0 +1,380 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"
+)
+
+type fakePublicIPDiscoverer struct {
+	publicIP netip.Addr
+	err      error
+	calls    int
+	server   string
+}
+
+type flakyPublicIPDiscoverer struct {
+	failures int
+	calls    int
+}
+
+type blockingPublicIPDiscoverer struct {
+	calls int
+}
+
+type signalingPublicIPDiscoverer struct {
+	calls chan struct{}
+}
+
+func (s signalingPublicIPDiscoverer) DiscoverPublicIP(ctx context.Context, _ string) (netip.Addr, error) {
+	select {
+	case s.calls <- struct{}{}:
+		return netip.MustParseAddr("203.0.113.20"), nil
+	case <-ctx.Done():
+		return netip.Addr{}, ctx.Err()
+	}
+}
+
+func testPublicIPDiscoveryConfig(enabled bool) publicIPDiscoveryConfig {
+	return publicIPDiscoveryConfig{
+		Enabled:              enabled,
+		Server:               "stun.example.com:3478",
+		RecheckInterval:      time.Hour,
+		InitialDelayLimit:    time.Minute,
+		CleanupRetryInterval: publicIPDiscoveryCleanupRetryInterval,
+	}
+}
+
+func (f *fakePublicIPDiscoverer) DiscoverPublicIP(_ context.Context, server string) (netip.Addr, error) {
+	f.calls++
+	f.server = server
+
+	return f.publicIP, f.err
+}
+
+func (f *flakyPublicIPDiscoverer) DiscoverPublicIP(_ context.Context, _ string) (netip.Addr, error) {
+	f.calls++
+	if f.calls <= f.failures {
+		return netip.Addr{}, errors.New("STUN request failed")
+	}
+
+	return netip.MustParseAddr("203.0.113.20"), nil
+}
+
+func (b *blockingPublicIPDiscoverer) DiscoverPublicIP(ctx context.Context, _ string) (netip.Addr, error) {
+	b.calls++
+
+	<-ctx.Done()
+
+	return netip.Addr{}, ctx.Err()
+}
+
+func TestRunPublicIPDiscoveryRechecks(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+	cfg := testPublicIPDiscoveryConfig(true)
+	cfg.InitialDelayLimit = 0
+	cfg.RecheckInterval = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	calls := make(chan struct{})
+
+	go func() {
+		runPublicIPDiscovery(ctx, clientset, "node-a", cfg, signalingPublicIPDiscoverer{calls: calls})
+		close(done)
+	}()
+
+	for range 2 {
+		select {
+		case <-calls:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for public IP discovery")
+		}
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("public IP discovery did not stop after cancellation")
+	}
+}
+
+func TestRunPublicIPDiscoveryRetriesDisabledCleanup(t *testing.T) {
+	t.Parallel()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", Annotations: map[string]string{
+		unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation: "203.0.113.20",
+	}}}
+	clientset := fake.NewClientset(node)
+	getCalls := 0
+
+	clientset.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls == 1 {
+			return true, nil, errors.New("transient get failure")
+		}
+
+		return false, nil, nil
+	})
+
+	cfg := testPublicIPDiscoveryConfig(false)
+	cfg.InitialDelayLimit = 24 * time.Hour
+	cfg.CleanupRetryInterval = time.Millisecond
+
+	if delay := publicIPDiscoveryInitialDelay(node.Name, cfg.InitialDelayLimit); delay <= time.Second {
+		t.Fatalf("test setup produced initial delay %s, want greater than one second", delay)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	runPublicIPDiscovery(ctx, clientset, node.Name, cfg, &fakePublicIPDiscoverer{})
+
+	if getCalls != 2 {
+		t.Fatalf("Node GET calls = %d, want 2", getCalls)
+	}
+
+	got, err := clientset.CoreV1().Nodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get Node after cleanup retry: %v", err)
+	}
+
+	if _, exists := got.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation]; exists {
+		t.Fatal("disabled cleanup retry left the discovered public IP annotation")
+	}
+}
+
+func TestDiscoverAndAnnotateNodePublicIPRetriesDiscovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		failures    int
+		wantErr     bool
+		wantPatches int
+	}{
+		{name: "second attempt succeeds", failures: 1, wantPatches: 1},
+		{name: "third attempt succeeds", failures: 2, wantPatches: 1},
+		{name: "all attempts fail", failures: 3, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clientset := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+			discoverer := &flakyPublicIPDiscoverer{failures: tt.failures}
+
+			err := discoverAndAnnotateNodePublicIP(
+				t.Context(),
+				clientset,
+				"node-a",
+				testPublicIPDiscoveryConfig(true),
+				discoverer,
+				0,
+				0,
+			)
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "failed after 3 attempts") {
+					t.Fatalf("error = %v, want three-attempt failure", err)
+				}
+			} else if err != nil {
+				t.Fatalf("discoverAndAnnotateNodePublicIP() error = %v", err)
+			}
+
+			wantCalls := min(tt.failures+1, 3)
+			if discoverer.calls != wantCalls {
+				t.Fatalf("DiscoverPublicIP() calls = %d, want %d", discoverer.calls, wantCalls)
+			}
+
+			actions := clientset.Actions()
+			if len(actions) != 1+tt.wantPatches || actions[0].GetVerb() != "get" {
+				t.Fatalf("client actions = %#v, want one GET and %d PATCH actions", actions, tt.wantPatches)
+			}
+
+			if tt.wantPatches == 1 && actions[1].GetVerb() != "patch" {
+				t.Fatalf("second client action = %s, want patch", actions[1].GetVerb())
+			}
+		})
+	}
+}
+
+func TestDiscoverPublicIPWithRetryStopsOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	discoverer := &blockingPublicIPDiscoverer{}
+
+	_, err := discoverPublicIPWithRetry(ctx, discoverer, "stun.example.com:3478", 0, 0)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context deadline exceeded", err)
+	}
+
+	if discoverer.calls != 1 {
+		t.Fatalf("DiscoverPublicIP() calls = %d, want 1", discoverer.calls)
+	}
+}
+
+func TestPublicIPDiscoveryInitialDelayIsStableAndBounded(t *testing.T) {
+	t.Parallel()
+
+	const limit = 10 * time.Minute
+
+	first := publicIPDiscoveryInitialDelay("node-a", limit)
+
+	second := publicIPDiscoveryInitialDelay("node-a", limit)
+	if first != second || first < 0 || first >= limit {
+		t.Fatalf("delays = %s, %s; want equal values in [0, %s)", first, second, limit)
+	}
+}
+
+func TestDiscoverAndAnnotateNodePublicIPCleansUpSupersededDiscovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		enabled       bool
+		hasDeclaredIP bool
+		declaredIP    string
+		externalIP    bool
+	}{
+		{name: "disabled"},
+		{name: "administrator declaration", enabled: true, hasDeclaredIP: true, declaredIP: "203.0.113.30"},
+		{name: "empty administrator declaration", enabled: true, hasDeclaredIP: true},
+		{name: "provider external IP", enabled: true, externalIP: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name: "node-a",
+				Annotations: map[string]string{
+					unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation:          "203.0.113.20",
+					unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation: time.Now().Add(time.Hour).Format(time.RFC3339),
+				},
+			}}
+			if tt.hasDeclaredIP {
+				node.Annotations[unboundednetv1alpha1.NodeDeclaredPublicIPAnnotation] = tt.declaredIP
+			}
+
+			if tt.externalIP {
+				node.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "203.0.113.40"}}
+			}
+
+			clientset := fake.NewClientset(node)
+			discoverer := &fakePublicIPDiscoverer{publicIP: netip.MustParseAddr("203.0.113.50")}
+			cfg := testPublicIPDiscoveryConfig(tt.enabled)
+
+			if err := discoverAndAnnotateNodePublicIP(t.Context(), clientset, node.Name, cfg, discoverer); err != nil {
+				t.Fatalf("discoverAndAnnotateNodePublicIP() error = %v", err)
+			}
+
+			got, err := clientset.CoreV1().Nodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get Node: %v", err)
+			}
+
+			if _, exists := got.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation]; exists {
+				t.Fatal("discovered public IP was not removed")
+			}
+
+			if _, exists := got.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation]; exists {
+				t.Fatal("discovered public IP expiry was not removed")
+			}
+
+			clientset.ClearActions()
+
+			if err := discoverAndAnnotateNodePublicIP(t.Context(), clientset, node.Name, cfg, discoverer); err != nil {
+				t.Fatalf("second discoverAndAnnotateNodePublicIP() error = %v", err)
+			}
+
+			for _, action := range clientset.Actions() {
+				if action.GetVerb() == "patch" || action.GetVerb() == "update" {
+					t.Fatalf("second cleanup emitted a write: %#v", action)
+				}
+			}
+
+			if discoverer.calls != 0 {
+				t.Fatalf("DiscoverPublicIP() calls = %d, want 0", discoverer.calls)
+			}
+		})
+	}
+}
+
+func TestDiscoverAndAnnotateNodePublicIPRefreshesSuccessfulDiscovery(t *testing.T) {
+	t.Parallel()
+
+	const nodeName = "node-a"
+
+	cfg := testPublicIPDiscoveryConfig(true)
+	beforeDiscovery := time.Now().UTC()
+	clientset := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: nodeName,
+		Annotations: map[string]string{
+			unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation:          "203.0.113.20",
+			unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation: beforeDiscovery.Add(2 * cfg.RecheckInterval).Format(time.RFC3339Nano),
+		},
+	}})
+	discoverer := &fakePublicIPDiscoverer{publicIP: netip.MustParseAddr("203.0.113.20")}
+
+	if err := discoverAndAnnotateNodePublicIP(t.Context(), clientset, nodeName, cfg, discoverer); err != nil {
+		t.Fatalf("discoverAndAnnotateNodePublicIP() error = %v", err)
+	}
+
+	afterDiscovery := time.Now().UTC()
+
+	got, err := clientset.CoreV1().Nodes().Get(t.Context(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get Node: %v", err)
+	}
+
+	if got.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation] != "203.0.113.20" {
+		t.Fatalf("discovered public IP = %q", got.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPAnnotation])
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339Nano, got.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation])
+	if err != nil || expiresAt.Before(beforeDiscovery.Add(3*cfg.RecheckInterval)) || expiresAt.After(afterDiscovery.Add(3*cfg.RecheckInterval)) {
+		t.Fatalf("expiry = %q, err = %v", got.Annotations[unboundednetv1alpha1.NodeDiscoveredPublicIPExpiresAtAnnotation], err)
+	}
+
+	if discoverer.calls != 1 || discoverer.server != cfg.Server {
+		t.Fatalf("DiscoverPublicIP() calls = %d server = %q", discoverer.calls, discoverer.server)
+	}
+}
+
+func TestDiscoverAndAnnotateNodePublicIPReturnsPatchError(t *testing.T) {
+	t.Parallel()
+
+	cfg := testPublicIPDiscoveryConfig(true)
+	clientset := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+	clientset.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("patch rejected")
+	})
+
+	err := discoverAndAnnotateNodePublicIP(t.Context(), clientset, "node-a", cfg, &fakePublicIPDiscoverer{publicIP: netip.MustParseAddr("203.0.113.20")})
+	if err == nil || !strings.Contains(err.Error(), "patch rejected") {
+		t.Fatalf("error = %v, want Node PATCH error", err)
+	}
+}

--- a/cmd/unbounded-net-node/stun_client.go
+++ b/cmd/unbounded-net-node/stun_client.go
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"time"
+
+	"github.com/pion/stun/v3"
+	"k8s.io/klog/v2"
+)
+
+type stunPublicIPDiscoverer struct{}
+
+func (stunPublicIPDiscoverer) DiscoverPublicIP(ctx context.Context, server string) (netip.Addr, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "udp", server)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("dial: %w", err)
+	}
+
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			klog.V(4).Infof("Failed to close STUN connection: %v", closeErr)
+		}
+	}()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return netip.Addr{}, fmt.Errorf("set connection deadline: %w", err)
+		}
+	}
+
+	stopCancellation := context.AfterFunc(ctx, func() {
+		if err := conn.SetDeadline(time.Now()); err != nil {
+			klog.V(4).Infof("Failed to interrupt STUN connection: %v", err)
+		}
+	})
+	defer stopCancellation()
+
+	request, err := stun.Build(stun.TransactionID, stun.BindingRequest)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("build binding request: %w", err)
+	}
+
+	if _, err := conn.Write(request.Raw); err != nil {
+		return netip.Addr{}, fmt.Errorf("send binding request: %w", err)
+	}
+
+	response := make([]byte, 2048)
+
+	read, err := conn.Read(response)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return netip.Addr{}, ctxErr
+		}
+
+		return netip.Addr{}, fmt.Errorf("read binding response: %w", err)
+	}
+
+	return publicIPFromSTUNResponse(response[:read], request.TransactionID)
+}
+
+func publicIPFromSTUNResponse(raw []byte, transactionID [stun.TransactionIDSize]byte) (netip.Addr, error) {
+	response := &stun.Message{Raw: raw}
+	if err := response.Decode(); err != nil {
+		return netip.Addr{}, fmt.Errorf("decode binding response: %w", err)
+	}
+
+	if response.TransactionID != transactionID {
+		return netip.Addr{}, fmt.Errorf("binding response transaction ID does not match request")
+	}
+
+	if raw[0]&0xc0 != 0 {
+		return netip.Addr{}, fmt.Errorf("binding response has non-zero reserved message type bits")
+	}
+
+	if response.Type != stun.BindingSuccess {
+		return netip.Addr{}, fmt.Errorf("unexpected binding response type %s", response.Type)
+	}
+
+	encodedAddress, err := response.Get(stun.AttrXORMappedAddress)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("read XOR-MAPPED-ADDRESS: %w", err)
+	}
+
+	var mappedAddress stun.XORMappedAddress
+	if err := mappedAddress.GetFrom(response); err != nil {
+		return netip.Addr{}, fmt.Errorf("read XOR-MAPPED-ADDRESS: %w", err)
+	}
+
+	expectedLength := 4 + len(mappedAddress.IP)
+	if len(encodedAddress) != expectedLength {
+		return netip.Addr{}, fmt.Errorf("XOR-MAPPED-ADDRESS length is %d, want %d", len(encodedAddress), expectedLength)
+	}
+
+	publicIP, ok := netip.AddrFromSlice(mappedAddress.IP)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("binding response contains invalid mapped IP %q", mappedAddress.IP)
+	}
+
+	publicIP = publicIP.Unmap()
+	if !publicIP.IsGlobalUnicast() {
+		return netip.Addr{}, fmt.Errorf("binding response contains an unusable mapped IP")
+	}
+
+	return publicIP, nil
+}

--- a/cmd/unbounded-net-node/stun_client_test.go
+++ b/cmd/unbounded-net-node/stun_client_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pion/stun/v3"
+)
+
+func TestSTUNPublicIPDiscovererStopsOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	server, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for STUN request: %v", err)
+	}
+	defer server.Close()
+
+	requestReceived := make(chan struct{}, 1)
+
+	go func() {
+		request := make([]byte, 2048)
+		if _, _, readErr := server.ReadFrom(request); readErr == nil {
+			requestReceived <- struct{}{}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	result := make(chan error, 1)
+
+	go func() {
+		_, discoverErr := (stunPublicIPDiscoverer{}).DiscoverPublicIP(ctx, server.LocalAddr().String())
+		result <- discoverErr
+	}()
+
+	select {
+	case <-requestReceived:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for STUN request")
+	}
+
+	cancel()
+
+	select {
+	case discoverErr := <-result:
+		if !errors.Is(discoverErr, context.Canceled) {
+			t.Fatalf("DiscoverPublicIP() error = %v, want context canceled", discoverErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("STUN discovery did not stop after cancellation")
+	}
+}
+
+func TestPublicIPFromSTUNResponse(t *testing.T) {
+	t.Parallel()
+
+	transactionID := [stun.TransactionIDSize]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	otherTransactionID := transactionID
+	otherTransactionID[0]++
+	reservedTypeBits := buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("203.0.113.20"))
+	reservedTypeBits[0] |= 0xc0
+	undersizedAddress := buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("203.0.113.20"))
+	undersizedAddress[23] = 7
+	invalidAddressFamily := buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("203.0.113.20"))
+	invalidAddressFamily[25] = 3
+	mappedIPv4 := buildIPv6FamilySTUNResponse(
+		t,
+		stun.BindingSuccess,
+		transactionID,
+		netip.MustParseAddr("::ffff:203.0.113.20"),
+	)
+
+	tests := []struct {
+		name          string
+		raw           []byte
+		transactionID [stun.TransactionIDSize]byte
+		want          netip.Addr
+		wantErr       string
+	}{
+		{name: "IPv4", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("203.0.113.20")), transactionID: transactionID, want: netip.MustParseAddr("203.0.113.20")},
+		{name: "IPv6", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("2001:db8::20")), transactionID: transactionID, want: netip.MustParseAddr("2001:db8::20")},
+		{name: "IPv4-mapped IPv6", raw: mappedIPv4, transactionID: transactionID, want: netip.MustParseAddr("203.0.113.20")},
+		{name: "private IPv4", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("10.0.0.20")), transactionID: transactionID, want: netip.MustParseAddr("10.0.0.20")},
+		{name: "carrier-grade NAT IPv4", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("100.64.0.20")), transactionID: transactionID, want: netip.MustParseAddr("100.64.0.20")},
+		{name: "unique-local IPv6", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("fd00::20")), transactionID: transactionID, want: netip.MustParseAddr("fd00::20")},
+		{name: "unspecified", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("0.0.0.0")), transactionID: transactionID, wantErr: "unusable mapped IP"},
+		{name: "loopback", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("::1")), transactionID: transactionID, wantErr: "unusable mapped IP"},
+		{name: "multicast", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("224.0.0.1")), transactionID: transactionID, wantErr: "unusable mapped IP"},
+		{name: "link-local", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("fe80::1")), transactionID: transactionID, wantErr: "unusable mapped IP"},
+		{name: "limited broadcast", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("255.255.255.255")), transactionID: transactionID, wantErr: "unusable mapped IP"},
+		{name: "malformed", raw: []byte{1, 2, 3}, transactionID: transactionID, wantErr: "decode binding response"},
+		{name: "wrong transaction", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, net.ParseIP("203.0.113.20")), transactionID: otherTransactionID, wantErr: "transaction ID"},
+		{name: "error response", raw: buildSTUNResponse(t, stun.BindingError, transactionID, nil), transactionID: transactionID, wantErr: "unexpected binding response type"},
+		{name: "missing address", raw: buildSTUNResponse(t, stun.BindingSuccess, transactionID, nil), transactionID: transactionID, wantErr: "XOR-MAPPED-ADDRESS"},
+		{name: "reserved response type bits", raw: reservedTypeBits, transactionID: transactionID, wantErr: "reserved message type bits"},
+		{name: "undersized address", raw: undersizedAddress, transactionID: transactionID, wantErr: "length is 7, want 8"},
+		{name: "invalid address family", raw: invalidAddressFamily, transactionID: transactionID, wantErr: "XOR-MAPPED-ADDRESS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := publicIPFromSTUNResponse(tt.raw, tt.transactionID)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("publicIPFromSTUNResponse() error = %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("publicIPFromSTUNResponse() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func buildSTUNResponse(t *testing.T, messageType stun.MessageType, transactionID [stun.TransactionIDSize]byte, ip net.IP) []byte {
+	t.Helper()
+
+	setters := []stun.Setter{messageType, stun.NewTransactionIDSetter(transactionID)}
+	if ip != nil {
+		setters = append(setters, stun.XORMappedAddress{IP: ip, Port: 51820})
+	}
+
+	message, err := stun.Build(setters...)
+	if err != nil {
+		t.Fatalf("build STUN response: %v", err)
+	}
+
+	return message.Raw
+}
+
+func buildIPv6FamilySTUNResponse(
+	t *testing.T,
+	messageType stun.MessageType,
+	transactionID [stun.TransactionIDSize]byte,
+	ip netip.Addr,
+) []byte {
+	t.Helper()
+
+	if !ip.Is6() {
+		t.Fatalf("mapped address %s is not IPv6", ip)
+	}
+
+	const magicCookie = 0x2112a442
+
+	value := make([]byte, 20)
+	binary.BigEndian.PutUint16(value[0:2], 2)
+	binary.BigEndian.PutUint16(value[2:4], uint16(51820)^uint16(magicCookie>>16))
+
+	xorMask := make([]byte, 16)
+	binary.BigEndian.PutUint32(xorMask[0:4], magicCookie)
+	copy(xorMask[4:], transactionID[:])
+
+	address := ip.As16()
+	for index, octet := range address {
+		value[4+index] = octet ^ xorMask[index]
+	}
+
+	message, err := stun.Build(
+		messageType,
+		stun.NewTransactionIDSetter(transactionID),
+		stun.RawAttribute{Type: stun.AttrXORMappedAddress, Value: value},
+	)
+	if err != nil {
+		t.Fatalf("build IPv6-family STUN response: %v", err)
+	}
+
+	return message.Raw
+}

--- a/deploy/net/01-configmap.yaml.tmpl
+++ b/deploy/net/01-configmap.yaml.tmpl
@@ -36,6 +36,10 @@ data:
         resourceName: "{{ default "unbounded-net-controller" .ControllerLeaderElectionResourceName }}"
 
     node:
+      stunEnabled: {{ default "false" .NodeSTUNEnabled }}
+      stunHost: "{{ default "" .NodeSTUNHost }}"
+      stunPort: {{ default "3478" .NodeSTUNPort }}
+      stunRecheckInterval: "{{ default "1h" .NodeSTUNRecheckInterval }}"
       cniConfDir: "{{ default "/host/etc/cni/net.d" .NodeCNIConfDir }}"
       cniConfFile: "{{ default "10-unbounded.conflist" .NodeCNIConfFile }}"
       bridgeName: "{{ default "cbr0" .NodeBridgeName }}"

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/opencontainers/umoci v0.6.0
 	github.com/oracle/oci-go-sdk/v65 v65.123.1
 	github.com/pin/tftp/v3 v3.2.0
+	github.com/pion/stun/v3 v3.1.5
 	github.com/prometheus/client_golang v1.24.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -262,7 +263,6 @@ require (
 	github.com/pion/sctp v1.8.39 // indirect
 	github.com/pion/sdp/v3 v3.0.18 // indirect
 	github.com/pion/srtp/v3 v3.0.6 // indirect
-	github.com/pion/stun/v3 v3.1.5 // indirect
 	github.com/pion/transport/v3 v3.0.7 // indirect
 	github.com/pion/transport/v4 v4.0.2 // indirect
 	github.com/pion/turn/v4 v4.0.2 // indirect

--- a/internal/net/config/runtime_config.go
+++ b/internal/net/config/runtime_config.go
@@ -60,6 +60,10 @@ type ControllerLeaderElectionYAML struct {
 type NodeRuntimeConfig struct {
 	InformerResyncPeriod string `yaml:"informerResyncPeriod"`
 	NodeName             string `yaml:"nodeName"`
+	STUNEnabled          *bool  `yaml:"stunEnabled"`
+	STUNHost             string `yaml:"stunHost"`
+	STUNPort             *int   `yaml:"stunPort"`
+	STUNRecheckInterval  string `yaml:"stunRecheckInterval"`
 	CNIConfDir           string `yaml:"cniConfDir"`
 	CNIConfFile          string `yaml:"cniConfFile"`
 	BridgeName           string `yaml:"bridgeName"`

--- a/internal/operator/components/net/net_test.go
+++ b/internal/operator/components/net/net_test.go
@@ -169,6 +169,22 @@ func TestEnsureConfigCreatesDefaultOnlyWhenAbsent(t *testing.T) {
 	if got.Data["config.yaml"] == "" || hash != component.ConfigMapPayloadHash(&got) {
 		t.Fatalf("default net config/hash missing: hash=%q data=%#v", hash, got.Data)
 	}
+
+	if !strings.Contains(got.Data["config.yaml"], "stunEnabled: false") {
+		t.Fatal("default net config must explicitly disable STUN")
+	}
+
+	if !strings.Contains(got.Data["config.yaml"], "stunHost: \"\"\n  stunPort: 3478") {
+		t.Fatal("default net config must not select a STUN endpoint")
+	}
+
+	if !strings.Contains(got.Data["config.yaml"], "stunRecheckInterval: \"1h\"") {
+		t.Fatal("default net config must expose the STUN recheck interval")
+	}
+
+	if strings.Contains(got.Data["config.yaml"], "stunTimeout:") {
+		t.Fatal("default net config must not expose the STUN request timeout")
+	}
 }
 
 func TestEnsureConfigPreservesExistingPayload(t *testing.T) {


### PR DESCRIPTION
Add opt-in STUN public IP discovery to the network node agent.

When enabled, the agent queries the configured STUN server, validates the response, and publishes the mapped address on its Node with an expiry. It refreshes the address periodically and removes it when STUN is disabled, an administrator override is present, or the provider reports an ExternalIP.

STUN remains disabled by default and no server is selected automatically. Startup requests use deterministic jitter capped at five minutes. Failed requests are attempted up to three times with short backoff, and disabled cleanup retries until it succeeds.

The default recheck interval is one hour. A successful address remains valid for three recheck intervals. Discovery failures are recorded with a Prometheus counter.
