### PR TITLE
Add CentOS Stream 9 and 10 to agent E2E matrix

### DIFF
--- a/.github/workflows/agent-e2e-kind.yaml
+++ b/.github/workflows/agent-e2e-kind.yaml
@@ -67,7 +67,7 @@ jobs:
         include:
           - host-base-os: ubuntu2404
             nspawn-base-os: ubuntu2404
-          # Fedora and AlmaLinux cover RPM hosts with Azure Linux nspawn.
+          # Fedora, AlmaLinux, and CentOS Stream cover RPM hosts with Azure Linux nspawn.
           # Azure Linux 3 does not currently publish a QEMU-ready VHD that this
           # e2e can boot directly as the host VM.
           - host-base-os: fedora
@@ -75,6 +75,10 @@ jobs:
           - host-base-os: almalinux9
             nspawn-base-os: azlinux3
           - host-base-os: almalinux10
+            nspawn-base-os: azlinux3
+          - host-base-os: centosstream9
+            nspawn-base-os: azlinux3
+          - host-base-os: centosstream10
             nspawn-base-os: azlinux3
           - host-base-os: ubuntu2604
             nspawn-base-os: ubuntu2604

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -1411,10 +1411,23 @@ def host_image() -> HostImage:
             packages=["curl", "jq", "ca-certificates", "net-tools"],
             network_interface="eth0",
         )
+    if HOST_BASE_OS in {"centosstream9", "centosstream10"}:
+        version = HOST_BASE_OS.removeprefix("centosstream")
+        return HostImage(
+            url=HOST_IMAGE_URL
+            or f"https://cloud.centos.org/centos/{version}-stream/x86_64/images/"
+            f"CentOS-Stream-GenericCloud-{version}-latest.x86_64.qcow2",
+            file_name=f"centos-stream-{version}-cloud-amd64.qcow2",
+            backing_format="qcow2",
+            sudo_group="wheel",
+            packages=["curl", "jq", "ca-certificates", "net-tools"],
+            network_interface="eth0",
+        )
 
     die(
         f"Unsupported HOST_BASE_OS {HOST_BASE_OS!r}; "
-        "expected ubuntu2404, ubuntu2604, fedora, almalinux9, or almalinux10"
+        "expected ubuntu2404, ubuntu2604, fedora, almalinux9, almalinux10, "
+        "centosstream9, or centosstream10"
     )
 
 

--- a/hack/agent/e2e-kind/e2e.py
+++ b/hack/agent/e2e-kind/e2e.py
@@ -1421,7 +1421,7 @@ def host_image() -> HostImage:
             backing_format="qcow2",
             sudo_group="wheel",
             packages=["curl", "jq", "ca-certificates", "net-tools"],
-            network_interface="eth0",
+            network_interface="eth0" if version == "9" else "ens3",
         )
 
     die(


### PR DESCRIPTION
## Summary
- add CentOS Stream 9 and CentOS Stream 10 host lanes paired with the Azure Linux 3 nspawn rootfs
- use official public CentOS GenericCloud qcow2 images
- exercise the full agent lifecycle on both current CentOS Stream releases

## Validation
- Python compilation
- workflow YAML parsing
- targeted CentOS Stream 9 and 10 host-image selection probes
- HTTP 200 responses from both official image URLs
- `git diff --check`