### PR TITLE
metalman: delete unreferenced helpers

### DIFF
--- a/internal/metalman/commands/helpers.go
+++ b/internal/metalman/commands/helpers.go
@@ -29,7 +29,6 @@ const (
 	dim   = "\033[2m"
 	reset = "\033[0m"
 	green = "\033[32m"
-	cyan  = "\033[36m"
 )
 
 // StatusUpdater implements attestation.StatusUpdater using a controller-runtime client.
@@ -85,10 +84,6 @@ func LeaderElectionID(site string) string {
 	}
 
 	return "metalman-" + site
-}
-
-func PrintStep(msg string) {
-	fmt.Printf("  %s-->%s %s\n", cyan, reset, msg)
 }
 
 func PrintConfig(key, value string) {

--- a/internal/metalman/machineops/controller.go
+++ b/internal/metalman/machineops/controller.go
@@ -33,15 +33,14 @@ import (
 const (
 	siteLabel = "unbounded-cloud.io/site"
 
-	reasonSucceeded                = "Succeeded"
-	reasonInvalidTargetScope       = "InvalidTargetScope"
-	reasonNoMatchingOwnedMachines  = "NoMatchingOwnedMachines"
-	reasonMachineNotFound          = "MachineNotFound"
-	reasonUnsupportedTarget        = "UnsupportedTarget"
-	reasonTargetNoLongerOwned      = "TargetNoLongerOwned"
-	reasonExecutionFailed          = "ExecutionFailed"
-	reasonWaitingForOlderOperation = "WaitingForOlderOperation"
-	reasonTimedOut                 = "TimedOut"
+	reasonSucceeded               = "Succeeded"
+	reasonInvalidTargetScope      = "InvalidTargetScope"
+	reasonNoMatchingOwnedMachines = "NoMatchingOwnedMachines"
+	reasonMachineNotFound         = "MachineNotFound"
+	reasonUnsupportedTarget       = "UnsupportedTarget"
+	reasonTargetNoLongerOwned     = "TargetNoLongerOwned"
+	reasonExecutionFailed         = "ExecutionFailed"
+	reasonTimedOut                = "TimedOut"
 
 	cloudInitTimeout = 5 * time.Minute
 )

--- a/internal/metalman/netboot/oci_cache.go
+++ b/internal/metalman/netboot/oci_cache.go
@@ -63,20 +63,11 @@ func (c *OCICache) SetDigestForArchitecture(imageRef, architecture, digest strin
 	c.digests[imageRefCacheKey(imageRef, architecture)] = digest
 }
 
-func (c *OCICache) DigestFor(imageRef string) string {
-	return c.DigestForArchitecture(imageRef, v1alpha3.DefaultPXEArchitecture)
-}
-
 func (c *OCICache) DigestForArchitecture(imageRef, architecture string) string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	return c.digests[imageRefCacheKey(imageRef, architecture)]
-}
-
-// ImageDir returns the base directory for a cached image by digest.
-func (c *OCICache) ImageDir(digest string) string {
-	return c.ImageDirForArchitecture(digest, v1alpha3.DefaultPXEArchitecture)
 }
 
 // ImageDirForArchitecture returns the base directory for a cached image by
@@ -97,21 +88,10 @@ func (c *OCICache) DiskDirForArchitecture(digest, architecture string) string {
 	return filepath.Join(c.ImageDirForArchitecture(digest, architecture), "disk")
 }
 
-// IsCached returns true if the image digest is already unpacked locally.
-func (c *OCICache) IsCached(digest string) bool {
-	return c.IsCachedForArchitecture(digest, v1alpha3.DefaultPXEArchitecture)
-}
-
 // IsCachedForArchitecture returns true if the image digest is already unpacked locally.
 func (c *OCICache) IsCachedForArchitecture(digest, architecture string) bool {
 	_, err := os.Stat(c.DiskDirForArchitecture(digest, architecture))
 	return err == nil
-}
-
-// Metadata returns the parsed metadata.yaml for a cached image,
-// reading it from disk and caching in memory on first access.
-func (c *OCICache) Metadata(digest string) (*ImageMetadata, error) {
-	return c.MetadataForArchitecture(digest, v1alpha3.DefaultPXEArchitecture)
 }
 
 // MetadataForArchitecture returns the parsed metadata.yaml for a cached image.
@@ -224,21 +204,6 @@ func (c *OCICache) ResolvePathForArchitecture(imageRef, architecture, reqPath st
 	}
 
 	return "", false, fmt.Errorf("file not found in image %q: %s", imageRef, reqPath)
-}
-
-// InvalidateRef removes the digest mapping for an image reference,
-// so it will be re-pulled on next reconcile.
-func (c *OCICache) InvalidateRef(imageRef string) {
-	c.InvalidateRefForArchitecture(imageRef, v1alpha3.DefaultPXEArchitecture)
-}
-
-// InvalidateRefForArchitecture removes the digest mapping for an image
-// reference and target architecture, so it will be re-pulled on next reconcile.
-func (c *OCICache) InvalidateRefForArchitecture(imageRef, architecture string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	delete(c.digests, imageRefCacheKey(imageRef, architecture))
 }
 
 func imageRefCacheKey(imageRef, architecture string) imageRefKey {


### PR DESCRIPTION
Part of the #670 dead-code sweep, split by component. The tooling that produced these findings is #673; this PR is deletions only and is independent of the other eight — the file sets are disjoint, so they can be reviewed and merged in any order and in parallel.

### Why two analyzers were needed to find this

`unused` cannot see dead exported code under `internal/`. That is a documented design decision, not a gap: `unused/unused.go:48-62` holds that a package uses its exported named types and a named type uses its exported methods, so every method on an exported type is transitively live *because the type is exported*.

`x/tools/cmd/deadcode` does not close that gap on its own either. `x/tools/go/callgraph/rta/rta.go:281-287,433-437` — converting a value to an interface materializes its runtime type and marks **every exported method of that type reachable**, because reflection could call any of them. One `var i any = x` anywhere buys all of `x`'s exported methods a clean bill of health.

So #673 adds both `deadcode` and `hack/cmd/unreferenced`, which resolves identifiers instead of tracing reachability. Neither subsumes the other, and findings below are attributed to whichever one saw them.

---

## metalman: delete unreferenced helpers

netboot.OCICache loses five default-architecture wrappers - DigestFor,
ImageDir, IsCached, Metadata and InvalidateRef - each a one-liner delegating to
its ...ForArchitecture counterpart with v1alpha3.DefaultPXEArchitecture. The
architecture-aware variants are what the reconciler and the netboot handlers
call; the wrappers are what multi-architecture support left behind.
InvalidateRefForArchitecture goes with them: once InvalidateRef was gone it had
no caller of its own.

commands.PrintStep had no reference. The cyan constant it was the only user of
goes with it; the identically named constant in
cmd/kubectl-unbounded/app/machine_ops.go is live and untouched.

machineops' reasonWaitingForOlderOperation is an unexported constant with no
reader. It sits in a const group whose other members are all live, which is why
`unused` never reported it, and the string "WaitingForOlderOperation" does not
appear anywhere else in the tree either.

Refs #670


---

### Verification

`go build ./...`, `go vet ./...`, `golangci-lint` over the touched trees (0 issues), `make fmt` producing no diff, and `go build -tags e2e,integrationtest,storageboundary ./...`. Full suite runs in CI.

The eight deletion branches were reassembled onto the tooling commits and diffed against the original combined branch: byte-identical, so nothing was lost or duplicated in the split.