### PR TITLE
Add AlmaLinux 9 and 10 to agent E2E matrix

### DIFF
--- a/.github/workflows/agent-e2e-kind.yaml
+++ b/.github/workflows/agent-e2e-kind.yaml
@@ -57,32 +57,27 @@ permissions:
   packages: read
 
 jobs:
-  agent-e2e-matrix:
-    name: Build agent E2E matrix
-    runs-on: ubuntu-24.04
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - name: Build matrix
-        id: matrix
-        env:
-          TRUSTED_EVENT: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        shell: bash
-        run: |
-          matrix='{"include":[{"host-base-os":"ubuntu2404","nspawn-base-os":"ubuntu2404"},{"host-base-os":"fedora","nspawn-base-os":"azlinux3"},{"host-base-os":"ubuntu2604","nspawn-base-os":"ubuntu2604"}]}'
-          if [[ "${TRUSTED_EVENT}" == "true" ]]; then
-            matrix='{"include":[{"host-base-os":"ubuntu2404","nspawn-base-os":"ubuntu2404"},{"host-base-os":"fedora","nspawn-base-os":"azlinux3"},{"host-base-os":"rhel9","nspawn-base-os":"azlinux3","host-image-url-secret":"RHEL9_E2E_IMAGE_URL"},{"host-base-os":"rhel10","nspawn-base-os":"azlinux3","host-image-url-secret":"RHEL10_E2E_IMAGE_URL"},{"host-base-os":"ubuntu2604","nspawn-base-os":"ubuntu2604"}]}'
-          fi
-          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
-
   agent-e2e:
     name: agent e2e (host ${{ matrix.host-base-os }}, nspawn ${{ matrix.nspawn-base-os }})
-    needs: agent-e2e-matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.agent-e2e-matrix.outputs.matrix) }}
+      matrix:
+        include:
+          - host-base-os: ubuntu2404
+            nspawn-base-os: ubuntu2404
+          # Fedora and AlmaLinux cover RPM hosts with Azure Linux nspawn.
+          # Azure Linux 3 does not currently publish a QEMU-ready VHD that this
+          # e2e can boot directly as the host VM.
+          - host-base-os: fedora
+            nspawn-base-os: azlinux3
+          - host-base-os: almalinux9
+            nspawn-base-os: azlinux3
+          - host-base-os: almalinux10
+            nspawn-base-os: azlinux3
+          - host-base-os: ubuntu2604
+            nspawn-base-os: ubuntu2604
     env:
       KIND_CLUSTER_NAME: agent-e2e-${{ matrix.host-base-os }}-${{ matrix.nspawn-base-os }}
       VM_NAME: agent-e2e-${{ matrix.host-base-os }}-${{ matrix.nspawn-base-os }}
@@ -90,16 +85,7 @@ jobs:
       VM_IP: "192.168.100.10"
       AGENT_MACHINE_NAME: agent-e2e-${{ matrix.host-base-os }}-${{ matrix.nspawn-base-os }}
       HOST_BASE_OS: ${{ matrix.host-base-os }}
-      HOST_IMAGE_URL: ${{ secrets[matrix.host-image-url-secret] }}
     steps:
-      - name: Check RHEL image configuration
-        shell: bash
-        run: |
-          if [[ "${HOST_BASE_OS}" == rhel* && -z "${HOST_IMAGE_URL}" ]]; then
-            echo "::error::Configure the ${HOST_BASE_OS^^}_E2E_IMAGE_URL repository secret with a CI-accessible qcow2 URL"
-            exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/agent-e2e-kind.yaml
+++ b/.github/workflows/agent-e2e-kind.yaml
@@ -59,6 +59,7 @@ permissions:
 jobs:
   agent-e2e:
     name: agent e2e (host ${{ matrix.host-base-os }}, nspawn ${{ matrix.nspawn-base-os }})
+    if: ${{ !matrix.requires-secrets || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -72,6 +73,17 @@ jobs:
           # e2e can boot directly as the host VM.
           - host-base-os: fedora
             nspawn-base-os: azlinux3
+          # RHEL cloud images require an authenticated Red Hat download or a
+          # repository-managed mirror. Fork pull requests cannot read the URL
+          # secrets, so run those lanes for trusted events only.
+          - host-base-os: rhel9
+            nspawn-base-os: azlinux3
+            host-image-url-secret: RHEL9_E2E_IMAGE_URL
+            requires-secrets: true
+          - host-base-os: rhel10
+            nspawn-base-os: azlinux3
+            host-image-url-secret: RHEL10_E2E_IMAGE_URL
+            requires-secrets: true
           - host-base-os: ubuntu2604
             nspawn-base-os: ubuntu2604
     env:
@@ -81,7 +93,16 @@ jobs:
       VM_IP: "192.168.100.10"
       AGENT_MACHINE_NAME: agent-e2e-${{ matrix.host-base-os }}-${{ matrix.nspawn-base-os }}
       HOST_BASE_OS: ${{ matrix.host-base-os }}
+      HOST_IMAGE_URL: ${{ secrets[matrix.host-image-url-secret] }}
     steps:
+      - name: Check RHEL image configuration
+        shell: bash
+        run: |
+          if [[ "${HOST_BASE_OS}" == rhel* && -z "${HOST_IMAGE_URL}" ]]; then
+            echo "::error::Configure the ${HOST_BASE_OS^^}_E2E_IMAGE_URL repository secret with a CI-accessible qcow2 URL"
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/agent-e2e-kind.yaml
+++ b/.github/workflows/agent-e2e-kind.yaml
@@ -57,35 +57,32 @@ permissions:
   packages: read
 
 jobs:
+  agent-e2e-matrix:
+    name: Build agent E2E matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Build matrix
+        id: matrix
+        env:
+          TRUSTED_EVENT: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        shell: bash
+        run: |
+          matrix='{"include":[{"host-base-os":"ubuntu2404","nspawn-base-os":"ubuntu2404"},{"host-base-os":"fedora","nspawn-base-os":"azlinux3"},{"host-base-os":"ubuntu2604","nspawn-base-os":"ubuntu2604"}]}'
+          if [[ "${TRUSTED_EVENT}" == "true" ]]; then
+            matrix='{"include":[{"host-base-os":"ubuntu2404","nspawn-base-os":"ubuntu2404"},{"host-base-os":"fedora","nspawn-base-os":"azlinux3"},{"host-base-os":"rhel9","nspawn-base-os":"azlinux3","host-image-url-secret":"RHEL9_E2E_IMAGE_URL"},{"host-base-os":"rhel10","nspawn-base-os":"azlinux3","host-image-url-secret":"RHEL10_E2E_IMAGE_URL"},{"host-base-os":"ubuntu2604","nspawn-base-os":"ubuntu2604"}]}'
+          fi
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
   agent-e2e:
     name: agent e2e (host ${{ matrix.host-base-os }}, nspawn ${{ matrix.nspawn-base-os }})
-    if: ${{ !matrix.requires-secrets || github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: agent-e2e-matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - host-base-os: ubuntu2404
-            nspawn-base-os: ubuntu2404
-          # Fedora covers the RPM host path for Azure Linux nspawn testing.
-          # Azure Linux 3 does not currently publish a QEMU-ready VHD that this
-          # e2e can boot directly as the host VM.
-          - host-base-os: fedora
-            nspawn-base-os: azlinux3
-          # RHEL cloud images require an authenticated Red Hat download or a
-          # repository-managed mirror. Fork pull requests cannot read the URL
-          # secrets, so run those lanes for trusted events only.
-          - host-base-os: rhel9
-            nspawn-base-os: azlinux3
-            host-image-url-secret: RHEL9_E2E_IMAGE_URL
-            requires-secrets: true
-          - host-base-os: rhel10
-            nspawn-base-os: azlinux3
-            host-image-url-secret: RHEL10_E2E_IMAGE_URL
-            requires-secrets: true
-          - host-base-os: ubuntu2604
-            nspawn-base-os: ubuntu2604
+      matrix: ${{ fromJSON(needs.agent-e2e-matrix.outputs.matrix) }}
     env:
       KIND_CLUSTER_NAME: agent-e2e-${{ matrix.host-base-os }}-${{ matrix.nspawn-base-os }}
       VM_NAME: agent-e2e-${{ matrix.host-base-os }}-${{ matrix.nspawn-base-os }}

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -1398,7 +1398,6 @@ def host_image() -> HostImage:
             backing_format="qcow2",
             sudo_group="wheel",
             packages=["curl", "jq", "ca-certificates", "net-tools"],
-            network_interface="eth0",
         )
     if HOST_BASE_OS in {"almalinux9", "almalinux10"}:
         version = HOST_BASE_OS.removeprefix("almalinux")

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -1398,12 +1398,13 @@ def host_image() -> HostImage:
             sudo_group="wheel",
             packages=["curl", "jq", "ca-certificates", "net-tools"],
         )
-    if HOST_BASE_OS in {"rhel9", "rhel10"}:
-        if not HOST_IMAGE_URL:
-            die(f"HOST_IMAGE_URL is required for {HOST_BASE_OS}; Red Hat cloud images require authenticated access")
+    if HOST_BASE_OS in {"almalinux9", "almalinux10"}:
+        version = HOST_BASE_OS.removeprefix("almalinux")
         return HostImage(
-            url=HOST_IMAGE_URL,
-            file_name=f"{HOST_BASE_OS}-cloud-amd64.qcow2",
+            url=HOST_IMAGE_URL
+            or f"https://repo.almalinux.org/almalinux/{version}/cloud/x86_64/images/"
+            f"AlmaLinux-{version}-GenericCloud-latest.x86_64.qcow2",
+            file_name=f"almalinux-{version}-cloud-amd64.qcow2",
             backing_format="qcow2",
             sudo_group="wheel",
             packages=["curl", "jq", "ca-certificates", "net-tools"],
@@ -1411,7 +1412,7 @@ def host_image() -> HostImage:
 
     die(
         f"Unsupported HOST_BASE_OS {HOST_BASE_OS!r}; "
-        "expected ubuntu2404, ubuntu2604, fedora, rhel9, or rhel10"
+        "expected ubuntu2404, ubuntu2604, fedora, almalinux9, or almalinux10"
     )
 
 

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -1398,8 +1398,21 @@ def host_image() -> HostImage:
             sudo_group="wheel",
             packages=["curl", "jq", "ca-certificates", "net-tools"],
         )
+    if HOST_BASE_OS in {"rhel9", "rhel10"}:
+        if not HOST_IMAGE_URL:
+            die(f"HOST_IMAGE_URL is required for {HOST_BASE_OS}; Red Hat cloud images require authenticated access")
+        return HostImage(
+            url=HOST_IMAGE_URL,
+            file_name=f"{HOST_BASE_OS}-cloud-amd64.qcow2",
+            backing_format="qcow2",
+            sudo_group="wheel",
+            packages=["curl", "jq", "ca-certificates", "net-tools"],
+        )
 
-    die(f"Unsupported HOST_BASE_OS {HOST_BASE_OS!r}; expected ubuntu2404, ubuntu2604, or fedora")
+    die(
+        f"Unsupported HOST_BASE_OS {HOST_BASE_OS!r}; "
+        "expected ubuntu2404, ubuntu2604, fedora, rhel9, or rhel10"
+    )
 
 
 def ubuntu_netplan_write_files() -> str:

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -1362,6 +1362,7 @@ class HostImage:
     backing_format: str
     sudo_group: str
     packages: list[str]
+    network_interface: str = "ens3"
     write_files: str = ""
     pre_marker_commands: list[str] | None = None
 
@@ -1397,6 +1398,7 @@ def host_image() -> HostImage:
             backing_format="qcow2",
             sudo_group="wheel",
             packages=["curl", "jq", "ca-certificates", "net-tools"],
+            network_interface="eth0",
         )
     if HOST_BASE_OS in {"almalinux9", "almalinux10"}:
         version = HOST_BASE_OS.removeprefix("almalinux")
@@ -1408,6 +1410,7 @@ def host_image() -> HostImage:
             backing_format="qcow2",
             sudo_group="wheel",
             packages=["curl", "jq", "ca-certificates", "net-tools"],
+            network_interface="eth0",
         )
 
     die(
@@ -1514,7 +1517,7 @@ def _launch_vm(ssh_pub_key: str) -> None:
     network_config.write_text(textwrap.dedent(f"""\
         version: 2
         ethernets:
-          ens3:
+          {image.network_interface}:
             addresses:
               - {VM_IP}/24
             gateway4: {VM_GATEWAY}


### PR DESCRIPTION
## Summary
- add AlmaLinux 9 and AlmaLinux 10 host lanes paired with the Azure Linux 3 nspawn rootfs
- use official public AlmaLinux GenericCloud qcow2 images
- exercise enterprise Linux RPM-family hosts without requiring Red Hat subscriptions or repository secrets

## Validation
- Python compilation
- workflow YAML parsing
- targeted AlmaLinux 9 and AlmaLinux 10 host image selection probes
- HTTP 200 responses from both official image URLs
- `git diff --check`