### PR TITLE
net/netlink: a failed link lookup is not an absent interface

### DIFF
--- a/internal/net/netlink/gateway_policy_manager.go
+++ b/internal/net/netlink/gateway_policy_manager.go
@@ -713,7 +713,24 @@ func (m *GatewayPolicyManager) pruneStaleInterfacesLocked() error {
 	}
 
 	for iface, tableNum := range seen {
-		if _, err := netlink.LinkByName(iface); err == nil {
+		// netlinkLinkByName and isLinkGoneError are declared in
+		// link_manager.go, same package. The lookup goes through the seam so
+		// this classification can be exercised the same way the link manager's
+		// is; the other direct netlink.LinkByName calls in this file and in
+		// route_manager.go do not, because they only ever treat the error as
+		// fatal or best-effort.
+		_, err := netlinkLinkByName(iface)
+		if err == nil {
+			continue
+		}
+
+		// Only an interface that is genuinely gone justifies tearing down its
+		// rules. A lookup that failed for some other reason says nothing about
+		// whether the interface is there, and pruning on that would remove
+		// policy routing from an interface that is still carrying traffic.
+		if !isLinkGoneError(err) {
+			klog.V(2).Infof("Keeping gateway policy rules for %s (table %d): link lookup failed: %v", iface, tableNum, err)
+
 			continue
 		}
 

--- a/internal/net/netlink/gateway_policy_manager.go
+++ b/internal/net/netlink/gateway_policy_manager.go
@@ -729,6 +729,7 @@ func (m *GatewayPolicyManager) pruneStaleInterfacesLocked() error {
 		// whether the interface is there, and pruning on that would remove
 		// policy routing from an interface that is still carrying traffic.
 		if !isLinkGoneError(err) {
+			InterfaceOperationErrors.WithLabelValues("lookup").Inc()
 			klog.V(2).Infof("Keeping gateway policy rules for %s (table %d): link lookup failed: %v", iface, tableNum, err)
 
 			continue

--- a/internal/net/netlink/link_manager.go
+++ b/internal/net/netlink/link_manager.go
@@ -17,6 +17,20 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// Package-level netlink link function vars for testability, following the
+// same convention as the rule functions in route_table_setup.go.
+//
+// Every link lookup, add and delete in link_manager.go goes through these. A
+// test that cannot intercept the lookup cannot exercise how its error is
+// classified, and that classification is what isLinkGoneError exists for.
+// Other files in this package still call netlink directly where they only
+// ever treat the error as fatal or best-effort.
+var (
+	netlinkLinkByName = netlink.LinkByName
+	netlinkLinkAdd    = netlink.LinkAdd
+	netlinkLinkDel    = netlink.LinkDel
+)
+
 // LinkManager manages a network link (interface) and its addresses
 type LinkManager struct {
 	ifaceName string
@@ -32,7 +46,7 @@ func NewLinkManager(ifaceName string) *LinkManager {
 // EnsureIPIPInterfaceWithRemote creates a point-to-point IPIP tunnel interface
 // with 20 bytes of overhead (just an outer IP header, no UDP wrapper).
 func (lm *LinkManager) EnsureIPIPInterfaceWithRemote(local, remote net.IP) error {
-	_, err := netlink.LinkByName(lm.ifaceName)
+	_, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		return nil
 	}
@@ -46,7 +60,7 @@ func (lm *LinkManager) EnsureIPIPInterfaceWithRemote(local, remote net.IP) error
 		Local:  local,
 		Remote: remote,
 	}
-	if err := netlink.LinkAdd(ipipLink); err != nil {
+	if err := netlinkLinkAdd(ipipLink); err != nil {
 		InterfaceOperationErrors.WithLabelValues("create").Inc()
 		return fmt.Errorf("failed to create IPIP interface: %w", err)
 	}
@@ -61,7 +75,7 @@ func (lm *LinkManager) EnsureIPIPInterfaceWithRemote(local, remote net.IP) error
 // for use with the eBPF tunnel dataplane. The BPF program sets the tunnel
 // destination per-packet via bpf_skb_set_tunnel_key.
 func (lm *LinkManager) EnsureIPIPExternalInterface() error {
-	existing, err := netlink.LinkByName(lm.ifaceName)
+	existing, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		if tun, ok := existing.(*netlink.Iptun); ok && tun.FlowBased {
 			return nil
@@ -69,7 +83,7 @@ func (lm *LinkManager) EnsureIPIPExternalInterface() error {
 		// Exists but not flow-based -- delete and recreate
 		klog.Infof("Recreating IPIP interface %s with external mode", lm.ifaceName)
 
-		if delErr := netlink.LinkDel(existing); delErr != nil {
+		if delErr := netlinkLinkDel(existing); delErr != nil {
 			return fmt.Errorf("failed to delete IPIP interface %s for recreation: %w", lm.ifaceName, delErr)
 		}
 	}
@@ -82,7 +96,7 @@ func (lm *LinkManager) EnsureIPIPExternalInterface() error {
 		},
 		FlowBased: true,
 	}
-	if err := netlink.LinkAdd(ipipLink); err != nil {
+	if err := netlinkLinkAdd(ipipLink); err != nil {
 		InterfaceOperationErrors.WithLabelValues("create").Inc()
 		return fmt.Errorf("failed to create IPIP external interface: %w", err)
 	}
@@ -96,7 +110,7 @@ func (lm *LinkManager) EnsureIPIPExternalInterface() error {
 // EnsureGeneveInterfaceWithRemote creates a point-to-point GENEVE interface
 // with a fixed remote tunnel endpoint. Each peer gets its own interface.
 func (lm *LinkManager) EnsureGeneveInterfaceWithRemote(vni uint32, dstPort int, remote net.IP) error {
-	_, err := netlink.LinkByName(lm.ifaceName)
+	_, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		return nil
 	}
@@ -111,7 +125,7 @@ func (lm *LinkManager) EnsureGeneveInterfaceWithRemote(vni uint32, dstPort int, 
 		Remote: remote,
 	}
 
-	if err := netlink.LinkAdd(geneveLink); err != nil {
+	if err := netlinkLinkAdd(geneveLink); err != nil {
 		InterfaceOperationErrors.WithLabelValues("create").Inc()
 		return fmt.Errorf("failed to create GENEVE interface: %w", err)
 	}
@@ -132,14 +146,14 @@ func (lm *LinkManager) EnsureGeneveInterfaceWithRemote(vni uint32, dstPort int, 
 // subsequent LinkSetHardwareAddr is silently dropped, leaving the
 // device with a kernel-randomized MAC.
 func (lm *LinkManager) EnsureGeneveInterface(vni uint32, dstPort int, mac net.HardwareAddr) error {
-	existing, err := netlink.LinkByName(lm.ifaceName)
+	existing, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		// If the existing interface is not in external/FlowBased mode (or has
 		// a fixed VNI), delete and recreate it.
 		if gn, ok := existing.(*netlink.Geneve); ok && (!gn.FlowBased || gn.ID != 0) {
 			klog.Infof("Recreating GENEVE interface %s with external mode (was FlowBased=%v, VNI=%d)", lm.ifaceName, gn.FlowBased, gn.ID)
 
-			if delErr := netlink.LinkDel(existing); delErr != nil {
+			if delErr := netlinkLinkDel(existing); delErr != nil {
 				return fmt.Errorf("failed to delete GENEVE interface %s for recreation: %w", lm.ifaceName, delErr)
 			}
 		} else {
@@ -157,7 +171,7 @@ func (lm *LinkManager) EnsureGeneveInterface(vni uint32, dstPort int, mac net.Ha
 		FlowBased: true,
 	}
 
-	if err := netlink.LinkAdd(geneveLink); err != nil {
+	if err := netlinkLinkAdd(geneveLink); err != nil {
 		InterfaceOperationErrors.WithLabelValues("create").Inc()
 		return fmt.Errorf("failed to create GENEVE interface: %w", err)
 	}
@@ -185,7 +199,7 @@ func (lm *LinkManager) EnsureGeneveInterface(vni uint32, dstPort int, mac net.Ha
 // subsequent LinkSetHardwareAddr is silently dropped, leaving the
 // device with a kernel-randomized MAC.
 func (lm *LinkManager) EnsureVXLANInterface(dstPort, srcPortLow, srcPortHigh int, mac net.HardwareAddr) error {
-	_, err := netlink.LinkByName(lm.ifaceName)
+	_, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		return nil
 	}
@@ -204,7 +218,7 @@ func (lm *LinkManager) EnsureVXLANInterface(dstPort, srcPortLow, srcPortHigh int
 		PortHigh:  srcPortHigh,
 	}
 
-	if err := netlink.LinkAdd(vxlanLink); err != nil {
+	if err := netlinkLinkAdd(vxlanLink); err != nil {
 		InterfaceOperationErrors.WithLabelValues("create").Inc()
 		return fmt.Errorf("failed to create VXLAN interface: %w", err)
 	}
@@ -218,7 +232,7 @@ func (lm *LinkManager) EnsureVXLANInterface(dstPort, srcPortLow, srcPortHigh int
 // EnsureWireGuardInterface creates the WireGuard interface if it doesn't exist
 func (lm *LinkManager) EnsureWireGuardInterface() error {
 	// Check if interface exists
-	_, err := netlink.LinkByName(lm.ifaceName)
+	_, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		// Interface already exists
 		return nil
@@ -232,7 +246,7 @@ func (lm *LinkManager) EnsureWireGuardInterface() error {
 		},
 	}
 
-	if err := netlink.LinkAdd(wgLink); err != nil {
+	if err := netlinkLinkAdd(wgLink); err != nil {
 		InterfaceOperationErrors.WithLabelValues("create").Inc()
 		return fmt.Errorf("failed to create WireGuard interface: %w", err)
 	}
@@ -245,7 +259,7 @@ func (lm *LinkManager) EnsureWireGuardInterface() error {
 
 // SetLinkUp brings the interface up
 func (lm *LinkManager) SetLinkUp() error {
-	link, err := netlink.LinkByName(lm.ifaceName)
+	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return fmt.Errorf("failed to get link %s: %w", lm.ifaceName, err)
 	}
@@ -261,7 +275,7 @@ func (lm *LinkManager) SetLinkUp() error {
 // flow-based tunnel interfaces where the BPF program handles encapsulation --
 // the kernel should send packets directly without neighbor resolution.
 func (lm *LinkManager) SetLinkNoARP() error {
-	link, err := netlink.LinkByName(lm.ifaceName)
+	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return fmt.Errorf("failed to get link %s: %w", lm.ifaceName, err)
 	}
@@ -275,7 +289,7 @@ func (lm *LinkManager) SetLinkNoARP() error {
 
 // SetLinkAddress sets the hardware (MAC) address on the interface.
 func (lm *LinkManager) SetLinkAddress(addr net.HardwareAddr) error {
-	link, err := netlink.LinkByName(lm.ifaceName)
+	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return fmt.Errorf("failed to get link %s: %w", lm.ifaceName, err)
 	}
@@ -289,7 +303,7 @@ func (lm *LinkManager) SetLinkAddress(addr net.HardwareAddr) error {
 
 // DeleteLink removes the interface
 func (lm *LinkManager) DeleteLink() error {
-	link, err := netlink.LinkByName(lm.ifaceName)
+	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		// Interface doesn't exist, nothing to do
 		return nil
@@ -297,7 +311,7 @@ func (lm *LinkManager) DeleteLink() error {
 
 	klog.Infof("Removing interface %s", lm.ifaceName)
 
-	if err := netlink.LinkDel(link); err != nil {
+	if err := netlinkLinkDel(link); err != nil {
 		return fmt.Errorf("failed to delete link %s: %w", lm.ifaceName, err)
 	}
 
@@ -308,7 +322,7 @@ func (lm *LinkManager) DeleteLink() error {
 // it up. Used to ensure cbr0 exists on gateway nodes where the CNI plugin
 // may not have created it.
 func (lm *LinkManager) EnsureBridge() error {
-	_, err := netlink.LinkByName(lm.ifaceName)
+	_, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		return nil
 	}
@@ -320,7 +334,7 @@ func (lm *LinkManager) EnsureBridge() error {
 			Name: lm.ifaceName,
 		},
 	}
-	if err := netlink.LinkAdd(bridge); err != nil {
+	if err := netlinkLinkAdd(bridge); err != nil {
 		return fmt.Errorf("failed to create bridge %s: %w", lm.ifaceName, err)
 	}
 
@@ -337,7 +351,7 @@ func (lm *LinkManager) EnsureBridge() error {
 // encapsulation and redirect. ARP/NDP requests on dummy interfaces go
 // nowhere (no physical medium), so no neighbor resolution issues.
 func (lm *LinkManager) EnsureDummyInterface() error {
-	existing, err := netlink.LinkByName(lm.ifaceName)
+	existing, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		// Ensure NOARP is set (may need to be set on existing interfaces
 		// from older code versions that didn't set it).
@@ -357,11 +371,11 @@ func (lm *LinkManager) EnsureDummyInterface() error {
 			Name: lm.ifaceName,
 		},
 	}
-	if err := netlink.LinkAdd(dummy); err != nil {
+	if err := netlinkLinkAdd(dummy); err != nil {
 		return fmt.Errorf("failed to create dummy interface %s: %w", lm.ifaceName, err)
 	}
 
-	link, err := netlink.LinkByName(lm.ifaceName)
+	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return fmt.Errorf("failed to get dummy interface %s after creation: %w", lm.ifaceName, err)
 	}
@@ -384,7 +398,7 @@ func (lm *LinkManager) EnsureDummyInterface() error {
 // when false, link-local addresses are preserved (normal operational mode).
 // Returns the number of addresses added and removed.
 func (lm *LinkManager) SyncAddresses(desiredAddrs []string, removeAll bool) (added, removed int, err error) {
-	link, err := netlink.LinkByName(lm.ifaceName)
+	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get link %s: %w", lm.ifaceName, err)
 	}
@@ -459,7 +473,7 @@ func (lm *LinkManager) SyncAddresses(desiredAddrs []string, removeAll bool) (add
 
 // GetAddresses returns the current addresses on the interface
 func (lm *LinkManager) GetAddresses() ([]string, error) {
-	link, err := netlink.LinkByName(lm.ifaceName)
+	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get link %s: %w", lm.ifaceName, err)
 	}
@@ -521,7 +535,7 @@ func parseAddress(addrStr string) (*netlink.Addr, error) {
 // the desired value if it differs. Returns nil when the MTU is already
 // correct or was successfully updated.
 func (lm *LinkManager) EnsureMTU(mtu int) error {
-	link, err := netlink.LinkByName(lm.ifaceName)
+	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return fmt.Errorf("failed to get link %s: %w", lm.ifaceName, err)
 	}
@@ -546,7 +560,7 @@ func (lm *LinkManager) EnsureMTU(mtu int) error {
 // EnsureBridgePortMTUs sets the MTU on every veth interface enslaved to the
 // managed bridge. Links removed concurrently with pod teardown are ignored.
 func (lm *LinkManager) EnsureBridgePortMTUs(mtu int) error {
-	bridge, err := netlink.LinkByName(lm.ifaceName)
+	bridge, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return fmt.Errorf("failed to get bridge %s: %w", lm.ifaceName, err)
 	}
@@ -586,7 +600,7 @@ func (lm *LinkManager) EnsureBridgePortMTUs(mtu int) error {
 // EnsureBridgePodMTUs sets the MTU on the pod-side peer of every veth
 // interface enslaved to the managed bridge.
 func (lm *LinkManager) EnsureBridgePodMTUs(procDir string, mtu int) error {
-	bridge, err := netlink.LinkByName(lm.ifaceName)
+	bridge, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
 		return fmt.Errorf("failed to get bridge %s: %w", lm.ifaceName, err)
 	}
@@ -1043,7 +1057,7 @@ func detectDefaultRouteInterfaceImpl(cache *NetlinkCache) (string, int, error) {
 
 // Exists returns true if the interface exists
 func (lm *LinkManager) Exists() bool {
-	_, err := netlink.LinkByName(lm.ifaceName)
+	_, err := netlinkLinkByName(lm.ifaceName)
 	return err == nil
 }
 
@@ -1056,7 +1070,7 @@ func (lm *LinkManager) EnsureGeneveInterfaceWithCache(cache *NetlinkCache, vni u
 			return nil
 		}
 	} else {
-		if _, err := netlink.LinkByName(lm.ifaceName); err == nil {
+		if _, err := netlinkLinkByName(lm.ifaceName); err == nil {
 			return nil
 		}
 	}
@@ -1071,7 +1085,7 @@ func (lm *LinkManager) EnsureGeneveInterfaceWithCache(cache *NetlinkCache, vni u
 		Remote: remote,
 	}
 
-	if err := netlink.LinkAdd(geneveLink); err != nil {
+	if err := netlinkLinkAdd(geneveLink); err != nil {
 		InterfaceOperationErrors.WithLabelValues("create").Inc()
 		return fmt.Errorf("failed to create GENEVE interface: %w", err)
 	}
@@ -1091,7 +1105,7 @@ func (lm *LinkManager) EnsureIPIPInterfaceWithCache(cache *NetlinkCache, local, 
 			return nil
 		}
 	} else {
-		if _, err := netlink.LinkByName(lm.ifaceName); err == nil {
+		if _, err := netlinkLinkByName(lm.ifaceName); err == nil {
 			return nil
 		}
 	}
@@ -1105,7 +1119,7 @@ func (lm *LinkManager) EnsureIPIPInterfaceWithCache(cache *NetlinkCache, local, 
 		Remote: remote,
 	}
 
-	if err := netlink.LinkAdd(ipipLink); err != nil {
+	if err := netlinkLinkAdd(ipipLink); err != nil {
 		InterfaceOperationErrors.WithLabelValues("create").Inc()
 		return fmt.Errorf("failed to create IPIP interface: %w", err)
 	}
@@ -1127,7 +1141,7 @@ func (lm *LinkManager) SetLinkUpWithCache(cache *NetlinkCache) error {
 	if link == nil {
 		var err error
 
-		link, err = netlink.LinkByName(lm.ifaceName)
+		link, err = netlinkLinkByName(lm.ifaceName)
 		if err != nil {
 			return fmt.Errorf("failed to get link %s: %w", lm.ifaceName, err)
 		}
@@ -1151,7 +1165,7 @@ func (lm *LinkManager) EnsureMTUWithCache(cache *NetlinkCache, mtu int) error {
 	if link == nil {
 		var err error
 
-		link, err = netlink.LinkByName(lm.ifaceName)
+		link, err = netlinkLinkByName(lm.ifaceName)
 		if err != nil {
 			return fmt.Errorf("failed to get link %s: %w", lm.ifaceName, err)
 		}

--- a/internal/net/netlink/link_manager.go
+++ b/internal/net/netlink/link_manager.go
@@ -329,13 +329,9 @@ func (lm *LinkManager) SetLinkAddress(addr net.HardwareAddr) error {
 func (lm *LinkManager) DeleteLink() error {
 	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
-		// Absent is the goal state, so nothing to do. Any other lookup
-		// failure has to surface: reporting success here would tell the
-		// caller the interface was removed when it is still there.
-		if isLinkGoneError(err) {
-			return nil
-		}
-
+		// Absent is the goal state, so lookupError reports nothing for it. Any
+		// other lookup failure has to surface: reporting success here would
+		// tell the caller the interface was removed when it is still there.
 		return lm.lookupError(err)
 	}
 
@@ -1121,8 +1117,8 @@ func detectDefaultRouteInterfaceImpl(cache *NetlinkCache) (string, int, error) {
 //
 // A lookup that fails for any other reason also reports false, because every
 // caller is a reconcile predicate that will be retried. The condition is
-// logged rather than returned so that "false" caused by a broken lookup can
-// be told apart from "false" caused by an absent interface.
+// counted and logged rather than returned, so that a false caused by a broken
+// lookup can be told apart from a false caused by an absent interface.
 func (lm *LinkManager) Exists() bool {
 	_, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
@@ -1130,6 +1126,7 @@ func (lm *LinkManager) Exists() bool {
 	}
 
 	if !isLinkGoneError(err) {
+		InterfaceOperationErrors.WithLabelValues("lookup").Inc()
 		klog.V(2).Infof("Link lookup for %s failed, reporting it as absent: %v", lm.ifaceName, err)
 	}
 

--- a/internal/net/netlink/link_manager.go
+++ b/internal/net/netlink/link_manager.go
@@ -51,6 +51,10 @@ func (lm *LinkManager) EnsureIPIPInterfaceWithRemote(local, remote net.IP) error
 		return nil
 	}
 
+	if lookupErr := lm.lookupError(err); lookupErr != nil {
+		return lookupErr
+	}
+
 	klog.Infof("Creating IPIP interface %s (local %s, remote %s)", lm.ifaceName, local, remote)
 
 	ipipLink := &netlink.Iptun{
@@ -76,7 +80,11 @@ func (lm *LinkManager) EnsureIPIPInterfaceWithRemote(local, remote net.IP) error
 // destination per-packet via bpf_skb_set_tunnel_key.
 func (lm *LinkManager) EnsureIPIPExternalInterface() error {
 	existing, err := netlinkLinkByName(lm.ifaceName)
-	if err == nil {
+	if err != nil {
+		if lookupErr := lm.lookupError(err); lookupErr != nil {
+			return lookupErr
+		}
+	} else {
 		if tun, ok := existing.(*netlink.Iptun); ok && tun.FlowBased {
 			return nil
 		}
@@ -115,6 +123,10 @@ func (lm *LinkManager) EnsureGeneveInterfaceWithRemote(vni uint32, dstPort int, 
 		return nil
 	}
 
+	if lookupErr := lm.lookupError(err); lookupErr != nil {
+		return lookupErr
+	}
+
 	klog.Infof("Creating GENEVE interface %s (VNI %d, port %d, remote %s)", lm.ifaceName, vni, dstPort, remote)
 	geneveLink := &netlink.Geneve{
 		LinkAttrs: netlink.LinkAttrs{
@@ -147,7 +159,11 @@ func (lm *LinkManager) EnsureGeneveInterfaceWithRemote(vni uint32, dstPort int, 
 // device with a kernel-randomized MAC.
 func (lm *LinkManager) EnsureGeneveInterface(vni uint32, dstPort int, mac net.HardwareAddr) error {
 	existing, err := netlinkLinkByName(lm.ifaceName)
-	if err == nil {
+	if err != nil {
+		if lookupErr := lm.lookupError(err); lookupErr != nil {
+			return lookupErr
+		}
+	} else {
 		// If the existing interface is not in external/FlowBased mode (or has
 		// a fixed VNI), delete and recreate it.
 		if gn, ok := existing.(*netlink.Geneve); ok && (!gn.FlowBased || gn.ID != 0) {
@@ -204,6 +220,10 @@ func (lm *LinkManager) EnsureVXLANInterface(dstPort, srcPortLow, srcPortHigh int
 		return nil
 	}
 
+	if lookupErr := lm.lookupError(err); lookupErr != nil {
+		return lookupErr
+	}
+
 	klog.Infof("Creating VXLAN interface %s (port %d, srcPorts %d-%d, external/FlowBased)", lm.ifaceName, dstPort, srcPortLow, srcPortHigh)
 	vxlanLink := &netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
@@ -236,6 +256,10 @@ func (lm *LinkManager) EnsureWireGuardInterface() error {
 	if err == nil {
 		// Interface already exists
 		return nil
+	}
+
+	if lookupErr := lm.lookupError(err); lookupErr != nil {
+		return lookupErr
 	}
 
 	// Create WireGuard interface
@@ -305,8 +329,14 @@ func (lm *LinkManager) SetLinkAddress(addr net.HardwareAddr) error {
 func (lm *LinkManager) DeleteLink() error {
 	link, err := netlinkLinkByName(lm.ifaceName)
 	if err != nil {
-		// Interface doesn't exist, nothing to do
-		return nil
+		// Absent is the goal state, so nothing to do. Any other lookup
+		// failure has to surface: reporting success here would tell the
+		// caller the interface was removed when it is still there.
+		if isLinkGoneError(err) {
+			return nil
+		}
+
+		return lm.lookupError(err)
 	}
 
 	klog.Infof("Removing interface %s", lm.ifaceName)
@@ -325,6 +355,10 @@ func (lm *LinkManager) EnsureBridge() error {
 	_, err := netlinkLinkByName(lm.ifaceName)
 	if err == nil {
 		return nil
+	}
+
+	if lookupErr := lm.lookupError(err); lookupErr != nil {
+		return lookupErr
 	}
 
 	klog.Infof("Creating bridge %s", lm.ifaceName)
@@ -362,6 +396,10 @@ func (lm *LinkManager) EnsureDummyInterface() error {
 		_ = netlink.LinkSetARPOff(existing) //nolint:errcheck
 
 		return nil
+	}
+
+	if lookupErr := lm.lookupError(err); lookupErr != nil {
+		return lookupErr
 	}
 
 	klog.Infof("Creating dummy interface %s (NOARP)", lm.ifaceName)
@@ -815,6 +853,30 @@ func isLinkGoneError(err error) bool {
 		errors.Is(err, syscall.ENOENT)
 }
 
+// lookupError returns the error to propagate for a link lookup, or nil if
+// there is nothing to propagate: either the lookup succeeded, or it failed
+// only because the interface is absent.
+//
+// The distinction matters because a lookup can fail without the interface
+// being missing. Code that reads "lookup failed, so create it" will, on a
+// transient netlink failure, try to create an interface that already exists;
+// code that reads "lookup failed, so it is already gone" will report a
+// deletion it never performed.
+//
+// A nil error must map to nil. isLinkGoneError(nil) is false, so without the
+// first condition this would wrap nil and hand back a non-nil error reading
+// "%!w(<nil>)". Callers that fall through to here with err == nil, having
+// deleted an interface they are about to recreate, would then abort instead.
+func (lm *LinkManager) lookupError(err error) error {
+	if err == nil || isLinkGoneError(err) {
+		return nil
+	}
+
+	InterfaceOperationErrors.WithLabelValues("lookup").Inc()
+
+	return fmt.Errorf("failed to look up interface %s: %w", lm.ifaceName, err)
+}
+
 func bridgeVethLinks(bridgeIndex int, links []netlink.Link) []netlink.Link {
 	ports := make([]netlink.Link, 0)
 
@@ -1055,10 +1117,23 @@ func detectDefaultRouteInterfaceImpl(cache *NetlinkCache) (string, int, error) {
 	return "", 0, fmt.Errorf("no default route found")
 }
 
-// Exists returns true if the interface exists
+// Exists returns true if the interface exists.
+//
+// A lookup that fails for any other reason also reports false, because every
+// caller is a reconcile predicate that will be retried. The condition is
+// logged rather than returned so that "false" caused by a broken lookup can
+// be told apart from "false" caused by an absent interface.
 func (lm *LinkManager) Exists() bool {
 	_, err := netlinkLinkByName(lm.ifaceName)
-	return err == nil
+	if err == nil {
+		return true
+	}
+
+	if !isLinkGoneError(err) {
+		klog.V(2).Infof("Link lookup for %s failed, reporting it as absent: %v", lm.ifaceName, err)
+	}
+
+	return false
 }
 
 // EnsureGeneveInterfaceWithCache is like EnsureGeneveInterfaceWithRemote but
@@ -1070,8 +1145,13 @@ func (lm *LinkManager) EnsureGeneveInterfaceWithCache(cache *NetlinkCache, vni u
 			return nil
 		}
 	} else {
-		if _, err := netlinkLinkByName(lm.ifaceName); err == nil {
+		_, err := netlinkLinkByName(lm.ifaceName)
+		if err == nil {
 			return nil
+		}
+
+		if lookupErr := lm.lookupError(err); lookupErr != nil {
+			return lookupErr
 		}
 	}
 
@@ -1105,8 +1185,13 @@ func (lm *LinkManager) EnsureIPIPInterfaceWithCache(cache *NetlinkCache, local, 
 			return nil
 		}
 	} else {
-		if _, err := netlinkLinkByName(lm.ifaceName); err == nil {
+		_, err := netlinkLinkByName(lm.ifaceName)
+		if err == nil {
 			return nil
+		}
+
+		if lookupErr := lm.lookupError(err); lookupErr != nil {
+			return lookupErr
 		}
 	}
 

--- a/internal/net/netlink/link_manager_test.go
+++ b/internal/net/netlink/link_manager_test.go
@@ -1,0 +1,387 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package netlink
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// These tests swap the package-level netlinkLink* seams, so none of them may
+// call t.Parallel(): parallel subtests would overwrite each other's stubs and
+// the failures would look like the code under test misbehaving.
+
+// errTransient stands in for a netlink failure that says nothing about
+// whether the interface exists: a busy socket, a permissions problem, a
+// truncated response. The distinction under test is between this and the
+// "gone" errors that isLinkGoneError recognises.
+var errTransient = fmt.Errorf("netlink busy: %w", syscall.EBUSY)
+
+// goneErrors are the three shapes isLinkGoneError treats as "not there".
+//
+// netlink.LinkNotFoundError embeds an error interface that is unexported, so
+// a composite literal from outside that package can only leave it nil, and
+// calling Error() on this value would panic. That is safe here only because
+// every path these tests reach checks isLinkGoneError before formatting the
+// error. Adding a log line on a gone path would turn these tests into panics.
+func goneErrors() map[string]error {
+	return map[string]error{
+		"LinkNotFoundError": netlink.LinkNotFoundError{},
+		"ENODEV":            syscall.ENODEV,
+		"ENOENT":            syscall.ENOENT,
+	}
+}
+
+// stubLinks redirects the three netlink link seams for the duration of a test
+// and restores them afterwards, following the convention in
+// gateway_policy_manager_mock_test.go.
+//
+// addErr and delErr default to a sentinel, so a test that does not opt in
+// fails loudly if the code under test mutates anything. Tests that exercise
+// the delete-and-recreate paths set delErr to nil so execution carries on to
+// the create.
+type linkStubs struct {
+	addCalls int
+	delCalls int
+	addErr   error
+	delErr   error
+}
+
+var errStubNotExpected = errors.New("netlink mutation should not have been reached")
+
+func stubLinks(t *testing.T, byName func(string) (netlink.Link, error)) *linkStubs {
+	t.Helper()
+
+	origByName, origAdd, origDel := netlinkLinkByName, netlinkLinkAdd, netlinkLinkDel
+
+	t.Cleanup(func() {
+		netlinkLinkByName, netlinkLinkAdd, netlinkLinkDel = origByName, origAdd, origDel
+	})
+
+	s := &linkStubs{addErr: errStubNotExpected, delErr: errStubNotExpected}
+
+	netlinkLinkByName = byName
+	netlinkLinkAdd = func(netlink.Link) error {
+		s.addCalls++
+
+		return s.addErr
+	}
+	netlinkLinkDel = func(netlink.Link) error {
+		s.delCalls++
+
+		return s.delErr
+	}
+
+	return s
+}
+
+func lookupFails(err error) func(string) (netlink.Link, error) {
+	return func(string) (netlink.Link, error) { return nil, err }
+}
+
+func lookupReturns(link netlink.Link) func(string) (netlink.Link, error) {
+	return func(string) (netlink.Link, error) { return link, nil }
+}
+
+// ensureFuncs are the interface-creating methods that decide whether to
+// create based on a link lookup. Each must refuse to create when the lookup
+// fails for a reason other than the interface being absent.
+func ensureFuncs() map[string]func(*LinkManager) error {
+	return map[string]func(*LinkManager) error{
+		"EnsureIPIPInterfaceWithRemote": func(lm *LinkManager) error {
+			return lm.EnsureIPIPInterfaceWithRemote(net.IPv4(10, 0, 0, 1), net.IPv4(10, 0, 0, 2))
+		},
+		"EnsureIPIPExternalInterface": func(lm *LinkManager) error {
+			return lm.EnsureIPIPExternalInterface()
+		},
+		"EnsureGeneveInterfaceWithRemote": func(lm *LinkManager) error {
+			return lm.EnsureGeneveInterfaceWithRemote(1, 6081, net.IPv4(10, 0, 0, 2))
+		},
+		"EnsureGeneveInterface": func(lm *LinkManager) error {
+			return lm.EnsureGeneveInterface(0, 6081, nil)
+		},
+		"EnsureVXLANInterface": func(lm *LinkManager) error {
+			return lm.EnsureVXLANInterface(4789, 30000, 40000, nil)
+		},
+		"EnsureWireGuardInterface": func(lm *LinkManager) error {
+			return lm.EnsureWireGuardInterface()
+		},
+		"EnsureBridge": func(lm *LinkManager) error {
+			return lm.EnsureBridge()
+		},
+		"EnsureDummyInterface": func(lm *LinkManager) error {
+			return lm.EnsureDummyInterface()
+		},
+		"EnsureGeneveInterfaceWithCache": func(lm *LinkManager) error {
+			return lm.EnsureGeneveInterfaceWithCache(nil, 1, 6081, net.IPv4(10, 0, 0, 2))
+		},
+		"EnsureIPIPInterfaceWithCache": func(lm *LinkManager) error {
+			return lm.EnsureIPIPInterfaceWithCache(nil, net.IPv4(10, 0, 0, 1), net.IPv4(10, 0, 0, 2))
+		},
+	}
+}
+
+// A lookup failure that does not mean "absent" must not be read as "absent".
+// Before this was fixed every one of these would fall through and try to
+// create an interface that may well already exist.
+func TestEnsureRefusesToCreateWhenLookupFails(t *testing.T) {
+	for name, ensure := range ensureFuncs() {
+		t.Run(name, func(t *testing.T) {
+			stubs := stubLinks(t, lookupFails(errTransient))
+
+			err := ensure(NewLinkManager("unb0"))
+			if err == nil {
+				t.Fatal("expected an error when the link lookup fails for a non-absent reason")
+			}
+
+			if !errors.Is(err, syscall.EBUSY) {
+				t.Fatalf("expected the underlying lookup error to be wrapped, got %v", err)
+			}
+
+			if stubs.addCalls != 0 {
+				t.Fatalf("interface creation attempted despite a failed lookup (%d calls)", stubs.addCalls)
+			}
+
+			if stubs.delCalls != 0 {
+				t.Fatalf("interface deletion attempted despite a failed lookup (%d calls)", stubs.delCalls)
+			}
+		})
+	}
+}
+
+// The absent case must still reach creation, otherwise the fix above would
+// have disabled interface creation entirely.
+func TestEnsureStillCreatesWhenLinkIsAbsent(t *testing.T) {
+	for name, ensure := range ensureFuncs() {
+		for errName, goneErr := range goneErrors() {
+			t.Run(name+"/"+errName, func(t *testing.T) {
+				stubs := stubLinks(t, lookupFails(goneErr))
+
+				// stubLinks makes LinkAdd fail, so the error we expect back is
+				// that one. Reaching it is the point: it proves the method got
+				// past the lookup and tried to create.
+				if err := ensure(NewLinkManager("unb0")); err == nil {
+					t.Fatal("expected the stubbed LinkAdd error to surface")
+				}
+
+				if stubs.addCalls != 1 {
+					t.Fatalf("expected exactly one creation attempt, got %d", stubs.addCalls)
+				}
+			})
+		}
+	}
+}
+
+// DeleteLink is the site that reported success without doing anything: any
+// lookup error was read as "already gone".
+func TestDeleteLinkFailsWhenLookupFails(t *testing.T) {
+	stubs := stubLinks(t, lookupFails(errTransient))
+
+	err := NewLinkManager("unb0").DeleteLink()
+	if err == nil {
+		t.Fatal("expected an error rather than a silent success when the lookup fails")
+	}
+
+	if !errors.Is(err, syscall.EBUSY) {
+		t.Fatalf("expected the underlying lookup error to be wrapped, got %v", err)
+	}
+
+	if stubs.delCalls != 0 {
+		t.Fatalf("deletion attempted despite a failed lookup (%d calls)", stubs.delCalls)
+	}
+}
+
+// Deleting an interface that is already absent is still success: the caller
+// asked for it to be gone and it is.
+func TestDeleteLinkIsNilWhenAlreadyAbsent(t *testing.T) {
+	for errName, goneErr := range goneErrors() {
+		t.Run(errName, func(t *testing.T) {
+			stubs := stubLinks(t, lookupFails(goneErr))
+
+			if err := NewLinkManager("unb0").DeleteLink(); err != nil {
+				t.Fatalf("expected nil for an already-absent interface, got %v", err)
+			}
+
+			if stubs.delCalls != 0 {
+				t.Fatalf("deletion attempted for an absent interface (%d calls)", stubs.delCalls)
+			}
+		})
+	}
+}
+
+// Exists deliberately keeps its bool signature: every caller is a reconcile
+// predicate that retries. It must still report false rather than panic or
+// report true when the lookup breaks.
+func TestExistsReportsFalseOnAnyLookupFailure(t *testing.T) {
+	cases := goneErrors()
+	cases["transient"] = errTransient
+
+	for name, err := range cases {
+		t.Run(name, func(t *testing.T) {
+			stubLinks(t, lookupFails(err))
+
+			if NewLinkManager("unb0").Exists() {
+				t.Fatal("expected Exists to report false when the lookup fails")
+			}
+		})
+	}
+}
+
+func TestExistsReportsTrueWhenLookupSucceeds(t *testing.T) {
+	stubLinks(t, func(string) (netlink.Link, error) {
+		return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "unb0"}}, nil
+	})
+
+	if !NewLinkManager("unb0").Exists() {
+		t.Fatal("expected Exists to report true when the lookup succeeds")
+	}
+}
+
+// lookupError is what the call sites above share, so pin its contract
+// directly as well.
+func TestLookupErrorDistinguishesAbsentFromBroken(t *testing.T) {
+	lm := NewLinkManager("unb0")
+
+	for name, goneErr := range goneErrors() {
+		t.Run(name+"/absent is not an error", func(t *testing.T) {
+			if err := lm.lookupError(goneErr); err != nil {
+				t.Fatalf("expected nil for an absent interface, got %v", err)
+			}
+		})
+	}
+
+	t.Run("broken lookup is an error naming the interface", func(t *testing.T) {
+		err := lm.lookupError(errTransient)
+		if err == nil {
+			t.Fatal("expected an error for a lookup that failed for another reason")
+		}
+
+		if !errors.Is(err, syscall.EBUSY) {
+			t.Fatalf("expected the cause to be wrapped, got %v", err)
+		}
+	})
+}
+
+// A nil error is not a failed lookup. isLinkGoneError(nil) is false, so a
+// lookupError that only consulted it would wrap nil and hand back a non-nil
+// error rendering as "%!w(<nil>)". The recreate paths below reach lookupError
+// with err == nil after deleting an interface they are about to recreate, and
+// would abort on that phantom error instead of recreating.
+func TestLookupErrorIsNilForNilError(t *testing.T) {
+	if err := NewLinkManager("unb0").lookupError(nil); err != nil {
+		t.Fatalf("expected nil for a lookup that succeeded, got %v", err)
+	}
+}
+
+// recreateCase describes an interface that already exists but in the wrong
+// mode, so the manager has to delete it and create it again.
+type recreateCase struct {
+	name        string
+	existing    netlink.Link
+	ensure      func(*LinkManager) error
+	wantDelete  bool
+	description string
+}
+
+func recreateCases() []recreateCase {
+	ipipExternal := func(lm *LinkManager) error { return lm.EnsureIPIPExternalInterface() }
+	geneveExternal := func(lm *LinkManager) error { return lm.EnsureGeneveInterface(0, 6081, nil) }
+
+	return []recreateCase{
+		{
+			name:        "IPIP not flow-based is recreated",
+			existing:    &netlink.Iptun{LinkAttrs: netlink.LinkAttrs{Name: "unb0"}, FlowBased: false},
+			ensure:      ipipExternal,
+			wantDelete:  true,
+			description: "an IPIP interface left over in point-to-point mode has to be replaced",
+		},
+		{
+			name:        "IPIP already flow-based is left alone",
+			existing:    &netlink.Iptun{LinkAttrs: netlink.LinkAttrs{Name: "unb0"}, FlowBased: true},
+			ensure:      ipipExternal,
+			wantDelete:  false,
+			description: "already in the desired mode, so nothing should be touched",
+		},
+		{
+			name:        "GENEVE not flow-based is recreated",
+			existing:    &netlink.Geneve{LinkAttrs: netlink.LinkAttrs{Name: "unb0"}, FlowBased: false},
+			ensure:      geneveExternal,
+			wantDelete:  true,
+			description: "a GENEVE interface left over in point-to-point mode has to be replaced",
+		},
+		{
+			name:        "GENEVE with a fixed VNI is recreated",
+			existing:    &netlink.Geneve{LinkAttrs: netlink.LinkAttrs{Name: "unb0"}, FlowBased: true, ID: 5},
+			ensure:      geneveExternal,
+			wantDelete:  true,
+			description: "flow-based but pinned to a VNI, which the eBPF dataplane cannot use",
+		},
+		{
+			name:        "GENEVE already external is left alone",
+			existing:    &netlink.Geneve{LinkAttrs: netlink.LinkAttrs{Name: "unb0"}, FlowBased: true, ID: 0},
+			ensure:      geneveExternal,
+			wantDelete:  false,
+			description: "already in the desired mode, so nothing should be touched",
+		},
+	}
+}
+
+// The delete-and-recreate paths reach the lookup guard with err == nil. They
+// must carry on to the create rather than report a lookup failure that did
+// not happen, and the paths that need no change must touch nothing at all.
+func TestEnsureRecreatesInterfaceInTheWrongMode(t *testing.T) {
+	for _, tc := range recreateCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			stubs := stubLinks(t, lookupReturns(tc.existing))
+			// Let the delete succeed so execution reaches the create.
+			stubs.delErr = nil
+			stubs.addErr = nil
+
+			if err := tc.ensure(NewLinkManager("unb0")); err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.description, err)
+			}
+
+			wantDeletes, wantAdds := 0, 0
+			if tc.wantDelete {
+				wantDeletes, wantAdds = 1, 1
+			}
+
+			if stubs.delCalls != wantDeletes {
+				t.Fatalf("%s: expected %d deletes, got %d", tc.description, wantDeletes, stubs.delCalls)
+			}
+
+			if stubs.addCalls != wantAdds {
+				t.Fatalf("%s: expected %d creates, got %d", tc.description, wantAdds, stubs.addCalls)
+			}
+		})
+	}
+}
+
+// A delete that fails must abort rather than fall through to the create,
+// which would leave the old interface in place and report success.
+func TestEnsureStopsWhenRecreateDeleteFails(t *testing.T) {
+	for _, tc := range recreateCases() {
+		if !tc.wantDelete {
+			continue
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			stubs := stubLinks(t, lookupReturns(tc.existing))
+			stubs.delErr = errTransient
+
+			if err := tc.ensure(NewLinkManager("unb0")); err == nil {
+				t.Fatal("expected the delete failure to surface")
+			}
+
+			if stubs.addCalls != 0 {
+				t.Fatalf("creation attempted after a failed delete (%d calls)", stubs.addCalls)
+			}
+		})
+	}
+}

--- a/internal/net/netlink/link_manager_test.go
+++ b/internal/net/netlink/link_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/vishvananda/netlink"
 )
 
@@ -384,4 +385,41 @@ func TestEnsureStopsWhenRecreateDeleteFails(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The counter exists so that lookups failing for a reason other than absence
+// are visible in Prometheus, not only in logs. Exists() is the path where that
+// matters most: it swallows the condition entirely and returns a plain bool,
+// so without the counter a node whose netlink lookups are failing looks
+// identical to one whose interfaces are legitimately absent.
+func TestExistsCountsLookupFailuresThatAreNotAbsence(t *testing.T) {
+	counter := InterfaceOperationErrors.WithLabelValues("lookup")
+
+	t.Run("a broken lookup is counted", func(t *testing.T) {
+		stubLinks(t, lookupFails(errTransient))
+
+		before := testutil.ToFloat64(counter)
+
+		NewLinkManager("unb0").Exists()
+
+		if got := testutil.ToFloat64(counter) - before; got != 1 {
+			t.Fatalf("expected the lookup failure to be counted once, got %v", got)
+		}
+	})
+
+	t.Run("an absent interface is not counted", func(t *testing.T) {
+		for name, goneErr := range goneErrors() {
+			t.Run(name, func(t *testing.T) {
+				stubLinks(t, lookupFails(goneErr))
+
+				before := testutil.ToFloat64(counter)
+
+				NewLinkManager("unb0").Exists()
+
+				if got := testutil.ToFloat64(counter) - before; got != 0 {
+					t.Fatalf("an absent interface is not an error and must not be counted, got %v", got)
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
First of three PRs splitting out the net fixes found while working through #657. This one is a bug fix and changes no lint configuration; `nilerr` and `predeclared` get enabled in the last of the three.

> **Force-pushed twice after review.** Round 1 fixed the `lookupError(nil)` regression in place. Round 2 corrected commit 3's message, which stated something false about the gateway prune, and added the missing metric coverage. Commits 1 and 2 are unchanged since round 1. See "Review responses" at the bottom.

## The bug

`netlink.LinkByName` can fail without the interface being missing: a busy socket, a permissions problem, a truncated response. `link_manager.go` read every such error as "not there" in **twelve** places — ten `Ensure*` paths, `DeleteLink` and `Exists()` — and drew one of two wrong conclusions.

**`DeleteLink` drew the worse one.** Any lookup error returned `nil`, so a caller that asked for an interface to be removed was told it had been, when nothing was deleted.

**The ten `Ensure*` paths drew the other.** On a lookup failure they fell through to creation, turning a transient error into an attempt to create an interface that already exists. Self-correcting via `EEXIST`, but noisy on a healthy system. Five of those ten turn out to have no production caller at all (see [below](#known-five-tested-methods-are-unreachable--670)); the live ones span IPIP, GENEVE, VXLAN, WireGuard and the dummy interface.

The fix defers to `isLinkGoneError`, which **already existed in this file** (`link_manager.go:844`) and was already used for exactly this distinction by `EnsureBridgePortMTUs` and `EnsureBridgePodMTUs`.

A reviewer independently confirmed the helper is complete for `netlink@v1.3.1` — `ENODEV` (`link_linux.go:2030`), zero-message (`:2039`) and the EINVAL dump fallback (`:1904`) all yield `LinkNotFoundError`. So there is no gap that would make `Ensure*` permanently refuse to create.

## Four commits

1. **`route link calls through seams, no behaviour change`** — 3 seam vars following the `netlinkRuleList` convention in `route_table_setup.go:20-22`; 36 call sites rerouted (23 `LinkByName`, 10 `LinkAdd`, 3 `LinkDel`). Provably mechanical: reversing the rename and removing the var block reproduces the previous file byte for byte.
2. **`a failed link lookup is not an absent interface`** — the fix, plus `link_manager_test.go`.
3. **`do not prune gateway rules on a failed link lookup`** — **separable; drop this commit alone if you disagree.**
4. **`count the lookup failures that are only logged`** — metric coverage for the two paths that swallow the condition, and removal of a redundant `isLinkGoneError` check in `DeleteLink`.

## `lookupError` treats nil as nothing to report, and that is load bearing

`isLinkGoneError(nil)` is **false** — `errors.As` returns false for a nil error (`errors/wrap.go:103`), and `errors.Is(nil, ENODEV)` reduces to `nil == ENODEV` (`:46-48`). Without the nil case it would wrap nil and return an error rendering as `%!w(<nil>)`.

`EnsureIPIPExternalInterface` and `EnsureGeneveInterface` reach it with `err == nil` after deleting an interface they are about to recreate. They would delete and then abort. Both are additionally written as `if err != nil { … } else { … }` so control flow does not depend on the helper being total.

## Scope of the `DeleteLink` fix: latent, not manifesting

Worth being straight about. All 8 `DeleteLink` production callers only log the error — `V(2)`, `Warningf` or `Errorf` — and none propagate or retry. Five sit behind `if lm.Exists()`, which this PR deliberately keeps returning `false` on a broken lookup, so `DeleteLink` is not even reached from them. The one `continue` on the error path (`site_watch_reconcile.go:631-634`) skips only a success log, and a `LinkDel` sweep follows at `:640`.

The fix is correct and worth keeping as prophylaxis. It does not fix an outage anyone is currently having.

After commit 4 it is simply `return lm.lookupError(err)`; the earlier explicit `isLinkGoneError` check tested the same condition the helper already tests.

## `Exists()` keeps its `bool`

All six callers — `tunnel_config.go:307,363,432,886`, `wireguard_config.go:96`, `mtu.go:39` — are reconcile predicates that retry, so a transient `false` is harmless. Commit 4 makes it count the condition as well as log it, so a node whose lookups are failing is distinguishable from one whose interfaces are legitimately absent, which a plain `bool` otherwise hides.

## Commit 3, on honest grounds

The gateway prune tore down policy routing for interfaces that were still up whenever a lookup failed for a non-absence reason. That was wrong and is worth fixing.

But my original justification was false, and is corrected in the commit message. `ReconcileExpectedInterfaces` already clears both managed mangle chains and rebuilds from `expected` (`gateway_policy_manager.go:1016-1047`), then replaces `configuredIfaces` wholesale (`:584-589`); `cleanupStaleIPRulesLocked` flushes stale route tables off `netlinkRuleList` with no link lookup. So the prune is **not** the only cleanup, and declining to prune does not strand rules indefinitely.

Exposure is close to zero anyway: `EnablePolicyRouting` is `false` in the flag default (`main.go:278`), the runtime config default (`:200`), the ConfigMap template (`01-configmap.yaml.tmpl:44`) and the rendered output, and is documented as deprecated in favour of the `UNBOUNDED-FORWARD` chain (`runtime_config.go:68-70`). Both this prune's caller and `ReconcileExpectedInterfaces` are gated on it.

## The honest cost of the trade — #671

Deferring a reconcile pass is **not** benign on the tunnel path. `pendingBPFEntries` is nil'd before `configureTunnelPeers` (`site_watch_reconcile.go:2047`); an abort leaves it nil; the caller only warns (`:2066`); `reconcilePendingBPFEntries` still runs (`:2147`); `entries == nil` becomes an **empty map** (`tunnel_config.go:760-762`); and `TunnelMap.Reconcile` deletes everything not in desired (`tunnel_map.go:288-296`). So an aborted pass withdraws every tunnel peer from the LPM trie.

This is pre-existing and unchanged in the common case, because the old code fell through to `LinkAdd`, hit `EEXIST` and aborted at the same line. The one genuinely new way to reach it is a transient lookup failure where the interface really is absent: the old code created it, the new code defers. Right trade, real cost. Filed as **#671**.

<a name="known-five-tested-methods-are-unreachable--670"></a>
## Known: five tested methods are unreachable — #670

`EnsureIPIPInterfaceWithRemote`, `EnsureGeneveInterfaceWithRemote`, `EnsureBridge`, `EnsureGeneveInterfaceWithCache` and `EnsureIPIPInterfaceWithCache` have **no production caller**; the tests added here are their only callers. Two further exported `LinkManager` methods, `SetLinkNoARP` and `GetAddresses`, have no references anywhere — **7 of 22** exported methods on the type. None of the seven is required to satisfy an interface, so none is load-bearing.

`unused` is enabled and cannot see any of it: rule (1.1) makes the package use exported named type `LinkManager`, and (2.1) makes that type use all its exported methods, so they are transitively live because the type is exported.

Two consequences for this PR's claims:
- The `Ensure*` fix does **not** cover the CNI bridge. `EnsureBridge` is dead; the live bridge path is the `cniBridgeLinkManager` interface in `mtu.go:19-24` — `Exists`/`EnsureMTUWithCache`/`EnsureBridgePortMTUs`/`EnsureBridgePodMTUs` — and is untouched here.
- The `*WithCache` methods, which decide via `cache.HasLink()` and go straight to creation on a miss, retain the same bug shape sourced from a stale cache rather than a failed syscall. That is **not live residual risk**, because nothing calls them.

Deliberately not deleted here, to keep this PR to one idea. Tracked in **#670**, along with a proposal to evaluate `x/tools/cmd/deadcode`, which does the whole-program analysis `unused` declines to.

## The tests fail without the fix

Measured against this branch's HEAD, in both directions:

- Reverting the ten guards and `DeleteLink`: **10 failing `Ensure*` subtests and a failing `DeleteLink`**.
- Reverting only the nil case: **3 failing recreate subtests**, with `%!w(<nil>)` in the output.
- Removing the `Exists()` counter: the metric test fails.
- The no-op cases are covered too — already-correct interfaces, already-absent interfaces — so no fix can pass by refusing to act at all.

The seams are package-level vars, so no test calls `t.Parallel()`: parallel subtests overwrite each other's stubs and the failures look like the code misbehaving. There is a comment saying so. This is enforced by convention, not by the compiler.

## Verification

Against the pinned golangci-lint v2.13.1 (`Makefile:435`), not a locally-installed version.

- `go build ./...` clean, `make lint` **0 issues**, `make fmt` idempotent
- `go test -race ./internal/net/...` all pass
- `nilerr` measured alone: **14 → 13**, with `link_manager.go` gone from the list

**Risk worth naming:** this touches every live tunnel-creation path on the node. The tests are unit-level with seams and cannot prove real netlink behaviour. `gantry e2e`, `agent e2e` and `pxe-smoke` are the actual safety net.

The first CI run after the round-2 push showed two failures, `Lint` and `Storage Integration`. Both were transient module-proxy errors during dependency download — `sum.golang.org` and `proxy.golang.org` returning `INTERNAL_ERROR` three minutes apart — and both died before reaching any code from this branch. Rerun is green.

---

## Review responses

### Round 2

| # | Finding | Outcome |
|---|---|---|
| 1 | 5 of 10 tested `Ensure*` have no production caller | **Confirmed.** Body corrected; found 2 more (7 of 22). Deletion deferred to #670 |
| 2 | `DeleteLink`'s error return is unobservable | **Confirmed.** Restated as latent above |
| 3 | Commit 3's rationale is factually wrong | **Confirmed.** Message rewritten; exposure ≈ zero documented |
| 4 | Aborted pass wipes the LPM trie | **Confirmed.** Documented above, filed as #671 |
| m1 | `DeleteLink` double-checks `isLinkGoneError` | **Fixed** in commit 4 |
| m2 | Metric under-reports | **Fixed** in commit 4, with a test |
| m3 | `klog` in `Exists()` would trip the nil-fixture panic | **Not reproduced** — see below |
| m4 | Seams are unsynchronised globals | **Confirmed**, noted above as convention-enforced |
| m5 | `route_manager.go:161` same shape | **Confirmed**, benign: a documented best-effort constructor lookup |

**On m3.** The `klog.V(2)` in `Exists()` is gated on `!isLinkGoneError(err)`, which excludes precisely the gone errors, so `LinkNotFoundError{}` never reaches that format string at any verbosity. `errors.As` type-matches by reflection and never calls `Error()`. The trap is real for any *future* log placed on the gone path — which the fixture comment already warns about — but it is not reachable today.

### Round 1

| # | Finding | Outcome |
|---|---|---|
| 1 | `lookupError(nil)` non-nil regresses 2 paths | **Confirmed, fixed.** Nil-safe helper *and* both functions restructured |
| 2 | Tests never enter the recreate branch | **Confirmed, fixed.** 5 recreate cases + delete-failure + `lookupError(nil)` |
| 3 | `misspell` should flag `recognises` | **Not reproduced.** No `misspell` block exists in `.golangci.yaml`, so no `locale: US`; `"recognises"` appears only in `words_us.go:960`, gated behind it. Verified twice at 0 issues |
| 4 | `LinkNotFoundError{}` would panic if formatted | **Confirmed.** Comment added on the fixture |
| 5 | PR body mischaracterises `WithCache` | **Confirmed, corrected** |
| 6 | No metric on the new error paths | **Confirmed.** Added on the error-returning path in round 1, completed in round 2 (see m2) |
| 7 | Commit 3 is retention, not deferral | **Superseded** by round 2 finding 3 |
| 8 | Seam asymmetry needs a comment | **Confirmed, added** |


