### PR TITLE
fix(net): honor kube-proxy JSON health

### DIFF
--- a/cmd/unbounded-net-node/kube_proxy_monitor.go
+++ b/cmd/unbounded-net-node/kube_proxy_monitor.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +24,10 @@ type kubeProxyMonitor struct {
 
 	mu      sync.Mutex
 	warning string // empty when healthy
+}
+
+type kubeProxyHealthResponse struct {
+	Healthy bool `json:"healthy"`
 }
 
 // newKubeProxyMonitor creates a monitor that checks kube-proxy health at
@@ -82,9 +87,19 @@ func (m *kubeProxyMonitor) check() {
 
 	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 256)) //nolint:errcheck
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		m.setWarning(fmt.Sprintf("read kube-proxy healthz response: %v", err))
+		return
+	}
 
-	if resp.StatusCode == http.StatusOK {
+	var health kubeProxyHealthResponse
+	if err := json.Unmarshal(body, &health); err != nil {
+		m.setWarning(fmt.Sprintf("parse kube-proxy healthz response: %v", err))
+		return
+	}
+
+	if health.Healthy {
 		m.clearWarning()
 		return
 	}

--- a/cmd/unbounded-net-node/kube_proxy_monitor_test.go
+++ b/cmd/unbounded-net-node/kube_proxy_monitor_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,7 +15,23 @@ import (
 func TestKubeProxyMonitorHealthy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
+		_, _ = w.Write([]byte(`{"healthy":true}`))
+	}))
+	defer srv.Close()
+
+	m := newKubeProxyMonitor(100 * time.Millisecond)
+	m.url = srv.URL + "/healthz"
+	m.check()
+
+	if w := m.GetWarning(); w != "" {
+		t.Fatalf("expected no warning, got: %s", w)
+	}
+}
+
+func TestKubeProxyMonitorHealthyWithServiceUnavailableStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"nodeEligible":false,"healthy":true}`))
 	}))
 	defer srv.Close()
 
@@ -30,7 +47,7 @@ func TestKubeProxyMonitorHealthy(t *testing.T) {
 func TestKubeProxyMonitorUnhealthy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		_, _ = w.Write([]byte("not ready"))
+		_, _ = w.Write([]byte(`{"healthy":false}`))
 	}))
 	defer srv.Close()
 
@@ -43,8 +60,24 @@ func TestKubeProxyMonitorUnhealthy(t *testing.T) {
 		t.Fatal("expected warning, got empty")
 	}
 
-	if w != "kube-proxy healthz returned 503: not ready" {
+	if w != `kube-proxy healthz returned 503: {"healthy":false}` {
 		t.Fatalf("unexpected warning: %s", w)
+	}
+}
+
+func TestKubeProxyMonitorInvalidResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	m := newKubeProxyMonitor(100 * time.Millisecond)
+	m.url = srv.URL + "/healthz"
+	m.check()
+
+	if w := m.GetWarning(); w == "" {
+		t.Fatal("expected warning for invalid response")
 	}
 }
 
@@ -68,6 +101,8 @@ func TestKubeProxyMonitorRecovery(t *testing.T) {
 		} else {
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
+
+		_, _ = fmt.Fprintf(w, `{"healthy":%t}`, healthy)
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary

- parse kube-proxy `/healthz` JSON instead of relying solely on HTTP status
- treat `healthy: true` as healthy when node eligibility causes HTTP 503
- retain warnings for unhealthy, malformed, and unreachable responses

## Problem

Unbounded-managed nodes carry the `node.kubernetes.io/exclude-from-external-load-balancers=true` label. kube-proxy intentionally reports these nodes as `nodeEligible:false`, so its `/healthz` endpoint returns HTTP 503 even while the response body reports `healthy:true` and both IPv4 and IPv6 proxy synchronization are healthy.

The node monitor currently interprets every non-200 response as a kube-proxy failure. That warning is included in the node status sent to the controller, causing the controller and dashboard to report a false kube-proxy error for otherwise healthy excluded nodes.

## Fix

The monitor now parses the kube-proxy health JSON and uses its `healthy` field as the authoritative proxy-health signal. A 503 response with `healthy:true` no longer creates a warning, while `healthy:false`, malformed responses, and unreachable endpoints continue to surface errors.

## Testing

- `go test ./cmd/unbounded-net-node -run '^TestKubeProxyMonitor' -count=1`