### PR TITLE
Verify OCI blob content against its descriptor

### DIFF
--- a/pkg/agent/internal/ociartifact/download.go
+++ b/pkg/agent/internal/ociartifact/download.go
@@ -6,6 +6,7 @@ package ociartifact
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
@@ -50,7 +52,56 @@ func Open(ctx context.Context, source string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("fetch OCI blob %q: %w", title, err)
 	}
 
-	return body, nil
+	return newVerifyingReadCloser(body, desc, title), nil
+}
+
+// verifyingReadCloser streams a blob while hashing it, and fails the final Read
+// when the content does not match the descriptor.
+//
+// oras-go does not verify blob content on its own. Repository.Fetch only
+// compares the Docker-Content-Digest response header against the expected
+// digest, and skips even that when the registry omits the header, so the bytes
+// themselves are never checked. Content that is the right size but the wrong
+// bytes would otherwise be accepted.
+//
+// The mismatch is surfaced through Read rather than Close because callers
+// reliably check read errors and frequently ignore the error from Close.
+type verifyingReadCloser struct {
+	verifier *content.VerifyReader
+	closer   io.Closer
+	title    string
+	verified bool
+}
+
+func newVerifyingReadCloser(body io.ReadCloser, desc ocispec.Descriptor, title string) *verifyingReadCloser {
+	return &verifyingReadCloser{
+		verifier: content.NewVerifyReader(body, desc),
+		closer:   body,
+		title:    title,
+	}
+}
+
+func (v *verifyingReadCloser) Read(p []byte) (int, error) {
+	n, err := v.verifier.Read(p)
+	if !errors.Is(err, io.EOF) {
+		return n, err
+	}
+
+	// The stream is complete, so the digest can now be checked. Report a
+	// mismatch as a read failure so it cannot be mistaken for a clean EOF.
+	if !v.verified {
+		if verifyErr := v.verifier.Verify(); verifyErr != nil {
+			return n, fmt.Errorf("verify OCI blob %q: %w", v.title, verifyErr)
+		}
+
+		v.verified = true
+	}
+
+	return n, io.EOF
+}
+
+func (v *verifyingReadCloser) Close() error {
+	return v.closer.Close()
 }
 
 // FetchManifest resolves an OCI artifact source and returns its selected

--- a/pkg/agent/internal/ociartifact/verify_test.go
+++ b/pkg/agent/internal/ociartifact/verify_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package ociartifact
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nopCloser adapts a reader so it can stand in for a fetched blob body.
+type nopCloser struct{ io.Reader }
+
+func (nopCloser) Close() error { return nil }
+
+func descriptorFor(content string) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		Digest: digest.FromString(content),
+		Size:   int64(len(content)),
+	}
+}
+
+// TestVerifyingReadCloserAcceptsMatchingContent is the baseline: a blob whose
+// bytes match its descriptor reads through cleanly and terminates with io.EOF.
+func TestVerifyingReadCloserAcceptsMatchingContent(t *testing.T) {
+	t.Parallel()
+
+	body := "sysext contents"
+	rc := newVerifyingReadCloser(nopCloser{strings.NewReader(body)}, descriptorFor(body), "blob.raw")
+
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(got))
+	require.NoError(t, rc.Close())
+}
+
+// TestVerifyingReadCloserRejectsTamperedContent is the case oras-go does not
+// catch on its own: the content is the declared size but the wrong bytes, so
+// only hashing the stream detects it. Registries may omit the
+// Docker-Content-Digest header entirely, in which case oras-go performs no
+// check at all.
+func TestVerifyingReadCloserRejectsTamperedContent(t *testing.T) {
+	t.Parallel()
+
+	// Same length as the descriptor describes, different bytes.
+	desc := descriptorFor("sysext contents")
+	tampered := "SYSEXT CONTENTS"
+	require.Equal(t, desc.Size, int64(len(tampered)), "test requires an equal-length substitution")
+
+	rc := newVerifyingReadCloser(nopCloser{strings.NewReader(tampered)}, desc, "blob.raw")
+
+	_, err := io.ReadAll(rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verify OCI blob")
+	assert.Contains(t, err.Error(), "blob.raw")
+}
+
+// TestVerifyingReadCloserRejectsTruncatedContent covers a short read, which
+// must not be mistaken for a clean end of stream.
+func TestVerifyingReadCloserRejectsTruncatedContent(t *testing.T) {
+	t.Parallel()
+
+	desc := descriptorFor("sysext contents")
+	rc := newVerifyingReadCloser(nopCloser{strings.NewReader("sysext")}, desc, "blob.raw")
+
+	_, err := io.ReadAll(rc)
+	require.Error(t, err)
+	assert.True(t,
+		errors.Is(err, io.ErrUnexpectedEOF) || strings.Contains(err.Error(), "verify OCI blob"),
+		"expected a truncation or verification failure, got %v", err)
+}
+
+// TestVerifyingReadCloserRejectsOverlongContent covers extra trailing bytes.
+func TestVerifyingReadCloserRejectsOverlongContent(t *testing.T) {
+	t.Parallel()
+
+	desc := descriptorFor("sysext")
+	rc := newVerifyingReadCloser(nopCloser{strings.NewReader("sysext and then some")}, desc, "blob.raw")
+
+	_, err := io.ReadAll(rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verify OCI blob")
+}
+
+// TestVerifyingReadCloserSurfacesFailureThroughRead pins the design choice:
+// verification failures must reach callers through Read, because Close errors
+// are widely ignored and a silent Close failure would let corrupt content
+// through.
+func TestVerifyingReadCloserSurfacesFailureThroughRead(t *testing.T) {
+	t.Parallel()
+
+	desc := descriptorFor("sysext contents")
+	rc := newVerifyingReadCloser(nopCloser{strings.NewReader("SYSEXT CONTENTS")}, desc, "blob.raw")
+
+	buf := make([]byte, 64)
+
+	var readErr error
+
+	for {
+		_, err := rc.Read(buf)
+		if err != nil {
+			readErr = err
+
+			break
+		}
+	}
+
+	require.Error(t, readErr)
+	assert.NotErrorIs(t, readErr, io.EOF, "a digest mismatch must not present as a clean EOF")
+	assert.NoError(t, rc.Close(), "Close should not be where the failure is reported")
+}


### PR DESCRIPTION
Blobs fetched from an OCI registry were never checked against their descriptor
digest.

`oras-go`'s `Repository.Fetch` calls `verifyContentDigest`, which compares only
the `Docker-Content-Digest` **response header** against the expected digest, and
returns success when the registry omits that header:

```go
digestStr := resp.Header.Get(headerDockerContentDigest)
if len(digestStr) == 0 {
    return nil          // no header, no verification
}
```

The bytes themselves are never hashed. Content of the declared size but the
wrong bytes was accepted, and a registry that omits the header got no integrity
check at all.

## Impact

This affects every `oci://` artifact source reaching
`pkg/agent/internal/ociartifact.Open`, including offline bootstrap bundles
resolved through `bootstrapartifacts`. Those are binaries the agent installs
into the node root filesystem, so the content is executed.

Some callers layer their own protection: `DownloadWithSHA256Verification` hashes
the stream, and Kubernetes binaries, CoreDNS and container image archives fetch
a sibling `.sha256`. Callers using `Open` or `ReadAll` directly, and the
components fetched without a checksum sidecar, had none.

## Fix

Wrap the fetched body so the stream is hashed as it is read, and check the
digest once the content is complete, using `oras-go`'s `content.VerifyReader`.

**The failure is reported through `Read`, not `Close`.** Callers reliably check
read errors and frequently ignore the error from `Close`, so reporting a
mismatch there would let corrupt content through unnoticed. A digest mismatch
therefore cannot be mistaken for a clean end of stream, which is pinned by a
test.

## Tests

Five cases on the wrapper, including the one `oras-go` does not catch on its
own: content of exactly the declared size with substituted bytes. Also covers
truncated and overlong streams, and asserts that the failure arrives via `Read`
while `Close` stays clean.

## How this was found

While evaluating whether a checksum sidecar could be dropped for `oci://`
sources on the grounds that OCI blobs are content-addressed. They are addressed
by digest, but nothing was enforcing it.

Split out of #687 because it is a correctness issue in a shared code path,
independent of the Azure Container Linux work it was found during.
