### PR TITLE
operator, orca, playpen: delete unreferenced helpers

### DIFF
--- a/internal/operator/component/env.go
+++ b/internal/operator/component/env.go
@@ -291,23 +291,6 @@ func (e *Env) decodeManifestData(data []byte, mutate func(*unstructured.Unstruct
 	return objects, nil
 }
 
-// ApplyOperations wraps decoded objects as apply operations attributed to a
-// component and Site. Site is empty for cluster-scoped components.
-func ApplyOperations(objects []*unstructured.Unstructured, componentName, site string) []Operation {
-	ops := make([]Operation, 0, len(objects))
-
-	for _, obj := range objects {
-		ops = append(ops, Operation{
-			Kind:      OpApply,
-			Object:    obj,
-			Component: componentName,
-			Site:      site,
-		})
-	}
-
-	return ops
-}
-
 // DeleteOperation builds a delete operation for a typed object.
 func DeleteOperation(obj client.Object, componentName, site string) Operation {
 	return Operation{

--- a/internal/operator/component/execute.go
+++ b/internal/operator/component/execute.go
@@ -136,11 +136,6 @@ func (r ExecutionResult) Skipped() []OperationResult {
 	return r.withStatus(OpSkipped)
 }
 
-// Dropped returns the operations removed from the plan before execution.
-func (r ExecutionResult) Dropped() []OperationResult {
-	return r.withStatus(OpDropped)
-}
-
 // DeferredResults returns the operations that were not written this pass
 // because the cluster moved under it.
 func (r ExecutionResult) DeferredResults() []OperationResult {

--- a/internal/operator/override/problem.go
+++ b/internal/operator/override/problem.go
@@ -4,7 +4,6 @@
 package override
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -76,30 +75,6 @@ func ProblemsError(problems []Problem) error {
 	sort.Strings(rendered)
 
 	return fmt.Errorf("invalid override document:\n  %s", strings.Join(rendered, "\n  "))
-}
-
-// ProblemsErr joins the underlying errors without the document framing, for
-// callers that want to wrap them in their own message.
-func ProblemsErr(problems []Problem) error {
-	errs := make([]error, 0, len(problems))
-	for _, problem := range problems {
-		errs = append(errs, errors.New(problem.String()))
-	}
-
-	return errors.Join(errs...)
-}
-
-// AnyKeyLevel reports whether any problem covers a whole key, which is what
-// decides between withholding the workloads a set of entries names and
-// withholding every workload an override could reach.
-func AnyKeyLevel(problems []Problem) bool {
-	for _, problem := range problems {
-		if problem.KeyLevel() {
-			return true
-		}
-	}
-
-	return false
 }
 
 // keyProblem builds a problem covering a whole ConfigMap key.

--- a/internal/orca/app/app.go
+++ b/internal/orca/app/app.go
@@ -63,8 +63,7 @@ type App struct {
 	errCh       chan error
 
 	// cachestoreReady is set true once the cachestore self-test has
-	// passed (or skipped via WithSkipCachestoreSelfTest). Gated by
-	// the /readyz endpoint.
+	// passed. Gated by the /readyz endpoint.
 	cachestoreReady bool
 }
 
@@ -73,7 +72,6 @@ type options struct {
 	clusterOpt          cluster.Option
 	origin              origin.Origin
 	cacheStore          cachestore.CacheStore
-	skipCacheSelfTest   bool
 	internalHandlerWrap func(http.Handler) http.Handler
 	edgeListener        net.Listener
 	internalListener    net.Listener
@@ -111,13 +109,6 @@ func WithOrigin(or origin.Origin) Option {
 // a real s3 client (or to use an in-memory implementation).
 func WithCacheStore(cs cachestore.CacheStore) Option {
 	return func(o *options) { o.cacheStore = cs }
-}
-
-// WithSkipCachestoreSelfTest disables the boot-time cachestore
-// self-test. Useful only in tests that wire a cachestore decorator
-// already known to provide read-after-write visibility.
-func WithSkipCachestoreSelfTest() Option {
-	return func(o *options) { o.skipCacheSelfTest = true }
 }
 
 // WithInternalHandlerWrap installs a decorator around the internal
@@ -191,22 +182,13 @@ func Start(ctx context.Context, cfg *config.Config, opts ...Option) (*App, error
 		return nil, err
 	}
 
-	cachestoreReady := false
-
-	if o.skipCacheSelfTest {
-		// Caller has asserted the cachestore decorator provides
-		// read-after-write visibility (the in-memory store used by
-		// tests). Treat readiness as satisfied immediately.
-		cachestoreReady = true
-	} else {
-		if err := cs.SelfTest(ctx); err != nil {
-			return nil, fmt.Errorf("cachestore self-test failed: %w", err)
-		}
-
-		log.LogAttrs(ctx, slog.LevelInfo, "cachestore self-test passed")
-
-		cachestoreReady = true
+	if err := cs.SelfTest(ctx); err != nil {
+		return nil, fmt.Errorf("cachestore self-test failed: %w", err)
 	}
+
+	log.LogAttrs(ctx, slog.LevelInfo, "cachestore self-test passed")
+
+	cachestoreReady := true
 
 	clusterOpts := []cluster.Option{cluster.WithLogger(log)}
 	if o.clusterOpt != nil {

--- a/internal/orca/inttest/azurite.go
+++ b/internal/orca/inttest/azurite.go
@@ -13,9 +13,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -128,35 +125,6 @@ func (az *Azurite) UploadBlockBlob(ctx context.Context, t *testing.T, ctr, name 
 	if _, err := cli.UploadBuffer(ctx, ctr, name, data, nil); err != nil {
 		t.Fatalf("upload block blob %s/%s: %v", ctr, name, err)
 	}
-}
-
-// UploadPageBlob uploads bytes as a page blob (used to exercise the
-// unsupported-blob-type rejection path in the azureblob driver). Size
-// must be a multiple of 512.
-func (az *Azurite) UploadPageBlob(ctx context.Context, t *testing.T, ctr, name string, size int64) {
-	t.Helper()
-
-	cred, err := azblob.NewSharedKeyCredential(az.AccountName(), az.AccountKey())
-	if err != nil {
-		t.Fatalf("azurite shared key cred: %v", err)
-	}
-
-	containerCli, err := container.NewClientWithSharedKeyCredential(
-		fmt.Sprintf("%s/%s", az.endpoint, ctr), cred, nil,
-	)
-	if err != nil {
-		t.Fatalf("container client: %v", err)
-	}
-
-	pbCli := containerCli.NewPageBlobClient(name)
-	if _, err := pbCli.Create(ctx, size, &pageblob.CreateOptions{
-		HTTPHeaders: &blob.HTTPHeaders{},
-	}); err != nil {
-		t.Fatalf("create page blob: %v", err)
-	}
-	// Page blobs created here are zero-filled; tests don't read content
-	// because the azureblob driver rejects non-Block-Blob types before
-	// the GET stage.
 }
 
 // uniqueName returns a short random-suffixed name suitable for

--- a/internal/orca/inttest/internalwrap.go
+++ b/internal/orca/inttest/internalwrap.go
@@ -73,22 +73,6 @@ func (w *CountingInternalHandlerWrap) Count(selfIP string, status int) int64 {
 	return c.Load()
 }
 
-// CountAcross returns the count summed across all known selfIPs.
-func (w *CountingInternalHandlerWrap) CountAcross(status int) int64 {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	var total int64
-
-	for _, byStatus := range w.counts {
-		if c, ok := byStatus[status]; ok {
-			total += c.Load()
-		}
-	}
-
-	return total
-}
-
 func (w *CountingInternalHandlerWrap) record(selfIP string, status int) {
 	w.mu.Lock()
 

--- a/internal/orca/inttest/originwrap.go
+++ b/internal/orca/inttest/originwrap.go
@@ -28,9 +28,6 @@ func NewCountingOrigin(inner origin.Origin) *CountingOrigin {
 	return &CountingOrigin{inner: inner}
 }
 
-// Heads returns the number of Head() calls observed.
-func (c *CountingOrigin) Heads() int64 { return c.heads.Load() }
-
 // GetRanges returns the number of GetRange() calls observed.
 func (c *CountingOrigin) GetRanges() int64 { return c.getRanges.Load() }
 

--- a/internal/orca/inttest/seed.go
+++ b/internal/orca/inttest/seed.go
@@ -39,11 +39,6 @@ func HugeBlob() SeedBlob {
 	return SeedBlob{Key: "sample-64chunk", Data: deterministicBytes(64*1024*1024, 0xd4)}
 }
 
-// AllBlobs returns the canonical seed set used across most tests.
-func AllBlobs() []SeedBlob {
-	return []SeedBlob{SmallBlob(), MediumBlob(), HugeBlob()}
-}
-
 // SeedS3 uploads each blob to the named bucket via the provided
 // S3-backend-friendly S3 client.
 func SeedS3(ctx context.Context, t *testing.T, cli *s3.Client, bucket string, blobs []SeedBlob) {

--- a/internal/playpen/client/client.go
+++ b/internal/playpen/client/client.go
@@ -201,11 +201,6 @@ func (c *Client) deallocate(ctx context.Context, idempotencyKey string) error {
 	return c.doJSON(req, http.StatusNoContent, nil)
 }
 
-// WireGuardPrivateKey returns the client's WireGuard private key for this playpen.
-func (p *Playpen) WireGuardPrivateKey() string {
-	return p.wireGuardPrivateKey
-}
-
 // TunnelConfig returns the local tunnel settings for this playpen.
 func (p *Playpen) TunnelConfig() TunnelConfig {
 	p.mu.Lock()


### PR DESCRIPTION
Part of the #670 dead-code sweep, split by component. The tooling that produced these findings is #673; this PR is deletions only and is independent of the other eight — the file sets are disjoint, so they can be reviewed and merged in any order and in parallel.

### Why two analyzers were needed to find this

`unused` cannot see dead exported code under `internal/`. That is a documented design decision, not a gap: `unused/unused.go:48-62` holds that a package uses its exported named types and a named type uses its exported methods, so every method on an exported type is transitively live *because the type is exported*.

`x/tools/cmd/deadcode` does not close that gap on its own either. `x/tools/go/callgraph/rta/rta.go:281-287,433-437` — converting a value to an interface materializes its runtime type and marks **every exported method of that type reachable**, because reflection could call any of them. One `var i any = x` anywhere buys all of `x`'s exported methods a clean bill of health.

So #673 adds both `deadcode` and `hack/cmd/unreferenced`, which resolves identifiers instead of tracing reachability. Neither subsumes the other, and findings below are attributed to whichever one saw them.

---

## operator, orca, playpen: delete unreferenced helpers

operator:

  - component.ApplyOperations and ExecutionResult.Dropped have no reference.
  - override.ProblemsErr and override.AnyKeyLevel likewise; ProblemsErr was the
    package's only use of the errors import.

override.PermittedPaths, override.ProtectedPaths and override.ValidateErr are
reported by `make deadcode` without -test and are kept. They are called from
override_examples_test.go, which compares the documented allowlist against the
declared one, so they are the mechanism that keeps the docs honest rather than
leftovers from a deleted caller.

orca:

  - app.WithSkipCachestoreSelfTest set a skipCacheSelfTest field that nothing
    else ever set, which made the branch it guarded unreachable and the
    cachestore self-test unconditional in every configuration including the
    integration harness. The option, the field and the dead branch go, and the
    self-test now reads as the single path it already was. The struct comment
    that advertised the escape hatch is corrected.
  - inttest loses four harness affordances with no caller: AllBlobs,
    Azurite.UploadPageBlob (the file's only use of the azblob blob, container
    and pageblob packages), CountingInternalHandlerWrap.CountAcross and
    CountingOrigin.Heads.

The seven remaining app.WithX options and cluster.WithPeerSource /
WithHTTPClient are dead in the default configuration and live under
integrationtest, so they stay. That difference is exactly why `make deadcode`
scans both tag sets.

playpen: Playpen.WireGuardPrivateKey had no caller. The AllocateOptions field of
the same name is unaffected and still read.

Refs #670


---

### Verification

`go build ./...`, `go vet ./...`, `golangci-lint` over the touched trees (0 issues), `make fmt` producing no diff, and `go build -tags e2e,integrationtest,storageboundary ./...`. Full suite runs in CI.

The eight deletion branches were reassembled onto the tooling commits and diffed against the original combined branch: byte-identical, so nothing was lost or duplicated in the split.