### PR TITLE
hack: delete unreferenced dev-tooling helpers

### DIFF
--- a/hack/cmd/notice/internal/npm/npm.go
+++ b/hack/cmd/notice/internal/npm/npm.go
@@ -34,9 +34,6 @@ type Collector struct {
 // Option configures a Collector.
 type Option func(*Collector)
 
-// WithFS injects a FileSystem. Defaults to the host filesystem.
-func WithFS(f FileSystem) Option { return func(c *Collector) { c.fs = f } }
-
 // New constructs a Collector with production defaults.
 func New(opts ...Option) *Collector {
 	c := &Collector{fs: osFS{}}

--- a/hack/cmd/notice/internal/testutil/licenses.go
+++ b/hack/cmd/notice/internal/testutil/licenses.go
@@ -36,39 +36,6 @@ func Apache2License() string {
 	return apache2Boilerplate
 }
 
-// BSD3License returns a minimal BSD-3-Clause license body with the given
-// copyright line.
-func BSD3License(copyrightLine string) string {
-	return copyrightLine + `
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-`
-}
-
 const apache2Boilerplate = `                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/hack/cmd/orcadev/orcadev/percentile.go
+++ b/hack/cmd/orcadev/orcadev/percentile.go
@@ -8,24 +8,6 @@ import (
 	"time"
 )
 
-// percentile returns the v-th percentile of samples where v is in
-// (0, 100]. Empty samples returns 0. The input is sorted in-place;
-// callers must pass a slice they own or copy first.
-//
-// Uses the nearest-rank method with ceiling: index = ceil(N*v/100)-1
-// clamped to [0, N-1]. This matches Prometheus / Grafana convention
-// for percentile reporting on small-to-medium sample sizes and
-// avoids interpolation surprises on log-distributed latency data.
-func percentile(samples []time.Duration, v float64) time.Duration {
-	if len(samples) == 0 {
-		return 0
-	}
-
-	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
-
-	return percentileSorted(samples, v)
-}
-
 // latencyStats is the canonical set of percentile + min/max numbers
 // the bench / scenario subcommands emit in both human and JSON form.
 type latencyStats struct {

--- a/hack/cmd/orcadev/orcadev/percentile_test.go
+++ b/hack/cmd/orcadev/orcadev/percentile_test.go
@@ -8,22 +8,22 @@ import (
 	"time"
 )
 
-func TestPercentile(t *testing.T) {
+func TestPercentileSorted(t *testing.T) {
 	t.Parallel()
 
-	// Inputs are intentionally unsorted to exercise the in-place
-	// sort path.
+	// percentileSorted requires ascending input; computeLatencyStats is what
+	// sorts before calling it.
 	samples := func() []time.Duration {
 		return []time.Duration{
-			10 * time.Millisecond,
 			1 * time.Millisecond,
-			5 * time.Millisecond,
-			100 * time.Millisecond,
-			3 * time.Millisecond,
-			50 * time.Millisecond,
-			7 * time.Millisecond,
-			20 * time.Millisecond,
 			2 * time.Millisecond,
+			3 * time.Millisecond,
+			5 * time.Millisecond,
+			7 * time.Millisecond,
+			10 * time.Millisecond,
+			20 * time.Millisecond,
+			50 * time.Millisecond,
+			100 * time.Millisecond,
 			200 * time.Millisecond,
 		}
 	}
@@ -42,19 +42,19 @@ func TestPercentile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := percentile(samples(), tt.v)
+			got := percentileSorted(samples(), tt.v)
 			if got != tt.want {
-				t.Errorf("percentile(%v) = %v want %v", tt.v, got, tt.want)
+				t.Errorf("percentileSorted(%v) = %v want %v", tt.v, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestPercentile_Empty(t *testing.T) {
+func TestPercentileSorted_Empty(t *testing.T) {
 	t.Parallel()
 
-	if got := percentile([]time.Duration{}, 50); got != 0 {
-		t.Errorf("percentile on empty samples = %v want 0", got)
+	if got := percentileSorted([]time.Duration{}, 50); got != 0 {
+		t.Errorf("percentileSorted on empty samples = %v want 0", got)
 	}
 }
 

--- a/hack/cmd/orcadev/orcadev/portforward.go
+++ b/hack/cmd/orcadev/orcadev/portforward.go
@@ -266,30 +266,6 @@ func probeTCP(host, port string, timeout time.Duration) bool {
 	return true
 }
 
-// hostPortFromURL parses u and returns the host and port. Missing
-// port is filled from the scheme default (80 for http, 443 for
-// https). A parse error is surfaced verbatim. Retained for the
-// existing unit tests.
-func hostPortFromURL(u string) (string, string, error) {
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return "", "", err
-	}
-
-	host := parsed.Hostname()
-
-	port := parsed.Port()
-	if port == "" {
-		if parsed.Scheme == "https" {
-			port = "443"
-		} else {
-			port = "80"
-		}
-	}
-
-	return host, port, nil
-}
-
 // portForwardStderrCapacity bounds the in-memory buffer used to
 // surface kubectl stderr in failure messages. 16 KiB is more than
 // enough for an "Unable to listen on port" stanza yet small enough

--- a/hack/cmd/orcadev/orcadev/portforward_test.go
+++ b/hack/cmd/orcadev/orcadev/portforward_test.go
@@ -10,48 +10,6 @@ import (
 	"time"
 )
 
-func TestHostPortFromURL(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		in       string
-		wantHost string
-		wantPort string
-		wantErr  bool
-	}{
-		{"http://localhost:8443", "localhost", "8443", false},
-		{"http://127.0.0.1:8443", "127.0.0.1", "8443", false},
-		{"https://orca.example.com", "orca.example.com", "443", false},
-		{"http://orca.example.com", "orca.example.com", "80", false},
-		{"http://localhost:8443/some/path", "localhost", "8443", false},
-		// Bare "://x" is parseable by url.Parse (returns empty scheme/host)
-		// so we don't expect an error here, just empty host/port-default.
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.in, func(t *testing.T) {
-			h, p, err := hostPortFromURL(tt.in)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("hostPortFromURL(%q) = (%q, %q, nil) want error", tt.in, h, p)
-				}
-
-				return
-			}
-
-			if err != nil {
-				t.Errorf("hostPortFromURL(%q) unexpected error: %v", tt.in, err)
-				return
-			}
-
-			if h != tt.wantHost || p != tt.wantPort {
-				t.Errorf("hostPortFromURL(%q) = (%q, %q) want (%q, %q)",
-					tt.in, h, p, tt.wantHost, tt.wantPort)
-			}
-		})
-	}
-}
-
 // TestProbeTCP_Open spins up a real loopback listener on an
 // OS-assigned port and verifies probeTCP detects it.
 func TestProbeTCP_Open(t *testing.T) {

--- a/hack/cmd/relctl/relctl/annotations.go
+++ b/hack/cmd/relctl/relctl/annotations.go
@@ -21,7 +21,6 @@ import (
 // would have seen it, and nothing fails.
 const (
 	actionsWarning = "::warning::"
-	actionsError   = "::error::"
 )
 
 // underActions reports whether output is being read by GitHub Actions.

--- a/hack/cmd/relctl/relctl/gh/client.go
+++ b/hack/cmd/relctl/relctl/gh/client.go
@@ -35,15 +35,6 @@ type Client struct {
 // Repo returns the owner/name slug this client is scoped to.
 func (c *Client) Repo() string { return c.owner + "/" + c.repo }
 
-// Owner returns the repository owner.
-func (c *Client) Owner() string { return c.owner }
-
-// Name returns the repository name.
-func (c *Client) Name() string { return c.repo }
-
-// API exposes the underlying client for calls this package does not wrap.
-func (c *Client) API() *github.Client { return c.api }
-
 // repoPart matches one path segment of a GitHub slug.
 //
 // GitHub allows alphanumerics, hyphen, underscore and dot, and nothing else.

--- a/hack/cmd/relctl/relctl/gh/client_test.go
+++ b/hack/cmd/relctl/relctl/gh/client_test.go
@@ -158,8 +158,8 @@ func TestNewUsesTheSuppliedTokenSource(t *testing.T) {
 		t.Fatalf("Repo() = %q", client.Repo())
 	}
 
-	if client.Owner() != "someone" || client.Name() != "fork" {
-		t.Fatalf("Owner()/Name() = %q/%q", client.Owner(), client.Name())
+	if client.owner != "someone" || client.repo != "fork" {
+		t.Fatalf("owner/repo = %q/%q", client.owner, client.repo)
 	}
 }
 
@@ -255,7 +255,7 @@ func TestNewHonorsBaseURL(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	if _, _, err := client.API().Users.Get(t.Context(), "someone"); err != nil {
+	if _, _, err := client.api.Users.Get(t.Context(), "someone"); err != nil {
 		t.Fatalf("Users.Get against the stub: %v", err)
 	}
 

--- a/hack/cmd/relctl/relctl/version/git.go
+++ b/hack/cmd/relctl/relctl/version/git.go
@@ -25,9 +25,6 @@ func NewGitRepo(ctx context.Context, dir string) *GitRepo {
 	return &GitRepo{ctx: ctx, dir: dir}
 }
 
-// Dir returns the working tree this reads from.
-func (g *GitRepo) Dir() string { return g.dir }
-
 func (g *GitRepo) run(args ...string) (string, error) {
 	cmd := exec.CommandContext(g.ctx, "git", args...) //nolint:gosec // fixed binary, args built here
 	cmd.Dir = g.dir


### PR DESCRIPTION
Part of the #670 dead-code sweep, split by component. The tooling that produced these findings is #673; this PR is deletions only and is independent of the other eight — the file sets are disjoint, so they can be reviewed and merged in any order and in parallel.

### Why two analyzers were needed to find this

`unused` cannot see dead exported code under `internal/`. That is a documented design decision, not a gap: `unused/unused.go:48-62` holds that a package uses its exported named types and a named type uses its exported methods, so every method on an exported type is transitively live *because the type is exported*.

`x/tools/cmd/deadcode` does not close that gap on its own either. `x/tools/go/callgraph/rta/rta.go:281-287,433-437` — converting a value to an interface materializes its runtime type and marks **every exported method of that type reachable**, because reflection could call any of them. One `var i any = x` anywhere buys all of `x`'s exported methods a clean bill of health.

So #673 adds both `deadcode` and `hack/cmd/unreferenced`, which resolves identifiers instead of tracing reachability. Neither subsumes the other, and findings below are attributed to whichever one saw them.

---

## hack: delete unreferenced dev-tooling helpers

Zero-reference removals in the development tooling:

  - notice/internal/npm.WithFS. The identically named gomod.WithFS is used by
    gomod's tests and stays.
  - notice/internal/testutil.BSD3License. MITLicense, Apache2License and
    WriteTree in the same file are all used.
  - relctl/version.GitRepo.Dir.
  - relctl/gh.Client.API, .Name and .Owner. These had callers - three lines in
    client_test.go - but the test is in package gh, so it can read api, owner
    and repo directly. Exported accessors that exist only for a same-package
    test are surface with no reader.
  - relctl's actionsError, an unexported constant in a const group whose other
    members are live, which is why `unused` never reported it.

orcadev:

  - hostPortFromURL had no caller outside its own test; both go.
  - percentile sorted its input and delegated to percentileSorted. Only its
    test called it; computeLatencyStats, the live path, calls percentileSorted
    directly having sorted once. The wrapper goes and TestPercentile moves to
    percentileSorted with pre-sorted input, which keeps the p0-to-min and
    p100-to-max edge cases that computeLatencyStats' own test does not cover.

Refs #670


---

### Verification

`go build ./...`, `go vet ./...`, `golangci-lint` over the touched trees (0 issues), `make fmt` producing no diff, and `go build -tags e2e,integrationtest,storageboundary ./...`. Full suite runs in CI.

The eight deletion branches were reassembled onto the tooling commits and diffed against the original combined branch: byte-identical, so nothing was lost or duplicated in the split.