### PR TITLE
Enforce ownership of public IP annotations

### DIFF
--- a/deploy/net/controller/09-vap.yaml.tmpl
+++ b/deploy/net/controller/09-vap.yaml.tmpl
@@ -144,3 +144,55 @@ metadata:
 spec:
   policyName: unbounded-net-node-field-restriction
   validationActions: ["Deny"]
+
+---
+# Protect the ownership of public IP annotations on every Node. The discovered
+# address and its expiry belong to the agent running on that Node. The declared
+# address belongs to an administrator whose Node update was authorized by RBAC.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: unbounded-net-public-ip-annotation-ownership
+  labels:
+    app.kubernetes.io/name: unbounded-net-controller
+    app.kubernetes.io/component: controller
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["nodes"]
+  validations:
+    - expression: >-
+        !has(object.metadata.annotations) ||
+        (request.userInfo.username == 'system:serviceaccount:{{ default "unbounded-system" .Namespace }}:unbounded-net-node' &&
+          request.userInfo.extra[?'authentication.kubernetes.io/node-name'][0].orValue('') == object.metadata.name &&
+          request.userInfo.extra[?'authentication.kubernetes.io/node-uid'][0].orValue('') == object.metadata.uid) ||
+        ['net.unbounded-cloud.io/discovered-public-ip', 'net.unbounded-cloud.io/discovered-public-ip-expires-at'].all(annotation,
+          !(annotation in object.metadata.annotations) ||
+          (oldObject != null && has(oldObject.metadata.annotations) &&
+            annotation in oldObject.metadata.annotations &&
+            object.metadata.annotations[annotation] == oldObject.metadata.annotations[annotation]))
+      message: "only the unbounded-net-node agent running on a Node may add or change its public IP discovery annotations"
+    - expression: >-
+        !has(object.metadata.annotations) ||
+        !('net.unbounded-cloud.io/declared-public-ip' in object.metadata.annotations) ||
+        (oldObject != null && has(oldObject.metadata.annotations) &&
+          'net.unbounded-cloud.io/declared-public-ip' in oldObject.metadata.annotations &&
+          object.metadata.annotations['net.unbounded-cloud.io/declared-public-ip'] == oldObject.metadata.annotations['net.unbounded-cloud.io/declared-public-ip']) ||
+        (!request.userInfo.username.startsWith('system:serviceaccount:') &&
+          !request.userInfo.username.startsWith('system:node:'))
+      message: "service accounts and kubelets may not add or change the administrator-declared public IP annotation"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: unbounded-net-public-ip-annotation-ownership
+  labels:
+    app.kubernetes.io/name: unbounded-net-controller
+    app.kubernetes.io/component: controller
+spec:
+  policyName: unbounded-net-public-ip-annotation-ownership
+  validationActions: ["Deny"]

--- a/internal/operator/components/net/net_test.go
+++ b/internal/operator/components/net/net_test.go
@@ -1417,6 +1417,8 @@ Apply ValidatingAdmissionPolicy/unbounded-net-create-restriction
 Apply ValidatingAdmissionPolicyBinding/unbounded-net-create-restriction
 Apply ValidatingAdmissionPolicy/unbounded-net-node-field-restriction
 Apply ValidatingAdmissionPolicyBinding/unbounded-net-node-field-restriction
+Apply ValidatingAdmissionPolicy/unbounded-net-public-ip-annotation-ownership
+Apply ValidatingAdmissionPolicyBinding/unbounded-net-public-ip-annotation-ownership
 Apply ClusterRole/unbounded-net-status-viewer
 Apply ServiceAccount/unbounded-system/unbounded-net-node
 Apply ClusterRole/unbounded-net-node
@@ -1434,7 +1436,7 @@ Apply DaemonSet/unbounded-system/unbounded-net-node [overridable] [after ConfigM
 //
 // Withholding is a property of the plan rather than of a second apply, so it is
 // visible here: exactly the three objects that route apiserver traffic at the
-// controller Service are absent, and nothing else is. The two
+// controller Service are absent, and nothing else is. The three
 // ValidatingAdmissionPolicy pairs stay, because the apiserver evaluates them
 // itself and they have no backend to wait for.
 func TestPlanGoldenWithholdsRegistrationsWhileTheBackendIsDown(t *testing.T) {
@@ -1465,6 +1467,8 @@ Apply ValidatingAdmissionPolicy/unbounded-net-create-restriction
 Apply ValidatingAdmissionPolicyBinding/unbounded-net-create-restriction
 Apply ValidatingAdmissionPolicy/unbounded-net-node-field-restriction
 Apply ValidatingAdmissionPolicyBinding/unbounded-net-node-field-restriction
+Apply ValidatingAdmissionPolicy/unbounded-net-public-ip-annotation-ownership
+Apply ValidatingAdmissionPolicyBinding/unbounded-net-public-ip-annotation-ownership
 Apply ClusterRole/unbounded-net-status-viewer
 Apply ServiceAccount/unbounded-system/unbounded-net-node
 Apply ClusterRole/unbounded-net-node
@@ -1526,6 +1530,8 @@ Apply ValidatingAdmissionPolicy/unbounded-net-create-restriction
 Apply ValidatingAdmissionPolicyBinding/unbounded-net-create-restriction
 Apply ValidatingAdmissionPolicy/unbounded-net-node-field-restriction
 Apply ValidatingAdmissionPolicyBinding/unbounded-net-node-field-restriction
+Apply ValidatingAdmissionPolicy/unbounded-net-public-ip-annotation-ownership
+Apply ValidatingAdmissionPolicyBinding/unbounded-net-public-ip-annotation-ownership
 `
 
 	got, err := plan.ExecutionOrder()

--- a/internal/operator/components/net/vap_test.go
+++ b/internal/operator/components/net/vap_test.go
@@ -4,6 +4,7 @@
 package net
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -14,9 +15,14 @@ import (
 )
 
 const (
-	wireGuardPortAnnotation          = "net.unbounded-cloud.io/wireguard-port"
-	nodeServiceAccountUsername       = "system:serviceaccount:unbounded-system:unbounded-net-node"
-	controllerServiceAccountUsername = "system:serviceaccount:unbounded-system:unbounded-net-controller"
+	wireGuardPortAnnotation               = "net.unbounded-cloud.io/wireguard-port"
+	discoveredPublicIPAnnotation          = "net.unbounded-cloud.io/discovered-public-ip"
+	discoveredPublicIPExpiresAtAnnotation = "net.unbounded-cloud.io/discovered-public-ip-expires-at"
+	declaredPublicIPAnnotation            = "net.unbounded-cloud.io/declared-public-ip"
+	nodeServiceAccountUsername            = "system:serviceaccount:unbounded-system:unbounded-net-node"
+	controllerServiceAccountUsername      = "system:serviceaccount:unbounded-system:unbounded-net-controller"
+	nodeNameExtra                         = "authentication.kubernetes.io/node-name"
+	nodeUIDExtra                          = "authentication.kubernetes.io/node-uid"
 )
 
 func TestNodeFieldPolicyProtectsWireGuardPort(t *testing.T) {
@@ -87,6 +93,278 @@ func TestNodeFieldPolicyProtectsWireGuardPort(t *testing.T) {
 	}
 }
 
+func TestPublicIPAnnotationOwnershipPolicyScope(t *testing.T) {
+	t.Parallel()
+
+	policy := plannedNetObject(t, "ValidatingAdmissionPolicy", "unbounded-net-public-ip-annotation-ownership")
+
+	failurePolicy, found, err := unstructured.NestedString(policy.Object, "spec", "failurePolicy")
+	if err != nil || !found || failurePolicy != "Fail" {
+		t.Fatalf("spec.failurePolicy = %q, found=%v err=%v, want Fail", failurePolicy, found, err)
+	}
+
+	if _, matchConditionsFound, matchConditionsErr := unstructured.NestedFieldNoCopy(
+		policy.Object,
+		"spec",
+		"matchConditions",
+	); matchConditionsErr != nil || matchConditionsFound {
+		t.Fatalf("spec.matchConditions: found=%v err=%v, want absent", matchConditionsFound, matchConditionsErr)
+	}
+
+	rules, found, err := unstructured.NestedSlice(policy.Object, "spec", "matchConstraints", "resourceRules")
+	if err != nil || !found || len(rules) != 1 {
+		t.Fatalf("spec.matchConstraints.resourceRules: found=%v len=%d err=%v, want one rule", found, len(rules), err)
+	}
+
+	rule := rules[0].(map[string]any) //nolint:errcheck
+	assertStringSliceField(t, rule, []string{""}, "apiGroups")
+	assertStringSliceField(t, rule, []string{"v1"}, "apiVersions")
+	assertStringSliceField(t, rule, []string{"CREATE", "UPDATE"}, "operations")
+	assertStringSliceField(t, rule, []string{"nodes"}, "resources")
+
+	validations, found, err := unstructured.NestedSlice(policy.Object, "spec", "validations")
+	if err != nil || !found || len(validations) != 2 {
+		t.Fatalf("spec.validations: found=%v len=%d err=%v, want two validations", found, len(validations), err)
+	}
+
+	binding := plannedNetObject(t, "ValidatingAdmissionPolicyBinding", "unbounded-net-public-ip-annotation-ownership")
+
+	policyName, found, err := unstructured.NestedString(binding.Object, "spec", "policyName")
+	if err != nil || !found || policyName != policy.GetName() {
+		t.Fatalf("binding spec.policyName = %q, found=%v err=%v, want %q", policyName, found, err, policy.GetName())
+	}
+
+	actions, found, err := unstructured.NestedStringSlice(binding.Object, "spec", "validationActions")
+	if err != nil || !found || !reflect.DeepEqual(actions, []string{"Deny"}) {
+		t.Fatalf("binding spec.validationActions = %v, found=%v err=%v, want [Deny]", actions, found, err)
+	}
+}
+
+func TestPublicIPAnnotationOwnershipPolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := plannedNetObject(t, "ValidatingAdmissionPolicy", "unbounded-net-public-ip-annotation-ownership")
+	nodeTokenExtras := func(name, uid string) map[string][]string {
+		return map[string][]string{
+			nodeNameExtra: {name},
+			nodeUIDExtra:  {uid},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		username       string
+		extra          map[string][]string
+		oldAnnotations map[string]string
+		annotations    map[string]string
+		create         bool
+		wantAllowed    bool
+	}{
+		{
+			name:     "node agent adds discovery for its node",
+			username: nodeServiceAccountUsername,
+			extra:    nodeTokenExtras("node-a", "uid-a"),
+			annotations: map[string]string{
+				discoveredPublicIPAnnotation:          "192.0.2.10",
+				discoveredPublicIPExpiresAtAnnotation: "2026-08-26T12:00:00Z",
+				declaredPublicIPAnnotation:            "192.0.2.20",
+			},
+			oldAnnotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+			wantAllowed:    true,
+		},
+		{
+			name:     "node agent changes discovery for its node",
+			username: nodeServiceAccountUsername,
+			extra:    nodeTokenExtras("node-a", "uid-a"),
+			oldAnnotations: map[string]string{
+				discoveredPublicIPAnnotation:          "192.0.2.10",
+				discoveredPublicIPExpiresAtAnnotation: "2026-08-26T12:00:00Z",
+			},
+			annotations: map[string]string{
+				discoveredPublicIPAnnotation:          "192.0.2.11",
+				discoveredPublicIPExpiresAtAnnotation: "2026-08-26T13:00:00Z",
+			},
+			wantAllowed: true,
+		},
+		{
+			name:        "cross-node agent adds discovery",
+			username:    nodeServiceAccountUsername,
+			extra:       nodeTokenExtras("node-b", "uid-a"),
+			annotations: map[string]string{discoveredPublicIPAnnotation: "192.0.2.10"},
+		},
+		{
+			name:     "cross-node agent changes discovery",
+			username: nodeServiceAccountUsername,
+			extra:    nodeTokenExtras("node-b", "uid-a"),
+			oldAnnotations: map[string]string{
+				discoveredPublicIPAnnotation: "192.0.2.10",
+			},
+			annotations: map[string]string{
+				discoveredPublicIPAnnotation: "192.0.2.11",
+			},
+		},
+		{
+			name:        "node UID mismatch",
+			username:    nodeServiceAccountUsername,
+			extra:       nodeTokenExtras("node-a", "uid-b"),
+			annotations: map[string]string{discoveredPublicIPAnnotation: "192.0.2.10"},
+		},
+		{
+			name:        "node token extras missing",
+			username:    nodeServiceAccountUsername,
+			extra:       map[string][]string{},
+			annotations: map[string]string{discoveredPublicIPExpiresAtAnnotation: "2026-08-26T12:00:00Z"},
+		},
+		{
+			name:        "unrelated service account adds discovery with matching extras",
+			username:    "system:serviceaccount:unbounded-system:unbounded-storage-supervisor",
+			extra:       nodeTokenExtras("node-a", "uid-a"),
+			annotations: map[string]string{discoveredPublicIPAnnotation: "192.0.2.10"},
+		},
+		{
+			name:     "unrelated service account changes discovery with matching extras",
+			username: "system:serviceaccount:unbounded-system:unbounded-storage-supervisor",
+			extra:    nodeTokenExtras("node-a", "uid-a"),
+			oldAnnotations: map[string]string{
+				discoveredPublicIPAnnotation: "192.0.2.10",
+			},
+			annotations: map[string]string{
+				discoveredPublicIPAnnotation: "192.0.2.11",
+			},
+		},
+		{
+			name:     "human changes discovery",
+			username: "operator@example.com",
+			extra:    nodeTokenExtras("node-a", "uid-a"),
+			oldAnnotations: map[string]string{
+				discoveredPublicIPAnnotation: "192.0.2.10",
+			},
+			annotations: map[string]string{
+				discoveredPublicIPAnnotation: "192.0.2.11",
+			},
+		},
+		{
+			name:     "unchanged discovery is accepted from any caller",
+			username: "system:node:node-a",
+			oldAnnotations: map[string]string{
+				discoveredPublicIPAnnotation:          "192.0.2.10",
+				discoveredPublicIPExpiresAtAnnotation: "2026-08-26T12:00:00Z",
+			},
+			annotations: map[string]string{
+				discoveredPublicIPAnnotation:          "192.0.2.10",
+				discoveredPublicIPExpiresAtAnnotation: "2026-08-26T12:00:00Z",
+			},
+			wantAllowed: true,
+		},
+		{
+			name:     "discovery deletion is accepted from any caller",
+			username: "system:serviceaccount:unbounded-system:unbounded-storage-supervisor",
+			oldAnnotations: map[string]string{
+				discoveredPublicIPAnnotation:          "192.0.2.10",
+				discoveredPublicIPExpiresAtAnnotation: "2026-08-26T12:00:00Z",
+			},
+			wantAllowed: true,
+		},
+		{
+			name:        "discovery on create is rejected from a human",
+			username:    "operator@example.com",
+			annotations: map[string]string{discoveredPublicIPAnnotation: "192.0.2.10"},
+			create:      true,
+		},
+		{
+			name:        "human adds declared address",
+			username:    "operator@example.com",
+			annotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+			wantAllowed: true,
+		},
+		{
+			name:           "human changes declared address",
+			username:       "operator@example.com",
+			oldAnnotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+			annotations:    map[string]string{declaredPublicIPAnnotation: "192.0.2.21"},
+			wantAllowed:    true,
+		},
+		{
+			name:        "human adds declared address on create",
+			username:    "operator@example.com",
+			annotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+			create:      true,
+			wantAllowed: true,
+		},
+		{
+			name:        "service account adds declared address",
+			username:    "system:serviceaccount:unbounded-system:unbounded-storage-supervisor",
+			annotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+		},
+		{
+			name:           "node agent changes declared address",
+			username:       nodeServiceAccountUsername,
+			extra:          nodeTokenExtras("node-a", "uid-a"),
+			oldAnnotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+			annotations:    map[string]string{declaredPublicIPAnnotation: "192.0.2.21"},
+		},
+		{
+			name:        "kubelet adds declared address",
+			username:    "system:node:node-a",
+			annotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+		},
+		{
+			name:           "unchanged declared address is accepted from any caller",
+			username:       nodeServiceAccountUsername,
+			oldAnnotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+			annotations:    map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+			wantAllowed:    true,
+		},
+		{
+			name:           "declared address deletion is accepted from any caller",
+			username:       "system:node:node-a",
+			oldAnnotations: map[string]string{declaredPublicIPAnnotation: "192.0.2.20"},
+			wantAllowed:    true,
+		},
+		{
+			name:        "present empty annotations are accepted",
+			username:    nodeServiceAccountUsername,
+			annotations: map[string]string{},
+			wantAllowed: true,
+		},
+		{
+			name:        "absent annotations are accepted",
+			username:    nodeServiceAccountUsername,
+			wantAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var oldObject any = publicIPNodeAdmissionObject("node-a", "uid-a", tt.oldAnnotations)
+			if tt.create {
+				oldObject = nil
+			}
+
+			extra := tt.extra
+			if extra == nil {
+				extra = map[string][]string{}
+			}
+
+			got := policyAllows(t, policy, map[string]any{
+				"oldObject": oldObject,
+				"object":    publicIPNodeAdmissionObject("node-a", "uid-a", tt.annotations),
+				"request": map[string]any{
+					"userInfo": map[string]any{
+						"username": tt.username,
+						"extra":    extra,
+					},
+				},
+			})
+			if got != tt.wantAllowed {
+				t.Fatalf("allowed = %v, want %v", got, tt.wantAllowed)
+			}
+		})
+	}
+}
+
 func plannedNetObject(t *testing.T, kind, name string) *unstructured.Unstructured {
 	t.Helper()
 
@@ -126,8 +404,49 @@ func policyValidationExpression(t *testing.T, policy *unstructured.Unstructured,
 	return ""
 }
 
+func policyAllows(t *testing.T, policy *unstructured.Unstructured, activation map[string]any) bool {
+	t.Helper()
+
+	validations, found, err := unstructured.NestedSlice(policy.Object, "spec", "validations")
+	if err != nil || !found {
+		t.Fatalf("read spec.validations: found=%v err=%v", found, err)
+	}
+
+	for _, validation := range validations {
+		fields := validation.(map[string]any) //nolint:errcheck
+
+		expression := fields["expression"].(string) //nolint:errcheck
+		if !evalCEL(t, expression, activation) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func assertStringSliceField(t *testing.T, object map[string]any, want []string, fields ...string) {
+	t.Helper()
+
+	got, found, err := unstructured.NestedStringSlice(object, fields...)
+	if err != nil || !found || !reflect.DeepEqual(got, want) {
+		t.Fatalf("%v = %v, found=%v err=%v, want %v", fields, got, found, err, want)
+	}
+}
+
 func nodeAdmissionObject(annotations map[string]string) map[string]any {
 	metadata := map[string]any{}
+	if annotations != nil {
+		metadata["annotations"] = annotations
+	}
+
+	return map[string]any{"metadata": metadata}
+}
+
+func publicIPNodeAdmissionObject(name, uid string, annotations map[string]string) map[string]any {
+	metadata := map[string]any{
+		"name": name,
+		"uid":  uid,
+	}
 	if annotations != nil {
 		metadata["annotations"] = annotations
 	}
@@ -142,6 +461,7 @@ func evalCEL(t *testing.T, expression string, activation map[string]any) bool {
 		cel.Variable("object", cel.DynType),
 		cel.Variable("oldObject", cel.DynType),
 		cel.Variable("request", cel.DynType),
+		cel.OptionalTypes(),
 	)
 	if err != nil {
 		t.Fatalf("create CEL environment: %v", err)


### PR DESCRIPTION
Pre-requisite to #658 

Protect the annotations used for discovered public IPs and administrator overrides.

Only the node agent running on a Node can add or change that Node's discovered address and expiration. The agent's bound token must match the Node name and UID.

Apply the policy globally so other service accounts cannot bypass it. Service accounts and kubelets cannot add or change the administrator override. Unchanged values and deletions remain allowed for callers that already have Node patch permission.


@phealy @cchildress 

It does not close the broader authorization gap caused by every node agent sharing one ServiceAccount with cluster-wide Node and `GatewayPoolNode` permissions.

Follow-up PRs should extend per-node identity enforcement to all agent-owned Node annotations, including `wg-pubkey` and `tunnel-mtu`, define a strict allowlist for other networking fields, and apply equivalent ownership checks to `GatewayPoolNode` operations.
