### PR TITLE
agent: delete unreferenced helpers and unread constants

### DIFF
--- a/cmd/agent/internal/attest/attest.go
+++ b/cmd/agent/internal/attest/attest.go
@@ -393,11 +393,6 @@ func expBackoff(attempt int) time.Duration {
 	return time.Duration(secs * float64(time.Second))
 }
 
-// CleanupAttestArtifacts is a no-op now that the attestation is performed
-// entirely in Go. The TPM handles are cleaned up when the device file
-// descriptor is closed, and no scripts or config files are written to disk.
-func CleanupAttestArtifacts() {}
-
 // applyAttestation is a task that conditionally runs TPM attestation and
 // applies the result to the node-start goal state. When attestation is
 // not configured (nil config or empty URL), the task is a no-op.

--- a/internal/provision/agent_config.go
+++ b/internal/provision/agent_config.go
@@ -301,12 +301,6 @@ func ResolveDownloadOverridesWithOfflineArtifacts(ctx context.Context, cfg *Unbo
 	return goalstates.ResolveDownloadOverridesWithOfflineArtifacts(ctx, &cfg.AgentConfig, resolveDownloadOverrides(cfg.Downloads))
 }
 
-// ResolveDownloadOverrides converts the provision AgentDownloads into the
-// goalstates.DownloadOverrides shape that rootfs phase tasks consume.
-func ResolveDownloadOverrides(d *AgentDownloads) *goalstates.DownloadOverrides {
-	return resolveDownloadOverrides(d)
-}
-
 func resolveDownloadOverrides(d *AgentDownloads) *goalstates.DownloadOverrides {
 	if d == nil {
 		return nil

--- a/pkg/agent/agentbinary/agentbinary_test.go
+++ b/pkg/agent/agentbinary/agentbinary_test.go
@@ -25,44 +25,6 @@ import (
 	"github.com/Azure/unbounded/pkg/agent/goalstates"
 )
 
-func TestInstallFromTarGzVerifiesInstalledBinary(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range []struct {
-		name     string
-		exitCode int
-		wantErr  string
-	}{
-		{name: "valid", exitCode: 0},
-		{name: "broken", exitCode: 42, wantErr: "verify agent binary"},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				require.NoError(t, writeTestAgentArchive(w, testAgentScript(tt.name, tt.exitCode)))
-			}))
-			t.Cleanup(server.Close)
-
-			targetPath := filepath.Join(t.TempDir(), "unbounded-agent")
-
-			err := installFromTarGz(context.Background(), targetPath, InstallOptions{
-				DownloadURL:    server.URL,
-				ExpectedMember: "unbounded-agent",
-				Mode:           0o755,
-			})
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
-
-				return
-			}
-
-			require.NoError(t, err)
-		})
-	}
-}
-
 func TestInstallAndSwitchFromTarGz(t *testing.T) {
 	t.Parallel()
 
@@ -106,18 +68,6 @@ func TestInstallAndSwitchFromTarGz(t *testing.T) {
 	assertSymlinkTarget(t, paths.CurrentPath, paths.BluePath)
 	assertSymlinkTarget(t, paths.LastGoodPath, paths.BinaryPath)
 	assertFileContent(t, paths.BluePath, string(release))
-}
-
-func TestInstallFromTarGzRejectsUnsupportedScheme(t *testing.T) {
-	t.Parallel()
-
-	err := installFromTarGz(context.Background(), filepath.Join(t.TempDir(), "agent"), InstallOptions{
-		DownloadURL:    "file:///tmp/unbounded-agent.tar.gz",
-		ExpectedMember: "unbounded-agent",
-		Mode:           0o755,
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported agent download URL scheme")
 }
 
 func TestVerifyBoundsInheritedOutputWait(t *testing.T) {

--- a/pkg/agent/agentbinary/upgrade.go
+++ b/pkg/agent/agentbinary/upgrade.go
@@ -158,34 +158,6 @@ func validateLayout(paths Layout) error {
 	return nil
 }
 
-func installFromTarGz(ctx context.Context, targetPath string, opts InstallOptions) error {
-	normalized, err := normalizeInstallOptions(opts)
-	if err != nil {
-		return err
-	}
-
-	opts = normalized.options
-
-	archivePath, err := downloadArchive(
-		ctx,
-		opts.HTTPClient,
-		normalized.parsedURL,
-		normalized.expectedDigest,
-		normalized.verifyDigest,
-		opts.MaxArchiveBytes,
-	)
-	if err != nil {
-		return err
-	}
-	defer os.Remove(archivePath) //nolint:errcheck // temporary archive cleanup
-
-	if err := extractOnlyArchiveMember(archivePath, targetPath, opts); err != nil {
-		return err
-	}
-
-	return Verify(ctx, targetPath)
-}
-
 // InstallAndSwitchFromTarGz downloads a bounded HTTP or HTTPS release
 // archive, installs the configured member into the inactive slot, and atomically
 // updates the last-good and current links. When ExactMember is set, the archive

--- a/pkg/agent/config/localdns.go
+++ b/pkg/agent/config/localdns.go
@@ -17,7 +17,6 @@ import (
 const (
 	DefaultLocalDNSNodeListenerIP    = "169.254.10.10"
 	DefaultLocalDNSClusterListenerIP = "169.254.10.11"
-	DefaultLocalDNSMetricsPort       = "9253"
 	DefaultLocalDNSCPUMilliCores     = 2000
 	DefaultLocalDNSMemoryLimitMB     = 128
 )

--- a/pkg/agent/goalstates/constants.go
+++ b/pkg/agent/goalstates/constants.go
@@ -88,12 +88,6 @@ func AppliedConfigPath(machineName string) string {
 	return fmt.Sprintf("%s/%s-applied-config.json", AgentConfigDir, machineName)
 }
 
-// ContainerImageArchivePath returns the path inside the nspawn machine where a
-// preloaded container image archive is staged before importing into containerd.
-func ContainerImageArchivePath(index int) string {
-	return fmt.Sprintf("%s/image-%d.tar", ContainerImageArchiveDir, index)
-}
-
 func KubeProxyImage(kubernetesVersion string) string {
 	kubernetesVersion = strings.TrimSpace(kubernetesVersion)
 	if kubernetesVersion == "" {
@@ -182,7 +176,6 @@ const (
 	KubeletConfigurationPath       = "/var/lib/kubelet/config.yaml"
 	KubeletKubeconfigPath          = "/var/lib/kubelet/kubeconfig"
 	KubeletBootstrapKubeconfigPath = "/var/lib/kubelet/bootstrap-kubeconfig"
-	KubeletPKIDir                  = "/etc/kubernetes/pki"
 	KubeletAPIServerCACertPath     = "/etc/kubernetes/pki/apiserver-client-ca.crt"
 	KubeletServiceDropInDir        = "/etc/systemd/system/kubelet.service.d"
 	KubeletStaticPodManifestsDir   = "/etc/kubernetes/manifests"

--- a/pkg/agent/goalstates/localdns.go
+++ b/pkg/agent/goalstates/localdns.go
@@ -21,15 +21,23 @@ import (
 )
 
 const (
-	CoreDNSVersion            = "1.12.3"
-	LocalDNSInterfaceName     = "localdns"
-	LocalDNSCorefilePath      = "/etc/unbounded/localdns/Corefile"
-	LocalDNSUpstreamsPath     = "/etc/unbounded/localdns/node-upstreams"
+	CoreDNSVersion        = "1.12.3"
+	LocalDNSInterfaceName = "localdns"
+
+	// The next three have no Go reader, and are kept anyway. Their values are
+	// a contract with code outside this module: the Corefile and upstreams
+	// paths are hardcoded in
+	// pkg/agent/phases/rootfs/assets/localdns-supervisor.sh, and the nftables
+	// rule comment is asserted by hack/agent/e2e-kind/e2e.py. "No caller" here
+	// means "no Go caller", which is not the same thing.
+	LocalDNSCorefilePath  = "/etc/unbounded/localdns/Corefile"
+	LocalDNSUpstreamsPath = "/etc/unbounded/localdns/node-upstreams"
+	LocalDNSRuleComment   = "unbounded-localdns: skip conntrack"
+
 	LocalDNSServiceUnit       = "localdns.service"
 	LocalDNSSliceUnit         = "localdns.slice"
 	LocalDNSReadinessPort     = 8181
 	LocalDNSMetricsPort       = 9253
-	LocalDNSRuleComment       = "unbounded-localdns: skip conntrack"
 	LocalDNSNFTTable          = "unbounded_localdns"
 	LocalDNSNetworkUnit       = "unbounded-localdns-network.service"
 	LocalDNSSupervisorPath    = "/usr/local/libexec/unbounded-localdns-supervisor"

--- a/pkg/agent/internal/utilio/download.go
+++ b/pkg/agent/internal/utilio/download.go
@@ -20,11 +20,6 @@ import (
 
 const remoteHTTPProbeTimeout = 10 * time.Second
 
-var remoteHTTPClient = &http.Client{
-	Timeout:       10 * time.Minute, // FIXME: proper configuration
-	CheckRedirect: CheckRedirectNoHTTPSDowngrade,
-}
-
 var remoteHTTPProbeClient = &http.Client{
 	Transport:     newRemoteHTTPProbeTransport(),
 	Timeout:       remoteHTTPProbeTimeout,
@@ -104,29 +99,6 @@ func newRemoteHTTPProbeTransport() http.RoundTripper {
 	return transport.Clone()
 }
 
-func downloadFromRemote(ctx context.Context, source string) (io.ReadCloser, error) {
-	if err := validateHTTPDownloadSource(source); err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, http.NoBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", RedactHTTPError(err))
-	}
-
-	resp, err := remoteHTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to perform HTTP request: %w", RedactHTTPError(err))
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		_ = resp.Body.Close() //nolint:errcheck // body close
-		return nil, fmt.Errorf("download %q failed with status code %d", RedactURLQuery(source), resp.StatusCode)
-	}
-
-	return resp.Body, nil
-}
-
 func validateHTTPDownloadSource(source string) error {
 	parsed, err := url.Parse(source)
 	if err != nil {
@@ -194,24 +166,6 @@ type TarFile struct {
 }
 
 type TarFileSeq = iter.Seq2[*TarFile, error]
-
-// DecompressTarGzFromRemote returns an iterator that yields the files contained in a .tar.gz file located at the given HTTP(S) URL.
-func DecompressTarGzFromRemote(ctx context.Context, url string) TarFileSeq {
-	return func(yield func(*TarFile, error) bool) {
-		body, err := downloadFromRemote(ctx, url)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-		defer body.Close() //nolint:errcheck // body close
-
-		for tarFile, err := range DecompressTarGz(body) {
-			if !yield(tarFile, err) {
-				return
-			}
-		}
-	}
-}
 
 // DecompressTarGz returns an iterator that yields the files contained in a gzip-compressed tar stream.
 func DecompressTarGz(body io.Reader) TarFileSeq {

--- a/pkg/agent/internal/utilio/fs.go
+++ b/pkg/agent/internal/utilio/fs.go
@@ -5,7 +5,6 @@ package utilio
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -32,44 +31,6 @@ func IsDirEmpty(dir string) (bool, error) {
 	}
 
 	return false, err
-}
-
-// CleanDir removes everything in a directory, but not the directory itself.
-func CleanDir(path string) (retErr error) {
-	_, err := os.Stat(path)
-	switch {
-	case errors.Is(err, os.ErrNotExist):
-		// nothing to do
-		return nil
-	case err != nil:
-		return err
-	default:
-		// proceed to clean
-	}
-
-	d, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if cerr := d.Close(); cerr != nil && retErr == nil {
-			retErr = fmt.Errorf("close directory: %w", cerr)
-		}
-	}()
-
-	entries, err := d.Readdirnames(-1)
-	if err != nil {
-		return err
-	}
-
-	for _, entry := range entries {
-		if err := os.RemoveAll(filepath.Join(path, entry)); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // UpdateSymlink atomically updates linkPath to point at targetPath.

--- a/pkg/agent/phases/host/preflight_host.go
+++ b/pkg/agent/phases/host/preflight_host.go
@@ -110,11 +110,6 @@ func checkIsPrivilegedUser(log *slog.Logger, deps hostCheckDeps) preflight.Check
 	}}
 }
 
-// CheckHostPackages verifies all required host packages are already installed.
-func CheckHostPackages(log *slog.Logger) preflight.Checker {
-	return checkHostPackages(log, false, defaultHostCheckDeps())
-}
-
 func checkHostPackages(log *slog.Logger, failMissing bool, deps hostCheckDeps) preflight.Checker {
 	return simpleHostChecker{name: checkHostPackagesName, check: func(ctx context.Context) []preflight.Result {
 		pm, err := deps.detectPackageManager(deps.lookupPath)


### PR DESCRIPTION
Part of the #670 dead-code sweep, split by component. The tooling that produced these findings is #673; this PR is deletions only and is independent of the other eight — the file sets are disjoint, so they can be reviewed and merged in any order and in parallel.

### Why two analyzers were needed to find this

`unused` cannot see dead exported code under `internal/`. That is a documented design decision, not a gap: `unused/unused.go:48-62` holds that a package uses its exported named types and a named type uses its exported methods, so every method on an exported type is transitively live *because the type is exported*.

`x/tools/cmd/deadcode` does not close that gap on its own either. `x/tools/go/callgraph/rta/rta.go:281-287,433-437` — converting a value to an interface materializes its runtime type and marks **every exported method of that type reachable**, because reflection could call any of them. One `var i any = x` anywhere buys all of `x`'s exported methods a clean bill of health.

So #673 adds both `deadcode` and `hack/cmd/unreferenced`, which resolves identifiers instead of tracing reachability. Neither subsumes the other, and findings below are attributed to whichever one saw them.

---

## agent: delete unreferenced helpers and unread constants

Straight zero-reference removals:

  - attest.CleanupAttestArtifacts
  - provision.ResolveDownloadOverrides
  - utilio.CleanDir, utilio.DecompressTarGzFromRemote and the private
    downloadFromRemote it wrapped. Removing them left remoteHTTPClient with no
    reader, which `unused` then reported - the linter can see the cascade once
    the exported entry point is gone, which is the whole shape of the problem
    this series is about.
  - phases/host.CheckHostPackages

goalstates.ContainerImageArchivePath took an index and had no caller. It is not
the bootstrapartifacts.ContainerImageArchivePath of the same name, which takes
(arch, imageTag) and is called from offline_artifacts.go and the artifacts
builder. Only the goalstates one is removed.

agentbinary.installFromTarGz had no caller either. It is not the body of
InstallAndSwitchFromTarGz, which does its own download and extraction; the two
had diverged. Its two tests, TestInstallFromTarGzVerifiesInstalledBinary and
TestInstallFromTarGzRejectsUnsupportedScheme, were the only callers and go with
it. TestInstallAndSwitchFromTarGz still covers the live path.

Constants:

  - config.DefaultLocalDNSMetricsPort is a string "9253" duplicating
    goalstates.LocalDNSMetricsPort, which is the int the code actually uses.
  - goalstates.KubeletPKIDir had no reader and the literal
    "/etc/kubernetes/pki" appears nowhere else in the tree.

Three constants that the analyzers report are kept, with a comment saying why,
because their consumers are not Go:

  - LocalDNSCorefilePath and LocalDNSUpstreamsPath are hardcoded in
    pkg/agent/phases/rootfs/assets/localdns-supervisor.sh.
  - LocalDNSRuleComment is asserted by hack/agent/e2e-kind/e2e.py.

Neither analyzer sees across the language boundary, so "no caller" there means
"no Go caller". That is a different claim, and deleting on it would have
removed the only in-tree record of an interface the shell script depends on.

pkg/agent/daemon is deliberately untouched. NewMachinaMachineOperationReconciler
and NoopMachineOperationReconciler are test-only, but they are exported from
pkg/, not internal/, so the module is not the closed world for them that it is
for internal/.

Refs #670


---

### Verification

`go build ./...`, `go vet ./...`, `golangci-lint` over the touched trees (0 issues), `make fmt` producing no diff, and `go build -tags e2e,integrationtest,storageboundary ./...`. Full suite runs in CI.

The eight deletion branches were reassembled onto the tooling commits and diffed against the original combined branch: byte-identical, so nothing was lost or duplicated in the split.