### PR TITLE
golangci: run the linters this file claims to configure

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,51 +1,92 @@
 version: "2"
+
+# Every linter that runs is named in `linters.enable`, and every block under
+# `linters.settings` belongs to a linter in that list. `linters.default: none`
+# is what makes both true. Under the implicit default (`standard`) neither was:
+# a linter could run without being named here, and settings for linters that
+# never ran accumulated in this file, reading as policy while enforcing
+# nothing.
+#
+# The same rule applies to `formatters`: a block under `formatters.settings`
+# does nothing unless the formatter is in `formatters.enable`.
+#
+# `golangci-lint run` ignores settings keys it does not recognise, silently and
+# without failing, so a typo or a renamed key is invisible. To check this file
+# against the schema for the pinned version:
+#
+#   golangci-lint config verify -c .golangci.yaml
+
 run:
   # Lint code behind all build tags used as well.
   build-tags:
     - e2e
-    - int
     - integrationtest
     - storageboundary
   # With default 1m timeout CI sometimes fails.
   timeout: 10m
+
 linters:
+  # Nothing runs unless it is listed below. See the note at the top of the file.
+  default: none
+
   enable:
+    # golangci-lint's "standard" set, spelled out so that a version bump cannot
+    # change what runs without showing up as a diff here.
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+    # Project policy.
     - goheader
     - wsl_v5
-  disable:
-    # Unlikely to ever Enable
-    # =======================
 
-    # Measures a subjective "cognitive complexity" of functions. Highly subjective
-    # and likely to cause people to write silly code to avoid the linter.
-    - gocognit
+    # Correctness and hygiene checks that report nothing on the tree as it
+    # stands. These are on to keep it that way, not to work through a backlog.
+    - asasalint
+    - asciicheck
+    - bidichk
+    - durationcheck
+    - exptostd
+    - fatcontext
+    - gocheckcompilerdirectives
+    - iface
+    - interfacebloat
+    - loggercheck
+    - misspell
+    - nakedret
+    - nilnesserr
+    - reassign
+    - spancheck
+    - tagalign
+    - testableexamples
+    - whitespace
 
-    # We use replace directives extensively for well-understood reasons.
-    - gomoddirectives
+  # Not enabled, and unlikely to ever be:
+  #
+  #   gocognit          Measures a subjective "cognitive complexity" of
+  #                     functions. Highly subjective and likely to cause people
+  #                     to write silly code to avoid the linter.
+  #   gomoddirectives   We use replace directives extensively for
+  #                     well-understood reasons.
+  #
+  # The remaining linters are off because they have findings to work through,
+  # not because they were rejected. They are being enabled in batches; see
+  # https://github.com/Azure/unbounded/issues/657 for the inventory and the
+  # order. Do not add a `settings` block for one of them before enabling it:
+  # settings for linters that never ran are what this file was full of.
+
   settings:
-    goheader:
-      template: |-
-        Copyright (c) Microsoft Corporation.
-        Licensed under the MIT License.
     errcheck:
       # Treat type assertion as erroneous operation, though assertions should be avoided in general.
       check-type-assertions: true
       # Don't allow assigning an error to '_' identifier to avoid error checking.
       check-blank: true
-    godot:
-      period: true
-
-      # too strict, makes documenting unexported stuff annoying as devs usually start them with a lowercase
-      # like "frobNob is ..."
-      capital: false
-    godox:
-      keywords:
-        - "BAD"
-        - "BUG"
-        - "FIX"
-        - "FIXME"
-        - "HACK"
-        - "TODO"
+    goheader:
+      template: |-
+        Copyright (c) Microsoft Corporation.
+        Licensed under the MIT License.
     govet:
       # In most cases we do not care about the slowdown caused by misaligned fields and having them e.g. grouped is
       # better for readability.
@@ -53,14 +94,6 @@ linters:
         - fieldalignment
       # Ensure also optional linters are enabled in Vet to provide extra consistency.
       enable-all: true
-    nolintlint:
-      # Disabling linters should be justified to make sure the problem cannot actually be resolved.
-      require-explanation: true
-      # Require explicitly specifying which linter is disabled to avoid hiding problems.
-      require-specific: true
-    varnamelen:
-      ignore-decls:
-        - t test.Context
     wsl_v5:
       # By default, force error checking to happen right after the erroneous statement.
       allow-first-in-block: true
@@ -76,12 +109,12 @@ linters:
       - linters:
           - govet
         text: 'shadow: declaration of "err" shadows declaration at line'
+      # Only ever name enabled linters here. An exclusion for a linter that is
+      # off is indistinguishable from one that is load-bearing, and it silently
+      # stops applying if the linter is later enabled under a different name.
       - path: _test\.go
         linters:
-          - gocyclo
           - errcheck
-          - dupl
-          - gosec
     paths:
       - examples$
       - hack/scratch
@@ -90,11 +123,18 @@ issues:
   # Always show all issues found for stable output and to make it easier to go over them.
   max-issues-per-linter: 0
   max-same-issues: 0
+
 formatters:
   enable:
     - gofmt
     - gofumpt
     - goimports
+    # gci is what actually enforces the import grouping described under
+    # settings.gci. goimports sorts within the groups a file already has but
+    # will not move an import between them, so without gci the third section
+    # below was advisory only.
+    - gci
+
   settings:
     gci:
       # Configure name of internal metrics which should be imported as a 3rd group, which is a common pattern.
@@ -104,11 +144,17 @@ formatters:
         - prefix(github.com/Azure/unbounded)
     gofumpt:
       # Enables only grouping of the arguments with the same type, the more consistency we can get, the better.
+      #
+      # This is deliberately narrower than gofumpt's `-extra` flag, which turns
+      # on every extra rule. `make fmt` therefore runs plain `gofumpt -w` and
+      # leaves this rule to the golangci-lint pass in the same target; passing
+      # -extra there would apply rules this file does not ask for.
       extra:
         group-params: true
     goimports:
       local-prefixes:
         - github.com/Azure/unbounded
+
   exclusions:
     generated: lax
     paths:

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,16 @@ GOBUILD=$(GOCMD) build
 GOTEST=$(GOCMD) test
 GOMOD=$(GOCMD) mod
 GOLINT=golangci-lint run -c .golangci.yaml
-GO_PACKAGE_PATTERNS=./api/... ./cmd/... ./e2e/... ./hack/... ./internal/... ./pkg/...
+GO_PACKAGE_PATTERNS=./api/... ./cmd/... ./deploy/... ./e2e/... ./hack/... ./internal/... ./pkg/...
 # e2e packages hold nothing but files behind the e2e build tag, so `go list`
 # needs the tag to see them at all. Without it they are silently skipped by
 # both the formatter and the linter, which is how they accumulated whitespace
 # and unchecked-error violations that CI never reported. Code generation has no
 # business in e2e suites, so GO_PACKAGES stays without the tag.
+#
+# deploy/ holds the embed.go files and the render tests that guard the shipped
+# manifests. Those load on a fresh clone by design (see deploy/machina/embed.go),
+# so there is no reason for the linter to skip them, and it did.
 GO_PACKAGES=$(shell $(GOCMD) list ./api/... ./cmd/... ./hack/... ./internal/... ./pkg/...)
 GO_PACKAGE_DIRS=$(shell $(GOCMD) list -tags e2e -f '{{.Dir}}' $(GO_PACKAGE_PATTERNS))
 
@@ -495,9 +499,14 @@ check-deps: ## Verify required tools (gofumpt, golangci-lint v2) are installed
 		  echo "  Install v2 with:"; \
 		  echo "  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"; exit 1; }
 
-fmt: check-deps ## Format all Go source files (gofumpt + wsl_v5 whitespace)
+# --fix applies every auto-fixable linter and formatter that .golangci.yaml
+# enables, wsl_v5 among them; it does not need to be named again here. It is
+# also what applies gofumpt's group-params rule, which the plain `gofumpt -w`
+# recipe line does not: gofumpt's standalone -extra flag is all-or-nothing and
+# would pull in rules .golangci.yaml does not ask for.
+fmt: check-deps ## Format all Go source files (gofumpt + golangci-lint auto-fixes)
 	$(GOFMT) -w $(GO_PACKAGE_DIRS)
-	$(GOLINT) --fix -E wsl_v5 $(GO_PACKAGE_PATTERNS)
+	$(GOLINT) --fix $(GO_PACKAGE_PATTERNS)
 
 # lint runs the same checks locally and in CI and does NOT auto-fix. Run
 # `make fmt` to apply fixes. wsl_v5 is enforced via .golangci.yaml.

--- a/cmd/kubectl-unbounded/app/config_create.go
+++ b/cmd/kubectl-unbounded/app/config_create.go
@@ -9,9 +9,8 @@ import (
 	"io"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/cmd/kubectl-unbounded/app/install_test.go
+++ b/cmd/kubectl-unbounded/app/install_test.go
@@ -12,6 +12,7 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,8 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/Azure/unbounded/internal/operator"
 )

--- a/cmd/kubectl-unbounded/app/machine_soft_reboot.go
+++ b/cmd/kubectl-unbounded/app/machine_soft_reboot.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-
-	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/cmd/kubectl-unbounded/app/site_init_test.go
+++ b/cmd/kubectl-unbounded/app/site_init_test.go
@@ -21,10 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ---------------------------------------------------------------------------

--- a/cmd/machina/machina/controller/machine_controller.go
+++ b/cmd/machina/machina/controller/machine_controller.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrs "errors"
 	"fmt"
 	"net"
 	"strings"
@@ -23,8 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	stderrs "errors"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	"github.com/Azure/unbounded/internal/provision"

--- a/cmd/unbounded-net-controller/cluster_status_test.go
+++ b/cmd/unbounded-net-controller/cluster_status_test.go
@@ -20,9 +20,8 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	controllerpkg "github.com/Azure/unbounded/internal/net/controller"
-
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
+	controllerpkg "github.com/Azure/unbounded/internal/net/controller"
 )
 
 type failingNodeLister struct{}

--- a/cmd/unbounded-net-controller/main.go
+++ b/cmd/unbounded-net-controller/main.go
@@ -12,11 +12,10 @@ import (
 	"syscall"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"

--- a/cmd/unping/main.go
+++ b/cmd/unping/main.go
@@ -15,12 +15,11 @@ import (
 	"syscall"
 	"time"
 
+	flag "github.com/spf13/pflag"
 	"google.golang.org/protobuf/proto"
 
 	pb "github.com/Azure/unbounded/internal/net/healthcheck/proto"
 	"github.com/Azure/unbounded/internal/version"
-
-	flag "github.com/spf13/pflag"
 )
 
 func main() {

--- a/hack/cmd/forge/forge/azsdk/azsdk_test.go
+++ b/hack/cmd/forge/forge/azsdk/azsdk_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	azcorecloud "github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/hack/cmd/forge/forge/azsdk/clients.go
+++ b/hack/cmd/forge/forge/azsdk/clients.go
@@ -23,11 +23,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armfeatures"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 )
 
 // ClientSet contains all necessary Azure API clients used throughout the core parts of

--- a/internal/inventory/agent/publish.go
+++ b/internal/inventory/agent/publish.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"fmt"
 
-	inventoryv1 "github.com/Azure/unbounded/api/inventory/v1"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	inventoryv1 "github.com/Azure/unbounded/api/inventory/v1"
 )
 
 // RemoteWriter dials the inventory-collector gRPC service at addr and submits the

--- a/internal/inventory/aggregator/server.go
+++ b/internal/inventory/aggregator/server.go
@@ -8,10 +8,10 @@ import (
 	"database/sql"
 	"log/slog"
 
-	inventoryv1 "github.com/Azure/unbounded/api/inventory/v1"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	inventoryv1 "github.com/Azure/unbounded/api/inventory/v1"
 )
 
 // Server implements the InventoryAggregator gRPC service.

--- a/internal/metalman/netboot/tftp.go
+++ b/internal/metalman/netboot/tftp.go
@@ -13,9 +13,9 @@ import (
 	"os"
 	"strings"
 
-	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
-
 	"github.com/pin/tftp/v3"
+
+	v1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 )
 
 type TFTPServer struct {

--- a/internal/net/controller/site_controller.go
+++ b/internal/net/controller/site_controller.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,12 +31,9 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
-
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	unboundednetv1alpha1 "github.com/Azure/unbounded/api/net/v1alpha1"

--- a/internal/operator/components/metalman/metalman_test.go
+++ b/internal/operator/components/metalman/metalman_test.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,6 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	"github.com/Azure/unbounded/internal/operator/component"

--- a/internal/operator/components/storage/storage_test.go
+++ b/internal/operator/components/storage/storage_test.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	"github.com/Azure/unbounded/internal/operator/component"

--- a/internal/operator/overrides_test.go
+++ b/internal/operator/overrides_test.go
@@ -13,7 +13,6 @@ import (
 	"unicode/utf8"
 
 	appsv1 "k8s.io/api/apps/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -18,14 +18,13 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	"k8s.io/client-go/tools/events"
 
 	unboundedv1alpha3 "github.com/Azure/unbounded/api/machina/v1alpha3"
 	"github.com/Azure/unbounded/internal/operator/component"

--- a/internal/playpen/client/client.go
+++ b/internal/playpen/client/client.go
@@ -17,9 +17,8 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/client-go/rest"
-
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"k8s.io/client-go/rest"
 
 	"github.com/Azure/unbounded/internal/playpen/operator"
 )

--- a/internal/playpen/operator/operator_test.go
+++ b/internal/playpen/operator/operator_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +29,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 func TestAllocAllocatesRunnerWithHostPortEndpoint(t *testing.T) {

--- a/pkg/agent/config/config_test.go
+++ b/pkg/agent/config/config_test.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/validation"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 


### PR DESCRIPTION
Fixes #657.

`.golangci.yaml` never set `linters.default`, so it took golangci-lint v2's implicit `standard` set. Seven linters ran; the rest of the file was inert:

| Location | Configured | Status |
|---|---|---|
| `:35-63` | `godot`, `godox`, `nolintlint`, `varnamelen` settings | linters never ran |
| `:15-24` | `disable: gocognit, gomoddirectives` | already off under `standard` |
| `:79-84` | `_test.go` exclusion | 3 of 4 linters named were off |
| `:99-104` | `formatters.settings.gci` | `gci` absent from `formatters.enable` |
| `:6` | `run.build-tags: int` | no `//go:build int` in the tree |

## What changed

**`default: none`, every linter named.** Listing the five `standard` linters costs five lines and buys two things: a golangci-lint bump can't change what runs without a diff here, and "every settings block belongs to an enabled linter" becomes checkable by reading the file.

**Eighteen linters enabled**, each verified at zero findings individually against the pinned v2.13.1: `asasalint`, `asciicheck`, `bidichk`, `durationcheck`, `exptostd`, `fatcontext`, `gocheckcompilerdirectives`, `iface`, `interfacebloat`, `loggercheck`, `misspell`, `nakedret`, `nilnesserr`, `reassign`, `spancheck`, `tagalign`, `testableexamples`, `whitespace`.

`decorder` also reports zero and is deliberately excluded: every one of its checks defaults to `disable-*: true`, so enabling it would re-create exactly the problem this PR fixes.

**`gci` enabled.** Not cosmetic. `goimports` sorts within the groups a file already has but never moves an import between them, so the `prefix(github.com/Azure/unbounded)` section was advisory and first-party imports had settled into the third-party group. Positive control on v2.13.1:

```
# without gci                          # with gci
import (                               import (
    "context"                              "context"

    inv "github.com/Azure/unbounded/…"     "google.golang.org/grpc"

    "google.golang.org/grpc"               inv "github.com/Azure/unbounded/…"
)                                      )
```

That accounts for all 21 Go files in this diff. They are imports only, no logic.

**`./deploy/...` added to `GO_PACKAGE_PATTERNS`.** The `embed.go` files and the render tests guarding the shipped manifests were linted by nothing. They already pass, and the packages load on a fresh clone by design (`deploy/machina/embed.go:11-17`).

## Not in scope

The linters with real findings land separately, per #657. Starting batch is `nilerr` (14) and `predeclared` (20), which the issue calls out. `nilerr` is not all noise: `internal/net/controller/site_controller.go:877` treats every lister error as "node was deleted", `internal/operator/migrate.go:1666` returns `false, nil` on `err != nil`, and `internal/net/netlink/link_manager.go:295` treats any `LinkByName` failure as "doesn't exist". The tree also already carries 5 `//nolint:nilerr` and 3 `//nolint:nilnil` directives written against linters that had never run.

## Found while doing this, filed separately

`make fmt` has a latent race. `GO_PACKAGE_DIRS` contains nested package dirs and `gofumpt` recurses, so nested files get visited once per ancestor, concurrently. It's masked only because gofumpt currently has nothing to rewrite; an experiment that made it rewrite files hit it immediately:

```
error: size of hack/cmd/relctl/relctl/version/resolve.go changed during reading
make: *** [Makefile:508: fmt] Error 2
```

Pre-existing and unrelated to #657, so not fixed here.

## Verification

Against the pinned v2.13.1 (`Makefile:435`), not a locally-installed version — the schema for `formatters.settings.gofumpt` changed between v2.11 and v2.13, and reading the wrong one sends you the wrong way.

- `golangci-lint config verify` passes; it did not before.
- `make lint` clean, `make fmt` idempotent, `go build ./...` clean.
- Tests pass for all 21 affected packages.
