### PR TITLE
gantry: delete unused fakes, options and the unadopted log vocabulary

### DIFF
--- a/internal/gantry/advertise/advertise.go
+++ b/internal/gantry/advertise/advertise.go
@@ -109,26 +109,6 @@ func WithReconcileInterval(d time.Duration) Option {
 	}
 }
 
-// WithProvideTimeout caps the per-Provide RPC budget. Zero or negative
-// leaves the default (30 seconds).
-func WithProvideTimeout(d time.Duration) Option {
-	return func(a *Advertiser) {
-		if d > 0 {
-			a.provideTimeout = d
-		}
-	}
-}
-
-// WithWithdrawTimeout caps the per-Withdraw RPC budget. Zero or
-// negative leaves the default (10 seconds).
-func WithWithdrawTimeout(d time.Duration) Option {
-	return func(a *Advertiser) {
-		if d > 0 {
-			a.withdrawTimeout = d
-		}
-	}
-}
-
 // WithMetrics registers metric callbacks. The Hooks struct is copied
 // by value so subsequent mutations by the caller do not affect the
 // running advertiser.

--- a/internal/gantry/cdsub/cdsub.go
+++ b/internal/gantry/cdsub/cdsub.go
@@ -33,7 +33,6 @@ import (
 	"errors"
 	"log/slog"
 	"math/rand/v2"
-	"sync"
 	"time"
 
 	"github.com/Azure/unbounded/internal/gantry/digest"
@@ -88,9 +87,6 @@ type Subscriber struct {
 	backoffMax     time.Duration
 
 	metrics metricsHooks
-
-	closeOnce sync.Once
-	closed    chan struct{}
 }
 
 type metricsHooks struct {
@@ -164,7 +160,6 @@ func New(src ImageSource, dht ifaces.DHT, opts ...Option) *Subscriber {
 		provideTimeout: 30 * time.Second,
 		backoffInitial: time.Second,
 		backoffMax:     30 * time.Second,
-		closed:         make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -214,11 +209,6 @@ func (s *Subscriber) Run(ctx context.Context) error {
 			backoff = s.backoffMax
 		}
 	}
-}
-
-// Close releases any subscriber-owned resources. Safe to call multiple times.
-func (s *Subscriber) Close() {
-	s.closeOnce.Do(func() { close(s.closed) })
 }
 
 func (s *Subscriber) runOnce(ctx context.Context) error {

--- a/internal/gantry/cdsub/source_containerd.go
+++ b/internal/gantry/cdsub/source_containerd.go
@@ -98,15 +98,6 @@ func WithContainerdLogger(l *slog.Logger) ContainerdSourceOption {
 	}
 }
 
-// WithContainerdConnectTimeout overrides the dial-timeout default.
-func WithContainerdConnectTimeout(d time.Duration) ContainerdSourceOption {
-	return func(s *ContainerdSource) {
-		if d > 0 {
-			s.connectTimeout = d
-		}
-	}
-}
-
 // NewContainerdSource dials containerd at socket and pins all
 // subsequent calls to namespace. Returns an error if the socket
 // cannot be reached or the gRPC handshake fails.

--- a/internal/gantry/cdsub/walk_test.go
+++ b/internal/gantry/cdsub/walk_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -141,28 +140,6 @@ var (
 	_ content.Store    = (*fakeContentStore)(nil)
 	_ content.ReaderAt = (*fakeReaderAt)(nil)
 )
-
-// stringsToSet converts digest strings into a lookup map keyed on the
-// digest's string form, so test assertions can use set semantics
-// instead of order-dependent slice equality.
-func digestSet(t *testing.T, in any) map[string]struct{} {
-	t.Helper()
-
-	out := map[string]struct{}{}
-
-	switch v := in.(type) {
-	case []godigest.Digest:
-		for _, d := range v {
-			out[d.String()] = struct{}{}
-		}
-	default:
-		// Reflective fallback for []gdigest.Digest (gantry-internal type)
-		// not worth importing here - caller must convert first.
-		t.Fatalf("digestSet: unsupported type %T", in)
-	}
-
-	return out
-}
 
 // TestWalkBlobs_SimpleImage covers the common case: an image manifest
 // whose config + layer descriptors are all present in the content store.
@@ -375,9 +352,3 @@ func (e *errorStore) Info(ctx context.Context, dgst godigest.Digest) (content.In
 
 	return e.fakeContentStore.Info(ctx, dgst)
 }
-
-// silence digestSet linter when unused in this file
-var (
-	_ = digestSet
-	_ = regexp.Compile
-)

--- a/internal/gantry/containerdstore/store.go
+++ b/internal/gantry/containerdstore/store.go
@@ -138,16 +138,6 @@ func WithNamespace(ns string) Option {
 	}
 }
 
-// WithRefPrefix overrides the ingest ref prefix used by Writer. Empty
-// string is ignored.
-func WithRefPrefix(p string) Option {
-	return func(s *Store) {
-		if p != "" {
-			s.refPrefix = p
-		}
-	}
-}
-
 // New builds a Store bound to cs and the supplied namespace. Panics on
 // nil cs because constructing a Store without a backing content store
 // is always a programming error, not a runtime one.

--- a/internal/gantry/coord/coord.go
+++ b/internal/gantry/coord/coord.go
@@ -35,7 +35,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"sync"
 	"time"
 
@@ -258,16 +257,6 @@ func WithStreamHandshakeTimeout(d time.Duration) Option {
 	return func(s *Server) {
 		if d > 0 {
 			s.streamHandshakeTimeout = d
-		}
-	}
-}
-
-// WithMaxConcurrentStreams overrides DefaultMaxConcurrentStreams. Non-positive
-// values are ignored.
-func WithMaxConcurrentStreams(n int) Option {
-	return func(s *Server) {
-		if n > 0 {
-			s.streamSem = make(chan struct{}, n)
 		}
 	}
 }
@@ -888,24 +877,6 @@ type Client struct {
 // ClientOption configures a Client.
 type ClientOption func(*Client)
 
-// WithDialTimeout overrides the per-RPC dial timeout (default 2s).
-func WithDialTimeout(d time.Duration) ClientOption {
-	return func(c *Client) {
-		if d > 0 {
-			c.dialTimeout = d
-		}
-	}
-}
-
-// WithRPCTimeout overrides the per-RPC end-to-end timeout (default 2s).
-func WithRPCTimeout(d time.Duration) ClientOption {
-	return func(c *Client) {
-		if d > 0 {
-			c.rpcTimeout = d
-		}
-	}
-}
-
 // WithClientMaxDigestsPerPleasePull overrides the client-side chunk size used
 // for PleasePull. Non-positive values are ignored.
 func WithClientMaxDigestsPerPleasePull(n int) ClientOption {
@@ -1244,12 +1215,4 @@ func pleasePullKindFromProto(k coordv1.PleasePullRequest_Kind) ifaces.OriginRefK
 }
 
 // Compile-time conformance.
-var (
-	_ ifaces.Coordinator = (*Client)(nil)
-	_ net.Addr           = (*nopAddr)(nil)
-)
-
-type nopAddr struct{}
-
-func (nopAddr) Network() string { return "coord" }
-func (nopAddr) String() string  { return "coord" }
+var _ ifaces.Coordinator = (*Client)(nil)

--- a/internal/gantry/ifaces/fakes/fakes.go
+++ b/internal/gantry/ifaces/fakes/fakes.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"sync"
-	"time"
 
 	"github.com/containerd/errdefs"
 
@@ -158,19 +157,12 @@ type OriginPuller struct {
 	entries map[string][]byte
 	// PullCount records pull attempts per digest for assertions.
 	pullCount map[string]int
-	// HeadCount records HEAD attempts per digest for assertions
-	// (used by mirror tests to assert that HEAD on a cache miss
-	// routes through Head, NOT through Pull - see
-	// TestMirror_OriginSuccessMetric_FiresOnlyOnCacheCommit's HEAD
-	// subtest).
-	headCount map[string]int
 }
 
 func NewOriginPuller() *OriginPuller {
 	return &OriginPuller{
 		entries:   map[string][]byte{},
 		pullCount: map[string]int{},
-		headCount: map[string]int{},
 	}
 }
 
@@ -204,8 +196,6 @@ func (o *OriginPuller) Head(_ context.Context, ref ifaces.OriginRef) (int64, str
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	o.headCount[ref.Digest.String()]++
-
 	b, ok := o.entries[ref.Digest.String()]
 	if !ok {
 		return 0, "", &ifaces.OriginError{Ref: ref, Class: ifaces.FailureNotFound, Err: errors.New("404")}
@@ -222,14 +212,6 @@ func (o *OriginPuller) PullCount(d digest.Digest) int {
 	return o.pullCount[d.String()]
 }
 
-// HeadCount returns the number of Head invocations seen for d.
-func (o *OriginPuller) HeadCount(d digest.Digest) int {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	return o.headCount[d.String()]
-}
-
 // ---------------------------------------------------------------------------
 // PeerDialer
 // ---------------------------------------------------------------------------
@@ -237,13 +219,12 @@ func (o *OriginPuller) HeadCount(d digest.Digest) int {
 // PeerDialer routes FetchFromPeer to a per-address ifaces.LocalContentStore. Tests wire
 // each "peer's" local cache into this map.
 type PeerDialer struct {
-	mu     sync.Mutex
-	peers  map[string]ifaces.LocalContentStore
-	failOn map[string]error // address -> error (transport-level failure)
+	mu    sync.Mutex
+	peers map[string]ifaces.LocalContentStore
 }
 
 func NewPeerDialer() *PeerDialer {
-	return &PeerDialer{peers: map[string]ifaces.LocalContentStore{}, failOn: map[string]error{}}
+	return &PeerDialer{peers: map[string]ifaces.LocalContentStore{}}
 }
 
 func (p *PeerDialer) Register(addr string, cache ifaces.LocalContentStore) {
@@ -253,24 +234,10 @@ func (p *PeerDialer) Register(addr string, cache ifaces.LocalContentStore) {
 	p.peers[addr] = cache
 }
 
-// FailOn forces FetchFromPeer to return err for any request to addr. Used to
-// model unreachable peers in tests.
-func (p *PeerDialer) FailOn(addr string, err error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	p.failOn[addr] = err
-}
-
 func (p *PeerDialer) FetchFromPeer(ctx context.Context, addr string, ref ifaces.OriginRef) (io.ReadCloser, int64, error) {
 	p.mu.Lock()
 	cache, ok := p.peers[addr]
-	failErr, failing := p.failOn[addr]
 	p.mu.Unlock()
-
-	if failing {
-		return nil, 0, failErr
-	}
 
 	if !ok {
 		return nil, 0, fmt.Errorf("fakes: no peer registered at %q", addr)
@@ -320,13 +287,6 @@ func NewDHT() *DHT {
 		provideCall:  map[string]int{},
 		withdrawCall: map[string]int{},
 	}
-}
-
-func (d *DHT) SetHealth(score float64) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.health = score
 }
 
 // SetFindProvidersError programs the next (and all subsequent)
@@ -407,78 +367,6 @@ func (d *DHT) FindProviders(_ context.Context, dg digest.Digest) ([]ifaces.Provi
 	return out, nil
 }
 
-// ---------------------------------------------------------------------------
-// Coordinator
-// ---------------------------------------------------------------------------
-
-// Coordinator is an in-memory ifaces.Coordinator. Per-peer responses are
-// programmed via Program.
-type Coordinator struct {
-	mu sync.Mutex
-
-	intent     map[key]ifaces.PullIntent
-	pleasePull map[key][]ifaces.PleasePullOutcome
-}
-
-type key struct {
-	peer   ifaces.NodeID
-	digest string
-}
-
-func NewCoordinator() *Coordinator {
-	return &Coordinator{
-		intent:     map[key]ifaces.PullIntent{},
-		pleasePull: map[key][]ifaces.PleasePullOutcome{},
-	}
-}
-
-// ProgramIntent sets the canned PullIntent response for (peer, d).
-func (c *Coordinator) ProgramIntent(peer ifaces.NodeID, d digest.Digest, intent ifaces.PullIntent) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.intent[key{peer, d.String()}] = intent
-}
-
-// ProgramPleasePull sets the canned per-digest outcome for (peer, d). Tests
-// programming a batched please_pull MUST seed each digest.
-func (c *Coordinator) ProgramPleasePull(peer ifaces.NodeID, d digest.Digest, outcome ifaces.PleasePullOutcome) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.pleasePull[key{peer, d.String()}] = append(c.pleasePull[key{peer, d.String()}], outcome)
-}
-
-func (c *Coordinator) PullIntentQuery(_ context.Context, peer ifaces.NodeID, d digest.Digest) (ifaces.PullIntent, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	intent, ok := c.intent[key{peer, d.String()}]
-	if !ok {
-		return ifaces.PullIntent{}, fmt.Errorf("fakes: no intent programmed for (%s, %s)", peer, d)
-	}
-
-	return intent, nil
-}
-
-func (c *Coordinator) PleasePull(_ context.Context, peer ifaces.NodeID, _, _ string, _ ifaces.OriginRefKind, digests []digest.Digest) ([]ifaces.PleasePullOutcome, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	out := make([]ifaces.PleasePullOutcome, 0, len(digests))
-	for _, d := range digests {
-		queue := c.pleasePull[key{peer, d.String()}]
-		if len(queue) == 0 {
-			return nil, fmt.Errorf("fakes: no please_pull outcome programmed for (%s, %s)", peer, d)
-		}
-
-		out = append(out, queue[0])
-		c.pleasePull[key{peer, d.String()}] = queue[1:]
-	}
-
-	return out, nil
-}
-
 // Compile-time assertions that the fakes implement the interfaces.
 var (
 	_ ifaces.LocalContentStore = (*Cache)(nil)
@@ -486,8 +374,4 @@ var (
 	_ ifaces.OriginPuller      = (*OriginPuller)(nil)
 	_ ifaces.PeerDialer        = (*PeerDialer)(nil)
 	_ ifaces.DHT               = (*DHT)(nil)
-	_ ifaces.Coordinator       = (*Coordinator)(nil)
 )
-
-// helper to keep go vet happy on unused time import in case of future trims
-var _ = time.Now

--- a/internal/gantry/log/log.go
+++ b/internal/gantry/log/log.go
@@ -8,8 +8,7 @@
 // log/slog with a consistent attribute vocabulary so those WARN lines are
 // uniformly tagged and machine-parseable.
 //
-// Standard attributes (use the helper constructors below to set them so
-// keys don't drift):
+// Standard attributes:
 //
 //	subsystem one of {"mirror","transfer","cache","origin","coord",
 //	 "discovery","hrw","members","cdsub","agent"}
@@ -29,8 +28,6 @@
 package log
 
 import (
-	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -63,43 +60,6 @@ func Subsystem(base *slog.Logger, name string) *slog.Logger {
 	return base.With(slog.String("subsystem", name))
 }
 
-// Attribute constructors. Each is a one-liner so callers don't keep typing
-// the key name and so a refactor of the vocabulary only has to touch this
-// file.
-
-// Digest builds a slog.Attr carrying the standard "digest" key.
-func Digest(d fmt.Stringer) slog.Attr { return slog.String("digest", safeString(d)) }
-
-// Peer builds a slog.Attr carrying the standard "peer" key.
-func Peer(p fmt.Stringer) slog.Attr { return slog.String("peer", safeString(p)) }
-
-// Registry builds a slog.Attr carrying the standard "registry" key.
-func Registry(name string) slog.Attr { return slog.String("registry", name) }
-
-// Repo builds a slog.Attr carrying the standard "repo" key.
-func Repo(name string) slog.Attr { return slog.String("repo", name) }
-
-// Class builds a slog.Attr carrying the standard "class" key (the design doc failure class).
-func Class(c string) slog.Attr { return slog.String("class", c) }
-
-// NodeID builds a slog.Attr carrying the standard "node_id" key.
-func NodeID(id fmt.Stringer) slog.Attr { return slog.String("node_id", safeString(id)) }
-
-// Err builds a slog.Attr carrying the standard "err" key.
-func Err(err error) slog.Attr { return slog.Any("err", err) }
-
-// Context is a tiny helper for the case where a function wants to bind
-// per-request attributes onto a child logger and pass it down - e.g., a
-// mirror request handler binding (registry, repo, digest) once at the top.
-func Context(_ context.Context, parent *slog.Logger, attrs ...slog.Attr) *slog.Logger {
-	anys := make([]any, 0, len(attrs))
-	for _, a := range attrs {
-		anys = append(anys, a)
-	}
-
-	return parent.With(anys...)
-}
-
 func parseLevel(s string) slog.Level {
 	switch strings.ToLower(s) {
 	case "debug":
@@ -111,12 +71,4 @@ func parseLevel(s string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
-}
-
-func safeString(v fmt.Stringer) string {
-	if v == nil {
-		return ""
-	}
-
-	return v.String()
 }

--- a/internal/gantry/mirror/mirror.go
+++ b/internal/gantry/mirror/mirror.go
@@ -550,16 +550,6 @@ func WithSelfPeerID(id ifaces.NodeID) Option {
 	return func(s *Server) { s.selfPeerID = id }
 }
 
-// WithProviderFailureCacheTTL configures TTLs used to suppress immediate
-// retries against recently-failed providers.
-func WithProviderFailureCacheTTL(staleTTL, unavailableTTL, suspiciousTTL time.Duration) Option {
-	return func(s *Server) {
-		s.staleProviderTTL = staleTTL
-		s.unavailablePeerTTL = unavailableTTL
-		s.suspiciousPeerTTL = suspiciousTTL
-	}
-}
-
 // ColdStartResolver is the subset of *coldstart.Resolver that mirror
 // needs. Kept narrow for testability - production wires the concrete
 // resolver via WithColdStart.

--- a/internal/gantry/transfer/client.go
+++ b/internal/gantry/transfer/client.go
@@ -57,11 +57,6 @@ func WithRequestTimeout(d time.Duration) ClientOption {
 	return func(o *clientOptions) { o.requestTimeout = d }
 }
 
-// WithReadIdleTimeout configures the h2 ping-based idle stall detector.
-func WithReadIdleTimeout(d time.Duration) ClientOption {
-	return func(o *clientOptions) { o.readIdleTimeout = d }
-}
-
 // WithClientByteMetrics registers a callback for bytes actually read from peer
 // response bodies, including partial failed transfers and retries.
 func WithClientByteMetrics(onBytesRead func(kind string, bytes int64)) ClientOption {


### PR DESCRIPTION
Part of the #670 dead-code sweep, split by component. The tooling that produced these findings is #673; this PR is deletions only and is independent of the other eight — the file sets are disjoint, so they can be reviewed and merged in any order and in parallel.

### Why two analyzers were needed to find this

`unused` cannot see dead exported code under `internal/`. That is a documented design decision, not a gap: `unused/unused.go:48-62` holds that a package uses its exported named types and a named type uses its exported methods, so every method on an exported type is transitively live *because the type is exported*.

`x/tools/cmd/deadcode` does not close that gap on its own either. `x/tools/go/callgraph/rta/rta.go:281-287,433-437` — converting a value to an interface materializes its runtime type and marks **every exported method of that type reachable**, because reflection could call any of them. One `var i any = x` anywhere buys all of `x`'s exported methods a clean bill of health.

So #673 adds both `deadcode` and `hack/cmd/unreferenced`, which resolves identifiers instead of tracing reachability. Neither subsumes the other, and findings below are attributed to whichever one saw them.

---

## gantry/log: delete the unadopted attribute vocabulary

Eight of the nine attribute constructors have no caller: Digest, Peer,
Registry, Repo, Class, NodeID, Err and Context, plus the private safeString
they share. Subsystem is the one that was adopted, and it stays.

The file's own comment said these existed "so callers don't keep typing the key
name and so a refactor of the vocabulary only has to touch this file". Callers
did keep typing the key name. A vocabulary nobody speaks is not a vocabulary,
and keeping the constructors on the strength of the comment would be preferring
the intent in the prose to what the code does.

The package doc still lists the standard attribute keys, because the keys are
real and the WARN-line contract the design docs describe still depends on them.
Only the claim that helper constructors set them is gone.

Refs #670

## gantry: delete unused fakes, options and dead lifecycle code

The whole Coordinator fake goes: NewCoordinator, ProgramIntent,
ProgramPleasePull, PullIntentQuery, PleasePull, the Coordinator type, the
private key type it was the only user of, and the compile-time assertion that
kept the type referenced. Nothing constructs it. coord's own tests use the real
Server.

Three affordances on fakes that are still in use had no caller either, and each
left state behind:

  - OriginPuller.HeadCount, with the headCount map, its initializer and the
    increment in Head. Its comment pointed at
    TestMirror_OriginSuccessMetric_FiresOnlyOnCacheCommit as the caller; that
    test exists but counts through mirror.WithOriginSuccessMetric instead, so
    the comment outlived the arrangement it described.
  - PeerDialer.FailOn, with the failOn map and the branch in FetchFromPeer it
    fed. With no writer the branch could never be taken. The mirror tests that
    model an unreachable peer declare their own dialer doubles
    (countingPeerDialer, resumingPeerDialer) rather than using this one.
  - DHT.SetHealth. Health is still read; only the setter was dead.

walk_test.go's digestSet helper was held up by an explicit `var _ = digestSet`
block commented "silence digestSet linter when unused in this file", which is
what kept `unused` quiet about it for as long as it has been dead. The block
and the regexp.Compile placeholder next to it go with it.

Subscriber.Close closed a `closed` channel that nothing ever selected on, so
the method, the channel and the sync.Once guarding it all go together. coord's
nopAddr existed only to satisfy a net.Addr assertion about itself.

Unused functional options: WithProvideTimeout and WithWithdrawTimeout
(advertise), WithContainerdConnectTimeout, WithRefPrefix,
WithMaxConcurrentStreams, WithDialTimeout, WithRPCTimeout (coord),
WithProviderFailureCacheTTL, WithReadIdleTimeout. Each configured a field that
keeps its default in every caller.

Refs #670


---

### Verification

`go build ./...`, `go vet ./...`, `golangci-lint` over the touched trees (0 issues), `make fmt` producing no diff, and `go build -tags e2e,integrationtest,storageboundary ./...`. Full suite runs in CI.

The eight deletion branches were reassembled onto the tooling commits and diffed against the original combined branch: byte-identical, so nothing was lost or duplicated in the split.